### PR TITLE
[Dev][OAuth2] Use the `Authorization` header instead of embedding the client_id+client_secret in the POST body.

### DIFF
--- a/src/common/api_utils.cpp
+++ b/src/common/api_utils.cpp
@@ -49,6 +49,7 @@ unique_ptr<HTTPResponse> APIUtils::DeleteRequest(ClientContext &context, const s
 }
 
 unique_ptr<HTTPResponse> APIUtils::PostRequest(ClientContext &context, const string &url, const string &post_data,
+                                               const unordered_map<string, string> &additional_headers,
                                                const string &content_type, const string &token) {
 	auto &db = DatabaseInstance::GetDatabase(context);
 
@@ -57,6 +58,9 @@ unique_ptr<HTTPResponse> APIUtils::PostRequest(ClientContext &context, const str
 	HTTPHeaders headers(db);
 	headers.Insert("X-Iceberg-Access-Delegation", "vended-credentials");
 	headers.Insert("Content-Type", StringUtil::Format("application/%s", content_type));
+	for (auto it : additional_headers) {
+		headers.Insert(it.first, it.second);
+	}
 	if (!token.empty()) {
 		headers.Insert("Authorization", StringUtil::Format("Bearer %s", token));
 	}

--- a/src/include/api_utils.hpp
+++ b/src/include/api_utils.hpp
@@ -37,6 +37,7 @@ public:
 	                                           const string &token = "");
 	static unique_ptr<HTTPResponse> DeleteRequest(ClientContext &context, const string &url, const string &token = "");
 	static unique_ptr<HTTPResponse> PostRequest(ClientContext &context, const string &url, const string &post_data,
+	                                            const unordered_map<string, string> &additional_headers,
 	                                            const string &content_type = "x-www-form-urlencoded",
 	                                            const string &token = "");
 	//! We use a singleton here to store the path, set by SelectCurlCertPath


### PR DESCRIPTION
This PR likely fixes #300 

From https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1:
> The authorization server MUST support the HTTP Basic
   authentication scheme for authenticating clients that were issued a
   client password.

