### PR TITLE
Fix duplicate entries reported in `ICTableSet::Scan`

### DIFF
--- a/src/storage/irc_table_set.cpp
+++ b/src/storage/irc_table_set.cpp
@@ -238,10 +238,10 @@ void ICTableSet::Scan(ClientContext &context, const std::function<void(CatalogEn
 	lock_guard<mutex> l(entry_lock);
 	LoadEntries(context);
 	for (auto &entry : entries) {
-		FillEntry(context, entry.second);
-		for (auto &schema : entry.second.schema_versions) {
-			callback(*schema.second);
-		}
+		auto &table_info = entry.second;
+		FillEntry(context, table_info);
+		auto schema_id = table_info.table_metadata.current_schema_id;
+		callback(*table_info.schema_versions[schema_id]);
 	}
 }
 

--- a/test/sql/local/irc/test_show_table_duplicates.test
+++ b/test/sql/local/irc/test_show_table_duplicates.test
@@ -1,0 +1,47 @@
+# name: test/sql/local/irc/test_show_table_duplicates.test
+# description: test integration with iceberg catalog read
+# group: [irc]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+
+statement ok
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181'
+);
+
+query I
+SELECT table_name,
+FROM information_schema.tables where table_name == 'schema_evolve_struct' and table_schema == 'default';
+----
+schema_evolve_struct


### PR DESCRIPTION
This PR fixes #329 

We were invoking the callback for every schema version, when we should only be invoking it once, with the latest schema version.