### PR TITLE
Fixup CI for PRs vs wasm branch

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   duckdb-stable-build:
+    if: ${{ github.ref != 'refs/heads/wasm' && github.base_ref != 'refs/heads/wasm' }}
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.3.0
     with:
@@ -36,14 +37,14 @@ jobs:
       deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
 
   duckdb-wasm-build:
-    if: ${{ github.ref == 'refs/heads/wasm' }}
+    if: ${{ github.ref == 'refs/heads/wasm' || github.base_ref == 'refs/heads/wasm' }}
     name: Build extension binaries for duckdb-wasm (experimental)
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: iceberg
       duckdb_version: v1.3.1
       ci_tools_version: main
-      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;linux_amd64_gcc4;linux_amd64;linux_arm64;osx_arm64;osx_amd64;windows_amd64'
+      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl;linux_amd64;linux_arm64;osx_arm64;osx_amd64;windows_amd64'
       extra_toolchains: 'python3'
 
   duckdb-wasm-deploy:
@@ -55,6 +56,6 @@ jobs:
       extension_name: iceberg
       duckdb_version: v1.3.1
       ci_tools_version: main
-      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;linux_amd64_gcc4;linux_amd64;linux_arm64;osx_arm64;osx_amd64;windows_amd64'
+      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl;linux_amd64;linux_arm64;osx_arm64;osx_amd64;windows_amd64'
       deploy_latest: ${{ github.ref == 'refs/heads/wasm' }}
       deploy_versioned: ${{ github.ref == 'refs/heads/wasm' }}


### PR DESCRIPTION
Actually this was problematic since linux_arm64_musl was built twice (instead of the needed 0 times)