### PR TITLE
[Dev][Caching] Move the `IRCSchemaSet` to the `IRCTransaction`, so it gets refreshed with every new transaction

### DIFF
--- a/src/catalog_api.cpp
+++ b/src/catalog_api.cpp
@@ -141,18 +141,6 @@ vector<IRCAPISchema> IRCAPI::GetSchemas(ClientContext &context, IRCatalog &catal
 	return result;
 }
 
-IRCAPISchema IRCAPI::CreateSchema(ClientContext &context, IRCatalog &catalog, const string &schema) {
-	throw NotImplementedException("IRCAPI::Create Schema not Implemented");
-}
-
-void IRCAPI::DropSchema(ClientContext &context, const string &schema) {
-	throw NotImplementedException("IRCAPI Drop Schema not Implemented");
-}
-
-void IRCAPI::DropTable(ClientContext &context, IRCatalog &catalog, const string &schema, string &table_name) {
-	throw NotImplementedException("IRCAPI Drop Table not Implemented");
-}
-
 static string json_to_string(yyjson_mut_doc *doc, yyjson_write_flag flags = YYJSON_WRITE_PRETTY) {
 	char *json_chars = yyjson_mut_write(doc, flags, NULL);
 	string json_str(json_chars);

--- a/src/include/catalog_api.hpp
+++ b/src/include/catalog_api.hpp
@@ -27,10 +27,6 @@ public:
 	static rest_api_objects::LoadTableResult GetTable(ClientContext &context, IRCatalog &catalog, const string &schema,
 	                                                  const string &table_name);
 	static vector<IRCAPISchema> GetSchemas(ClientContext &context, IRCatalog &catalog);
-
-	static IRCAPISchema CreateSchema(ClientContext &context, IRCatalog &catalog, const string &schema);
-	static void DropSchema(ClientContext &context, const string &schema);
-	static void DropTable(ClientContext &context, IRCatalog &catalog, const string &schema, string &table_name);
 };
 
 } // namespace duckdb

--- a/src/include/storage/irc_catalog.hpp
+++ b/src/include/storage/irc_catalog.hpp
@@ -88,8 +88,6 @@ public:
 	string prefix;
 
 private:
-	IRCSchemaSet schemas;
-
 	// defaults and overrides provided by a catalog.
 	case_insensitive_map_t<string> defaults;
 	case_insensitive_map_t<string> overrides;

--- a/src/include/storage/irc_schema_set.hpp
+++ b/src/include/storage/irc_schema_set.hpp
@@ -11,11 +11,8 @@ public:
 	explicit IRCSchemaSet(Catalog &catalog);
 
 public:
-	optional_ptr<CatalogEntry> CreateSchema(ClientContext &context, CreateSchemaInfo &info);
-	void DropSchema(ClientContext &context, DropInfo &info);
 	void LoadEntries(ClientContext &context);
 	optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const string &name);
-	void DropEntry(ClientContext &context, DropInfo &info);
 	void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
 
 protected:

