### PR TITLE
Throw whole api result as error if there is no error message

### DIFF
--- a/src/catalog_utils.cpp
+++ b/src/catalog_utils.cpp
@@ -244,8 +244,9 @@ yyjson_doc *ICUtils::api_result_to_doc(const string &api_result) {
 			throw InvalidInputException(err_msg);
 		} catch (InvalidConfigurationException &e) {
 			// keep going, we will throw the whole api result as an error message
+			throw InvalidConfigurationException(api_result);
 		}
-		throw InvalidConfigurationException(api_result);
+		throw InvalidConfigurationException("Could not parse api_result");
 	}
 	return doc;
 }

--- a/src/catalog_utils.cpp
+++ b/src/catalog_utils.cpp
@@ -196,7 +196,7 @@ LogicalType ICUtils::TypeToLogicalType(ClientContext &context, const string &typ
 
 LogicalType ICUtils::ToICType(const LogicalType &input) {
 	// todo do we need this mapping?
-	throw NotImplementedException("ToUCType not yet implemented");
+	throw NotImplementedException("ToICType not yet implemented");
 	switch (input.id()) {
 	case LogicalTypeId::BOOLEAN:
 	case LogicalTypeId::SMALLINT:
@@ -239,8 +239,12 @@ yyjson_doc *ICUtils::api_result_to_doc(const string &api_result) {
 	auto *root = yyjson_doc_get_root(doc);
 	auto *error = yyjson_obj_get(root, "error");
 	if (error != NULL) {
-		string err_msg = IcebergUtils::TryGetStrFromObject(error, "message");
-		throw InvalidInputException(err_msg);
+		try {
+			string err_msg = IcebergUtils::TryGetStrFromObject(error, "message");
+			throw InvalidInputException(err_msg);
+		} catch (InvalidInputException &e) {
+		}
+		throw InvalidInputException(api_result);
 	}
 	return doc;
 }

--- a/src/catalog_utils.cpp
+++ b/src/catalog_utils.cpp
@@ -242,9 +242,10 @@ yyjson_doc *ICUtils::api_result_to_doc(const string &api_result) {
 		try {
 			string err_msg = IcebergUtils::TryGetStrFromObject(error, "message");
 			throw InvalidInputException(err_msg);
-		} catch (InvalidInputException &e) {
+		} catch (InvalidConfigurationException &e) {
+			// keep going, we will throw the whole api result as an error message
 		}
-		throw InvalidInputException(api_result);
+		throw InvalidConfigurationException(api_result);
 	}
 	return doc;
 }


### PR DESCRIPTION
Ran into this today trying to connect to a fivetran catalog with invalid credentials. If an Api response has an error, there doesn't seem to be a consistent way to retrieve the error message. So for the fivetran iceberg catalog, a failing secret creation statement results in the following message

```
CREATE SECRET fivetransecret_its_exonerate (
    TYPE ICEBERG,
    CLIENT_ID '94b5736368eca81',
    CLIENT_SECRET '49603291bbbf412763544dabf619393',
    ENDPOINT 'https://polaris.fivetran.com/api/catalog'
  );
Invalid Configuration Error:
Could not get token from https://polaris.fivetran.com/api/catalog/v1/oauth/tokens, captured error message: Invalid field found while parsing field: messag
```

This PR changes this so that the error message is now
```
Could not get token from https://polaris.fivetran.com/api/catalog/v1/oauth/tokens, captured error message: {"error":"unauthorized_client","error_description":"The client is not authorized","error_uri":null
```

One worry though, is that if there is sensitive information in the response, we may end up leaking it