### PR TITLE
[Dev] Fix crash with malformed `version_name_format` parameter.

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -6,6 +6,16 @@
 
 namespace duckdb {
 
+idx_t IcebergUtils::CountOccurrences(const string &input, const string &to_find) {
+	size_t pos = input.find(to_find);
+	idx_t count = 0;
+	while (pos != std::string::npos) {
+		pos = input.find(to_find, pos + to_find.length()); // move past current match
+		count++;
+	}
+	return count;
+}
+
 string IcebergUtils::FileToString(const string &path, FileSystem &fs) {
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
 	auto file_size = handle->GetFileSize();

--- a/src/iceberg_functions/iceberg_metadata.cpp
+++ b/src/iceberg_functions/iceberg_metadata.cpp
@@ -21,6 +21,7 @@
 #include "duckdb/common/file_system.hpp"
 #include "iceberg_metadata.hpp"
 #include "iceberg_functions.hpp"
+#include "iceberg_utils.hpp"
 #include "yyjson.hpp"
 
 #include <string>
@@ -67,7 +68,14 @@ static unique_ptr<FunctionData> IcebergMetaDataBind(ClientContext &context, Tabl
 		} else if (loption == "version") {
 			options.table_version = StringValue::Get(kv.second);
 		} else if (loption == "version_name_format") {
-			options.version_name_format = StringValue::Get(kv.second);
+			auto value = StringValue::Get(kv.second);
+			auto string_substitutions = IcebergUtils::CountOccurrences(value, "%s");
+			if (string_substitutions != 2) {
+				throw InvalidInputException(
+				    "'version_name_format' has to contain two occurrences of '%s' in it, found %d", "%s",
+				    string_substitutions);
+			}
+			options.version_name_format = value;
 		}
 	}
 

--- a/src/iceberg_functions/iceberg_multi_file_reader.cpp
+++ b/src/iceberg_functions/iceberg_multi_file_reader.cpp
@@ -597,7 +597,13 @@ bool IcebergMultiFileReader::ParseOption(const string &key, const Value &val, Mu
 		return true;
 	}
 	if (loption == "version_name_format") {
-		this->options.version_name_format = StringValue::Get(val);
+		auto value = StringValue::Get(val);
+		auto string_substitutions = IcebergUtils::CountOccurrences(value, "%s");
+		if (string_substitutions != 2) {
+			throw InvalidInputException("'version_name_format' has to contain two occurrences of '%s' in it, found %d",
+			                            "%s", string_substitutions);
+		}
+		this->options.version_name_format = value;
 		return true;
 	}
 	if (loption == "snapshot_from_id") {

--- a/src/iceberg_functions/iceberg_snapshots.cpp
+++ b/src/iceberg_functions/iceberg_snapshots.cpp
@@ -59,7 +59,14 @@ static unique_ptr<FunctionData> IcebergSnapshotsBind(ClientContext &context, Tab
 		} else if (loption == "version") {
 			bind_data->options.table_version = StringValue::Get(kv.second);
 		} else if (loption == "version_name_format") {
-			bind_data->options.version_name_format = StringValue::Get(kv.second);
+			auto value = StringValue::Get(kv.second);
+			auto string_substitutions = IcebergUtils::CountOccurrences(value, "%s");
+			if (string_substitutions != 2) {
+				throw InvalidInputException(
+				    "'version_name_format' has to contain two occurrences of '%s' in it, found %d", "%s",
+				    string_substitutions);
+			}
+			bind_data->options.version_name_format = value;
 		} else if (loption == "skip_schema_inference") {
 			bind_data->options.skip_schema_inference = BooleanValue::Get(kv.second);
 		}

--- a/src/include/iceberg_utils.hpp
+++ b/src/include/iceberg_utils.hpp
@@ -39,6 +39,8 @@ public:
 	                                 bool default_val = false);
 	static string TryGetStrFromObject(yyjson_val *obj, const string &field, bool fail_on_missing,
 	                                  const char *default_val = "");
+
+	static idx_t CountOccurrences(const string &input, const string &to_find);
 };
 
 } // namespace duckdb

--- a/test/sql/local/version_name_format_error.test
+++ b/test/sql/local/version_name_format_error.test
@@ -1,0 +1,13 @@
+# name: test/sql/local/version_name_format_error.test
+# group: [local]
+
+require avro 
+
+require parquet
+
+require iceberg
+
+statement error
+select * from iceberg_scan('data/persistent/iceberg/lineitem_iceberg', version_name_format='%s') limit 10
+----
+Invalid Input Error: 'version_name_format' has to contain two occurrences of '%s' in it, found 1


### PR DESCRIPTION
Further down the codepath this is used with `StringUtil::Format` which throws if these requirements aren't met.