### PR TITLE
Move and don't copy Functions, something is off with ExtensionUtil registration

### DIFF
--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -52,7 +52,7 @@ static void LoadInternal(DatabaseInstance &instance) {
 
 	// Iceberg Table Functions
 	for (auto &fun : IcebergFunctions::GetTableFunctions(instance)) {
-		ExtensionUtil::RegisterFunction(instance, fun);
+		ExtensionUtil::RegisterFunction(instance, std::move(fun));
 	}
 
 	// Iceberg Scalar Functions

--- a/src/iceberg_functions.cpp
+++ b/src/iceberg_functions.cpp
@@ -10,9 +10,9 @@ namespace duckdb {
 vector<TableFunctionSet> IcebergFunctions::GetTableFunctions(DatabaseInstance &instance) {
 	vector<TableFunctionSet> functions;
 
-	functions.push_back(GetIcebergSnapshotsFunction());
-	functions.push_back(GetIcebergScanFunction(instance));
-	functions.push_back(GetIcebergMetadataFunction());
+	functions.push_back(std::move(GetIcebergSnapshotsFunction()));
+	functions.push_back(std::move(GetIcebergScanFunction(instance)));
+	functions.push_back(std::move(GetIcebergMetadataFunction()));
 
 	return functions;
 }


### PR DESCRIPTION
It seems something is likely off on duckdb/duckdb, but for now workaround extension side

This is visible in duckdb-wasm, but that's due to the different compiler (recent clang).