### PR TITLE
Fix Format Check CI

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -62,8 +62,3 @@ jobs:
           black --version
           make format-check-silent
 
-      - name: Generated Check
-        shell: bash
-        run: |
-          make generate-files
-          git diff --exit-code

--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: 'true'
 
       - name: Install
         shell: bash


### PR DESCRIPTION
The submodule was not being checked out, so it had no `extension-ci-tools` to use in the workflow.