### PR TITLE
Replace internal table secret on conflict

### DIFF
--- a/src/storage/irc_table_entry.cpp
+++ b/src/storage/irc_table_entry.cpp
@@ -56,13 +56,14 @@ TableFunction ICTableEntry::GetScanFunction(ClientContext &context, unique_ptr<F
 	}
 
 	auto &secret_manager = SecretManager::Get(context);
+	
 	// Get Credentials from IRC API
 	auto table_credentials = IRCAPI::GetTableCredentials(
 		ic_catalog.internal_name, table_data->schema_name, table_data->name, ic_catalog.credentials);
 	// First check if table credentials are set (possible the IC catalog does not return credentials)
 	if (!table_credentials.key_id.empty()) {
 		// Inject secret into secret manager scoped to this path
-		CreateSecretInfo info(OnCreateConflict::ERROR_ON_CONFLICT, SecretPersistType::TEMPORARY);
+		CreateSecretInfo info(OnCreateConflict::REPLACE_ON_CONFLICT, SecretPersistType::TEMPORARY);
 		info.name = "__internal_ic_" + table_data->table_id;
 		info.type = "s3";
 		info.provider = "config";


### PR DESCRIPTION
I was trying the latest Iceberg REST Catalog support and ran into an issue where it was attempting to recreate the secret every time you run a SELECT statement and throwing due to the conflict setting.

This PR is less than ideal--the right solution would be to cache table info and vended credentials to avoid extra API calls--but it allows repeated queries against the same table.