### PR TITLE
Set ENV variable via CMake to required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5...3.29)
 
 # Set extension name here
 set(TARGET_NAME iceberg)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.5...3.29)
 
+set(ENV{CMAKE_POLICY_VERSION_MINIMUM} "3.5")
 # Set extension name here
 set(TARGET_NAME iceberg)
 project(${TARGET_NAME})


### PR DESCRIPTION
This is an alternative to https://github.com/duckdb/duckdb-iceberg/pull/141

See https://cmake.org/cmake/help/latest/command/set.html#set-environment-variable, where they seems to suggest this is restored on exit, so should not pollute ENV.