### PR TITLE
BugFix: Allow read from empty tables

### DIFF
--- a/scripts/data_generators/generate_spark_rest/empty_table/q00.sql
+++ b/scripts/data_generators/generate_spark_rest/empty_table/q00.sql
@@ -1,0 +1,9 @@
+CREATE or REPLACE TABLE default.empty_table (
+     col1 date,
+     col2 integer,
+     col3 string
+)
+TBLPROPERTIES (
+    'format-version'='2',
+    'write.update.mode'='merge-on-read'
+);

--- a/src/common/iceberg.cpp
+++ b/src/common/iceberg.cpp
@@ -192,7 +192,7 @@ IcebergSnapshot IcebergSnapshot::ParseSnapShot(yyjson_val *snapshot, idx_t icebe
 		ret.timestamp_ms = Timestamp::FromEpochMs(IcebergUtils::TryGetNumFromObject(snapshot, "timestamp-ms"));
 		ret.manifest_list = IcebergUtils::TryGetStrFromObject(snapshot, "manifest-list");
 	} else {
-		ret.sequence_number = 0;
+		ret.snapshot_id = DConstants::INVALID_INDEX;
 	}
 
 	ret.iceberg_format_version = iceberg_format_version;

--- a/src/common/iceberg.cpp
+++ b/src/common/iceberg.cpp
@@ -88,10 +88,6 @@ IcebergSnapshot IcebergSnapshot::GetLatestSnapshot(const string &path, FileSyste
 	auto info = GetParseInfo(path, fs, options.metadata_compression_codec);
 	auto latest_snapshot = FindLatestSnapshotInternal(info->snapshots);
 
-	if (!latest_snapshot) {
-		throw IOException("No snapshots found");
-	}
-
 	return ParseSnapShot(latest_snapshot, info->iceberg_version, info->schema_id, info->schemas, options);
 }
 
@@ -181,20 +177,24 @@ string IcebergSnapshot::ReadMetaData(const string &path, FileSystem &fs, const s
 
 IcebergSnapshot IcebergSnapshot::ParseSnapShot(yyjson_val *snapshot, idx_t iceberg_format_version, idx_t schema_id, vector<yyjson_val *> &schemas, const IcebergOptions &options) {
 	IcebergSnapshot ret;
-	auto snapshot_tag = yyjson_get_type(snapshot);
-	if (snapshot_tag != YYJSON_TYPE_OBJ) {
-		throw IOException("Invalid snapshot field found parsing iceberg metadata.json");
-	}
-	ret.metadata_compression_codec = options.metadata_compression_codec;
-	if (iceberg_format_version == 1) {
+	if (snapshot) {
+ 		auto snapshot_tag = yyjson_get_type(snapshot);
+		if (snapshot_tag != YYJSON_TYPE_OBJ) {
+			throw IOException("Invalid snapshot field found parsing iceberg metadata.json");
+		}
+		ret.metadata_compression_codec = options.metadata_compression_codec;
+		if (iceberg_format_version == 1) {
+			ret.sequence_number = 0;
+		} else if (iceberg_format_version == 2) {
+			ret.sequence_number = IcebergUtils::TryGetNumFromObject(snapshot, "sequence-number");
+		}
+		ret.snapshot_id = IcebergUtils::TryGetNumFromObject(snapshot, "snapshot-id");
+		ret.timestamp_ms = Timestamp::FromEpochMs(IcebergUtils::TryGetNumFromObject(snapshot, "timestamp-ms"));
+		ret.manifest_list = IcebergUtils::TryGetStrFromObject(snapshot, "manifest-list");
+	} else {
 		ret.sequence_number = 0;
-	} else if (iceberg_format_version == 2) {
-		ret.sequence_number = IcebergUtils::TryGetNumFromObject(snapshot, "sequence-number");
 	}
 
-	ret.snapshot_id = IcebergUtils::TryGetNumFromObject(snapshot, "snapshot-id");
-	ret.timestamp_ms = Timestamp::FromEpochMs(IcebergUtils::TryGetNumFromObject(snapshot, "timestamp-ms"));
-	ret.manifest_list = IcebergUtils::TryGetStrFromObject(snapshot, "manifest-list");
 	ret.iceberg_format_version = iceberg_format_version;
 	ret.schema_id = schema_id;
 	if (!options.skip_schema_inference) {

--- a/src/iceberg_functions/iceberg_multi_file_reader.cpp
+++ b/src/iceberg_functions/iceberg_multi_file_reader.cpp
@@ -195,6 +195,12 @@ void IcebergMultiFileList::InitializeFiles() {
 	auto manifest_list_full_path = options.allow_moved_paths
 	                                   ? IcebergUtils::GetFullPath(iceberg_path, snapshot.manifest_list, fs)
 	                                   : snapshot.manifest_list;
+
+	if (manifest_list_full_path.empty()) {
+		// If the manifest list full path is empty, we are reading an empty table.
+		// Just return to populate the schema.
+		return;
+	}
 	auto scan = make_uniq<AvroScan>("IcebergManifestList", context, manifest_list_full_path);
 	manifest_reader->Initialize(std::move(scan));
 

--- a/test/sql/local/iceberg_scans/iceberg_scan.test
+++ b/test/sql/local/iceberg_scans/iceberg_scan.test
@@ -72,10 +72,11 @@ SELECT count(*) FROM ICEBERG_SCAN('data/persistent/iceberg/lineitem_iceberg_gz',
 ----
 111968
 
-statement error
+
+query I
 SELECT count(*) FROM ICEBERG_SCAN('data/persistent/iceberg/lineitem_iceberg_gz', ALLOW_MOVED_PATHS=TRUE, METADATA_COMPRESSION_CODEC="gzip", version='1');
 ----
-IO Error: No snapshots found
+0
 
 query I
 SELECT count(*) FROM ICEBERG_SCAN('data/persistent/iceberg/lineitem_iceberg_gz', ALLOW_MOVED_PATHS=TRUE, METADATA_COMPRESSION_CODEC="gzip", version='2', version_name_format='v%s%s.metadata.json');

--- a/test/sql/local/irc/test_read_empty_table.test
+++ b/test/sql/local/irc/test_read_empty_table.test
@@ -1,0 +1,40 @@
+# name: test/sql/local/test_read_empty_table.test
+# description: test integration with iceberg catalog read
+# group: [iceberg]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+
+statement ok
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    ENDPOINT 'http://127.0.0.1:8181'
+);
+
+query III
+select * from my_datalake.default.empty_table;
+----


### PR DESCRIPTION
fixes https://github.com/duckdb/duckdb-iceberg/issues/108

If there are no snapshots, then we are reading from an empty table. Early out from the `InitializeFiles` call so that we can populate the schema and just return.