### PR TITLE
Implement some basic caching

### DIFF
--- a/src/catalog_api.cpp
+++ b/src/catalog_api.cpp
@@ -333,19 +333,6 @@ static yyjson_doc *api_result_to_doc(const string &api_result) {
 	return doc;
 }
 
-static string GetTableMetadataCached(ClientContext &context, IRCatalog &catalog, const string &schema, const string &table, const string &secret_name) {
-	struct curl_slist *extra_headers = NULL;
-	auto url = catalog.GetBaseUrl();
-	url.AddPathComponent("namespaces");
-	url.AddPathComponent(schema);
-	url.AddPathComponent("tables");
-	url.AddPathComponent(table);
-	if (catalog.HasCachedValue(url.GetURL())) {
-		return catalog.GetCachedValue(url.GetURL());
-	}
-	return GetTableMetadata(context, catalog, secret_name, secret_name);
-}
-
 static string GetTableMetadata(ClientContext &context, IRCatalog &catalog, const string &schema, const string &table, const string &secret_name) {
 	struct curl_slist *extra_headers = NULL;
 	auto url = catalog.GetBaseUrl();
@@ -364,6 +351,20 @@ static string GetTableMetadata(ClientContext &context, IRCatalog &catalog, const
 	curl_slist_free_all(extra_headers);
 	return api_result;
 }
+
+static string GetTableMetadataCached(ClientContext &context, IRCatalog &catalog, const string &schema, const string &table, const string &secret_name) {
+	struct curl_slist *extra_headers = NULL;
+	auto url = catalog.GetBaseUrl();
+	url.AddPathComponent("namespaces");
+	url.AddPathComponent(schema);
+	url.AddPathComponent("tables");
+	url.AddPathComponent(table);
+	if (catalog.HasCachedValue(url.GetURL())) {
+		return catalog.GetCachedValue(url.GetURL());
+	}
+	return GetTableMetadata(context, catalog, schema, table, secret_name);
+}
+
 
 void IRCAPI::InitializeCurl() {
 	SelectCurlCertPath();

--- a/src/catalog_api.cpp
+++ b/src/catalog_api.cpp
@@ -2,6 +2,7 @@
 #include "catalog_utils.hpp"
 #include "storage/irc_catalog.hpp"
 #include "yyjson.hpp"
+#include "iceberg_utils.hpp"
 #include <curl/curl.h>
 #include <sys/stat.h>
 #include <aws/core/Aws.h>
@@ -42,14 +43,6 @@ static string certFileLocations[] = {
 
 const string IRCAPI::API_VERSION_1 = "v1";
 
-struct YyjsonDocDeleter {
-    void operator()(yyjson_doc* doc) {
-        yyjson_doc_free(doc);
-    }
-    void operator()(yyjson_mut_doc* doc) {
-        yyjson_mut_doc_free(doc);
-    }
-};
 
 // Look through the the above locations and if one of the files exists, set that as the location curl should use.
 static bool SelectCurlCertPath() {
@@ -77,34 +70,6 @@ static void InitializeCurlObject(CURL * curl, const string &token) {
 		curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BEARER);
 	}
     SetCurlCAFileInfo(curl);
-}
-
-template <class TYPE, uint8_t TYPE_NUM, TYPE (*get_function)(yyjson_val *obj)>
-static TYPE TemplatedTryGetYYJson(yyjson_val *obj, const string &field, TYPE default_val,
-                                  bool fail_on_missing = true) {
-	auto val = yyjson_obj_get(obj, field.c_str());
-	if (val && yyjson_get_type(val) == TYPE_NUM) {
-		return get_function(val);
-	} else if (!fail_on_missing) {
-		return default_val;
-	}
-	throw IOException("Invalid field found while parsing field: " + field);
-}
-
-static uint64_t TryGetNumFromObject(yyjson_val *obj, const string &field, bool fail_on_missing = true,
-                                    uint64_t default_val = 0) {
-	return TemplatedTryGetYYJson<uint64_t, YYJSON_TYPE_NUM, yyjson_get_uint>(obj, field, default_val,
-	                                                                                        fail_on_missing);
-}
-static bool TryGetBoolFromObject(yyjson_val *obj, const string &field, bool fail_on_missing = false,
-								 bool default_val = false) {
-	return TemplatedTryGetYYJson<bool, YYJSON_TYPE_BOOL, yyjson_get_bool>(obj, field, default_val,
-																						 fail_on_missing);
-}
-static string TryGetStrFromObject(yyjson_val *obj, const string &field, bool fail_on_missing = true,
-                                  const char *default_val = "") {
-	return TemplatedTryGetYYJson<const char *, YYJSON_TYPE_STR, yyjson_get_str>(obj, field, default_val,
-	                                                                                           fail_on_missing);
 }
 
 static string DeleteRequest(const string &url, const string &token = "", curl_slist *extra_headers = NULL) {
@@ -222,12 +187,8 @@ static string GetRequestAws(ClientContext &context, IRCEndpointBuilder endpoint_
 
 	auto signer = make_uniq<Aws::Client::AWSAuthV4Signer>(provider, service.c_str(), region.c_str());
 	signer->SignRequest(*req);
-	auto start = std::chrono::high_resolution_clock::now();
 	std::shared_ptr<Aws::Http::HttpResponse> res = MyHttpClient->MakeRequest(req);
 	Aws::Http::HttpResponseCode resCode = res->GetResponseCode();
-	auto stop = std::chrono::high_resolution_clock::now();
-	std::chrono::duration<double> elapsed = stop - start;
-	std::cout << "Elapsed time: " << elapsed.count() << " seconds\n";
 	if (resCode == Aws::Http::HttpResponseCode::OK) {
 		Aws::StringStream resBody;
 		resBody << res->GetResponseBody().rdbuf();
@@ -322,17 +283,6 @@ static string PostRequest(
 	return readBuffer;
 }
 
-static yyjson_doc *api_result_to_doc(const string &api_result) {
-	auto *doc = yyjson_read(api_result.c_str(), api_result.size(), 0);
-	auto *root = yyjson_doc_get_root(doc);
-	auto *error = yyjson_obj_get(root, "error");
-	if (error != NULL) {
-		string err_msg = TryGetStrFromObject(error, "message");
-		throw std::runtime_error(err_msg);
-	}
-	return doc;
-}
-
 static string GetTableMetadata(ClientContext &context, IRCatalog &catalog, const string &schema, const string &table, const string &secret_name) {
 	struct curl_slist *extra_headers = NULL;
 	auto url = catalog.GetBaseUrl();
@@ -347,6 +297,7 @@ static string GetTableMetadata(ClientContext &context, IRCatalog &catalog, const
 		secret_name,
 		catalog.credentials.token,
 		extra_headers);
+
 	catalog.SetCachedValue(url.GetURL(), api_result);
 	curl_slist_free_all(extra_headers);
 	return api_result;
@@ -376,26 +327,26 @@ vector<string> IRCAPI::GetCatalogs(ClientContext &context, IRCatalog &catalog, I
 
 static IRCAPIColumnDefinition ParseColumnDefinition(yyjson_val *column_def) {
 	IRCAPIColumnDefinition result;
-	result.name = TryGetStrFromObject(column_def, "name");
-	result.type_text = TryGetStrFromObject(column_def, "type");
-	result.precision = (result.type_text == "decimal") ? TryGetNumFromObject(column_def, "type_precision") : -1;
-	result.scale = (result.type_text == "decimal") ? TryGetNumFromObject(column_def, "type_scale") : -1;
-	result.position = TryGetNumFromObject(column_def, "id") - 1;
+	result.name = IcebergUtils::TryGetStrFromObject(column_def, "name");
+	result.type_text = IcebergUtils::TryGetStrFromObject(column_def, "type");
+	result.precision = (result.type_text == "decimal") ? IcebergUtils::TryGetNumFromObject(column_def, "type_precision") : -1;
+	result.scale = (result.type_text == "decimal") ? IcebergUtils::TryGetNumFromObject(column_def, "type_scale") : -1;
+	result.position = IcebergUtils::TryGetNumFromObject(column_def, "id") - 1;
 	return result;
 }
 
 IRCAPITableCredentials IRCAPI::GetTableCredentials(ClientContext &context, IRCatalog &catalog, const string &schema, const string &table, IRCCredentials credentials) {
 	IRCAPITableCredentials result;
 	string api_result = GetTableMetadataCached(context, catalog, schema, table, catalog.secret_name);
-	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> doc(api_result_to_doc(api_result));
+	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> doc(ICUtils::api_result_to_doc(api_result));
 	auto *root = yyjson_doc_get_root(doc.get());
 	auto *warehouse_credentials = yyjson_obj_get(root, "config");
 	auto credential_size = yyjson_obj_size(warehouse_credentials);
 	auto catalog_credentials = IRCatalog::GetSecret(context, catalog.secret_name);
 	if (warehouse_credentials && credential_size > 0) {
-		result.key_id = TryGetStrFromObject(warehouse_credentials, "s3.access-key-id", false);
-		result.secret = TryGetStrFromObject(warehouse_credentials, "s3.secret-access-key",  false);
-		result.session_token = TryGetStrFromObject(warehouse_credentials, "s3.session-token", false);
+		result.key_id = IcebergUtils::TryGetStrFromObject(warehouse_credentials, "s3.access-key-id", false);
+		result.secret = IcebergUtils::TryGetStrFromObject(warehouse_credentials, "s3.secret-access-key",  false);
+		result.session_token = IcebergUtils::TryGetStrFromObject(warehouse_credentials, "s3.session-token", false);
 		if (catalog_credentials) {
        		auto kv_secret = dynamic_cast<const KeyValueSecret &>(*catalog_credentials->secret);
 			auto region = kv_secret.TryGetValue("region").ToString();
@@ -408,23 +359,23 @@ IRCAPITableCredentials IRCAPI::GetTableCredentials(ClientContext &context, IRCat
 string IRCAPI::GetToken(ClientContext &context, string id, string secret, string endpoint) {
 	string post_data = "grant_type=client_credentials&client_id=" + id + "&client_secret=" + secret + "&scope=PRINCIPAL_ROLE:ALL";
 	string api_result = PostRequest(endpoint + "/v1/oauth/tokens", post_data);
-	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> doc(api_result_to_doc(api_result));
+	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> doc(ICUtils::api_result_to_doc(api_result));
 	auto *root = yyjson_doc_get_root(doc.get());
-	return TryGetStrFromObject(root, "access_token");
+	return IcebergUtils::TryGetStrFromObject(root, "access_token");
 }
 
 static void populateTableMetadata(IRCAPITable &table, yyjson_val *metadata_root) {
-	table.storage_location = TryGetStrFromObject(metadata_root, "metadata-location");
+	table.storage_location = IcebergUtils::TryGetStrFromObject(metadata_root, "metadata-location");
 	auto *metadata = yyjson_obj_get(metadata_root, "metadata");
-	//table_result.table_id = TryGetStrFromObject(metadata, "table-uuid");
+	//table_result.table_id = IcebergUtils::TryGetStrFromObject(metadata, "table-uuid");
 
-	uint64_t current_schema_id = TryGetNumFromObject(metadata, "current-schema-id");
+	uint64_t current_schema_id = IcebergUtils::TryGetNumFromObject(metadata, "current-schema-id");
 	auto *schemas = yyjson_obj_get(metadata, "schemas");
 	yyjson_val *schema;
 	size_t schema_idx, schema_max;
 	bool found = false;
 	yyjson_arr_foreach(schemas, schema_idx, schema_max, schema) {
-		uint64_t schema_id = TryGetNumFromObject(schema, "schema-id");
+		uint64_t schema_id = IcebergUtils::TryGetNumFromObject(schema, "schema-id");
 		if (schema_id == current_schema_id) {
 			found = true;
 			auto *columns = yyjson_obj_get(schema, "fields");
@@ -458,7 +409,7 @@ IRCAPITable IRCAPI::GetTable(ClientContext &context,
 	IRCAPITable table_result = createTable(catalog, schema, table_name);
 	if (credentials) {
 		string result = GetTableMetadata(context, catalog, schema, table_result.name, catalog.secret_name);
-		std::unique_ptr<yyjson_doc, YyjsonDocDeleter> doc(api_result_to_doc(result));
+		std::unique_ptr<yyjson_doc, YyjsonDocDeleter> doc(ICUtils::api_result_to_doc(result));
 		auto *metadata_root = yyjson_doc_get_root(doc.get());
 		populateTableMetadata(table_result, metadata_root);
 	} else {
@@ -483,13 +434,13 @@ vector<IRCAPITable> IRCAPI::GetTables(ClientContext &context, IRCatalog &catalog
 	url.AddPathComponent(schema);
 	url.AddPathComponent("tables");
 	string api_result = GetRequest(context, url, catalog.secret_name, catalog.credentials.token);
-	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> doc(api_result_to_doc(api_result));
+	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> doc(ICUtils::api_result_to_doc(api_result));
 	auto *root = yyjson_doc_get_root(doc.get());
 	auto *tables = yyjson_obj_get(root, "identifiers");
 	size_t idx, max;
 	yyjson_val *table;
 	yyjson_arr_foreach(tables, idx, max, table) {
-		auto table_result = GetTable(context, catalog, schema, TryGetStrFromObject(table, "name"), nullptr);
+		auto table_result = GetTable(context, catalog, schema, IcebergUtils::TryGetStrFromObject(table, "name"), nullptr);
 		result.push_back(table_result);
 	}
 
@@ -502,7 +453,7 @@ vector<IRCAPISchema> IRCAPI::GetSchemas(ClientContext &context, IRCatalog &catal
 	endpoint_builder.AddPathComponent("namespaces");
 	string api_result =
 	    GetRequest(context, endpoint_builder, catalog.secret_name, catalog.credentials.token);
-	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> doc(api_result_to_doc(api_result));
+	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> doc(ICUtils::api_result_to_doc(api_result));
 	auto *root = yyjson_doc_get_root(doc.get());
 	auto *schemas = yyjson_obj_get(root, "namespaces");
 	size_t idx, max;

--- a/src/catalog_utils.cpp
+++ b/src/catalog_utils.cpp
@@ -1,4 +1,5 @@
 #include "catalog_utils.hpp"
+#include "iceberg_utils.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "storage/irc_schema_entry.hpp"
 #include "storage/irc_transaction.hpp"
@@ -231,6 +232,17 @@ LogicalType ICUtils::ToICType(const LogicalType &input) {
 	default:
 		return LogicalType::VARCHAR;
 	}
+}
+
+yyjson_doc *ICUtils::api_result_to_doc(const string &api_result) {
+	auto *doc = yyjson_read(api_result.c_str(), api_result.size(), 0);
+	auto *root = yyjson_doc_get_root(doc);
+	auto *error = yyjson_obj_get(root, "error");
+	if (error != NULL) {
+		string err_msg = IcebergUtils::TryGetStrFromObject(error, "message");
+		throw std::runtime_error(err_msg);
+	}
+	return doc;
 }
 
 } // namespace duckdb

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -59,4 +59,32 @@ string IcebergUtils::TryGetStrFromObject(yyjson_val *obj, const string &field) {
 	return yyjson_get_str(val);
 }
 
+template <class TYPE, uint8_t TYPE_NUM, TYPE (*get_function)(yyjson_val *obj)>
+static TYPE TemplatedTryGetYYJson(yyjson_val *obj, const string &field, TYPE default_val,
+								  bool fail_on_missing = true) {
+	auto val = yyjson_obj_get(obj, field.c_str());
+	if (val && yyjson_get_type(val) == TYPE_NUM) {
+		return get_function(val);
+	} else if (!fail_on_missing) {
+		return default_val;
+	}
+	throw IOException("Invalid field found while parsing field: " + field);
+}
+
+uint64_t IcebergUtils::TryGetNumFromObject(yyjson_val *obj, const string &field, bool fail_on_missing,
+									uint64_t default_val) {
+	return TemplatedTryGetYYJson<uint64_t, YYJSON_TYPE_NUM, yyjson_get_uint>(obj, field, default_val,
+																							fail_on_missing);
+}
+bool IcebergUtils::TryGetBoolFromObject(yyjson_val *obj, const string &field, bool fail_on_missing,
+								 bool default_val) {
+	return TemplatedTryGetYYJson<bool, YYJSON_TYPE_BOOL, yyjson_get_bool>(obj, field, default_val,
+																						 fail_on_missing);
+}
+string IcebergUtils::TryGetStrFromObject(yyjson_val *obj, const string &field, bool fail_on_missing,
+								  const char *default_val) {
+	return TemplatedTryGetYYJson<const char *, YYJSON_TYPE_STR, yyjson_get_str>(obj, field, default_val,
+																							   fail_on_missing);
+}
+
 } // namespace duckdb

--- a/src/include/catalog_api.hpp
+++ b/src/include/catalog_api.hpp
@@ -50,17 +50,17 @@ public:
   	//! WARNING: not thread-safe. To be called once on extension initialization
   	static void InitializeCurl();
 
-	static IRCAPITableCredentials GetTableCredentials(ClientContext &context, const IRCatalog &catalog, const string &schema, const string &table, IRCCredentials credentials);
-	static vector<string> GetCatalogs(ClientContext &context, const IRCatalog &catalog, IRCCredentials credentials);
-	static vector<IRCAPITable> GetTables(ClientContext &context, const IRCatalog &catalog, const string &schema);
-	static IRCAPITable GetTable(ClientContext &context, const IRCatalog &catalog, const string &schema, const string &table_name, optional_ptr<IRCCredentials> credentials);
-	static vector<IRCAPISchema> GetSchemas(ClientContext &context, const IRCatalog &catalog, IRCCredentials credentials);
-	static vector<IRCAPITable> GetTablesInSchema(ClientContext &context, const IRCatalog &catalog, const string &schema, IRCCredentials credentials);
+	static IRCAPITableCredentials GetTableCredentials(ClientContext &context, IRCatalog &catalog, const string &schema, const string &table, IRCCredentials credentials);
+	static vector<string> GetCatalogs(ClientContext &context, IRCatalog &catalog, IRCCredentials credentials);
+	static vector<IRCAPITable> GetTables(ClientContext &context, IRCatalog &catalog, const string &schema);
+	static IRCAPITable GetTable(ClientContext &context, IRCatalog &catalog, const string &schema, const string &table_name, optional_ptr<IRCCredentials> credentials);
+	static vector<IRCAPISchema> GetSchemas(ClientContext &context, IRCatalog &catalog, IRCCredentials credentials);
+	static vector<IRCAPITable> GetTablesInSchema(ClientContext &context, IRCatalog &catalog, const string &schema, IRCCredentials credentials);
 	static string GetToken(ClientContext &context, string id, string secret, string endpoint);
-	static IRCAPISchema CreateSchema(ClientContext &context, const IRCatalog &catalog, const string &internal, const string &schema, IRCCredentials credentials);
+	static IRCAPISchema CreateSchema(ClientContext &context, IRCatalog &catalog, const string &internal, const string &schema, IRCCredentials credentials);
 	static void DropSchema(ClientContext &context, const string &internal, const string &schema, IRCCredentials credentials);
-	static IRCAPITable CreateTable(ClientContext &context, const IRCatalog &catalog, const string &internal, const string &schema, IRCCredentials credentials, CreateTableInfo *table_info);
-	static void DropTable(ClientContext &context, const IRCatalog &catalog, const string &internal, const string &schema, string &table_name, IRCCredentials credentials);
+	static IRCAPITable CreateTable(ClientContext &context, IRCatalog &catalog, const string &internal, const string &schema, IRCCredentials credentials, CreateTableInfo *table_info);
+	static void DropTable(ClientContext &context, IRCatalog &catalog, const string &internal, const string &schema, string &table_name, IRCCredentials credentials);
 };
 
 } // namespace duckdb

--- a/src/include/catalog_utils.hpp
+++ b/src/include/catalog_utils.hpp
@@ -3,7 +3,9 @@
 
 #include "duckdb.hpp"
 #include "catalog_api.hpp"
+#include "yyjson.hpp"
 
+using namespace duckdb_yyjson;
 namespace duckdb {
 class IRCSchemaEntry;
 class IRCTransaction;
@@ -22,6 +24,16 @@ public:
 	static LogicalType TypeToLogicalType(ClientContext &context, const string &columnDefinition);
 	static string TypeToString(const LogicalType &input);
 	static string LogicalToIcebergType(const LogicalType &input);
+	static yyjson_doc *api_result_to_doc(const string &api_result);
+};
+
+struct YyjsonDocDeleter {
+	void operator()(yyjson_doc* doc) {
+		yyjson_doc_free(doc);
+	}
+	void operator()(yyjson_mut_doc* doc) {
+		yyjson_mut_doc_free(doc);
+	}
 };
 
 } // namespace duckdb

--- a/src/include/iceberg_utils.hpp
+++ b/src/include/iceberg_utils.hpp
@@ -31,6 +31,13 @@ public:
 	static uint64_t TryGetNumFromObject(yyjson_val *obj, const string &field);
 	static string TryGetStrFromObject(yyjson_val *obj, const string &field);
 	static bool TryGetBoolFromObject(yyjson_val *obj, const string &field);
+
+	static uint64_t TryGetNumFromObject(yyjson_val *obj, const string &field, bool fail_on_missing,
+									uint64_t default_val = 0);
+	static bool TryGetBoolFromObject(yyjson_val *obj, const string &field, bool fail_on_missing,
+								 bool default_val = false);
+	static string TryGetStrFromObject(yyjson_val *obj, const string &field, bool fail_on_missing,
+								  const char *default_val = "");
 };
 
 } // namespace duckdb

--- a/src/include/storage/irc_catalog.hpp
+++ b/src/include/storage/irc_catalog.hpp
@@ -30,11 +30,14 @@ public:
 	static void ClearCacheOnSetting(ClientContext &context, SetScope scope, Value &parameter);
 };
 
-//struct MetadataCacheEntry {
-//	std::string data;
-//	std::chrono::steady_clock::time_point timestamp;
-//};
+class MetadataCacheValue {
+public:
+	std::string data;
+	std::chrono::system_clock::time_point expires_at;
+public:
+	MetadataCacheValue() {};
 
+};
 
 class IRCatalog : public Catalog {
 public:
@@ -105,7 +108,7 @@ private:
 	IRCSchemaSet schemas;
 	string default_schema;
 
-	unordered_map<string, string> metadata_cache;
+	unordered_map<string, unique_ptr<MetadataCacheValue>> metadata_cache;
 
 };
 

--- a/src/include/storage/irc_catalog.hpp
+++ b/src/include/storage/irc_catalog.hpp
@@ -35,8 +35,8 @@ public:
 	std::string data;
 	std::chrono::system_clock::time_point expires_at;
 public:
-	MetadataCacheValue() {};
-
+	MetadataCacheValue(std::string data_, std::chrono::system_clock::time_point expires_at_) :
+	      data(data_), expires_at(expires_at_) {};
 };
 
 class IRCatalog : public Catalog {

--- a/src/include/storage/irc_catalog.hpp
+++ b/src/include/storage/irc_catalog.hpp
@@ -30,6 +30,11 @@ public:
 	static void ClearCacheOnSetting(ClientContext &context, SetScope scope, Value &parameter);
 };
 
+//struct MetadataCacheEntry {
+//	std::string data;
+//	std::chrono::steady_clock::time_point timestamp;
+//};
+
 
 class IRCatalog : public Catalog {
 public:
@@ -89,12 +94,19 @@ public:
 
 	void ClearCache();
 
+	bool HasCachedValue(string url) const;
+	string GetCachedValue(string url) const;
+	bool SetCachedValue(string url, string value);
+
 private:
 	void DropSchema(ClientContext &context, DropInfo &info) override;
 
 private:
 	IRCSchemaSet schemas;
 	string default_schema;
+
+	unordered_map<string, string> metadata_cache;
+
 };
 
 } // namespace duckdb

--- a/src/storage/irc_catalog.cpp
+++ b/src/storage/irc_catalog.cpp
@@ -169,10 +169,8 @@ bool IRCatalog::SetCachedValue(string url, string value) {
 			return false;
 		}
 		auto epochMillis = std::stoll(expires_at);
-// 		auto inputTime = std::chrono::system_clock::time_point(std::chrono::milliseconds(epochMillis));
-		auto val = make_uniq<MetadataCacheValue>();
-		val->data = value;
-		val->expires_at = std::chrono::system_clock::time_point(std::chrono::milliseconds(epochMillis));
+		auto expired_time = std::chrono::system_clock::time_point(std::chrono::milliseconds(epochMillis));
+		auto val = make_uniq<MetadataCacheValue>(value, expired_time);
 		metadata_cache[url] = std::move(val);
 	}
 	return false;

--- a/src/storage/irc_catalog.cpp
+++ b/src/storage/irc_catalog.cpp
@@ -86,6 +86,8 @@ void IRCatalog::ClearCache() {
 	schemas.ClearEntries();
 }
 
+
+
 unique_ptr<SecretEntry> IRCatalog::GetSecret(ClientContext &context, const string &secret_name) {
 	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
 	// make sure a secret exists to connect to an AWS catalog
@@ -125,6 +127,23 @@ unique_ptr<PhysicalOperator> IRCatalog::PlanUpdate(ClientContext &context, Logic
 unique_ptr<LogicalOperator> IRCatalog::BindCreateIndex(Binder &binder, CreateStatement &stmt, TableCatalogEntry &table,
                                                        unique_ptr<LogicalOperator> plan) {
 	throw NotImplementedException("ICCatalog BindCreateIndex");
+}
+
+
+bool IRCatalog::HasCachedValue(string url) const {
+	return metadata_cache.find(url) != metadata_cache.end();
+}
+
+string IRCatalog::GetCachedValue(string url) const {
+	if (metadata_cache.find(url) != metadata_cache.end()) {
+		return metadata_cache.find(url)->second;
+	}
+	throw InternalException("Cached value does not exist");
+}
+
+bool IRCatalog::SetCachedValue(string url, string value) {
+	metadata_cache[url] = value;
+	return true;
 }
 
 } // namespace duckdb

--- a/src/storage/irc_schema_set.cpp
+++ b/src/storage/irc_schema_set.cpp
@@ -17,7 +17,6 @@ void IRCSchemaSet::LoadEntries(ClientContext &context) {
 	}
 
 	auto &ic_catalog = catalog.Cast<IRCatalog>();
-	std::cout << "Calling Load Entries" << std::endl;
 	auto schemas = IRCAPI::GetSchemas(context, ic_catalog, ic_catalog.credentials);
 	for (const auto &schema : schemas) {
 		CreateSchemaInfo info;

--- a/src/storage/irc_schema_set.cpp
+++ b/src/storage/irc_schema_set.cpp
@@ -17,6 +17,7 @@ void IRCSchemaSet::LoadEntries(ClientContext &context) {
 	}
 
 	auto &ic_catalog = catalog.Cast<IRCatalog>();
+	std::cout << "Calling Load Entries" << std::endl;
 	auto schemas = IRCAPI::GetSchemas(context, ic_catalog, ic_catalog.credentials);
 	for (const auto &schema : schemas) {
 		CreateSchemaInfo info;

--- a/src/storage/irc_table_entry.cpp
+++ b/src/storage/irc_table_entry.cpp
@@ -130,7 +130,7 @@ TableFunction ICTableEntry::GetScanFunction(ClientContext &context, unique_ptr<F
 	auto &get = op->Cast<LogicalGet>();
 	bind_data = std::move(get.bind_data);
 
-	Printer::Print("returning parquet scan function");
+//	Printer::Print("returning parquet scan function");
 	return parquet_scan_function;
 }
 

--- a/src/storage/irc_table_entry.cpp
+++ b/src/storage/irc_table_entry.cpp
@@ -102,11 +102,7 @@ TableFunction ICTableEntry::GetScanFunction(ClientContext &context, unique_ptr<F
 	TableFunctionBindInput bind_input(inputs, param_map, return_types, names, nullptr, nullptr, 
 									  iceberg_scan_function, empty_ref);
 
-	auto start = std::chrono::high_resolution_clock::now();
 	auto table_ref = iceberg_scan_function.bind_replace(context, bind_input);
-	auto stop = std::chrono::high_resolution_clock::now();
-	std::chrono::duration<double> elapsed = stop - start;
-	std::cout << "Elapsed time bind replace: " << elapsed.count() << " seconds\n";
 	// 1) Create a Binder and bind the parser-level TableRef -> BoundTableRef
 	auto binder = Binder::CreateBinder(context);
 	auto bound_ref = binder->Bind(*table_ref);

--- a/src/storage/irc_table_entry.cpp
+++ b/src/storage/irc_table_entry.cpp
@@ -102,8 +102,11 @@ TableFunction ICTableEntry::GetScanFunction(ClientContext &context, unique_ptr<F
 	TableFunctionBindInput bind_input(inputs, param_map, return_types, names, nullptr, nullptr, 
 									  iceberg_scan_function, empty_ref);
 
+	auto start = std::chrono::high_resolution_clock::now();
 	auto table_ref = iceberg_scan_function.bind_replace(context, bind_input);
-
+	auto stop = std::chrono::high_resolution_clock::now();
+	std::chrono::duration<double> elapsed = stop - start;
+	std::cout << "Elapsed time bind replace: " << elapsed.count() << " seconds\n";
 	// 1) Create a Binder and bind the parser-level TableRef -> BoundTableRef
 	auto binder = Binder::CreateBinder(context);
 	auto bound_ref = binder->Bind(*table_ref);
@@ -127,6 +130,7 @@ TableFunction ICTableEntry::GetScanFunction(ClientContext &context, unique_ptr<F
 	auto &get = op->Cast<LogicalGet>();
 	bind_data = std::move(get.bind_data);
 
+	Printer::Print("returning parquet scan function");
 	return parquet_scan_function;
 }
 

--- a/test/sql/cloud/test_glue.test
+++ b/test/sql/cloud/test_glue.test
@@ -2,13 +2,13 @@
 # description: test integration with iceberg catalog read
 # group: [iceberg]
 
-# require-env ICEBERG_SERVER_AVAILABLE
-#
-# require-env AWS_DEFAULT_REGION
-#
-# require-env AWS_ACCESS_KEY_ID
-#
-# require-env AWS_SECRET_ACCESS_KEY
+require-env ICEBERG_SERVER_AVAILABLE
+
+require-env AWS_DEFAULT_REGION
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
 
 require parquet
 

--- a/test/sql/cloud/test_glue.test
+++ b/test/sql/cloud/test_glue.test
@@ -2,13 +2,13 @@
 # description: test integration with iceberg catalog read
 # group: [iceberg]
 
-require-env ICEBERG_SERVER_AVAILABLE
-
-require-env AWS_DEFAULT_REGION
-
-require-env AWS_ACCESS_KEY_ID
-
-require-env AWS_SECRET_ACCESS_KEY
+# require-env ICEBERG_SERVER_AVAILABLE
+#
+# require-env AWS_DEFAULT_REGION
+#
+# require-env AWS_ACCESS_KEY_ID
+#
+# require-env AWS_SECRET_ACCESS_KEY
 
 require parquet
 
@@ -38,3 +38,20 @@ show all tables;
 
 statement ok
 SELECT count(*) FROM my_datalake.myblognamespace.lineitem;
+
+statement error
+attach '84014028:s3tablescatalog/pyiceberg-blog-bucket' as bad_account_id (
+    TYPE ICEBERG,
+    ENDPOINT_TYPE 'GLUE'
+);
+----
+IO Error
+
+statement error
+attach '840140254803:incorrect/pyiceberg-blog-bucket' as no_s3tables (
+    TYPE ICEBERG,
+    ENDPOINT_TYPE 'GLUE'
+);
+----
+IO Error
+

--- a/test/sql/cloud/tpch_on_cloud.test_slow
+++ b/test/sql/cloud/tpch_on_cloud.test_slow
@@ -4,7 +4,33 @@
 # setup creds
 
 # TODO, need to get access to a remote glue catalog merged first
+# TODO, also important to make the sf=0.1
 mode skip
+
+require httpfs
+
+require iceberg
+
+require aws
+
+require parquet
+
+require tpch
+
+statement ok
+CREATE SECRET glue_secret (
+    TYPE S3,
+    PROVIDER credential_chain,
+    CHAIN 'sts',
+    ASSUME_ROLE_ARN 'arn:aws:iam::840140254803:role/pyiceberg-etl-role',
+    REGION 'us-east-1'
+);
+
+statement ok
+attach '840140254803:s3tablescatalog/pyiceberg-blog-bucket' as my_datalake (
+    TYPE ICEBERG,
+    ENDPOINT_TYPE 'GLUE'
+);
 
 statement ok
 create view customer as select * from my_datalake.myblognamespace.customer;
@@ -36,7 +62,7 @@ loop i 1 9
 query I
 PRAGMA tpch(${i})
 ----
-<FILE>:duckdb/extension/tpch/dbgen/answers/sf0.1/q0${i}.csv
+<FILE>:duckdb/extension/tpch/dbgen/answers/sf1/q0${i}.csv
 
 endloop
 
@@ -45,6 +71,6 @@ loop i 10 23
 query I
 PRAGMA tpch(${i})
 ----
-<FILE>:duckdb/extension/tpch/dbgen/answers/sf0.1/q${i}.csv
+<FILE>:duckdb/extension/tpch/dbgen/answers/sf1/q${i}.csv
 
 endloop

--- a/test/sql/local/iceberg_catalog_read.test
+++ b/test/sql/local/iceberg_catalog_read.test
@@ -72,6 +72,7 @@ select * from my_datalake.default.table_more_deletes order by all;
 query I
 SELECT message FROM duckdb_logs where type='iceberg.Catalog.Curl.HTTPRequest' order by timestamp
 ----
+POST http://127.0.0.1:8181/v1/oauth/tokens (curl code 'No error')
 GET http://127.0.0.1:8181/v1/namespaces (curl code 'No error')
 GET http://127.0.0.1:8181/v1/namespaces/default/tables (curl code 'No error')
 GET http://127.0.0.1:8181/v1/namespaces/default/tables/table_unpartitioned (curl code 'No error')

--- a/test/sql/local/irc/test_mutliple_keys.test
+++ b/test/sql/local/irc/test_mutliple_keys.test
@@ -1,0 +1,64 @@
+# name: test/sql/local/irc/test_multiple_keys.test
+# description: test integration with iceberg catalog read
+# group: [iceberg]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require aws
+
+statement ok
+CREATE SECRET amazing_secret (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+statement ok
+CREATE SECRET glue_secret (
+    TYPE S3,
+    PROVIDER credential_chain,
+    CHAIN 'sts',
+    ASSUME_ROLE_ARN 'arn:aws:iam::840140254803:role/pyiceberg-etl-role',
+    REGION 'us-east-1'
+);
+
+# the assumed secret is amazing_secret, which has no region
+statement error
+attach '840140254803:s3tablescatalog/pyiceberg-blog-bucket' as glue_lake (
+    TYPE ICEBERG,
+    ENDPOINT_TYPE 'GLUE'
+);
+----
+IO Error
+
+statement ok
+CREATE or replace SECRET amazing_secret (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0,
+    REGION 'us-east-1'
+);
+
+# new secret has a region, so this passes since no request is made
+statement ok
+attach '840140254803:s3tablescatalog/pyiceberg-blog-bucket' as glue_lake (
+    TYPE ICEBERG,
+    ENDPOINT_TYPE 'GLUE'
+);
+
+statement error
+select * from glue_lake.myblognamespace.region_sf1;
+----
+IO Error


### PR DESCRIPTION
This moves around some yyjson utils and some iceberg utils so we can cache table entry credentials and the valid config credentials for as long as possible. 

The IRCatalog passed to the GetMetadataCache is no longer const since the IRCatalog owns the cache, which needs to be updated after requests.

This also adds some small sanity checks for AWS glue warehouse