### PR TITLE
Add support for `AUTHORIZATION_TYPE 'none'` (Nessie, Lakekeeper (in no-auth mode))

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(EXTENSION_SOURCES
     src/iceberg_functions/iceberg_scan.cpp
     src/iceberg_functions/iceberg_metadata.cpp
     src/storage/authorization/sigv4.cpp
+    src/storage/authorization/none.cpp
     src/storage/authorization/oauth2.cpp
     src/storage/irc_authorization.cpp
     src/storage/irc_catalog.cpp

--- a/scripts/lakekeeper/auth_type_none/create-demo-warehouse.json
+++ b/scripts/lakekeeper/auth_type_none/create-demo-warehouse.json
@@ -1,0 +1,20 @@
+{
+	"warehouse-name": "demo",
+	"project-id": "00000000-0000-0000-0000-000000000000",
+	"storage-profile": {
+		"type": "s3",
+		"bucket": "demo",
+		"assume-role-arn": null,
+		"endpoint": "http://minio:9000",
+		"region": "local-01",
+		"path-style-access": true,
+		"flavor": "minio",
+		"sts-enabled": true
+	},
+	"storage-credential": {
+		"type": "s3",
+		"credential-type": "access-key",
+		"aws-access-key-id": "minioadmin",
+		"aws-secret-access-key": "minioadmin"
+	}
+}

--- a/scripts/lakekeeper/auth_type_none/docker-compose.yaml
+++ b/scripts/lakekeeper/auth_type_none/docker-compose.yaml
@@ -1,0 +1,131 @@
+services:
+  minio:
+    image: quay.io/minio/minio:RELEASE.2024-05-10T01-41-38Z
+    container_name: minio
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio-data:/data
+
+  create-bucket:
+    image: minio/mc
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+        sleep 5;
+        mc alias set local http://minio:9000 minioadmin minioadmin;
+        mc mb -p local/demo;
+        mc policy set public local/demo;
+        exit 0;
+      "
+
+  postgresql:
+    image: bitnami/postgresql:16.6.0
+    container_name: lakekeeper-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres -p 5432 -d postgres" ]
+      interval: 2s
+      timeout: 10s
+      retries: 2
+      start_period: 10s
+    ports:
+      - "5432:5432"
+
+  catalog-migrate:
+    image: quay.io/lakekeeper/catalog:latest-main
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    command: migrate
+    environment:
+      - LAKEKEEPER__PG_ENCRYPTION_KEY=This-is-NOT-Secure!
+      - LAKEKEEPER__PG_DATABASE_URL_READ=postgresql://postgres:postgres@lakekeeper-postgres:5432/postgres
+      - LAKEKEEPER__PG_DATABASE_URL_WRITE=postgresql://postgres:postgres@lakekeeper-postgres:5432/postgres
+
+  lakekeeper:
+    image: quay.io/lakekeeper/catalog:latest-main
+    container_name: lakekeeper
+    depends_on:
+      create-bucket:
+        condition: service_completed_successfully
+      catalog-migrate:
+        condition: service_completed_successfully
+    ports:
+      - "8181:8181"
+    environment:
+      - LAKEKEEPER__PG_ENCRYPTION_KEY=This-is-NOT-Secure!
+      - LAKEKEEPER__PG_DATABASE_URL_READ=postgresql://postgres:postgres@lakekeeper-postgres:5432/postgres
+      - LAKEKEEPER__PG_DATABASE_URL_WRITE=postgresql://postgres:postgres@lakekeeper-postgres:5432/postgres
+      - LAKEKEEPER_CATALOGS_DEMO_TYPE=iceberg
+      - LAKEKEEPER_CATALOGS_DEMO_WAREHOUSE=s3://demo/
+      - LAKEKEEPER_CATALOGS_DEMO_AUTHORIZATION_TYPE=none
+      - AWS_ACCESS_KEY_ID=minioadmin
+      - AWS_SECRET_ACCESS_KEY=minioadmin
+      - AWS_REGION=us-east-1
+      - RUST_LOG=info
+    command: [ "serve" ]
+    healthcheck:
+      test: [ "CMD", "/home/nonroot/lakekeeper", "healthcheck" ]
+      interval: 1s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  catalog-bootstrap:
+    image: curlimages/curl
+    container_name: lakekeeper-tos
+    depends_on:
+      lakekeeper:
+        condition: service_healthy
+    restart: "no"
+    command:
+      - -w
+      - "%{http_code}"
+      - "-X"
+      - "POST"
+      - "-v"
+      - "http://lakekeeper:8181/management/v1/bootstrap"
+      - "-H"
+      - "Content-Type: application/json"
+      - "--data"
+      - '{"accept-terms-of-use": true}'
+      - "-o"
+      - "/dev/null"
+
+  init-datalakehouse:
+    image: curlimages/curl
+    container_name: lakekeeper-demo-warehouse-init
+    depends_on:
+      lakekeeper:
+        condition: service_healthy
+    restart: "no"
+    command:
+      - -w
+      - "%{http_code}"
+      - "-X"
+      - "POST"
+      - "-v"
+      - "http://lakekeeper:8181/management/v1/warehouse"
+      - "-H"
+      - "Content-Type: application/json"
+      - "--data"
+      - "@create-demo-warehouse.json"
+      - "-o"
+      - "/dev/null"
+      - "--fail-with-body"
+    volumes:
+      - ./create-demo-warehouse.json:/home/curl_user/create-demo-warehouse.json
+
+
+volumes:
+  minio-data:

--- a/scripts/lakekeeper/auth_type_none/populate.py
+++ b/scripts/lakekeeper/auth_type_none/populate.py
@@ -1,0 +1,70 @@
+from pyiceberg.catalog.rest import RestCatalog
+from pyiceberg.schema import Schema
+from pyiceberg.types import NestedField, TimeType, LongType, StringType
+from pyiceberg.partitioning import PartitionField, PartitionSpec
+from pyiceberg.transforms import IdentityTransform
+from pyiceberg.io.pyarrow import PyArrowFileIO
+from pyiceberg.table.snapshots import Snapshot
+from pyiceberg.table.metadata import TableMetadata
+from datetime import time
+import pyarrow as pa
+
+
+# Utility to convert 'HH:MM:SS' into microseconds since midnight
+def to_microseconds(t: time) -> int:
+    return (t.hour * 3600 + t.minute * 60 + t.second) * 1_000_000
+
+
+# Convert string times
+times = ["12:34:56", "08:21:09"]
+micros = [to_microseconds(time.fromisoformat(t)) for t in times]
+user_ids = [12345, 67890]
+event_types = ["click", "purchase"]
+
+# Define schema with non-nullable fields
+schema = pa.schema(
+    [("partition_col", pa.time64("us"), False), ("user_id", pa.int64(), False), ("event_type", pa.string(), False)]
+)
+
+arrays = [
+    pa.array(micros, type=pa.time64("us")),
+    pa.array(user_ids, type=pa.int64()),
+    pa.array(event_types, type=pa.string()),
+]
+
+# Build the RecordBatch using the schema
+record_batch = pa.RecordBatch.from_arrays(arrays, schema=schema)
+
+# Convert to Table
+table_data = pa.Table.from_batches([record_batch])
+
+# Load SQLite-backed local catalog
+catalog = RestCatalog(
+    "my_datalake",
+    **{
+        "uri": "http://localhost:8181/catalog",
+        "warehouse": "demo",
+        "header.X-Iceberg-Access-Delegation": "vended-credentials",
+    },
+)
+
+# Create the namespace if it doesn't exist
+try:
+    catalog.create_namespace("my_namespace")
+except Exception as e:
+    print(f"Note: {e}")  # Print but continue if namespace already exists
+
+schema = Schema(
+    NestedField(1, "partition_col", TimeType(), required=True),
+    NestedField(2, "user_id", LongType(), required=True),
+    NestedField(3, "event_type", StringType(), required=True),
+)
+
+# Create table
+table = catalog.create_table(
+    identifier="my_namespace.my_table",
+    schema=schema,
+)
+
+# Write records
+table.append(table_data)

--- a/src/common/api_utils.cpp
+++ b/src/common/api_utils.cpp
@@ -79,7 +79,9 @@ unique_ptr<HTTPResponse> APIUtils::GetRequest(ClientContext &context, const IRCE
 
 	HTTPHeaders headers(db);
 	headers.Insert("X-Iceberg-Access-Delegation", "vended-credentials");
-	headers.Insert("Authorization", StringUtil::Format("Bearer %s", token));
+	if (!token.empty()) {
+		headers.Insert("Authorization", StringUtil::Format("Bearer %s", token));
+	}
 
 	auto &http_util = HTTPUtil::Get(db);
 	unique_ptr<HTTPParams> params;

--- a/src/include/storage/authorization/none.hpp
+++ b/src/include/storage/authorization/none.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "storage/irc_authorization.hpp"
+
+namespace duckdb {
+
+class NoneAuthorization : public IRCAuthorization {
+public:
+	static constexpr const IRCAuthorizationType TYPE = IRCAuthorizationType::NONE;
+
+public:
+	NoneAuthorization();
+
+public:
+	static unique_ptr<IRCAuthorization> FromAttachOptions(IcebergAttachOptions &input);
+	unique_ptr<HTTPResponse> GetRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder) override;
+};
+
+} // namespace duckdb

--- a/src/include/storage/irc_authorization.hpp
+++ b/src/include/storage/irc_authorization.hpp
@@ -7,7 +7,7 @@
 
 namespace duckdb {
 
-enum class IRCAuthorizationType : uint8_t { OAUTH2, SIGV4, INVALID };
+enum class IRCAuthorizationType : uint8_t { OAUTH2, SIGV4, NONE, INVALID };
 
 struct IcebergAttachOptions {
 	string endpoint;

--- a/src/storage/authorization/none.cpp
+++ b/src/storage/authorization/none.cpp
@@ -1,0 +1,20 @@
+#include "storage/authorization/none.hpp"
+#include "api_utils.hpp"
+#include "storage/irc_catalog.hpp"
+
+namespace duckdb {
+
+NoneAuthorization::NoneAuthorization() : IRCAuthorization(IRCAuthorizationType::NONE) {
+}
+
+unique_ptr<IRCAuthorization> NoneAuthorization::FromAttachOptions(IcebergAttachOptions &input) {
+	auto result = make_uniq<NoneAuthorization>();
+	return result;
+}
+
+unique_ptr<HTTPResponse> NoneAuthorization::GetRequest(ClientContext &context,
+                                                       const IRCEndpointBuilder &endpoint_builder) {
+	return APIUtils::GetRequest(context, endpoint_builder, "");
+}
+
+} // namespace duckdb

--- a/src/storage/irc_authorization.cpp
+++ b/src/storage/irc_authorization.cpp
@@ -6,7 +6,8 @@ namespace duckdb {
 
 IRCAuthorizationType IRCAuthorization::TypeFromString(const string &type) {
 	static const case_insensitive_map_t<IRCAuthorizationType> mapping {{"oauth2", IRCAuthorizationType::OAUTH2},
-	                                                                   {"sigv4", IRCAuthorizationType::SIGV4}};
+	                                                                   {"sigv4", IRCAuthorizationType::SIGV4},
+	                                                                   {"none", IRCAuthorizationType::NONE}};
 
 	for (auto it : mapping) {
 		if (StringUtil::CIEquals(it.first, type)) {

--- a/src/storage/irc_catalog.cpp
+++ b/src/storage/irc_catalog.cpp
@@ -17,6 +17,7 @@
 #include "storage/irc_authorization.hpp"
 #include "storage/authorization/oauth2.hpp"
 #include "storage/authorization/sigv4.hpp"
+#include "storage/authorization/none.hpp"
 
 using namespace duckdb_yyjson;
 
@@ -408,6 +409,10 @@ unique_ptr<Catalog> IRCatalog::Attach(StorageExtensionInfo *storage_info, Client
 	}
 	case IRCAuthorizationType::SIGV4: {
 		auth_handler = SIGV4Authorization::FromAttachOptions(attach_options);
+		break;
+	}
+	case IRCAuthorizationType::NONE: {
+		auth_handler = NoneAuthorization::FromAttachOptions(attach_options);
 		break;
 	}
 	default:

--- a/test/sql/local/irc/errors/wrong_authorization_type.test
+++ b/test/sql/local/irc/errors/wrong_authorization_type.test
@@ -18,4 +18,4 @@ attach '' as my_datalake (
 	AUTHORIZATION_TYPE 'test'
 )
 ----
-Invalid Configuration Error: 'authorization_type' 'test' is not supported, valid options are: oauth2, sigv4
+Invalid Configuration Error: 'authorization_type' 'test' is not supported

--- a/test/sql/local/irc/test_lakekeeper_none.test
+++ b/test/sql/local/irc/test_lakekeeper_none.test
@@ -1,0 +1,31 @@
+# name: test/sql/local/irc/test_lakekeeper_none.test
+# group: [irc]
+
+# This test just serves as an example, see scripts/auth_type_none for a way to create a suitable environment
+mode skip
+
+require httpfs
+
+require avro
+
+require parquet
+
+require iceberg
+
+require-env LAKEKEEPER_SERVER_AVAILABLE
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+attach 'demo' as my_datalake (
+	type ICEBERG,
+	ENDPOINT 'http://localhost:8181/catalog',
+	AUTHORIZATION_TYPE 'none'
+);
+
+query III
+select * from my_datalake.my_namespace.my_table;
+----
+12:34:56	12345	click
+08:21:09	67890	purchase


### PR DESCRIPTION
This PR adds the ability to connect to Lakekeeper with `LAKEKEEPER_CATALOGS_DEMO_AUTHORIZATION_TYPE=none`

Thanks to https://github.com/duckdb/duckdb/discussions/17813 for motivating and providing a working reproducer.
As a side effect of working on this, I discovered that this connection is already possible on `main` (I think v1.3.0 release as well) using:
```sql
attach 'demo' as my_datalake (
	type ICEBERG,
	ENDPOINT 'http://localhost:8181/catalog',
	TOKEN ''
);
```

By supplying the TOKEN, we won't try to hit any authorization server, the only functional difference is that with this branch we won't send a Bearer token with the request, whereas on `main` we do send a Bearer token, but that should be ignored anyways if the authorization type is None on the Catalog server.