### PR TITLE
Improvements to glue support

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -8,8 +8,11 @@ duckdb_extension_load(iceberg
 
 duckdb_extension_load(tpch)
 
-duckdb_extension_load(aws
-        LOAD_TESTS
-        GIT_URL https://github.com/duckdb/duckdb-aws
-        GIT_TAG main
-)
+################## AWS
+if (NOT MINGW AND NOT ${WASM_ENABLED})
+    duckdb_extension_load(aws
+            LOAD_TESTS
+            GIT_URL https://github.com/duckdb/duckdb-aws
+            GIT_TAG main
+    )
+endif ()

--- a/src/catalog_api.cpp
+++ b/src/catalog_api.cpp
@@ -8,7 +8,7 @@
 #include <aws/s3/S3Client.h>
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
-#include <aws/core/http/curl/CurlHttpClient.h>
+#include <aws/core/http/HttpClient.h>
 #include <aws/core/http/HttpRequest.h>
 #include <duckdb/main/secret/secret.hpp>
 #include <duckdb/main/secret/secret_manager.hpp>
@@ -169,7 +169,6 @@ static string GetAwsRegion(const string host) {
 static string GetRequestAws(ClientContext &context, IRCEndpointBuilder endpoint_builder, const string &secret_name) {
 	auto clientConfig = make_uniq<Aws::Client::ClientConfiguration>();
 
-	auto curl_client = make_uniq<Aws::Http::CurlHttpClient>(*clientConfig);
 	std::shared_ptr<Aws::Http::HttpClientFactory> MyClientFactory;
 	std::shared_ptr<Aws::Http::HttpClient> MyHttpClient;
 

--- a/src/catalog_api.cpp
+++ b/src/catalog_api.cpp
@@ -232,7 +232,7 @@ static string GetRequestAws(ClientContext &context, IRCEndpointBuilder endpoint_
 	} else {
 		Aws::StringStream resBody;
 		resBody <<  res->GetResponseBody().rdbuf();
-		throw IOException("Failed to query %s, http error %d thrown", req->GetUri().GetURIString(true), res->GetResponseCode());
+		throw IOException("Failed to query %s, http error %d thrown. Message: %s", req->GetUri().GetURIString(true), res->GetResponseCode(), resBody.str());
 	}
 }
 

--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -98,7 +98,7 @@ static unique_ptr<Catalog> IcebergCatalogAttach(StorageExtensionInfo *storage_in
         auto kv_secret = dynamic_cast<const KeyValueSecret &>(*secret_entry->secret);
 		auto region = kv_secret.TryGetValue("region").ToString();
 		catalog->host = service + "." + region + ".amazonaws.com";
-		catalog->warehouse = warehouse;
+		catalog->warehouse = StringUtil::Replace(warehouse, "/", ":");
 		catalog->version = "v1";
 		catalog->secret_name = secret_name;
 		return std::move(catalog);

--- a/src/include/iceberg_types.hpp
+++ b/src/include/iceberg_types.hpp
@@ -26,6 +26,8 @@ static string IcebergManifestContentTypeToString(IcebergManifestContentType type
 		return "DATA";
 	case IcebergManifestContentType::DELETE:
 		return "DELETE";
+	default:
+		throw IOException("Invalid Manifest Content Type");
 	}
 }
 
@@ -39,6 +41,8 @@ static string IcebergManifestEntryStatusTypeToString(IcebergManifestEntryStatusT
 		return "ADDED";
 	case IcebergManifestEntryStatusType::DELETED:
 		return "DELETED";
+	default:
+		throw IOException("Invalid matifest entry type");
 	}
 }
 
@@ -52,6 +56,8 @@ static string IcebergManifestEntryContentTypeToString(IcebergManifestEntryConten
 		return "POSITION_DELETES";
 	case IcebergManifestEntryContentType::EQUALITY_DELETES:
 		return "EQUALITY_DELETES";
+	default:
+		throw IOException("Invalid Manifest Entry Content Type");
 	}
 }
 

--- a/src/storage/irc_table_entry.cpp
+++ b/src/storage/irc_table_entry.cpp
@@ -71,6 +71,14 @@ TableFunction ICTableEntry::GetScanFunction(ClientContext &context, unique_ptr<F
 			{"region", table_credentials.region},
 		};
 
+		if (StringUtil::StartsWith(ic_catalog.host, "glue")) {
+			auto secret_entry = IRCatalog::GetSecret(context, ic_catalog.secret_name);
+			auto kv_secret = dynamic_cast<const KeyValueSecret &>(*secret_entry->secret);
+			auto region = kv_secret.TryGetValue("region").ToString();
+			auto endpoint = "s3." + region + ".amazonaws.com";
+			info.options["endpoint"] = endpoint;
+		}
+
 		std::string lc_storage_location;
 		lc_storage_location.resize(table_data->storage_location.size());
 		std::transform(table_data->storage_location.begin(), table_data->storage_location.end(), lc_storage_location.begin(), ::tolower);

--- a/test/sql/cloud/test_glue.test
+++ b/test/sql/cloud/test_glue.test
@@ -28,7 +28,7 @@ CREATE SECRET glue_secret (
 );
 
 statement ok
-attach '840140254803:s3tablescatalog:pyiceberg-blog-bucket' as my_datalake (
+attach '840140254803:s3tablescatalog/pyiceberg-blog-bucket' as my_datalake (
     TYPE ICEBERG,
     ENDPOINT_TYPE 'GLUE'
 );


### PR DESCRIPTION
- Don't hit global s3 endpoint when reading from a glue catalog. 
- Use the s3tablescatalog name, and not a hardcoded prefix
- Print error message if AWS request fails.