### PR TITLE
make functions static

### DIFF
--- a/src/common/iceberg.cpp
+++ b/src/common/iceberg.cpp
@@ -184,7 +184,7 @@ IcebergSnapshot IcebergSnapshot::GetSnapshotByTimestamp(const string &path, File
 
 // Function to generate a metadata file url from version and format string
 // default format is "v%s%s.metadata.json" -> v00###-xxxxxxxxx-.gz.metadata.json"
-string GenerateMetaDataUrl(FileSystem &fs, const string &meta_path, string &table_version, const IcebergOptions &options) {
+static string GenerateMetaDataUrl(FileSystem &fs, const string &meta_path, string &table_version, const IcebergOptions &options) {
 	// TODO: Need to URL Encode table_version
 	string compression_suffix = "";
 	string url;

--- a/src/storage/irc_schema_entry.cpp
+++ b/src/storage/irc_schema_entry.cpp
@@ -93,7 +93,7 @@ void IRCSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) {
 	throw NotImplementedException("Alter Schema Entry");
 }
 
-bool CatalogTypeIsSupported(CatalogType type) {
+static bool CatalogTypeIsSupported(CatalogType type) {
 	switch (type) {
 	case CatalogType::INDEX_ENTRY:
 	case CatalogType::TABLE_ENTRY:


### PR DESCRIPTION
These cause symbol collisions when linking the iceberg extensions into duckdb together with other extensions