### PR TITLE
[Dev] Bump duckdb | `DUCKDB_LOG_WARN` and `DUCKDB_LOG_DEBUG` don't work like they used to anymore

### DIFF
--- a/src/aws.cpp
+++ b/src/aws.cpp
@@ -1,3 +1,5 @@
+#include "iceberg_logging.hpp"
+
 #include "aws.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/exception/http_exception.hpp"
@@ -89,9 +91,9 @@ string AWSInput::GetRequest(ClientContext &context) {
 	MyHttpClient = Aws::Http::CreateHttpClient(*clientConfig);
 	std::shared_ptr<Aws::Http::HttpResponse> res = MyHttpClient->MakeRequest(req);
 	Aws::Http::HttpResponseCode resCode = res->GetResponseCode();
-	DUCKDB_LOG_DEBUG(context, "iceberg.Catalog.Aws.HTTPRequest",
-	                 "GET %s (response %d) (signed with key_id '%s' for service '%s', in region '%s')",
-	                 uri.GetURIString(), resCode, key_id, service.c_str(), region.c_str());
+	DUCKDB_LOG(context, IcebergLogType,
+	           "GET %s (response %d) (signed with key_id '%s' for service '%s', in region '%s')", uri.GetURIString(),
+	           resCode, key_id, service.c_str(), region.c_str());
 
 	if (resCode != Aws::Http::HttpResponseCode::OK) {
 		Aws::StringStream resBody;

--- a/src/storage/authorization/oauth2.cpp
+++ b/src/storage/authorization/oauth2.cpp
@@ -188,8 +188,8 @@ unique_ptr<BaseSecret> OAuth2Authorization::CreateCatalogSecretFunction(ClientCo
 	if (oauth2_server_uri_it != result->secret_map.end()) {
 		server_uri = oauth2_server_uri_it->second.ToString();
 	} else if (endpoint_it != result->secret_map.end()) {
-		DUCKDB_LOG_WARN(
-		    context, "iceberg",
+		DUCKDB_LOG(
+		    context, IcebergLogType,
 		    "'oauth2_server_uri' is not set, defaulting to deprecated '{endpoint}/v1/oauth/tokens' oauth2_server_uri");
 		server_uri = StringUtil::Format("%s/v1/oauth/tokens", endpoint_it->second.ToString());
 	} else {

--- a/src/storage/irc_catalog.cpp
+++ b/src/storage/irc_catalog.cpp
@@ -3,6 +3,7 @@
 #include "catalog_api.hpp"
 #include "catalog_utils.hpp"
 #include "iceberg_utils.hpp"
+#include "iceberg_logging.hpp"
 #include "api_utils.hpp"
 #include "duckdb/storage/database_size.hpp"
 #include "duckdb/main/database.hpp"
@@ -195,8 +196,7 @@ void IRCatalog::GetConfig(ClientContext &context) {
 	}
 
 	if (prefix.empty()) {
-		DUCKDB_LOG_DEBUG(context, "iceberg.Catalog.HttpRequest", "No prefix found for catalog with warehouse value %s",
-		                 warehouse);
+		DUCKDB_LOG(context, IcebergLogType, "No prefix found for catalog with warehouse value %s", warehouse);
 	}
 	// TODO: store optional endpoints param as well. We can enforce per catalog the endpoints that
 	//  are allowed to be hit


### PR DESCRIPTION
I set out to bump duckdb because I was worried that https://github.com/duckdb/duckdb/pull/17553 would break the Iceberg MFR again, but it looks like we don't override the touched methods, so that's great

But while I was running our tests I saw an Internal Exception related to DUCKDB_LOG_WARN and DUCKDB_LOG_DEBUG, this PR fixes those, as well as bump duckdb.