--- a/src/include/storage/irc_transaction.hpp
+++ b/src/include/storage/irc_transaction.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "duckdb/transaction/transaction.hpp"
+#include "storage/irc_schema_set.hpp"
 
 namespace duckdb {
 class IRCatalog;
@@ -15,14 +16,20 @@ public:
 	IRCTransaction(IRCatalog &ic_catalog, TransactionManager &manager, ClientContext &context);
 	~IRCTransaction() override;
 
+public:
 	void Start();
 	void Commit();
 	void Rollback();
-
 	static IRCTransaction &Get(ClientContext &context, Catalog &catalog);
 	AccessMode GetAccessMode() const {
 		return access_mode;
 	}
+	IRCSchemaSet &GetSchemas() {
+		return schemas;
+	}
+
+public:
+	IRCSchemaSet schemas;
 
 private:
 	IRCTransactionState transaction_state;

--- a/src/storage/irc_schema_set.cpp
+++ b/src/storage/irc_schema_set.cpp
@@ -29,11 +29,6 @@ void IRCSchemaSet::Scan(ClientContext &context, const std::function<void(Catalog
 	}
 }
 
-void IRCSchemaSet::DropEntry(ClientContext &context, DropInfo &info) {
-	lock_guard<mutex> l(entry_lock);
-	entries.erase(info.name);
-}
-
 void IRCSchemaSet::LoadEntries(ClientContext &context) {
 	if (!entries.empty()) {
 		return;
@@ -58,21 +53,6 @@ optional_ptr<CatalogEntry> IRCSchemaSet::CreateEntryInternal(ClientContext &cont
 	}
 	entries.insert(make_pair(result->name, std::move(entry)));
 	return result;
-}
-
-optional_ptr<CatalogEntry> IRCSchemaSet::CreateSchema(ClientContext &context, CreateSchemaInfo &info) {
-	auto &ic_catalog = catalog.Cast<IRCatalog>();
-	auto schema = IRCAPI::CreateSchema(context, ic_catalog, info.schema);
-	auto schema_entry = make_uniq<IRCSchemaEntry>(catalog, info);
-	schema_entry->schema_data = make_uniq<IRCAPISchema>(schema);
-
-	return CreateEntryInternal(context, std::move(schema_entry));
-}
-
-void IRCSchemaSet::DropSchema(ClientContext &context, DropInfo &info) {
-	auto &ic_catalog = catalog.Cast<IRCatalog>();
-	IRCAPI::DropSchema(context, info.name);
-	DropEntry(context, info);
 }
 
 } // namespace duckdb

--- a/src/storage/irc_transaction.cpp
+++ b/src/storage/irc_transaction.cpp
@@ -7,7 +7,7 @@
 namespace duckdb {
 
 IRCTransaction::IRCTransaction(IRCatalog &ic_catalog, TransactionManager &manager, ClientContext &context)
-    : Transaction(manager, context), access_mode(ic_catalog.access_mode) {
+    : Transaction(manager, context), schemas(ic_catalog), access_mode(ic_catalog.access_mode) {
 	//	connection = ICConnection::Open(ic_catalog.path);
 }
 

--- a/test/sql/local/irc/iceberg_catalog_eager_refresh.test
+++ b/test/sql/local/irc/iceberg_catalog_eager_refresh.test
@@ -1,0 +1,99 @@
+# name: test/sql/local/irc/iceberg_catalog_eager_refresh.test
+# description: test integration with iceberg catalog read
+# group: [irc]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+pragma enable_logging('HTTP');
+
+statement ok
+set logging_level='debug'
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+
+statement ok
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181'
+);
+
+statement ok
+pragma truncate_duckdb_logs;
+
+
+statement ok
+begin transaction
+
+# These happen in the same transaction, so we hit only hit the catalog once
+
+statement ok
+select * from my_datalake.default.table_unpartitioned order by all;
+
+statement ok
+select * from my_datalake.default.table_more_deletes order by all;
+
+query II
+SELECT request.url, response.reason FROM duckdb_logs_parsed('HTTP') WHERE request.type='GET' AND (request.url).starts_with('http://127.0.0.1:8181/v1/') order by timestamp
+----
+http://127.0.0.1:8181/v1/namespaces	OK
+http://127.0.0.1:8181/v1/namespaces/default/tables	OK
+http://127.0.0.1:8181/v1/namespaces/default/tables/table_unpartitioned	OK
+http://127.0.0.1:8181/v1/namespaces/default/tables/table_more_deletes	OK
+
+statement ok
+pragma truncate_duckdb_logs;
+
+statement ok
+select * from my_datalake.default.table_more_deletes order by all;
+
+# No extra logs are created because all the metadata was already cached
+
+query II
+SELECT request.url, response.reason FROM duckdb_logs_parsed('HTTP') WHERE request.type='GET' AND (request.url).starts_with('http://127.0.0.1:8181/v1/') order by timestamp
+----
+
+statement ok
+commit
+
+# Now query the same table twice outside of a transaction
+
+statement ok
+select * from my_datalake.default.table_more_deletes order by all;
+
+statement ok
+select * from my_datalake.default.table_more_deletes order by all;
+
+# The catalog is hit every time, to get a potential refresh of the state of the schemas/tables in it
+
+query II
+SELECT request.url, response.reason FROM duckdb_logs_parsed('HTTP') WHERE request.type='GET' AND (request.url).starts_with('http://127.0.0.1:8181/v1/') order by timestamp
+----
+http://127.0.0.1:8181/v1/namespaces	OK
+http://127.0.0.1:8181/v1/namespaces/default/tables	OK
+http://127.0.0.1:8181/v1/namespaces/default/tables/table_more_deletes	OK
+http://127.0.0.1:8181/v1/namespaces	OK
+http://127.0.0.1:8181/v1/namespaces/default/tables	OK
+http://127.0.0.1:8181/v1/namespaces/default/tables/table_more_deletes	OK

--- a/test/sql/local/irc/iceberg_catalog_read.test
+++ b/test/sql/local/irc/iceberg_catalog_read.test
@@ -85,11 +85,15 @@ select * from my_datalake.default.table_more_deletes order by all;
 2023-03-11	11	k
 2023-03-12	12	l
 
-# Because we loaded the table already, we perform no extra requests here
-
 query II
 SELECT request.url, response.reason FROM duckdb_logs_parsed('HTTP') WHERE request.type='GET' AND (request.url).starts_with('http://127.0.0.1:8181/v1/') order by timestamp
 ----
+http://127.0.0.1:8181/v1/namespaces	OK
+http://127.0.0.1:8181/v1/namespaces/default/tables	OK
+http://127.0.0.1:8181/v1/namespaces/default/tables/table_unpartitioned	OK
+http://127.0.0.1:8181/v1/namespaces	OK
+http://127.0.0.1:8181/v1/namespaces/default/tables	OK
+http://127.0.0.1:8181/v1/namespaces/default/tables/table_more_deletes	OK
 
 query I
 select count(*) from my_datalake.default.pyspark_iceberg_table_v2;


### PR DESCRIPTION
This PR fixes #247 

Previously, the schemas and tables would only hit the REST endpoints once, to get the state of the Catalog at that point in time.
No refresh would ever be made.

This PR changes this behavior to hit the REST endpoints once **per transaction**
We realize this is a little too eager, and we will make further improvements to this to cache existing tables/schemas preventing unnecessary http requests.

But for now we make the choice to value correctness over performance in this case.