### PR TITLE
Use fixed Minio/mc image

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   mc:
     depends_on:
       - minio
-    image: minio/mc
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z-cpuv1
     container_name: mc
     networks:
       iceberg_net:


### PR DESCRIPTION
Seems like there was an update that also changed certain commands. 
This PR will fix the minio/mc container to the version we were using previously that did not cause any errors.