### PR TITLE
fix: Lakekeeper CI test

### DIFF
--- a/.github/workflows/LakekeeperTesting.yml
+++ b/.github/workflows/LakekeeperTesting.yml
@@ -14,7 +14,6 @@ jobs:
   rest:
     name: Test against Lakekeeper Catalog
     runs-on: ubuntu-latest
-    if: false # disabled until lakekeeper setup process is more stable
     env:
       VCPKG_TARGET_TRIPLET: 'x64-linux-release'
       GEN: ninja
@@ -79,10 +78,6 @@ jobs:
 
       - name: Set up for Lakekeeper
         run: |
-          # install java
-          # TODO: need a newer java version maybe?
-          sudo apt install -y -qq openjdk-21-jre-headless
-          sudo apt install -y -qq openjdk-21-jdk-headless
           sudo apt-get install -y -qq python3-venv
           git clone https://github.com/lakekeeper/lakekeeper.git lakekeeper
 
@@ -137,43 +132,6 @@ jobs:
           done
           echo "PostgreSQL is healthy"
 
-      - name: Run OpenFGA DB migrations
-        run: |
-          docker run --rm \
-            --network="host" \
-            -e OPENFGA_DATASTORE_ENGINE=postgres \
-            -e OPENFGA_DATASTORE_URI="postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable" \
-            openfga/openfga:v1.8 migrate
-
-      - name: Start OpenFGA
-        run: |
-          docker run -d \
-            --name openfga \
-            -p 8081:8081 \
-            -e OPENFGA_DATASTORE_ENGINE=postgres \
-            -e OPENFGA_DATASTORE_URI="postgres://postgres:postgres@localhost:5433/postgres?sslmode=disable" \
-            -e OPENFGA_AUTHN_METHOD=oidc \
-            -e OPENFGA_AUTHN_OIDC_ISSUER=http://localhost:30080/realms/iceberg \
-            -e OPENFGA_AUTHN_OIDC_AUDIENCE=openfga \
-            -e OPENFGA_HTTP_TLS_ENABLED=false \
-            --network="host" \
-            openfga/openfga:v1.8 run --playground-enabled=false
-
-      - name: Wait for OpenFGA
-        run: |
-          max_attempts=30
-          attempt=1
-          while ! curl -sf http://localhost:8080/healthz; do
-            if [ $attempt -gt $max_attempts ]; then
-              echo "OpenFGA failed to initialize after $max_attempts attempts"
-              exit 1
-            fi
-            echo "Waiting for OpenFGA to initialize (attempt $attempt/$max_attempts)..."
-            sleep 5
-            attempt=$((attempt + 1))
-          done
-          echo "OpenFGA is healthy"
-
       - name: Start Minio
         run: |
           docker run -d \
@@ -216,11 +174,6 @@ jobs:
             -e LAKEKEEPER__PG_ENCRYPTION_KEY=This-is-NOT-Secure! \
             -e LAKEKEEPER__PG_DATABASE_URL_READ=postgresql://postgres:postgres@localhost:5433/postgres?sslmode=disable \
             -e LAKEKEEPER__PG_DATABASE_URL_WRITE=postgresql://postgres:postgres@localhost:5433/postgres?sslmode=disable \
-            -e LAKEKEEPER__AUTHZ_BACKEND=openfga \
-            -e LAKEKEEPER__OPENFGA__ENDPOINT=http://localhost:8081 \
-            -e LAKEKEEPER__OPENFGA__CLIENT_ID=openfga \
-            -e LAKEKEEPER__OPENFGA__CLIENT_SECRET=xqE1vUrifVDKAZdLuz6JAnDxMYLdGu5z \
-            -e LAKEKEEPER__OPENFGA__TOKEN_ENDPOINT=http://localhost:30080/realms/iceberg/protocol/openid-connect/token \
             -e RUST_LOG=info,iceberg-catalog=info,middle=trace \
             quay.io/lakekeeper/catalog:latest-main migrate
 
@@ -236,9 +189,6 @@ jobs:
             -e LAKEKEEPER__OPENFGA__ENDPOINT=http://localhost:8081 \
             -e LAKEKEEPER__OPENID_PROVIDER_URI=http://localhost:30080/realms/iceberg \
             -e LAKEKEEPER__OPENID_AUDIENCE=lakekeeper \
