### PR TITLE
Fixed some race conditions in caching logic

### DIFF
--- a/src/catalog_api.cpp
+++ b/src/catalog_api.cpp
@@ -45,10 +45,12 @@ static string GetTableMetadataCached(ClientContext &context, IRCatalog &catalog,
 	url.AddPathComponent(schema);
 	url.AddPathComponent("tables");
 	url.AddPathComponent(table);
-	if (catalog.HasCachedValue(url.GetURL())) {
-		return catalog.GetCachedValue(url.GetURL());
+	auto cached_value = catalog.OptionalGetCachedValue(url.GetURL());
+	if (!cached_value.empty()) {
+		return cached_value;
+	} else {
+		return GetTableMetadata(context, catalog, schema, table);
 	}
-	return GetTableMetadata(context, catalog, schema, table);
 }
 
 vector<string> IRCAPI::GetCatalogs(ClientContext &context, IRCatalog &catalog) {

--- a/src/include/storage/irc_catalog.hpp
+++ b/src/include/storage/irc_catalog.hpp
@@ -23,19 +23,20 @@ public:
 
 class MetadataCacheValue {
 public:
-	std::string data;
-	std::chrono::system_clock::time_point expires_at;
+	const std::string data;
+	const system_clock::time_point expires_at;
 
 public:
-	MetadataCacheValue(std::string data_, std::chrono::system_clock::time_point expires_at_)
-	    : data(data_), expires_at(expires_at_) {};
+	MetadataCacheValue(const std::string &data_, const system_clock::time_point expires_at_)
+	    : data(data_), expires_at(expires_at_) {
+	}
 };
 
 class IRCatalog : public Catalog {
 public:
 	explicit IRCatalog(AttachedDatabase &db_p, AccessMode access_mode, unique_ptr<IRCAuthorization> auth_handler,
 	                   const string &warehouse, const string &uri, const string &version = "v1");
-	~IRCatalog();
+	~IRCatalog() override;
 
 	string internal_name;
 	AccessMode access_mode;
@@ -96,9 +97,8 @@ public:
 
 	void ClearCache();
 
-	bool HasCachedValue(string url) const;
-	string GetCachedValue(string url) const;
-	bool SetCachedValue(string url, const string &value, const rest_api_objects::LoadTableResult &result);
+	string OptionalGetCachedValue(const string &url) const;
+	bool SetCachedValue(const string &url, const string &value, const rest_api_objects::LoadTableResult &result);
 
 private:
 	void DropSchema(ClientContext &context, DropInfo &info) override;

--- a/src/include/storage/irc_catalog.hpp
+++ b/src/include/storage/irc_catalog.hpp
@@ -97,7 +97,7 @@ public:
 
 	void ClearCache();
 
-	string OptionalGetCachedValue(const string &url) const;
+	string OptionalGetCachedValue(const string &url);
 	bool SetCachedValue(const string &url, const string &value, const rest_api_objects::LoadTableResult &result);
 
 private:
@@ -111,6 +111,7 @@ private:
 	case_insensitive_map_t<string> defaults;
 	case_insensitive_map_t<string> overrides;
 
+	std::mutex metadata_cache_mutex;
 	unordered_map<string, unique_ptr<MetadataCacheValue>> metadata_cache;
 };
 


### PR DESCRIPTION
Even if `HasCachedValue` returns true, it is possible that `GetCachedValue` still throws an exception because the cached value has expired between the two function calls. 

I also added a mutex to prevent conflicts when the cached value is simultaneously written and read