### PR TITLE
Use the original `storage_location` instead of the lowercase version

### DIFF
--- a/src/storage/irc_table_entry.cpp
+++ b/src/storage/irc_table_entry.cpp
@@ -80,7 +80,7 @@ string ICTableEntry::PrepareIcebergScanFromEntry(ClientContext &context) {
 		               lc_storage_location.begin(), ::tolower);
 		size_t metadata_pos = lc_storage_location.find("metadata");
 		if (metadata_pos != std::string::npos) {
-			info.scope = {lc_storage_location.substr(0, metadata_pos)};
+			info.scope = {table_data->storage_location.substr(0, metadata_pos)};
 		} else {
 			throw InvalidInputException("Substring not found");
 		}


### PR DESCRIPTION
This PR fixes #231 

We transform the `storage_location` to lowercase so we can find `metadata` without having to deal with different casings, but then we also use this lowercase version in the scope, which is wrong.