-            -e LAKEKEEPER__OPENFGA__CLIENT_ID=openfga \
-            -e LAKEKEEPER__OPENFGA__CLIENT_SECRET=xqE1vUrifVDKAZdLuz6JAnDxMYLdGu5z \
-            -e LAKEKEEPER__OPENFGA__TOKEN_ENDPOINT=http://localhost:30080/realms/iceberg/protocol/openid-connect/token \
             -e LAKEKEEPER__METRICS_PORT=9002 \
             quay.io/lakekeeper/catalog serve
 
@@ -246,7 +196,7 @@ jobs:
         run: |
           max_attempts=30
           attempt=1
-          while ! docker exec lakekeeper /home/nonroot/iceberg-catalog healthcheck; do
+          while ! docker exec lakekeeper /home/nonroot/lakekeeper healthcheck; do
             if [ $attempt -gt $max_attempts ]; then
               echo "Lakekeeper failed to initialize after $max_attempts attempts"
               exit 1
@@ -278,4 +228,3 @@ jobs:
         run: |
           ./build/release/test/unittest "$PWD/test/*" --list-test-names-only || true
           ./build/release/test/unittest "$PWD/test/*"
-

--- a/scripts/lakekeeper/setup_lakekeeper_catalog.py
+++ b/scripts/lakekeeper/setup_lakekeeper_catalog.py
@@ -33,7 +33,6 @@ access_token = response.json()['access_token']
 print(access_token)
 
 # Check the 'info' endpoint of the Lakekeeper management API
-
 response = requests.get(
     url=f"{MANAGEMENT_URL}/v1/info",
     headers={"Authorization": f"Bearer {access_token}"},
@@ -42,47 +41,16 @@ response.raise_for_status()
 print(response.json())
 
 # Bootstrap
-
 response = requests.post(
     url=f"{MANAGEMENT_URL}/v1/bootstrap",
     headers={"Authorization": f"Bearer {access_token}"},
     json={
         "accept-terms-of-use": True,
-        # Optionally, we can override the name / type of the user:
-        # "user-email": "user@example.com",
-        # "user-name": "Roald Amundsen",
-        # "user-type": "human"
     },
 )
 response.raise_for_status()
 
-# Create a new user
-
-response = requests.post(
-    url=f"{MANAGEMENT_URL}/v1/permissions/server/assignments",
-    headers={"Authorization": f"Bearer {access_token}"},
-    json={"writes": [{"type": "admin", "user": "oidc~cfb55bf6-fcbb-4a1e-bfec-30c6649b52f8"}]},
-)
-response.raise_for_status()
-
-response = requests.post(
-    url=f"{MANAGEMENT_URL}/v1/permissions/project/assignments",
-    headers={"Authorization": f"Bearer {access_token}"},
-    json={"writes": [{"type": "project_admin", "user": "oidc~cfb55bf6-fcbb-4a1e-bfec-30c6649b52f8"}]},
-)
-response.raise_for_status()
-
-# Check the users, should have a result
-
-response = requests.get(
-    url=f"{MANAGEMENT_URL}/v1/user",
-    headers={"Authorization": f"Bearer {access_token}"},
-)
-response.raise_for_status()
-print(response.json())
-
 # Create a warehouse
-
 response = requests.post(
     url=f"{MANAGEMENT_URL}/v1/warehouse",
     headers={"Authorization": f"Bearer {access_token}"},
@@ -110,7 +78,6 @@ response.raise_for_status()
 print(response.json())
 
 # Populate the warehouse with Spark
-
 conf = {
     "spark.jars.packages": f"org.apache.iceberg:iceberg-spark-runtime-{SPARK_MINOR_VERSION}_2.12:{ICEBERG_VERSION},org.apache.iceberg:iceberg-aws-bundle:{ICEBERG_VERSION}",
     "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",


### PR DESCRIPTION
Dear DuckDB Team, Author of Lakekeeper here.
I am working on fixing the integration tests in this PR. The original problem was that we renamed our binary from `iceberg-catalog` to `lakekeeper` - and the name of the binary was used excplictly in the health probe.
While on it, I am also removing OpenFGA because I don't think there is a good reason for it here. Also Keycloak is optional, but as all other tests are without IdP, I thought it is probably good to keep some tests with Authentication.

I want to get the tests back running with this PR, then follow up in the next weeks with a second PR, moving to a docker compose setup that requires much less manual effort to get running.