### PR TITLE
MainDistributionPipeline.yml: publish also v1.2-histrionicus

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -31,4 +31,4 @@ jobs:
       duckdb_version: v1.2.2
       ci_tools_version: v1.2.1
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw'
-      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v1.2-histrionicus'}}


### PR DESCRIPTION
Enable publishing to `core_nightly` also v1.2-histrionicus branch.