### PR TITLE
[Dev] Slight clean up of extension (dependency) loading.

### DIFF
--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -127,11 +127,10 @@ static unique_ptr<Catalog> IcebergCatalogAttach(StorageExtensionInfo *storage_in
 	attach_options.warehouse = info.path;
 	attach_options.name = name;
 
-	if (!__AVRO_LOADED__) {
-		auto &db_instance = context.db;
-		ExtensionHelper::AutoLoadExtension(*db_instance, "avro");
-		__AVRO_LOADED__ = true;
-	}
+	//! Make sure avro is loaded, throws if it can't be loaded.
+	auto &instance = DatabaseInstance::GetDatabase(context);
+	ExtensionHelper::AutoLoadExtension(instance, "avro");
+
 	// check if we have a secret provided
 	string secret_name;
 	//! First handle generic attach options
@@ -234,11 +233,6 @@ public:
 static void LoadInternal(DatabaseInstance &instance) {
 	Aws::SDKOptions options;
 	Aws::InitAPI(options); // Should only be called once.
-
-	ExtensionHelper::AutoLoadExtension(instance, "parquet");
-	if (!instance.ExtensionIsLoaded("parquet")) {
-		throw MissingExtensionException("The iceberg extension requires the parquet extension to be loaded!");
-	}
 
 	auto &config = DBConfig::GetConfig(instance);
 

--- a/src/iceberg_functions/iceberg_multi_file_reader.cpp
+++ b/src/iceberg_functions/iceberg_multi_file_reader.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/parallel/thread_context.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/main/extension_helper.hpp"
 
 namespace duckdb {
 
@@ -324,6 +325,10 @@ void IcebergMultiFileReader::FinalizeBind(MultiFileReaderData &reader_data, cons
 
 void IcebergMultiFileList::ScanDeleteFile(const string &delete_file_path) const {
 	auto &instance = DatabaseInstance::GetDatabase(context);
+
+	//! Make sure parquet is loaded, throws if it can't be loaded.
+	ExtensionHelper::AutoLoadExtension(instance, "parquet");
+
 	auto &parquet_scan_entry = ExtensionUtil::GetTableFunction(instance, "parquet_scan");
 	auto &parquet_scan = parquet_scan_entry.functions.functions[0];
 

--- a/src/iceberg_functions/iceberg_scan.cpp
+++ b/src/iceberg_functions/iceberg_scan.cpp
@@ -20,6 +20,7 @@
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/main/extension_util.hpp"
+#include "duckdb/main/extension_helper.hpp"
 #include "iceberg_metadata.hpp"
 #include "iceberg_utils.hpp"
 #include "iceberg_multi_file_reader.hpp"
@@ -59,6 +60,9 @@ virtual_column_map_t IcebergVirtualColumns(ClientContext &, optional_ptr<Functio
 TableFunctionSet IcebergFunctions::GetIcebergScanFunction(DatabaseInstance &instance) {
 	// The iceberg_scan function is constructed by grabbing the parquet scan from the Catalog, then injecting the
 	// IcebergMultiFileReader into it to create a Iceberg-based multi file read
+
+	//! Make sure parquet is loaded, throws if it can't be loaded.
+	ExtensionHelper::AutoLoadExtension(instance, "parquet");
 
 	auto &parquet_scan = ExtensionUtil::GetTableFunction(instance, "parquet_scan");
 	auto parquet_scan_copy = parquet_scan.functions;

--- a/src/include/iceberg_extension.hpp
+++ b/src/include/iceberg_extension.hpp
@@ -4,8 +4,6 @@
 
 namespace duckdb {
 
-static bool __AVRO_LOADED__ = false;
-
 class IcebergExtension : public Extension {
 public:
 	void Load(DuckDB &db) override;

--- a/src/storage/authorization/oauth2.cpp
+++ b/src/storage/authorization/oauth2.cpp
@@ -158,11 +158,9 @@ unique_ptr<OAuth2Authorization> OAuth2Authorization::FromAttachOptions(ClientCon
 unique_ptr<BaseSecret> OAuth2Authorization::CreateCatalogSecretFunction(ClientContext &context,
                                                                         CreateSecretInput &input) {
 
-	if (!__AVRO_LOADED__) {
-		auto &db_instance = context.db;
-		ExtensionHelper::AutoLoadExtension(*db_instance, "avro");
-		__AVRO_LOADED__ = true;
-	}
+	//! Make sure avro is loaded, throws if it can't be loaded.
+	auto &instance = DatabaseInstance::GetDatabase(context);
+	ExtensionHelper::AutoLoadExtension(instance, "avro");
 
 	// apply any overridden settings
 	vector<string> prefix_paths;


### PR DESCRIPTION
The `__AVRO_LOADED__` was defined in a header, so it's duplicated across every translation unit (source file) that includes it, which doesn't sound like the intention.

We also already have prevention of duplicate loading built into core, through the `loaded_extensions_info` map (although this also doesn't seem thread-safe, but that's a different concern)

I tried to remove `parquet` from being required directly on `LOAD`, but since `iceberg_scan` is essentially a `parquet_scan` with extra logic, this isn't possible without a layer of indirection that I don't think is worth adding.

Instead I only moved the `AutoLoadExtension` call closer to where Parquet is actually required (which still happens during load, but now the connection is more obvious as to why this happens)
