### PR TITLE
Fix extension loading issue described in #84

### DIFF
--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -16,6 +16,15 @@
 namespace duckdb {
 
 static void LoadInternal(DatabaseInstance &instance) {
+	auto &config = DBConfig::GetConfig(instance);
+
+	config.AddExtensionOption(
+		"unsafe_enable_version_guessing",
+		"Enable globbing the filesystem (if possible) to find the latest version metadata. This could result in reading an uncommitted version.",
+		LogicalType::BOOLEAN,
+		Value::BOOLEAN(false)
+	);
+
 	// Iceberg Table Functions
 	for (auto &fun : IcebergFunctions::GetTableFunctions()) {
 		ExtensionUtil::RegisterFunction(instance, fun);
@@ -28,14 +37,6 @@ static void LoadInternal(DatabaseInstance &instance) {
 }
 
 void IcebergExtension::Load(DuckDB &db) {
-	auto &config = DBConfig::GetConfig(*db.instance);
-
-	config.AddExtensionOption(
-		"unsafe_enable_version_guessing",
-		"Enable globbing the filesystem (if possible) to find the latest version metadata. This could result in reading an uncommitted version.",
-		LogicalType::BOOLEAN,
-		Value::BOOLEAN(false)
-	);
 	LoadInternal(*db.instance);
 }
 std::string IcebergExtension::Name() {


### PR DESCRIPTION
This should fix #84 by changing where the `unsafe_enable_version_guessing` config value is defined to the same function where other new functions are defined. This has been tested by the following:
```
~/duckdb_iceberg$ make test
...
cd
~/$ duckdb -unsigned
D FORCE INSTALL 'duckdb_iceberg/build/release/repository/v1.1.3/linux_amd64/iceberg.duckdb_extension';
D LOAD iceberg;
D .quit
cd ~/duckdb_iceberg/data/iceberg
~/duckdb_iceberg/data/iceberg$ duckdb -unsigned # note this is my system version of duckdb
D LOAD iceberg;
D SET unsafe_enable_version_guessing=true;
D SELECT COUNT() FROM iceberg_scan('lineitem_iceberg_no_hint');
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│        51793 │
└──────────────┘
```
