### PR TITLE
Improve predicate transform architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ set(EXTENSION_SOURCES
     src/catalog_utils.cpp
     src/curl.cpp
     src/aws.cpp
+    src/iceberg_transform.cpp
+    src/iceberg_predicate.cpp
     src/common/utils.cpp
     src/common/url_utils.cpp
     src/common/schema.cpp

--- a/src/common/iceberg.cpp
+++ b/src/common/iceberg.cpp
@@ -123,14 +123,14 @@ bool IcebergPartitionSpec::IsUnpartitioned() const {
 	return !IsPartitioned();
 }
 
-const IcebergPartitionSpecField &IcebergPartitionSpec::GetFieldBySourceId(idx_t field_id) const {
+const IcebergPartitionSpecField &IcebergPartitionSpec::GetFieldBySourceId(idx_t source_id) const {
 	for (auto &field : fields) {
-		if (field.source_id == field_id) {
+		if (field.source_id == source_id) {
 			return field;
 		}
 	}
 	throw InvalidConfigurationException("Field with source_id %d doesn't exist in this partition spec (id %d)",
-	                                    field_id, spec_id);
+	                                    source_id, spec_id);
 }
 
 static void ParseFieldMappings(yyjson_val *obj, vector<IcebergFieldMapping> &mappings, idx_t &mapping_index,

--- a/src/common/iceberg.cpp
+++ b/src/common/iceberg.cpp
@@ -86,7 +86,7 @@ IcebergPartitionSpecField IcebergPartitionSpecField::ParseFromJson(yyjson_val *f
 	IcebergPartitionSpecField result;
 
 	result.name = IcebergUtils::TryGetStrFromObject(field, "name");
-	result.transform = IcebergUtils::TryGetStrFromObject(field, "transform");
+	result.transform = IcebergTransform(IcebergUtils::TryGetStrFromObject(field, "transform"));
 	result.source_id = IcebergUtils::TryGetNumFromObject(field, "source-id");
 	result.partition_field_id = IcebergUtils::TryGetNumFromObject(field, "field-id");
 	return result;
@@ -111,7 +111,7 @@ IcebergPartitionSpec IcebergPartitionSpec::ParseFromJson(yyjson_val *partition_s
 bool IcebergPartitionSpec::IsPartitioned() const {
 	//! A partition spec is considered partitioned if it has at least one field that doesn't have a 'void' transform
 	for (const auto &field : fields) {
-		if (!StringUtil::CIEquals(field.transform, "void")) {
+		if (field.transform != IcebergTransformType::VOID) {
 			return true;
 		}
 	}
@@ -121,6 +121,16 @@ bool IcebergPartitionSpec::IsPartitioned() const {
 
 bool IcebergPartitionSpec::IsUnpartitioned() const {
 	return !IsPartitioned();
+}
+
+const IcebergPartitionSpecField &IcebergPartitionSpec::GetFieldBySourceId(idx_t field_id) const {
+	for (auto &field : fields) {
+		if (field.source_id == field_id) {
+			return field;
+		}
+	}
+	throw InvalidConfigurationException("Field with source_id %d doesn't exist in this partition spec (id %d)",
+	                                    field_id, spec_id);
 }
 
 static void ParseFieldMappings(yyjson_val *obj, vector<IcebergFieldMapping> &mappings, idx_t &mapping_index,

--- a/src/iceberg_predicate.cpp
+++ b/src/iceberg_predicate.cpp
@@ -79,7 +79,7 @@ bool IcebergPredicate::MatchBounds(TableFilter &filter, const IcebergPredicateSt
 	case IcebergTransformType::VOID:
 		return true;
 	default:
-		throw InternalException("Transform '%s' not implemented", transform.RawType());
+		throw InvalidConfigurationException("Transform '%s' not implemented", transform.RawType());
 	}
 }
 

--- a/src/iceberg_predicate.cpp
+++ b/src/iceberg_predicate.cpp
@@ -1,0 +1,88 @@
+#include "iceberg_predicate.hpp"
+#include "duckdb/planner/filter/constant_filter.hpp"
+#include "duckdb/planner/filter/conjunction_filter.hpp"
+
+namespace duckdb {
+
+template <class TRANSFORM>
+bool MatchBoundsTemplated(TableFilter &filter, const Value &lower_bound, const Value &upper_bound,
+                          const IcebergTransform &transform);
+
+template <class TRANSFORM>
+static bool MatchBoundsConstantFilter(ConstantFilter &constant_filter, const Value &lower_bound,
+                                      const Value &upper_bound, const IcebergTransform &transform) {
+	auto constant_value = TRANSFORM::ApplyTransform(constant_filter.constant, transform);
+
+	switch (constant_filter.comparison_type) {
+	case ExpressionType::COMPARE_EQUAL:
+		return TRANSFORM::CompareEqual(constant_value, lower_bound, upper_bound);
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return TRANSFORM::CompareGreaterThan(constant_value, lower_bound, upper_bound);
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return TRANSFORM::CompareGreaterThanOrEqual(constant_value, lower_bound, upper_bound);
+	case ExpressionType::COMPARE_LESSTHAN:
+		return TRANSFORM::CompareLessThan(constant_value, lower_bound, upper_bound);
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return TRANSFORM::CompareLessThanOrEqual(constant_value, lower_bound, upper_bound);
+	default:
+		//! Conservative approach: we don't know, so we just say it's not filtered out
+		return true;
+	}
+}
+
+template <class TRANSFORM>
+static bool MatchBoundsConjunctionAndFilter(ConjunctionAndFilter &conjunction_and, const Value &lower_bound,
+                                            const Value &upper_bound, const IcebergTransform &transform) {
+	for (auto &child : conjunction_and.child_filters) {
+		if (!MatchBoundsTemplated<TRANSFORM>(*child, lower_bound, upper_bound, transform)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+template <class TRANSFORM>
+bool MatchBoundsTemplated(TableFilter &filter, const Value &lower_bound, const Value &upper_bound,
+                          const IcebergTransform &transform) {
+	//! TODO: support more filter types
+	switch (filter.filter_type) {
+	case TableFilterType::CONSTANT_COMPARISON: {
+		auto &constant_filter = filter.Cast<ConstantFilter>();
+		return MatchBoundsConstantFilter<TRANSFORM>(constant_filter, lower_bound, upper_bound, transform);
+	}
+	case TableFilterType::CONJUNCTION_AND: {
+		auto &conjunction_and_filter = filter.Cast<ConjunctionAndFilter>();
+		return MatchBoundsConjunctionAndFilter<TRANSFORM>(conjunction_and_filter, lower_bound, upper_bound, transform);
+	}
+	default:
+		//! Conservative approach: we don't know what this is, just say it doesn't filter anything
+		return true;
+	}
+}
+
+bool IcebergPredicate::MatchBounds(TableFilter &filter, const Value &lower_bound, const Value &upper_bound,
+                                   const IcebergTransform &transform) {
+	switch (transform.Type()) {
+	case IcebergTransformType::IDENTITY:
+		return MatchBoundsTemplated<IdentityTransform>(filter, lower_bound, upper_bound, transform);
+	case IcebergTransformType::BUCKET:
+		throw NotImplementedException("Transform '%s' not implemented", transform.RawType());
+	case IcebergTransformType::TRUNCATE:
+		throw NotImplementedException("Transform '%s' not implemented", transform.RawType());
+	case IcebergTransformType::YEAR:
+		throw NotImplementedException("Transform '%s' not implemented", transform.RawType());
+	case IcebergTransformType::MONTH:
+		throw NotImplementedException("Transform '%s' not implemented", transform.RawType());
+	case IcebergTransformType::DAY:
+		// return MatchBoundsTemplated<DayTransform>(filter, lower_bound, upper_bound, transform);
+		throw NotImplementedException("Transform '%s' not implemented", transform.RawType());
+	case IcebergTransformType::HOUR:
+		throw NotImplementedException("Transform '%s' not implemented", transform.RawType());
+	case IcebergTransformType::VOID:
+		throw NotImplementedException("Transform '%s' not implemented", transform.RawType());
+	default:
+		throw InternalException("Transform '%s' not implemented", transform.RawType());
+	}
+}
+
+} // namespace duckdb

--- a/src/iceberg_predicate.cpp
+++ b/src/iceberg_predicate.cpp
@@ -5,25 +5,24 @@
 namespace duckdb {
 
 template <class TRANSFORM>
-bool MatchBoundsTemplated(TableFilter &filter, const Value &lower_bound, const Value &upper_bound,
-                          const IcebergTransform &transform);
+bool MatchBoundsTemplated(TableFilter &filter, const IcebergPredicateStats &stats, const IcebergTransform &transform);
 
 template <class TRANSFORM>
-static bool MatchBoundsConstantFilter(ConstantFilter &constant_filter, const Value &lower_bound,
-                                      const Value &upper_bound, const IcebergTransform &transform) {
+static bool MatchBoundsConstantFilter(ConstantFilter &constant_filter, const IcebergPredicateStats &stats,
+                                      const IcebergTransform &transform) {
 	auto constant_value = TRANSFORM::ApplyTransform(constant_filter.constant, transform);
 
 	switch (constant_filter.comparison_type) {
 	case ExpressionType::COMPARE_EQUAL:
-		return TRANSFORM::CompareEqual(constant_value, lower_bound, upper_bound);
+		return TRANSFORM::CompareEqual(constant_value, stats);
 	case ExpressionType::COMPARE_GREATERTHAN:
-		return TRANSFORM::CompareGreaterThan(constant_value, lower_bound, upper_bound);
+		return TRANSFORM::CompareGreaterThan(constant_value, stats);
 	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-		return TRANSFORM::CompareGreaterThanOrEqual(constant_value, lower_bound, upper_bound);
+		return TRANSFORM::CompareGreaterThanOrEqual(constant_value, stats);
 	case ExpressionType::COMPARE_LESSTHAN:
-		return TRANSFORM::CompareLessThan(constant_value, lower_bound, upper_bound);
+		return TRANSFORM::CompareLessThan(constant_value, stats);
 	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
-		return TRANSFORM::CompareLessThanOrEqual(constant_value, lower_bound, upper_bound);
+		return TRANSFORM::CompareLessThanOrEqual(constant_value, stats);
 	default:
 		//! Conservative approach: we don't know, so we just say it's not filtered out
 		return true;
@@ -31,10 +30,10 @@ static bool MatchBoundsConstantFilter(ConstantFilter &constant_filter, const Val
 }
 
 template <class TRANSFORM>
-static bool MatchBoundsConjunctionAndFilter(ConjunctionAndFilter &conjunction_and, const Value &lower_bound,
-                                            const Value &upper_bound, const IcebergTransform &transform) {
+static bool MatchBoundsConjunctionAndFilter(ConjunctionAndFilter &conjunction_and, const IcebergPredicateStats &stats,
+                                            const IcebergTransform &transform) {
 	for (auto &child : conjunction_and.child_filters) {
-		if (!MatchBoundsTemplated<TRANSFORM>(*child, lower_bound, upper_bound, transform)) {
+		if (!MatchBoundsTemplated<TRANSFORM>(*child, stats, transform)) {
 			return false;
 		}
 	}
@@ -42,17 +41,16 @@ static bool MatchBoundsConjunctionAndFilter(ConjunctionAndFilter &conjunction_an
 }
 
 template <class TRANSFORM>
-bool MatchBoundsTemplated(TableFilter &filter, const Value &lower_bound, const Value &upper_bound,
-                          const IcebergTransform &transform) {
+bool MatchBoundsTemplated(TableFilter &filter, const IcebergPredicateStats &stats, const IcebergTransform &transform) {
 	//! TODO: support more filter types
 	switch (filter.filter_type) {
 	case TableFilterType::CONSTANT_COMPARISON: {
 		auto &constant_filter = filter.Cast<ConstantFilter>();
-		return MatchBoundsConstantFilter<TRANSFORM>(constant_filter, lower_bound, upper_bound, transform);
+		return MatchBoundsConstantFilter<TRANSFORM>(constant_filter, stats, transform);
 	}
 	case TableFilterType::CONJUNCTION_AND: {
 		auto &conjunction_and_filter = filter.Cast<ConjunctionAndFilter>();
-		return MatchBoundsConjunctionAndFilter<TRANSFORM>(conjunction_and_filter, lower_bound, upper_bound, transform);
+		return MatchBoundsConjunctionAndFilter<TRANSFORM>(conjunction_and_filter, stats, transform);
 	}
 	default:
 		//! Conservative approach: we don't know what this is, just say it doesn't filter anything
@@ -60,26 +58,26 @@ bool MatchBoundsTemplated(TableFilter &filter, const Value &lower_bound, const V
 	}
 }
 
-bool IcebergPredicate::MatchBounds(TableFilter &filter, const Value &lower_bound, const Value &upper_bound,
+bool IcebergPredicate::MatchBounds(TableFilter &filter, const IcebergPredicateStats &stats,
                                    const IcebergTransform &transform) {
 	switch (transform.Type()) {
 	case IcebergTransformType::IDENTITY:
-		return MatchBoundsTemplated<IdentityTransform>(filter, lower_bound, upper_bound, transform);
+		return MatchBoundsTemplated<IdentityTransform>(filter, stats, transform);
 	case IcebergTransformType::BUCKET:
-		throw NotImplementedException("Transform '%s' not implemented", transform.RawType());
+		return true;
 	case IcebergTransformType::TRUNCATE:
-		throw NotImplementedException("Transform '%s' not implemented", transform.RawType());
+		return true;
 	case IcebergTransformType::YEAR:
-		throw NotImplementedException("Transform '%s' not implemented", transform.RawType());
+		return true;
 	case IcebergTransformType::MONTH:
-		throw NotImplementedException("Transform '%s' not implemented", transform.RawType());
+		return true;
 	case IcebergTransformType::DAY:
-		// return MatchBoundsTemplated<DayTransform>(filter, lower_bound, upper_bound, transform);
-		throw NotImplementedException("Transform '%s' not implemented", transform.RawType());
+		// return MatchBoundsTemplated<DayTransform>(filter, stats, transform);
+		return true;
 	case IcebergTransformType::HOUR:
-		throw NotImplementedException("Transform '%s' not implemented", transform.RawType());
+		return true;
 	case IcebergTransformType::VOID:
-		throw NotImplementedException("Transform '%s' not implemented", transform.RawType());
+		return true;
 	default:
 		throw InternalException("Transform '%s' not implemented", transform.RawType());
 	}

--- a/src/iceberg_transform.cpp
+++ b/src/iceberg_transform.cpp
@@ -1,0 +1,44 @@
+#include "iceberg_transform.hpp"
+#include "duckdb/common/string_util.hpp"
+
+namespace duckdb {
+
+IcebergTransform::IcebergTransform() : raw_transform() {
+	type = IcebergTransformType::INVALID;
+}
+
+IcebergTransform::IcebergTransform(const string &transform) : raw_transform(transform) {
+	if (transform == "identity") {
+		type = IcebergTransformType::IDENTITY;
+	} else if (StringUtil::StartsWith(transform, "bucket")) {
+		type = IcebergTransformType::BUCKET;
+		D_ASSERT(transform[6] == '[');
+		D_ASSERT(transform.back() == ']');
+		auto start = transform.find('[');
+		auto end = transform.rfind(']');
+		auto digits = transform.substr(start + 1, end - start);
+		modulo = std::stoi(digits);
+	} else if (StringUtil::StartsWith(transform, "truncate")) {
+		type = IcebergTransformType::TRUNCATE;
+		D_ASSERT(transform[8] == '[');
+		D_ASSERT(transform.back() == ']');
+		auto start = transform.find('[');
+		auto end = transform.rfind(']');
+		auto digits = transform.substr(start + 1, end - start);
+		width = std::stoi(digits);
+	} else if (transform == "year") {
+		type = IcebergTransformType::YEAR;
+	} else if (transform == "month") {
+		type = IcebergTransformType::MONTH;
+	} else if (transform == "day") {
+		type = IcebergTransformType::DAY;
+	} else if (transform == "hour") {
+		type = IcebergTransformType::HOUR;
+	} else if (transform == "void") {
+		type = IcebergTransformType::VOID;
+	} else {
+		throw NotImplementedException("Unrecognized transform ('%s')", transform);
+	}
+}
+
+} // namespace duckdb

--- a/src/include/iceberg_metadata.hpp
+++ b/src/include/iceberg_metadata.hpp
@@ -14,6 +14,7 @@
 #include "iceberg_options.hpp"
 #include "rest_catalog/objects/struct_field.hpp"
 #include "duckdb/common/open_file_info.hpp"
+#include "iceberg_transform.hpp"
 
 using namespace duckdb_yyjson;
 
@@ -40,10 +41,8 @@ public:
 
 public:
 	string name;
-	//! FIXME: parse this, there are a set amount of valid transforms
-	//! See: https://iceberg.apache.org/spec/#partition-specs
 	//! "Applied to the source column(s) to produce a partition value"
-	string transform;
+	IcebergTransform transform;
 	//! NOTE: v3 replaces 'source-id' with 'source-ids'
 	//! "A source column id or a list of source column ids from the table’s schema"
 	uint64_t source_id;
@@ -58,6 +57,7 @@ public:
 public:
 	bool IsUnpartitioned() const;
 	bool IsPartitioned() const;
+	const IcebergPartitionSpecField &GetFieldBySourceId(idx_t field_id) const;
 
 public:
 	uint64_t spec_id;

--- a/src/include/iceberg_predicate.hpp
+++ b/src/include/iceberg_predicate.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "iceberg_transform.hpp"
+#include "iceberg_predicate_stats.hpp"
 #include "duckdb/planner/table_filter.hpp"
 
 namespace duckdb {
@@ -9,8 +10,7 @@ public:
 	IcebergPredicate() = delete;
 
 public:
-	static bool MatchBounds(TableFilter &filter, const Value &lower_bound, const Value &upper_bound,
-	                        const IcebergTransform &transform);
+	static bool MatchBounds(TableFilter &filter, const IcebergPredicateStats &stats, const IcebergTransform &transform);
 };
 
 } // namespace duckdb

--- a/src/include/iceberg_predicate.hpp
+++ b/src/include/iceberg_predicate.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include "iceberg_transform.hpp"
+#include "duckdb/planner/table_filter.hpp"
+
+namespace duckdb {
+
+struct IcebergPredicate {
+public:
+	IcebergPredicate() = delete;
+
+public:
+	static bool MatchBounds(TableFilter &filter, const Value &lower_bound, const Value &upper_bound,
+	                        const IcebergTransform &transform);
+};
+
+} // namespace duckdb

--- a/src/include/iceberg_predicate_stats.hpp
+++ b/src/include/iceberg_predicate_stats.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include "duckdb/common/types/value.hpp"
+
+namespace duckdb {
+
+struct IcebergPredicateStats {
+	Value lower_bound;
+	Value upper_bound;
+};
+
+} // namespace duckdb

--- a/src/include/iceberg_transform.hpp
+++ b/src/include/iceberg_transform.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "duckdb/common/types/value.hpp"
+
+namespace duckdb {
+
+enum class IcebergTransformType : uint8_t { IDENTITY, BUCKET, TRUNCATE, YEAR, MONTH, DAY, HOUR, VOID, INVALID };
+
+struct IcebergTransform {
+public:
+	IcebergTransform();
+	IcebergTransform(const string &transform);
+
+public:
+	operator IcebergTransformType() const {
+		return Type();
+	}
+
+public:
+	//! Singleton iceberg transform, used as stand-in when there is no partition field
+	static const IcebergTransform &Identity() {
+		static auto identity = IcebergTransform("identity");
+		return identity;
+	}
+	idx_t GetBucketModulo() const {
+		D_ASSERT(type == IcebergTransformType::BUCKET);
+		return modulo;
+	}
+	idx_t GetTruncateWidth() const {
+		D_ASSERT(type == IcebergTransformType::TRUNCATE);
+		return width;
+	}
+	IcebergTransformType Type() const {
+		D_ASSERT(type != IcebergTransformType::INVALID);
+		return type;
+	}
+	const string &RawType() const {
+		return raw_transform;
+	}
+
+private:
+	//! Preserve the input for debugging
+	string raw_transform;
+	IcebergTransformType type;
+	idx_t modulo;
+	idx_t width;
+};
+
+struct IdentityTransform {
+	static Value ApplyTransform(const Value &input, const IcebergTransform &transform) {
+		return input;
+	}
+	static bool CompareEqual(const Value &constant, const Value &lower, const Value &upper) {
+		return constant >= lower && constant <= upper;
+	}
+	static bool CompareLessThan(const Value &constant, const Value &lower, const Value &upper) {
+		return lower < constant;
+	}
+	static bool CompareLessThanOrEqual(const Value &constant, const Value &lower, const Value &upper) {
+		return lower <= constant;
+	}
+	static bool CompareGreaterThan(const Value &constant, const Value &lower, const Value &upper) {
+		return upper > constant;
+	}
+	static bool CompareGreaterThanOrEqual(const Value &constant, const Value &lower, const Value &upper) {
+		return upper >= constant;
+	}
+};
+
+// struct DayTransform {
+//	static Value ApplyTransform(const Value &input, const IcebergTransform &transform) {
+//		throw NotImplementedException("'day' transform ApplyTransform");
+//	}
+//	static bool CompareEqual(const Value &constant, const Value &lower, const Value &upper) {
+//		return constant >= lower && constant <= upper;
+//	}
+//	static bool CompareLessThan(const Value &constant, const Value &lower, const Value &upper) {
+//		return lower <= constant;
+//	}
+//	static bool CompareLessThanOrEqual(const Value &constant, const Value &lower, const Value &upper) {
+//		return lower <= constant;
+//	}
+//	static bool CompareGreaterThan(const Value &constant, const Value &lower, const Value &upper) {
+//		return upper >= constant;
+//	}
+//	static bool CompareGreaterThanOrEqual(const Value &constant, const Value &lower, const Value &upper) {
+//		return upper >= constant;
+//	}
+//};
+
+} // namespace duckdb

--- a/src/include/iceberg_transform.hpp
+++ b/src/include/iceberg_transform.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "duckdb/common/types/value.hpp"
+#include "iceberg_predicate_stats.hpp"
 
 namespace duckdb {
 
@@ -47,44 +47,44 @@ private:
 };
 
 struct IdentityTransform {
-	static Value ApplyTransform(const Value &input, const IcebergTransform &transform) {
-		return input;
+	static Value ApplyTransform(const Value &constant, const IcebergTransform &transform) {
+		return constant;
 	}
-	static bool CompareEqual(const Value &constant, const Value &lower, const Value &upper) {
-		return constant >= lower && constant <= upper;
+	static bool CompareEqual(const Value &constant, const IcebergPredicateStats &stats) {
+		return constant >= stats.lower_bound && constant <= stats.upper_bound;
 	}
-	static bool CompareLessThan(const Value &constant, const Value &lower, const Value &upper) {
-		return lower < constant;
+	static bool CompareLessThan(const Value &constant, const IcebergPredicateStats &stats) {
+		return stats.lower_bound < constant;
 	}
-	static bool CompareLessThanOrEqual(const Value &constant, const Value &lower, const Value &upper) {
-		return lower <= constant;
+	static bool CompareLessThanOrEqual(const Value &constant, const IcebergPredicateStats &stats) {
+		return stats.lower_bound <= constant;
 	}
-	static bool CompareGreaterThan(const Value &constant, const Value &lower, const Value &upper) {
-		return upper > constant;
+	static bool CompareGreaterThan(const Value &constant, const IcebergPredicateStats &stats) {
+		return stats.upper_bound > constant;
 	}
-	static bool CompareGreaterThanOrEqual(const Value &constant, const Value &lower, const Value &upper) {
-		return upper >= constant;
+	static bool CompareGreaterThanOrEqual(const Value &constant, const IcebergPredicateStats &stats) {
+		return stats.upper_bound >= constant;
 	}
 };
 
 // struct DayTransform {
-//	static Value ApplyTransform(const Value &input, const IcebergTransform &transform) {
+//	static Value ApplyTransform(const Value &constant, const IcebergTransform &transform) {
 //		throw NotImplementedException("'day' transform ApplyTransform");
 //	}
-//	static bool CompareEqual(const Value &constant, const Value &lower, const Value &upper) {
-//		return constant >= lower && constant <= upper;
+//	static bool CompareEqual(const Value &constant, const IcebergPredicateStats &stats) {
+//		return constant >= stats.lower_bound && constant <= stats.upper_bound;
 //	}
-//	static bool CompareLessThan(const Value &constant, const Value &lower, const Value &upper) {
-//		return lower <= constant;
+//	static bool CompareLessThan(const Value &constant, const IcebergPredicateStats &stats) {
+//		return stats.lower_bound <= constant;
 //	}
-//	static bool CompareLessThanOrEqual(const Value &constant, const Value &lower, const Value &upper) {
-//		return lower <= constant;
+//	static bool CompareLessThanOrEqual(const Value &constant, const IcebergPredicateStats &stats) {
+//		return stats.lower_bound <= constant;
 //	}
-//	static bool CompareGreaterThan(const Value &constant, const Value &lower, const Value &upper) {
-//		return upper >= constant;
+//	static bool CompareGreaterThan(const Value &constant, const IcebergPredicateStats &stats) {
+//		return stats.upper_bound >= constant;
 //	}
-//	static bool CompareGreaterThanOrEqual(const Value &constant, const Value &lower, const Value &upper) {
-//		return upper >= constant;
+//	static bool CompareGreaterThanOrEqual(const Value &constant, const IcebergPredicateStats &stats) {
+//		return stats.upper_bound >= constant;
 //	}
 //};
 

--- a/src/include/iceberg_types.hpp
+++ b/src/include/iceberg_types.hpp
@@ -121,6 +121,7 @@ public:
 	string file_format;
 	vector<int32_t> equality_ids;
 	int64_t record_count;
+	//! source_id -> blob
 	unordered_map<int32_t, string> lower_bounds;
 	unordered_map<int32_t, string> upper_bounds;
 	Value partition;


### PR DESCRIPTION
This PR paves the way for implementing transforms other than "identity".

### Refactor

We now parse the `transform` into an `IcebergTransform` structure (which parses the modulo for `bucket` and the width for `truncate`)
Adding functors for transforms in the filter matching logic, which has been moved to `iceberg_predicate.cpp`

### Bug fixes

Also fix a bug where we now properly check the transform type when filtering on the lower+upper bounds of the `data_file`, before we seemed to always assume this used an `identity` transform.