### PR TITLE
Fixup tests/ 2

### DIFF
--- a/test/sql/local/iceberg_scans/iceberg_metadata.test
+++ b/test/sql/local/iceberg_scans/iceberg_metadata.test
@@ -6,7 +6,7 @@
 statement error
 SELECT * FROM ICEBERG_METADATA('__WORKING_DIRECTORY__/data/persistent/iceberg/lineitem_iceberg');
 ----
-Catalog Error
+Error
 
 require avro
 

--- a/test/sql/local/iceberg_scans/iceberg_scan.test
+++ b/test/sql/local/iceberg_scans/iceberg_scan.test
@@ -6,7 +6,7 @@
 statement error
 SELECT * FROM ICEBERG_SCAN('__WORKING_DIRECTORY__/data/iceberg/lineitem_iceberg');
 ----
-Catalog Error
+Error
 
 require avro
 

--- a/test/sql/local/iceberg_scans/uuid_type.test
+++ b/test/sql/local/iceberg_scans/uuid_type.test
@@ -9,6 +9,8 @@ require iceberg
 
 require httpfs
 
+require no_extension_autoloading "EXPECTED: enable logging is not aware of where 'Iceberg' option comes from"
+
 statement ok
 pragma enable_logging('Iceberg');
 


### PR DESCRIPTION
Those will prevent iceberg from passing autoloading tests, meaning it will not be deployed nightly.