### PR TITLE
Move back to vcpkg-duckdb-ports

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -15,8 +15,16 @@
 		}
 	],
 	"vcpkg-configuration": {
-		"overlay-ports": [
-			"./extension-ci-tools/vcpkg_ports"
+		"registries": [
+			{
+				"kind": "git",
+				"repository": "https://github.com/duckdb/vcpkg-duckdb-ports",
+				"baseline": "02558971ebafdbaa697a0704a3ed7ba365cd5495",
+				"packages": [
+					"vcpkg-cmake",
+					"avro-c"
+				]
+			}
 		]
 	},
 	"builtin-baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b",


### PR DESCRIPTION
Previous approach had some problems while in the context of duckdb/duckdb Linux CI.

This seems the most safe change for today, to be revisited.