### PR TITLE
[Dev] Map to result `Vector` by Avro `field_id` when scanning manifest files / manifest lists

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -4,7 +4,7 @@ duckdb_extension_load(icu)
 duckdb_extension_load(avro
         LOAD_TESTS
         GIT_URL https://github.com/duckdb/duckdb_avro
-        GIT_TAG b5cc586b440bd14a7acdeeecfa158d5b0e16f423
+        GIT_TAG 01ee30bacdf7bac05b98b6a26f01c92eee17c8a7
 )
 
 # Extension from this repo

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -4,7 +4,7 @@ duckdb_extension_load(icu)
 duckdb_extension_load(avro
         LOAD_TESTS
         GIT_URL https://github.com/duckdb/duckdb_avro
-        GIT_TAG 01ee30bacdf7bac05b98b6a26f01c92eee17c8a7
+        GIT_TAG 141c70afa871d437bfdc689b826baf55409b1f72
 )
 
 # Extension from this repo

--- a/src/common/iceberg.cpp
+++ b/src/common/iceberg.cpp
@@ -18,7 +18,7 @@ unique_ptr<IcebergTable> IcebergTable::Load(const string &iceberg_path, const Ic
 	auto ret = make_uniq<IcebergTable>(snapshot);
 	ret->path = iceberg_path;
 
-	auto manifest_file_reader = make_uniq<ManifestFileReader>(metadata.iceberg_version, false);
+	auto manifest_file_reader = make_uniq<manifest_file::ManifestFileReader>(metadata.iceberg_version, false);
 
 	auto &fs = FileSystem::GetFileSystem(context);
 	auto manifest_list_full_path = options.allow_moved_paths
@@ -27,7 +27,7 @@ unique_ptr<IcebergTable> IcebergTable::Load(const string &iceberg_path, const Ic
 	IcebergManifestList manifest_list(manifest_list_full_path);
 
 	//! Read the manifest list
-	auto manifest_list_reader = make_uniq<ManifestListReader>(metadata.iceberg_version);
+	auto manifest_list_reader = make_uniq<manifest_list::ManifestListReader>(metadata.iceberg_version);
 	auto scan = make_uniq<AvroScan>("IcebergManifestList", context, manifest_list_full_path);
 	manifest_list_reader->Initialize(std::move(scan));
 	while (!manifest_list_reader->Finished()) {

--- a/src/iceberg_functions/iceberg_multi_file_list.cpp
+++ b/src/iceberg_functions/iceberg_multi_file_list.cpp
@@ -483,8 +483,8 @@ void IcebergMultiFileList::InitializeFiles(lock_guard<mutex> &guard) {
 	auto &metadata = GetMetadata();
 	auto &fs = FileSystem::GetFileSystem(context);
 
-	data_manifest_reader = make_uniq<ManifestFileReader>(metadata.iceberg_version);
-	delete_manifest_reader = make_uniq<ManifestFileReader>(metadata.iceberg_version);
+	data_manifest_reader = make_uniq<manifest_file::ManifestFileReader>(metadata.iceberg_version);
+	delete_manifest_reader = make_uniq<manifest_file::ManifestFileReader>(metadata.iceberg_version);
 
 	// Read the manifest list, we need all the manifests to determine if we've seen all deletes
 	auto manifest_list_full_path = options.allow_moved_paths
@@ -494,7 +494,7 @@ void IcebergMultiFileList::InitializeFiles(lock_guard<mutex> &guard) {
 	IcebergManifestList manifest_list(manifest_list_full_path);
 
 	//! Read the manifest list
-	auto manifest_list_reader = make_uniq<ManifestListReader>(metadata.iceberg_version);
+	auto manifest_list_reader = make_uniq<manifest_list::ManifestListReader>(metadata.iceberg_version);
 	auto scan = make_uniq<AvroScan>("IcebergManifestList", context, manifest_list_full_path);
 	manifest_list_reader->Initialize(std::move(scan));
 	while (!manifest_list_reader->Finished()) {

--- a/src/include/iceberg_multi_file_list.hpp
+++ b/src/include/iceberg_multi_file_list.hpp
@@ -156,8 +156,8 @@ public:
 	vector<LogicalType> types;
 	TableFilterSet table_filters;
 
-	unique_ptr<ManifestFileReader> data_manifest_reader;
-	unique_ptr<ManifestFileReader> delete_manifest_reader;
+	unique_ptr<manifest_file::ManifestFileReader> data_manifest_reader;
+	unique_ptr<manifest_file::ManifestFileReader> delete_manifest_reader;
 
 	vector<IcebergManifestEntry> data_files;
 	vector<IcebergManifest> data_manifests;

--- a/src/include/manifest_reader.hpp
+++ b/src/include/manifest_reader.hpp
@@ -41,30 +41,32 @@ protected:
 	bool finished = true;
 };
 
+namespace manifest_list {
+
+static constexpr const int32_t MANIFEST_PATH = 500;
+static constexpr const int32_t MANIFEST_LENGTH = 501;
+static constexpr const int32_t PARTITION_SPEC_ID = 502;
+static constexpr const int32_t CONTENT = 517;
+static constexpr const int32_t SEQUENCE_NUMBER = 515;
+static constexpr const int32_t MIN_SEQUENCE_NUMBER = 516;
+static constexpr const int32_t ADDED_SNAPSHOT_ID = 503;
+static constexpr const int32_t ADDED_FILES_COUNT = 504;
+static constexpr const int32_t EXISTING_FILES_COUNT = 505;
+static constexpr const int32_t DELETED_FILES_COUNT = 506;
+static constexpr const int32_t ADDED_ROWS_COUNT = 512;
+static constexpr const int32_t EXISTING_ROWS_COUNT = 513;
+static constexpr const int32_t DELETED_ROWS_COUNT = 514;
+static constexpr const int32_t PARTITIONS = 507;
+static constexpr const int32_t PARTITIONS_ELEMENT = 508;
+static constexpr const int32_t FIELD_SUMMARY_CONTAINS_NULL = 509;
+static constexpr const int32_t FIELD_SUMMARY_CONTAINS_NAN = 518;
+static constexpr const int32_t FIELD_SUMMARY_LOWER_BOUND = 510;
+static constexpr const int32_t FIELD_SUMMARY_UPPER_BOUND = 511;
+static constexpr const int32_t KEY_METADATA = 519;
+static constexpr const int32_t FIRST_ROW_ID = 520;
+
 //! Produces IcebergManifests read, from the 'manifest_list'
 class ManifestListReader : public BaseManifestReader {
-	static constexpr int32_t MANIFEST_PATH = 500;
-	static constexpr int32_t MANIFEST_LENGTH = 501;
-	static constexpr int32_t PARTITION_SPEC_ID = 502;
-	static constexpr int32_t CONTENT = 517;
-	static constexpr int32_t SEQUENCE_NUMBER = 515;
-	static constexpr int32_t MIN_SEQUENCE_NUMBER = 516;
-	static constexpr int32_t ADDED_SNAPSHOT_ID = 503;
-	static constexpr int32_t ADDED_FILES_COUNT = 504;
-	static constexpr int32_t EXISTING_FILES_COUNT = 505;
-	static constexpr int32_t DELETED_FILES_COUNT = 506;
-	static constexpr int32_t ADDED_ROWS_COUNT = 512;
-	static constexpr int32_t EXISTING_ROWS_COUNT = 513;
-	static constexpr int32_t DELETED_ROWS_COUNT = 514;
-	static constexpr int32_t PARTITIONS = 507;
-	static constexpr int32_t PARTITIONS_ELEMENT = 508;
-	static constexpr int32_t FIELD_SUMMARY_CONTAINS_NULL = 509;
-	static constexpr int32_t FIELD_SUMMARY_CONTAINS_NAN = 518;
-	static constexpr int32_t FIELD_SUMMARY_LOWER_BOUND = 510;
-	static constexpr int32_t FIELD_SUMMARY_UPPER_BOUND = 511;
-	static constexpr int32_t KEY_METADATA = 519;
-	static constexpr int32_t FIRST_ROW_ID = 520;
-
 public:
 	ManifestListReader(idx_t iceberg_version);
 	~ManifestListReader() override {
@@ -79,53 +81,57 @@ private:
 	idx_t ReadChunk(idx_t offset, idx_t count, vector<IcebergManifest> &result);
 };
 
+} // namespace manifest_list
+
+namespace manifest_file {
+
+static constexpr const int32_t STATUS = 0;
+static constexpr const int32_t SNAPSHOT_ID = 1;
+static constexpr const int32_t SEQUENCE_NUMBER = 3;
+static constexpr const int32_t FILE_SEQUENCE_NUMBER = 4;
+static constexpr const int32_t DATA_FILE = 2;
+static constexpr const int32_t CONTENT = 134;
+static constexpr const int32_t FILE_PATH = 100;
+static constexpr const int32_t FILE_FORMAT = 101;
+static constexpr const int32_t PARTITION = 102;
+static constexpr const int32_t RECORD_COUNT = 103;
+static constexpr const int32_t FILE_SIZE_IN_BYTES = 104;
+// static constexpr const int32_t BLOCK_SIZE_IN_BYTES = 105; // (deprecated)
+// static constexpr const int32_t FILE_ORDINAL = 106; // (deprecated)
+// static constexpr const int32_t SORT_COLUMNS = 107; // (deprecated)
+// static constexpr const int32_t SORT_COLUMNS_ELEMENT = 112; // (deprecated)
+static constexpr const int32_t COLUMN_SIZES = 108;
+static constexpr const int32_t COLUMN_SIZES_KEY = 117;
+static constexpr const int32_t COLUMN_SIZES_VALUE = 118;
+static constexpr const int32_t VALUE_COUNTS = 109;
+static constexpr const int32_t VALUE_COUNTS_KEY = 119;
+static constexpr const int32_t VALUE_COUNTS_VALUE = 120;
+static constexpr const int32_t NULL_VALUE_COUNTS = 110;
+static constexpr const int32_t NULL_VALUE_COUNTS_KEY = 121;
+static constexpr const int32_t NULL_VALUE_COUNTS_VALUE = 122;
+static constexpr const int32_t NAN_VALUE_COUNTS = 137;
+static constexpr const int32_t NAN_VALUE_COUNTS_KEY = 138;
+static constexpr const int32_t NAN_VALUE_COUNTS_VALUE = 139;
+// static constexpr const int32_t DISTINCT_COUNTS = 111; // (deprecated)
+static constexpr const int32_t LOWER_BOUNDS = 125;
+static constexpr const int32_t LOWER_BOUNDS_KEY = 126;
+static constexpr const int32_t LOWER_BOUNDS_VALUE = 127;
+static constexpr const int32_t UPPER_BOUNDS = 128;
+static constexpr const int32_t UPPER_BOUNDS_KEY = 129;
+static constexpr const int32_t UPPER_BOUNDS_VALUE = 130;
+// static constexpr const int32_t KEY_METADATA = 131; // (optional)
+static constexpr const int32_t SPLIT_OFFSETS = 132;
+static constexpr const int32_t SPLIT_OFFSETS_ELEMENT = 133;
+static constexpr const int32_t EQUALITY_IDS = 135;
+static constexpr const int32_t EQUALITY_IDS_ELEMENT = 136;
+static constexpr const int32_t SORT_ORDER_ID = 140;
+static constexpr const int32_t FIRST_ROW_ID = 142;
+static constexpr const int32_t REFERENCED_DATA_FILE = 143;
+static constexpr const int32_t CONTENT_OFFSET = 144;
+static constexpr const int32_t CONTENT_SIZE_IN_BYTES = 145;
+
 //! Produces IcebergManifestEntries read, from the 'manifest_file'
 class ManifestFileReader : public BaseManifestReader {
-	static constexpr int32_t STATUS = 0;
-	static constexpr int32_t SNAPSHOT_ID = 1;
-	static constexpr int32_t SEQUENCE_NUMBER = 3;
-	static constexpr int32_t FILE_SEQUENCE_NUMBER = 4;
-	static constexpr int32_t DATA_FILE = 2;
-	static constexpr int32_t CONTENT = 134;
-	static constexpr int32_t FILE_PATH = 100;
-	static constexpr int32_t FILE_FORMAT = 101;
-	static constexpr int32_t PARTITION = 102;
-	static constexpr int32_t RECORD_COUNT = 103;
-	static constexpr int32_t FILE_SIZE_IN_BYTES = 104;
-	// static constexpr int32_t BLOCK_SIZE_IN_BYTES = 105; // (deprecated)
-	// static constexpr int32_t FILE_ORDINAL = 106; // (deprecated)
-	// static constexpr int32_t SORT_COLUMNS = 107; // (deprecated)
-	// static constexpr int32_t SORT_COLUMNS_ELEMENT = 112; // (deprecated)
-	static constexpr int32_t COLUMN_SIZES = 108;
-	static constexpr int32_t COLUMN_SIZES_KEY = 117;
-	static constexpr int32_t COLUMN_SIZES_VALUE = 118;
-	static constexpr int32_t VALUE_COUNTS = 109;
-	static constexpr int32_t VALUE_COUNTS_KEY = 119;
-	static constexpr int32_t VALUE_COUNTS_VALUE = 120;
-	static constexpr int32_t NULL_VALUE_COUNTS = 110;
-	static constexpr int32_t NULL_VALUE_COUNTS_KEY = 121;
-	static constexpr int32_t NULL_VALUE_COUNTS_VALUE = 122;
-	static constexpr int32_t NAN_VALUE_COUNTS = 137;
-	static constexpr int32_t NAN_VALUE_COUNTS_KEY = 138;
-	static constexpr int32_t NAN_VALUE_COUNTS_VALUE = 139;
-	// static constexpr int32_t DISTINCT_COUNTS = 111; // (deprecated)
-	static constexpr int32_t LOWER_BOUNDS = 125;
-	static constexpr int32_t LOWER_BOUNDS_KEY = 126;
-	static constexpr int32_t LOWER_BOUNDS_VALUE = 127;
-	static constexpr int32_t UPPER_BOUNDS = 128;
-	static constexpr int32_t UPPER_BOUNDS_KEY = 129;
-	static constexpr int32_t UPPER_BOUNDS_VALUE = 130;
-	// static constexpr int32_t KEY_METADATA = 131; // (optional)
-	static constexpr int32_t SPLIT_OFFSETS = 132;
-	static constexpr int32_t SPLIT_OFFSETS_ELEMENT = 133;
-	static constexpr int32_t EQUALITY_IDS = 135;
-	static constexpr int32_t EQUALITY_IDS_ELEMENT = 136;
-	static constexpr int32_t SORT_ORDER_ID = 140;
-	static constexpr int32_t FIRST_ROW_ID = 142;
-	static constexpr int32_t REFERENCED_DATA_FILE = 143;
-	static constexpr int32_t CONTENT_OFFSET = 144;
-	static constexpr int32_t CONTENT_SIZE_IN_BYTES = 145;
-
 public:
 	ManifestFileReader(idx_t iceberg_version, bool skip_deleted = true);
 	~ManifestFileReader() override {
@@ -151,5 +157,7 @@ public:
 	//! Whether the deleted entries should be skipped outright
 	bool skip_deleted = false;
 };
+
+} // namespace manifest_file
 
 } // namespace duckdb

--- a/src/manifest_file_reader.cpp
+++ b/src/manifest_file_reader.cpp
@@ -2,6 +2,8 @@
 
 namespace duckdb {
 
+namespace manifest_file {
+
 ManifestFileReader::ManifestFileReader(idx_t iceberg_version, bool skip_deleted)
     : BaseManifestReader(iceberg_version), skip_deleted(skip_deleted) {
 }
@@ -269,5 +271,7 @@ idx_t ManifestFileReader::ReadChunk(idx_t offset, idx_t count, vector<IcebergMan
 	}
 	return produced;
 }
+
+} // namespace manifest_file
 
 } // namespace duckdb

--- a/src/manifest_file_reader.cpp
+++ b/src/manifest_file_reader.cpp
@@ -36,7 +36,10 @@ idx_t ManifestFileReader::Read(idx_t count, vector<IcebergManifestEntry> &result
 }
 
 void ManifestFileReader::CreateVectorMapping(idx_t column_id, MultiFileColumnDefinition &column) {
-	D_ASSERT(!column.identifier.IsNull() && column.identifier.type().id() == LogicalTypeId::INTEGER);
+	if (column.identifier.IsNull()) {
+		throw InvalidConfigurationException("Column '%s' of the manifest list is missing a field_id!", column.name);
+	}
+	D_ASSERT(column.identifier.type().id() == LogicalTypeId::INTEGER);
 
 	auto field_id = column.identifier.GetValue<int32_t>();
 	if (field_id != DATA_FILE) {

--- a/src/manifest_list_reader.cpp
+++ b/src/manifest_list_reader.cpp
@@ -155,7 +155,10 @@ bool ManifestListReader::ValidateVectorMapping() {
 }
 
 void ManifestListReader::CreateVectorMapping(idx_t column_id, MultiFileColumnDefinition &column) {
-	D_ASSERT(!column.identifier.IsNull() && column.identifier.type().id() == LogicalTypeId::INTEGER);
+	if (column.identifier.IsNull()) {
+		throw InvalidConfigurationException("Column '%s' of the manifest list is missing a field_id!", column.name);
+	}
+	D_ASSERT(column.identifier.type().id() == LogicalTypeId::INTEGER);
 
 	auto field_id = column.identifier.GetValue<int32_t>();
 	if (field_id != PARTITIONS) {

--- a/test/sql/local/iceberg_scans/big_query_read.test
+++ b/test/sql/local/iceberg_scans/big_query_read.test
@@ -7,6 +7,14 @@ require iceberg
 
 require avro
 
+statement error
+select * from iceberg_scan('data/persistent/big_query_error');
+----
+Invalid Configuration Error: Column 'added_files_count' of the manifest list is missing a field_id!
+
+# The produced avro files are malformed, field ids are not optional
+mode skip
+
 query III
 select * from iceberg_scan('data/persistent/big_query_error');
 ----


### PR DESCRIPTION
This PR changes the mapping logic from being name-based, to being field_id-based instead.

Note that this makes the test added by <https://github.com/duckdb/duckdb-iceberg/pull/295> error, because the Avro files are created without field ids.

The motivation for this PR was discovering that (some of) our tests uses the name `added_data_files_count` instead of `added_files_count` in the created avro files, but it does have the correct field id.
