### PR TITLE
[Dev] Remove traces of `aws` includes, `zlib` include, and do not require `aws`/`curl` in WASM builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,26 +51,30 @@ add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES} ${ALL_OBJECT_FILES})
 set(PARAMETERS "-warnings")
 build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
 
-find_package(CURL REQUIRED)
-find_package(AWSSDK REQUIRED COMPONENTS core sso sts)
-include_directories(${CURL_INCLUDE_DIRS})
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    find_package(CURL REQUIRED)
+    find_package(AWSSDK REQUIRED COMPONENTS core sso sts)
+    include_directories(${CURL_INCLUDE_DIRS})
+endif()
 
 # Reset the TARGET_NAME, the AWS find_package build could bleed into our build -
 # overriding `TARGET_NAME`
 set(TARGET_NAME iceberg)
 
-# AWS SDK FROM vcpkg
-target_include_directories(${EXTENSION_NAME}
-                           PUBLIC $<BUILD_INTERFACE:${AWSSDK_INCLUDE_DIRS}>)
-target_link_libraries(${EXTENSION_NAME} PUBLIC ${AWSSDK_LINK_LIBRARIES})
-target_include_directories(${TARGET_NAME}_loadable_extension
-                           PRIVATE $<BUILD_INTERFACE:${AWSSDK_INCLUDE_DIRS}>)
-target_link_libraries(${TARGET_NAME}_loadable_extension
-                      ${AWSSDK_LINK_LIBRARIES})
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    # AWS SDK FROM vcpkg
+    target_include_directories(${EXTENSION_NAME}
+                            PUBLIC $<BUILD_INTERFACE:${AWSSDK_INCLUDE_DIRS}>)
+    target_link_libraries(${EXTENSION_NAME} PUBLIC ${AWSSDK_LINK_LIBRARIES})
+    target_include_directories(${TARGET_NAME}_loadable_extension
+                            PRIVATE $<BUILD_INTERFACE:${AWSSDK_INCLUDE_DIRS}>)
+    target_link_libraries(${TARGET_NAME}_loadable_extension
+                        ${AWSSDK_LINK_LIBRARIES})
 
-# Link dependencies into extension
-target_link_libraries(${EXTENSION_NAME} PUBLIC ${CURL_LIBRARIES})
-target_link_libraries(${TARGET_NAME}_loadable_extension ${CURL_LIBRARIES})
+    # Link dependencies into extension
+    target_link_libraries(${EXTENSION_NAME} PUBLIC ${CURL_LIBRARIES})
+    target_link_libraries(${TARGET_NAME}_loadable_extension ${CURL_LIBRARIES})
+endif()
 
 install(
   TARGETS ${EXTENSION_NAME} ${TARGET_NAME}_loadable_extension

--- a/src/aws.cpp
+++ b/src/aws.cpp
@@ -44,7 +44,17 @@ protected:
 
 } // namespace
 
+static void InitAWSAPI() {
+	static bool loaded = false;
+	if (!loaded) {
+		Aws::SDKOptions options;
+		Aws::InitAPI(options); // Should only be called once.
+		loaded = true;
+	}
+}
+
 string AWSInput::GetRequest(ClientContext &context) {
+	InitAWSAPI();
 	auto clientConfig = make_uniq<Aws::Client::ClientConfiguration>();
 
 	if (!cert_path.empty()) {

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -1,6 +1,5 @@
 #include "duckdb.hpp"
 #include "iceberg_utils.hpp"
-#include "zlib.h"
 #include "fstream"
 #include "duckdb/common/gzip_file_system.hpp"
 #include "storage/irc_table_entry.hpp"

--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -16,8 +16,6 @@
 #include "iceberg_functions.hpp"
 #include "yyjson.hpp"
 #include "catalog_api.hpp"
-#include "aws/core/Aws.h"
-#include "aws/s3/S3Client.h"
 #include "duckdb/main/extension_helper.hpp"
 #include "storage/authorization/oauth2.hpp"
 #include "storage/authorization/sigv4.hpp"
@@ -41,9 +39,6 @@ public:
 };
 
 static void LoadInternal(DatabaseInstance &instance) {
-	Aws::SDKOptions options;
-	Aws::InitAPI(options); // Should only be called once.
-
 	ExtensionHelper::AutoLoadExtension(instance, "parquet");
 	if (!instance.ExtensionIsLoaded("parquet")) {
 		throw MissingExtensionException("The iceberg extension requires the parquet extension to be loaded!");


### PR DESCRIPTION
This PR takes the learnings from #245 and applies them to `main`