### PR TITLE
Fix scanning from the "local" REST catalog we create in CI

### DIFF
--- a/src/catalog_api.cpp
+++ b/src/catalog_api.cpp
@@ -137,8 +137,9 @@ IRCAPITableCredentials IRCAPI::GetTableCredentials(ClientContext &context, IRCat
 	auto *config_val = yyjson_obj_get(root, "config");
 	if (config_val && catalog_credentials) {
 		auto kv_secret = dynamic_cast<const KeyValueSecret &>(*catalog_credentials->secret);
-		auto region = kv_secret.TryGetValue("region").ToString();
-		config_options["region"] = region;
+		for (auto &option : kv_secret.secret_map) {
+			config_options.emplace(option);
+		}
 	}
 	ParseConfigOptions(config_val, config_options);
 

--- a/test/sql/local/iceberg_on_tpch.test
+++ b/test/sql/local/iceberg_on_tpch.test
@@ -22,7 +22,7 @@ CREATE SECRET (
     ENDPOINT '127.0.0.1:9000',
     URL_STYLE 'path',
     USE_SSL 0
-  );
+);
 
 statement ok
 ATTACH '' AS my_datalake (


### PR DESCRIPTION
The way this catalog works is that we create an S3 secret that should inform the options passed to the scoped secret we create from the `config` of the `LoadTableResult`

```sql
statement ok
CREATE SECRET (
    TYPE S3,
    KEY_ID 'admin',
    SECRET 'password',
    ENDPOINT '127.0.0.1:9000',
    URL_STYLE 'path',
    USE_SSL 0
);

statement ok
ATTACH '' AS my_datalake (
    TYPE ICEBERG,
    ENDPOINT 'http://127.0.0.1:8181'
);
```

Without this change, `url_style`, `use_ssl`, `endpoint`, etc.. would not be copied over, causing the scan to fail.