### PR TITLE
[Dev] Address a FIXME in `FileMatchesFilter`

### DIFF
--- a/src/iceberg_functions/iceberg_multi_file_list.cpp
+++ b/src/iceberg_functions/iceberg_multi_file_list.cpp
@@ -272,10 +272,9 @@ bool IcebergMultiFileList::FileMatchesFilter(const IcebergManifestEntry &file) {
 	auto &filters = table_filters.filters;
 	auto &schema = GetSchema().columns;
 
-	for (idx_t column_id = 0; column_id < schema.size(); column_id++) {
-		// FIXME: is there a potential mismatch between column_id / field_id lurking here?
-		auto &column = *schema[column_id];
-		auto it = filters.find(column_id);
+	for (idx_t index = 0; index < schema.size(); index++) {
+		auto &column = *schema[index];
+		auto it = filters.find(index);
 
 		if (it == filters.end()) {
 			continue;
@@ -285,9 +284,9 @@ bool IcebergMultiFileList::FileMatchesFilter(const IcebergManifestEntry &file) {
 			continue;
 		}
 
-		auto &source_id = column.id;
-		auto lower_bound_it = file.lower_bounds.find(source_id);
-		auto upper_bound_it = file.upper_bounds.find(source_id);
+		auto &column_id = column.id;
+		auto lower_bound_it = file.lower_bounds.find(column_id);
+		auto upper_bound_it = file.upper_bounds.find(column_id);
 		Value lower_bound;
 		Value upper_bound;
 		if (lower_bound_it != file.lower_bounds.end()) {
@@ -298,12 +297,12 @@ bool IcebergMultiFileList::FileMatchesFilter(const IcebergManifestEntry &file) {
 		}
 
 		auto stats = IcebergPredicateStats::DeserializeBounds(lower_bound, upper_bound, column.name, column.type);
-		auto null_counts_it = file.null_value_counts.find(source_id);
+		auto null_counts_it = file.null_value_counts.find(column_id);
 		if (null_counts_it != file.null_value_counts.end()) {
 			auto &null_counts = null_counts_it->second;
 			stats.has_null = null_counts != 0;
 		}
-		auto nan_counts_it = file.nan_value_counts.find(source_id);
+		auto nan_counts_it = file.nan_value_counts.find(column_id);
 		if (nan_counts_it != file.nan_value_counts.end()) {
 			auto &nan_counts = nan_counts_it->second;
 			stats.has_nan = nan_counts != 0;


### PR DESCRIPTION
We shouldn't use the name `column_id` when we're iterating through columns of the schema sequentially, that now uses `index`

Consequently, we use `column_id = column.id` now, rather than `source_id = column.id`, making the connection with the spec more clear when this is used:
> Map from column id to lower bound in the column serialized as binary [1]. Each value must be less than or equal to all non-null, non-NaN values in the column for the file [2]

```c++
		auto lower_bound_it = file.lower_bounds.find(column_id);
		auto upper_bound_it = file.upper_bounds.find(column_id);
```

Also removes a use of the term `source_id`, which is a term that should never have been coined by the Iceberg Table spec in the first place in my own humble opinion.