### PR TITLE
Add basic tests for the generated `nested_types` table

### DIFF
--- a/test/sql/local/irc/irc_nested_types.test
+++ b/test/sql/local/irc/irc_nested_types.test
@@ -1,0 +1,49 @@
+# name: test/sql/local/irc/irc_nested_types.test
+# description: test integration with iceberg catalog read
+# group: [irc]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+
+statement ok
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181'
+);
+
+statement ok
+use my_datalake.default;
+
+query IIIII
+select * from nested_types
+----
+1	Alice	{'street': 123 Main St, 'city': Metropolis, 'zip': 12345}	[123-456-7890, 987-654-3210]	{age=30, membership=gold}

--- a/test/sql/local/nested_types.test
+++ b/test/sql/local/nested_types.test
@@ -1,0 +1,17 @@
+# name: test/sql/local/nested_types.test
+# group: [local]
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require-env DUCKDB_ICEBERG_HAVE_GENERATED_DATA
+
+query IIIII
+select * from ICEBERG_SCAN('data/generated/iceberg/spark-local/default/nested_types');
+----
+1	Alice	{'street': 123 Main St, 'city': Metropolis, 'zip': 12345}	[123-456-7890, 987-654-3210]	{age=30, membership=gold}


### PR DESCRIPTION
Adding a test to scan the generated table from the `spark-local` and `spark-rest` connections.