### PR TITLE
[REST Catalog] Return catalog entry with the correct table schema for time travel queries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(EXTENSION_SOURCES
     src/iceberg_extension.cpp
     src/iceberg_functions.cpp
     src/iceberg_manifest.cpp
+    src/iceberg_snapshot_lookup.cpp
     src/catalog_api.cpp
     src/iceberg_logging.cpp
     src/catalog_utils.cpp

--- a/src/catalog_api.cpp
+++ b/src/catalog_api.cpp
@@ -220,83 +220,18 @@ IRCAPITableCredentials IRCAPI::GetTableCredentials(ClientContext &context, IRCat
 	return result;
 }
 
-static void populateTableMetadata(IRCAPITable &table, const rest_api_objects::LoadTableResult &load_table_result) {
-	if (!load_table_result.has_metadata_location) {
-		throw InvalidConfigurationException("'metadata-location' can only be missing in uncommitted transactions");
-	}
-	table.storage_location = load_table_result.metadata_location;
-	auto &metadata = load_table_result.metadata;
-	// table_result.table_id = load_table_result.metadata.table_uuid;
-
-	//! NOTE: these (schema-id and current-schema-id) are saved as int64_t in the parsed structure,
-	//! the spec lists them as 'int', so I think they are really int32_t. (?)
-	//! We parsed them as uint64_t before using the generated JSON->CPP parsing logic.
-	bool found = false;
-	if (!metadata.has_current_schema_id) {
-		//! It's required since v2, but we want to support reading v1 as well, no?
-		throw NotImplementedException("FIXME: We require the 'current-schema-id' always, the spec says it's optional?");
-		//! FIXME: for v1 we should check if `schema` is set and use that instead
-	}
-	int64_t current_schema_id = metadata.current_schema_id;
-	if (!metadata.has_schemas) {
-		throw NotImplementedException("'schemas' is not present! V1 not supported currently");
-		//! FIXME: for v1 we should check if `schema` is set and use that instead (see above)
-	}
-	for (auto &schema : metadata.schemas) {
-		auto &schema_internals = schema.object_1;
-		if (!schema_internals.has_schema_id) {
-			throw NotImplementedException("'schema-id' not present! V1 not supported currently!");
-		}
-		int64_t schema_id = schema_internals.schema_id;
-		if (schema_id == current_schema_id) {
-			found = true;
-			auto &columns = schema.struct_type.fields;
-			for (auto &col : columns) {
-				table.columns.push_back(IcebergColumnDefinition::ParseStructField(*col));
-			}
-		}
-	}
-
-	if (!found) {
-		throw InvalidInputException("Current schema not found");
-	}
-}
-
-static IRCAPITable createTable(IRCatalog &catalog, const string &schema, const string &table_name) {
-	IRCAPITable table_result;
-	table_result.catalog_name = catalog.GetName();
-	table_result.schema_name = schema;
-	table_result.name = table_name;
-	table_result.data_source_format = "ICEBERG";
-	table_result.table_id = "uuid-" + schema + "-" + "table";
-	std::replace(table_result.table_id.begin(), table_result.table_id.end(), '_', '-');
-	return table_result;
-}
-
-IRCAPITable IRCAPI::GetTable(ClientContext &context, IRCatalog &catalog, const string &schema, const string &table_name,
-                             bool perform_request) {
-	IRCAPITable table_result = createTable(catalog, schema, table_name);
-
-	if (perform_request) {
-		string result = GetTableMetadata(context, catalog, schema, table_result.name);
-		std::unique_ptr<yyjson_doc, YyjsonDocDeleter> doc(ICUtils::api_result_to_doc(result));
-		auto *metadata_root = yyjson_doc_get_root(doc.get());
-		auto load_table_result = rest_api_objects::LoadTableResult::FromJSON(metadata_root);
-		populateTableMetadata(table_result, load_table_result);
-	} else {
-		// Skip fetching metadata, we'll do it later when we access the table
-		auto col = make_uniq<IcebergColumnDefinition>();
-		col->name = "__";
-		col->id = 0;
-		col->type = LogicalType::UNKNOWN;
-		table_result.columns.push_back(std::move(col));
-	}
-	return table_result;
+rest_api_objects::LoadTableResult IRCAPI::GetTable(ClientContext &context, IRCatalog &catalog, const string &schema,
+                                                   const string &table_name) {
+	string result = GetTableMetadata(context, catalog, schema, table_name);
+	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> doc(ICUtils::api_result_to_doc(result));
+	auto *metadata_root = yyjson_doc_get_root(doc.get());
+	auto load_table_result = rest_api_objects::LoadTableResult::FromJSON(metadata_root);
+	return load_table_result;
 }
 
 // TODO: handle out-of-order columns using position property
-vector<IRCAPITable> IRCAPI::GetTables(ClientContext &context, IRCatalog &catalog, const string &schema) {
-	vector<IRCAPITable> result;
+vector<rest_api_objects::TableIdentifier> IRCAPI::GetTables(ClientContext &context, IRCatalog &catalog,
+                                                            const string &schema) {
 	auto url_builder = catalog.GetBaseUrl();
 	url_builder.AddPathComponent(catalog.prefix);
 	url_builder.AddPathComponent("namespaces");
@@ -315,11 +250,11 @@ vector<IRCAPITable> IRCAPI::GetTables(ClientContext &context, IRCatalog &catalog
 	if (!list_tables_response.has_identifiers) {
 		throw NotImplementedException("List of 'identifiers' is missing, missing support for Iceberg V1");
 	}
-	for (auto &table : list_tables_response.identifiers) {
-		auto table_result = GetTable(context, catalog, schema, table.name);
-		result.push_back(std::move(table_result));
-	}
-	return result;
+	// for (auto &table : list_tables_response.identifiers) {
+	//	auto table_result = GetTable(context, catalog, schema, table.name);
+	//	result.push_back(std::move(table_result));
+	//}
+	return std::move(list_tables_response.identifiers);
 }
 
 vector<IRCAPISchema> IRCAPI::GetSchemas(ClientContext &context, IRCatalog &catalog) {
@@ -374,11 +309,6 @@ static string json_to_string(yyjson_mut_doc *doc, yyjson_write_flag flags = YYJS
 	string json_str(json_chars);
 	free(json_chars);
 	return json_str;
-}
-
-IRCAPITable IRCAPI::CreateTable(ClientContext &context, IRCatalog &catalog, const string &schema,
-                                CreateTableInfo *table_info) {
-	throw NotImplementedException("IRCAPI Create Table not Implemented");
 }
 
 } // namespace duckdb

--- a/src/catalog_api.cpp
+++ b/src/catalog_api.cpp
@@ -250,10 +250,6 @@ vector<rest_api_objects::TableIdentifier> IRCAPI::GetTables(ClientContext &conte
 	if (!list_tables_response.has_identifiers) {
 		throw NotImplementedException("List of 'identifiers' is missing, missing support for Iceberg V1");
 	}
-	// for (auto &table : list_tables_response.identifiers) {
-	//	auto table_result = GetTable(context, catalog, schema, table.name);
-	//	result.push_back(std::move(table_result));
-	//}
 	return std::move(list_tables_response.identifiers);
 }
 

--- a/src/iceberg_functions/iceberg_multi_file_reader.cpp
+++ b/src/iceberg_functions/iceberg_multi_file_reader.cpp
@@ -732,7 +732,8 @@ void IcebergMultiFileReader::FinalizeBind(MultiFileReaderData &reader_data, cons
 	// The path of the data file where this chunk was read from
 	const auto &file_path = data_file.file_path;
 	{
-		std::lock_guard<mutex> guard(multi_file_list.delete_lock);
+		lock_guard<mutex> guard(multi_file_list.lock);
+		std::lock_guard<mutex> delete_guard(multi_file_list.delete_lock);
 		if (multi_file_list.current_delete_manifest != multi_file_list.delete_manifests.end()) {
 			multi_file_list.ProcessDeletes(global_columns);
 		}

--- a/src/iceberg_snapshot_lookup.cpp
+++ b/src/iceberg_snapshot_lookup.cpp
@@ -1,0 +1,33 @@
+#include "iceberg_options.hpp"
+
+namespace duckdb {
+
+IcebergSnapshotLookup IcebergSnapshotLookup::FromAtClause(optional_ptr<BoundAtClause> at) {
+	IcebergSnapshotLookup result;
+	if (!at) {
+		return result;
+	}
+
+	auto &unit = at->Unit();
+	auto &value = at->GetValue();
+
+	if (StringUtil::CIEquals(unit, "version")) {
+		if (value.type().id() != LogicalTypeId::BIGINT) {
+			throw InvalidInputException("'version' has to be provided as a BIGINT value");
+		}
+		result.snapshot_source = SnapshotSource::FROM_ID;
+		result.snapshot_id = value.GetValue<int64_t>();
+	} else if (StringUtil::CIEquals(unit, "timestamp")) {
+		if (value.type().id() != LogicalTypeId::TIMESTAMP) {
+			throw InvalidInputException("'timestamp' has to be provided as a TIMESTAMP value");
+		}
+		result.snapshot_source = SnapshotSource::FROM_TIMESTAMP;
+		result.snapshot_timestamp = value.GetValue<timestamp_t>();
+	} else {
+		throw InvalidInputException(
+		    "Unit '%s' for time travel is not valid, supported options are 'version' and 'timestamp'", unit);
+	}
+	return result;
+}
+
+} // namespace duckdb

--- a/src/iceberg_snapshot_lookup.cpp
+++ b/src/iceberg_snapshot_lookup.cpp
@@ -11,6 +11,9 @@ IcebergSnapshotLookup IcebergSnapshotLookup::FromAtClause(optional_ptr<BoundAtCl
 	auto &unit = at->Unit();
 	auto &value = at->GetValue();
 
+	if (value.IsNull()) {
+		throw InvalidInputException("NULL values can not be used as the 'unit' of a time travel clause");
+	}
 	if (StringUtil::CIEquals(unit, "version")) {
 		if (value.type().id() != LogicalTypeId::BIGINT) {
 			throw InvalidInputException("'version' has to be provided as a BIGINT value");

--- a/src/include/catalog_api.hpp
+++ b/src/include/catalog_api.hpp
@@ -5,38 +5,13 @@
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/parser/parsed_data/create_secret_info.hpp"
 #include "iceberg_metadata.hpp"
+#include "rest_catalog/objects/table_identifier.hpp"
+#include "rest_catalog/objects/load_table_result.hpp"
 //#include "storage/irc_catalog.hpp"
 
 namespace duckdb {
 
 class IRCatalog;
-
-struct IRCAPITable {
-public:
-	IRCAPITable(const string &table_id) : table_id(table_id) {
-	}
-	IRCAPITable() = default;
-
-	// Enable move constructor and move assignment
-	IRCAPITable(IRCAPITable &&) noexcept = default;
-	IRCAPITable &operator=(IRCAPITable &&) noexcept = default;
-
-	// Disable copy constructor and copy assignment
-	IRCAPITable(const IRCAPITable &) = delete;
-	IRCAPITable &operator=(const IRCAPITable &) = delete;
-
-public:
-	string table_id;
-
-	string name;
-	string catalog_name;
-	string schema_name;
-	string table_type;
-	string data_source_format;
-	string storage_location;
-
-	vector<unique_ptr<IcebergColumnDefinition>> columns;
-};
 
 struct IRCAPISchema {
 	string schema_name;
@@ -55,15 +30,14 @@ public:
 	static IRCAPITableCredentials GetTableCredentials(ClientContext &context, IRCatalog &catalog, const string &schema,
 	                                                  const string &table, const string &secret_base_name);
 	static vector<string> GetCatalogs(ClientContext &context, IRCatalog &catalog);
-	static vector<IRCAPITable> GetTables(ClientContext &context, IRCatalog &catalog, const string &schema);
-	static IRCAPITable GetTable(ClientContext &context, IRCatalog &catalog, const string &schema,
-	                            const string &table_name, bool perform_request = false);
+	static vector<rest_api_objects::TableIdentifier> GetTables(ClientContext &context, IRCatalog &catalog,
+	                                                           const string &schema);
+	static rest_api_objects::LoadTableResult GetTable(ClientContext &context, IRCatalog &catalog, const string &schema,
+	                                                  const string &table_name);
 	static vector<IRCAPISchema> GetSchemas(ClientContext &context, IRCatalog &catalog);
 
 	static IRCAPISchema CreateSchema(ClientContext &context, IRCatalog &catalog, const string &schema);
 	static void DropSchema(ClientContext &context, const string &schema);
-	static IRCAPITable CreateTable(ClientContext &context, IRCatalog &catalog, const string &schema,
-	                               CreateTableInfo *table_info);
 	static void DropTable(ClientContext &context, IRCatalog &catalog, const string &schema, string &table_name);
 };
 

--- a/src/include/iceberg_options.hpp
+++ b/src/include/iceberg_options.hpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/planner/tableref/bound_at_clause.hpp"
 
 namespace duckdb {
 
@@ -26,6 +27,19 @@ static string DEFAULT_TABLE_VERSION = UNKNOWN_TABLE_VERSION;
 
 enum class SnapshotSource : uint8_t { LATEST, FROM_TIMESTAMP, FROM_ID };
 
+struct IcebergSnapshotLookup {
+public:
+	SnapshotSource snapshot_source = SnapshotSource::LATEST;
+	int64_t snapshot_id;
+	timestamp_t snapshot_timestamp;
+
+public:
+	bool IsLatest() const {
+		return snapshot_source == SnapshotSource::LATEST;
+	}
+	static IcebergSnapshotLookup FromAtClause(optional_ptr<BoundAtClause> at);
+};
+
 struct IcebergOptions {
 	bool allow_moved_paths = false;
 	string metadata_compression_codec = "none";
@@ -33,9 +47,7 @@ struct IcebergOptions {
 	string table_version = DEFAULT_TABLE_VERSION;
 	string version_name_format = DEFAULT_TABLE_VERSION_FORMAT;
 
-	SnapshotSource snapshot_source = SnapshotSource::LATEST;
-	uint64_t snapshot_id;
-	timestamp_t snapshot_timestamp;
+	IcebergSnapshotLookup snapshot_lookup;
 };
 
 } // namespace duckdb

--- a/src/include/metadata/iceberg_table_metadata.hpp
+++ b/src/include/metadata/iceberg_table_metadata.hpp
@@ -39,7 +39,7 @@ public:
 
 	shared_ptr<IcebergTableSchema> GetSchemaFromId(int32_t schema_id);
 
-	optional_ptr<IcebergSnapshot> GetSnapshot(const IcebergOptions &options);
+	optional_ptr<IcebergSnapshot> GetSnapshot(const IcebergSnapshotLookup &lookup);
 
 public:
 	int32_t iceberg_version;

--- a/src/include/storage/irc_table_entry.hpp
+++ b/src/include/storage/irc_table_entry.hpp
@@ -7,6 +7,8 @@
 
 namespace duckdb {
 
+struct IcebergTableInformation;
+
 struct ICTableInfo {
 	ICTableInfo() {
 		create_info = make_uniq<CreateTableInfo>();
@@ -27,26 +29,24 @@ struct ICTableInfo {
 
 class ICTableEntry : public TableCatalogEntry {
 public:
-	ICTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTableInfo &info);
-	ICTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, ICTableInfo &info);
-
-	unique_ptr<IRCAPITable> table_data;
+	ICTableEntry(IcebergTableInformation &table_info, Catalog &catalog, SchemaCatalogEntry &schema,
+	             CreateTableInfo &info);
 
 	virtual_column_map_t GetVirtualColumns() const override;
 	vector<column_t> GetRowIdColumns() const override;
 
 public:
 	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id) override;
-
 	string PrepareIcebergScanFromEntry(ClientContext &context);
 	TableFunction GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) override;
 	TableFunction GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data,
 	                              const EntryLookupInfo &lookup) override;
-
 	TableStorageInfo GetStorageInfo(ClientContext &context) override;
-
 	void BindUpdateConstraints(Binder &binder, LogicalGet &get, LogicalProjection &proj, LogicalUpdate &update,
 	                           ClientContext &context) override;
+
+public:
+	IcebergTableInformation &table_info;
 };
 
 } // namespace duckdb

--- a/src/include/storage/irc_table_set.hpp
+++ b/src/include/storage/irc_table_set.hpp
@@ -8,38 +8,44 @@ struct CreateTableInfo;
 class ICResult;
 class IRCSchemaEntry;
 
+struct IcebergTableInformation {
+public:
+	IcebergTableInformation(IRCatalog &catalog, IRCSchemaEntry &schema, const string &name);
+
+public:
+	optional_ptr<CatalogEntry> GetSchemaVersion(optional_ptr<BoundAtClause> at);
+	optional_ptr<CatalogEntry> _CreateCatalogEntry(IcebergTableSchema &table_schema);
+
+public:
+	IRCatalog &catalog;
+	IRCSchemaEntry &schema;
+	string name;
+	string table_id;
+
+	rest_api_objects::LoadTableResult load_table_result;
+	IcebergTableMetadata table_metadata;
+	unordered_map<int32_t, unique_ptr<ICTableEntry>> schema_versions;
+	int32_t current_schema_id;
+};
+
 class ICTableSet {
 public:
 	explicit ICTableSet(IRCSchemaEntry &schema);
 
 public:
-	optional_ptr<CatalogEntry> CreateTable(ClientContext &context, BoundCreateTableInfo &info);
 	static unique_ptr<ICTableInfo> GetTableInfo(ClientContext &context, IRCSchemaEntry &schema,
 	                                            const string &table_name);
-	void AlterTable(ClientContext &context, AlterTableInfo &info);
-	void DropTable(ClientContext &context, DropInfo &info);
-	optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const string &name);
-	void DropEntry(ClientContext &context, DropInfo &info);
+	optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const EntryLookupInfo &lookup);
 	void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
 
 protected:
-	optional_ptr<CatalogEntry> CreateEntryInternal(ClientContext &context, unique_ptr<CatalogEntry> entry);
-
 	void LoadEntries(ClientContext &context);
-	void FillEntry(ClientContext &context, unique_ptr<CatalogEntry> &entry);
-
-	void AlterTable(ClientContext &context, RenameTableInfo &info);
-	void AlterTable(ClientContext &context, RenameColumnInfo &info);
-	void AlterTable(ClientContext &context, AddColumnInfo &info);
-	void AlterTable(ClientContext &context, RemoveColumnInfo &info);
-
-private:
-	unique_ptr<CatalogEntry> _CreateCatalogEntry(ClientContext &context, IRCAPITable &&table);
+	void FillEntry(ClientContext &context, IcebergTableInformation &table);
 
 protected:
 	IRCSchemaEntry &schema;
 	Catalog &catalog;
-	case_insensitive_map_t<unique_ptr<CatalogEntry>> entries;
+	case_insensitive_map_t<IcebergTableInformation> entries;
 
 private:
 	mutex entry_lock;

--- a/src/include/storage/irc_table_set.hpp
+++ b/src/include/storage/irc_table_set.hpp
@@ -14,7 +14,7 @@ public:
 
 public:
 	optional_ptr<CatalogEntry> GetSchemaVersion(optional_ptr<BoundAtClause> at);
-	optional_ptr<CatalogEntry> _CreateCatalogEntry(IcebergTableSchema &table_schema);
+	optional_ptr<CatalogEntry> CreateSchemaVersion(IcebergTableSchema &table_schema);
 
 public:
 	IRCatalog &catalog;
@@ -25,7 +25,6 @@ public:
 	rest_api_objects::LoadTableResult load_table_result;
 	IcebergTableMetadata table_metadata;
 	unordered_map<int32_t, unique_ptr<ICTableEntry>> schema_versions;
-	int32_t current_schema_id;
 };
 
 class ICTableSet {

--- a/src/metadata/iceberg_table_metadata.cpp
+++ b/src/metadata/iceberg_table_metadata.cpp
@@ -74,14 +74,14 @@ optional_ptr<IcebergSnapshot> IcebergTableMetadata::GetSnapshotByTimestamp(times
 	return snapshot;
 }
 
-optional_ptr<IcebergSnapshot> IcebergTableMetadata::GetSnapshot(const IcebergOptions &options) {
-	switch (options.snapshot_source) {
+optional_ptr<IcebergSnapshot> IcebergTableMetadata::GetSnapshot(const IcebergSnapshotLookup &lookup) {
+	switch (lookup.snapshot_source) {
 	case SnapshotSource::LATEST:
 		return GetLatestSnapshot();
 	case SnapshotSource::FROM_ID:
-		return GetSnapshotById(options.snapshot_id);
+		return GetSnapshotById(lookup.snapshot_id);
 	case SnapshotSource::FROM_TIMESTAMP:
-		return GetSnapshotByTimestamp(options.snapshot_timestamp);
+		return GetSnapshotByTimestamp(lookup.snapshot_timestamp);
 	default:
 		throw InternalException("SnapshotSource type not implemented");
 	}

--- a/src/storage/irc_schema_entry.cpp
+++ b/src/storage/irc_schema_entry.cpp
@@ -120,7 +120,7 @@ optional_ptr<CatalogEntry> IRCSchemaEntry::LookupEntry(CatalogTransaction transa
 	if (!CatalogTypeIsSupported(type)) {
 		return nullptr;
 	}
-	return GetCatalogSet(type).GetEntry(transaction.GetContext(), lookup_info.GetEntryName());
+	return GetCatalogSet(type).GetEntry(transaction.GetContext(), lookup_info);
 }
 
 ICTableSet &IRCSchemaEntry::GetCatalogSet(CatalogType type) {

--- a/src/storage/irc_table_set.cpp
+++ b/src/storage/irc_table_set.cpp
@@ -82,6 +82,7 @@ void ICTableSet::Scan(ClientContext &context, const std::function<void(CatalogEn
 	lock_guard<mutex> l(entry_lock);
 	LoadEntries(context);
 	for (auto &entry : entries) {
+		FillEntry(context, entry.second);
 		for (auto &schema : entry.second.schema_versions) {
 			callback(*schema.second);
 		}

--- a/src/storage/irc_table_set.cpp
+++ b/src/storage/irc_table_set.cpp
@@ -22,7 +22,7 @@ IcebergTableInformation::IcebergTableInformation(IRCatalog &catalog, IRCSchemaEn
 	table_id = "uuid-" + schema.name + "-" + name;
 }
 
-optional_ptr<CatalogEntry> IcebergTableInformation::_CreateCatalogEntry(IcebergTableSchema &table_schema) {
+optional_ptr<CatalogEntry> IcebergTableInformation::CreateSchemaVersion(IcebergTableSchema &table_schema) {
 	CreateTableInfo info;
 	info.table = name;
 	for (auto &col : table_schema.columns) {
@@ -73,9 +73,8 @@ void ICTableSet::FillEntry(ClientContext &context, IcebergTableInformation &tabl
 	//! It should be impossible to have a metadata file without any schema
 	D_ASSERT(!schemas.empty());
 	for (auto &table_schema : schemas) {
-		table._CreateCatalogEntry(*table_schema.second);
+		table.CreateSchemaVersion(*table_schema.second);
 	}
-	table.current_schema_id = table.table_metadata.current_schema_id;
 }
 
 void ICTableSet::Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback) {

--- a/src/storage/irc_table_set.cpp
+++ b/src/storage/irc_table_set.cpp
@@ -17,49 +17,75 @@
 
 namespace duckdb {
 
+IcebergTableInformation::IcebergTableInformation(IRCatalog &catalog, IRCSchemaEntry &schema, const string &name)
+    : catalog(catalog), schema(schema), name(name) {
+	table_id = "uuid-" + schema.name + "-" + name;
+}
+
+optional_ptr<CatalogEntry> IcebergTableInformation::_CreateCatalogEntry(IcebergTableSchema &table_schema) {
+	CreateTableInfo info;
+	info.table = name;
+	for (auto &col : table_schema.columns) {
+		info.columns.AddColumn(ColumnDefinition(col->name, col->type));
+	}
+
+	auto table_entry = make_uniq<ICTableEntry>(*this, catalog, schema, info);
+	if (!table_entry->internal) {
+		table_entry->internal = schema.internal;
+	}
+	auto result = table_entry.get();
+	if (result->name.empty()) {
+		throw InternalException("ICTableSet::CreateEntry called with empty name");
+	}
+	schema_versions.emplace(table_schema.schema_id, std::move(table_entry));
+	return result;
+}
+
+optional_ptr<CatalogEntry> IcebergTableInformation::GetSchemaVersion(optional_ptr<BoundAtClause> at) {
+	D_ASSERT(!schema_versions.empty());
+	auto snapshot_lookup = IcebergSnapshotLookup::FromAtClause(at);
+
+	int32_t schema_id;
+	if (snapshot_lookup.IsLatest()) {
+		schema_id = table_metadata.current_schema_id;
+	} else {
+		auto snapshot = table_metadata.GetSnapshot(snapshot_lookup);
+		D_ASSERT(snapshot);
+		schema_id = snapshot->schema_id;
+	}
+	return schema_versions[schema_id].get();
+}
+
 ICTableSet::ICTableSet(IRCSchemaEntry &schema) : schema(schema), catalog(schema.ParentCatalog()) {
 }
 
-static ColumnDefinition CreateColumnDefinition(ClientContext &context, IcebergColumnDefinition &coldef) {
-	return {coldef.name, coldef.type};
-}
-
-unique_ptr<CatalogEntry> ICTableSet::_CreateCatalogEntry(ClientContext &context, IRCAPITable &&table) {
-	D_ASSERT(schema.name == table.schema_name);
-	CreateTableInfo info;
-	info.table = table.name;
-
-	for (auto &col : table.columns) {
-		info.columns.AddColumn(CreateColumnDefinition(context, *col));
-	}
-
-	auto table_entry = make_uniq<ICTableEntry>(catalog, schema, info);
-	table_entry->table_data = make_uniq<IRCAPITable>(std::move(table));
-	return std::move(table_entry);
-}
-
-void ICTableSet::FillEntry(ClientContext &context, unique_ptr<CatalogEntry> &entry) {
-	auto *derived = static_cast<ICTableEntry *>(entry.get());
-	if (!derived->table_data->storage_location.empty()) {
+void ICTableSet::FillEntry(ClientContext &context, IcebergTableInformation &table) {
+	if (!table.schema_versions.empty()) {
+		//! Already filled
 		return;
 	}
 
 	auto &ic_catalog = catalog.Cast<IRCatalog>();
-	auto table = IRCAPI::GetTable(context, ic_catalog, schema.name, entry->name, true);
-	entry = _CreateCatalogEntry(context, std::move(table));
+	table.load_table_result = IRCAPI::GetTable(context, ic_catalog, schema.name, table.name);
+	table.table_metadata = IcebergTableMetadata::FromTableMetadata(table.load_table_result.metadata);
+	auto &schemas = table.table_metadata.schemas;
+
+	//! It should be impossible to have a metadata file without any schema
+	D_ASSERT(!schemas.empty());
+	for (auto &table_schema : schemas) {
+		table._CreateCatalogEntry(*table_schema.second);
+	}
+	table.current_schema_id = table.table_metadata.current_schema_id;
 }
 
 void ICTableSet::Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback) {
 	lock_guard<mutex> l(entry_lock);
 	LoadEntries(context);
 	for (auto &entry : entries) {
-		callback(*entry.second);
+		for (auto &schema : entry.second.schema_versions) {
+			callback(*schema.second);
+		}
 	}
-}
-
-void ICTableSet::DropEntry(ClientContext &context, DropInfo &info) {
-	lock_guard<mutex> l(entry_lock);
-	entries.erase(info.name);
 }
 
 void ICTableSet::LoadEntries(ClientContext &context) {
@@ -72,8 +98,7 @@ void ICTableSet::LoadEntries(ClientContext &context) {
 	auto tables = IRCAPI::GetTables(context, ic_catalog, schema.name);
 
 	for (auto &table : tables) {
-		auto entry = _CreateCatalogEntry(context, std::move(table));
-		CreateEntryInternal(context, std::move(entry));
+		entries.emplace(table.name, IcebergTableInformation(ic_catalog, schema, table.name));
 	}
 }
 
@@ -82,61 +107,15 @@ unique_ptr<ICTableInfo> ICTableSet::GetTableInfo(ClientContext &context, IRCSche
 	throw NotImplementedException("ICTableSet::GetTableInfo");
 }
 
-optional_ptr<CatalogEntry> ICTableSet::GetEntry(ClientContext &context, const string &name) {
+optional_ptr<CatalogEntry> ICTableSet::GetEntry(ClientContext &context, const EntryLookupInfo &lookup) {
 	LoadEntries(context);
 	lock_guard<mutex> l(entry_lock);
-	auto entry = entries.find(name);
+	auto entry = entries.find(lookup.GetEntryName());
 	if (entry == entries.end()) {
 		return nullptr;
 	}
 	FillEntry(context, entry->second);
-	return entry->second.get();
-}
-
-optional_ptr<CatalogEntry> ICTableSet::CreateEntryInternal(ClientContext &context, unique_ptr<CatalogEntry> entry) {
-	if (!entry->internal) {
-		entry->internal = schema.internal;
-	}
-	auto result = entry.get();
-	if (result->name.empty()) {
-		throw InternalException("ICTableSet::CreateEntry called with empty name");
-	}
-	entries.insert(make_pair(result->name, std::move(entry)));
-	return result;
-}
-
-optional_ptr<CatalogEntry> ICTableSet::CreateTable(ClientContext &context, BoundCreateTableInfo &info) {
-	auto &ic_catalog = catalog.Cast<IRCatalog>();
-	auto *table_info = dynamic_cast<CreateTableInfo *>(info.base.get());
-	auto table = IRCAPI::CreateTable(context, ic_catalog, schema.name, table_info);
-	auto entry = _CreateCatalogEntry(context, std::move(table));
-
-	return CreateEntryInternal(context, std::move(entry));
-}
-
-void ICTableSet::DropTable(ClientContext &context, DropInfo &info) {
-	auto &ic_catalog = catalog.Cast<IRCatalog>();
-	IRCAPI::DropTable(context, ic_catalog, schema.name, info.name);
-}
-
-void ICTableSet::AlterTable(ClientContext &context, RenameTableInfo &info) {
-	throw NotImplementedException("ICTableSet::AlterTable");
-}
-
-void ICTableSet::AlterTable(ClientContext &context, RenameColumnInfo &info) {
-	throw NotImplementedException("ICTableSet::AlterTable");
-}
-
-void ICTableSet::AlterTable(ClientContext &context, AddColumnInfo &info) {
-	throw NotImplementedException("ICTableSet::AlterTable");
-}
-
-void ICTableSet::AlterTable(ClientContext &context, RemoveColumnInfo &info) {
-	throw NotImplementedException("ICTableSet::AlterTable");
-}
-
-void ICTableSet::AlterTable(ClientContext &context, AlterTableInfo &alter) {
-	throw NotImplementedException("ICTableSet::AlterTable");
+	return entry->second.GetSchemaVersion(lookup.GetAtClause());
 }
 
 } // namespace duckdb

--- a/test/sql/local/iceberg_scans/iceberg_scan_schema_evo_timetravel.test
+++ b/test/sql/local/iceberg_scans/iceberg_scan_schema_evo_timetravel.test
@@ -1,0 +1,54 @@
+# name: test/sql/local/iceberg_scans/iceberg_scan_schema_evo_timetravel.test
+# group: [iceberg_scans]
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+
+statement ok
+ATTACH 'demo' AS my_datalake (
+	TYPE ICEBERG,
+	CLIENT_ID 'admin',
+	CLIENT_SECRET 'password',
+	ENDPOINT 'http://127.0.0.1:8181'
+);
+
+query I
+select count(snapshot_id::BIGINT) from iceberg_snapshots(
+	my_datalake.default.pyspark_iceberg_table_v2
+)
+----
+14
+
+statement ok
+set variable last_snapshot = (
+	select snapshot_id::BIGINT from iceberg_snapshots(
+		my_datalake.default.pyspark_iceberg_table_v2
+	) order by timestamp_ms
+	offset 13 limit 1
+)
+
+query I
+select
+	count(schema_evol_added_col_1)
+from
+	my_datalake.default.pyspark_iceberg_table_v2 AT (VERSION => getvariable('last_snapshot')) WHERE schema_evol_added_col_1 IS NOT NULL;
+----
+685

--- a/test/sql/local/irc/iceberg_catalog_read.test
+++ b/test/sql/local/irc/iceberg_catalog_read.test
@@ -50,6 +50,14 @@ select * from table_unpartitioned;
 ----
 <REGEX>:.*Did you mean.*my_datalake.default.table_unpartitioned.*
 
+query II
+SELECT request.url, response.reason FROM duckdb_logs_parsed('HTTP') WHERE request.type='POST' AND (request.url).starts_with('http://127.0.0.1:8181/v1/') order by timestamp
+----
+http://127.0.0.1:8181/v1/oauth/tokens	OK
+
+statement ok
+pragma truncate_duckdb_logs;
+
 query III
 select * from my_datalake.default.table_unpartitioned order by all;
 ----
@@ -82,18 +90,8 @@ select * from my_datalake.default.table_more_deletes order by all;
 query II
 SELECT request.url, response.reason FROM duckdb_logs_parsed('HTTP') WHERE request.type='GET' AND (request.url).starts_with('http://127.0.0.1:8181/v1/') order by timestamp
 ----
-http://127.0.0.1:8181/v1/config?warehouse=	OK
-http://127.0.0.1:8181/v1/namespaces	OK
-http://127.0.0.1:8181/v1/namespaces/default/tables	OK
-http://127.0.0.1:8181/v1/namespaces/default/tables/table_unpartitioned	OK
 http://127.0.0.1:8181/v1/namespaces/default/tables/table_unpartitioned	OK
 http://127.0.0.1:8181/v1/namespaces/default/tables/table_more_deletes	OK
-http://127.0.0.1:8181/v1/namespaces/default/tables/table_more_deletes	OK
-
-query II
-SELECT request.url, response.reason FROM duckdb_logs_parsed('HTTP') WHERE request.type='POST' AND (request.url).starts_with('http://127.0.0.1:8181/v1/') order by timestamp
-----
-http://127.0.0.1:8181/v1/oauth/tokens	OK
 
 query I
 select count(*) from my_datalake.default.pyspark_iceberg_table_v2;


### PR DESCRIPTION
This PR fixes #252 

This PR ended up doing a bunch of clean up to get this working correctly
We do away with the `IRCAPITable` struct, as it wasn't adding any value

The `IRCTableSet` entries are now `IcebergTableInformation`, which now holds the `unique_ptr<ICTableEntry>`, 1 for every schema that the table has.

`LoadEntries` no longer creates a `unique_ptr<ICTableEntry>`, this used to make a dummy, so we had something to return as a "candidate" for error messages, retrieved with `Scan`.
Instead we only create the entries with `FillEntry`, and `Scan` now calls `FillEntry`, to keep the same candidate information.