### PR TITLE
remove isdirectory check

### DIFF
--- a/src/common/iceberg.cpp
+++ b/src/common/iceberg.cpp
@@ -195,7 +195,6 @@ string IcebergSnapshot::GetMetaDataPath(ClientContext &context, const string &pa
 		// We've been given a real metadata path. Nothing else to do.
 		return path;
 	}
-
 	if(StringUtil::EndsWith(table_version, ".text")||StringUtil::EndsWith(table_version, ".txt")) {
 		// We were given a hint filename
 		version_hint = GetTableVersionFromHint(meta_path, fs, table_version);
@@ -213,7 +212,7 @@ string IcebergSnapshot::GetMetaDataPath(ClientContext &context, const string &pa
 	}
 	if (!UnsafeVersionGuessingEnabled(context)) {
 		// Make sure we're allowed to guess versions
-		throw InvalidInputException("No version was provided and no version-hint could be found, globbing the filesystem to locate the latest version is disabled by default as this is considered unsafe and could result in reading uncommitted data. To enable this use 'SET %s = true;'", VERSION_GUESSING_CONFIG_VARIABLE);
+		throw IOException("Failed to read iceberg table. No version was provided and no version-hint could be found, globbing the filesystem to locate the latest version is disabled by default as this is considered unsafe and could result in reading uncommitted data. To enable this use 'SET %s = true;'", VERSION_GUESSING_CONFIG_VARIABLE);
 	}
 
 	// We are allowed to guess to guess from file paths

--- a/src/common/iceberg.cpp
+++ b/src/common/iceberg.cpp
@@ -194,28 +194,30 @@ string IcebergSnapshot::GetMetaDataPath(ClientContext &context, const string &pa
 	if (StringUtil::EndsWith(path, ".json")) {
 		// We've been given a real metadata path. Nothing else to do.
 		return path;
-	} else if (!fs.DirectoryExists(meta_path)) {
-		// Make sure we have a metadata directory to look in
-		throw IOException("Cannot open \"%s\": Metadata directory does not exist", path);
-	} else if(StringUtil::EndsWith(table_version, ".text")||StringUtil::EndsWith(table_version, ".txt")) {
+	}
+
+	if(StringUtil::EndsWith(table_version, ".text")||StringUtil::EndsWith(table_version, ".txt")) {
 		// We were given a hint filename
 		version_hint = GetTableVersionFromHint(meta_path, fs, table_version);
 		return GenerateMetaDataUrl(fs, meta_path, version_hint, metadata_compression_codec, version_format);
-	} else if (table_version != UNKNOWN_TABLE_VERSION) {
+	}
+	if (table_version != UNKNOWN_TABLE_VERSION) {
 		// We were given an explicit version number
 		version_hint = table_version;
 		return GenerateMetaDataUrl(fs, meta_path, version_hint, metadata_compression_codec, version_format);
-	} else if (fs.FileExists(fs.JoinPath(meta_path, DEFAULT_VERSION_HINT_FILE))) {
+	}
+	if (fs.FileExists(fs.JoinPath(meta_path, DEFAULT_VERSION_HINT_FILE))) {
 		// We're guessing, but a version-hint.text exists so we'll use that
 		version_hint = GetTableVersionFromHint(meta_path, fs, DEFAULT_VERSION_HINT_FILE);
 		return GenerateMetaDataUrl(fs, meta_path, version_hint, metadata_compression_codec, version_format);
-	} else if (!UnsafeVersionGuessingEnabled(context)) {
+	}
+	if (!UnsafeVersionGuessingEnabled(context)) {
 		// Make sure we're allowed to guess versions
 		throw InvalidInputException("No version was provided and no version-hint could be found, globbing the filesystem to locate the latest version is disabled by default as this is considered unsafe and could result in reading uncommitted data. To enable this use 'SET %s = true;'", VERSION_GUESSING_CONFIG_VARIABLE);
-	} else {
-		// We are allowed to guess to guess from file paths
-		return GuessTableVersion(meta_path, fs, table_version, metadata_compression_codec, version_format);
 	}
+
+	// We are allowed to guess to guess from file paths
+	return GuessTableVersion(meta_path, fs, table_version, metadata_compression_codec, version_format);
 }
 
 

--- a/test/sql/iceberg_metadata.test
+++ b/test/sql/iceberg_metadata.test
@@ -51,7 +51,7 @@ lineitem_iceberg_gz/metadata/23f9dbea-1e7f-4694-a82c-dc3c9a94953e-m0.avro	0	DATA
 statement error
 SELECT * FROM ICEBERG_METADATA('data/iceberg/lineitem_iceberg_nonexistent');
 ----
-IO Error: Cannot open "data/iceberg/lineitem_iceberg_nonexistent": Metadata directory does not exist
+IO Error: Failed to read iceberg table. No version was provided and no version-hint could be found,
 
 statement error
 SELECT * FROM ICEBERG_METADATA('data/iceberg/lineitem_iceberg_no_hint', ALLOW_MOVED_PATHS=TRUE);

--- a/test/sql/iceberg_snapshots.test
+++ b/test/sql/iceberg_snapshots.test
@@ -41,7 +41,7 @@ SELECT * FROM ICEBERG_SNAPSHOTS('data/iceberg/lineitem_iceberg', version='1');
 statement error
 SELECT * FROM ICEBERG_SNAPSHOTS('data/iceberg/lineitem_iceberg_nonexistent');
 ----
-Invalid Input Error: No version was provided and no version-hint could be found
+IO Error: Failed to read iceberg table. No version was provided and no version-hint could be found,
 
 statement error
 SELECT * FROM ICEBERG_SNAPSHOTS('data/iceberg/lineitem_iceberg_gz');

--- a/test/sql/iceberg_snapshots.test
+++ b/test/sql/iceberg_snapshots.test
@@ -41,7 +41,7 @@ SELECT * FROM ICEBERG_SNAPSHOTS('data/iceberg/lineitem_iceberg', version='1');
 statement error
 SELECT * FROM ICEBERG_SNAPSHOTS('data/iceberg/lineitem_iceberg_nonexistent');
 ----
-IO Error: Cannot open "data/iceberg/lineitem_iceberg_nonexistent": Metadata directory does not exist
+Invalid Input Error: No version was provided and no version-hint could be found
 
 statement error
 SELECT * FROM ICEBERG_SNAPSHOTS('data/iceberg/lineitem_iceberg_gz');


### PR DESCRIPTION
The IsDirectory check is not supported on HTTPFileSystem. Leaving this check out is fine: the error message `Invalid Input Error: No version was provided and no version-hint could be found` is clear enough I think.