### PR TITLE
Fix compilation

### DIFF
--- a/src/storage/authorization/sigv4.cpp
+++ b/src/storage/authorization/sigv4.cpp
@@ -50,7 +50,7 @@ unique_ptr<IRCAuthorization> SIGV4Authorization::FromAttachOptions(IcebergAttach
 		}
 	}
 	input.options = std::move(remaining_options);
-	return result;
+	return std::move(result);
 }
 
 static string GetAwsRegion(const string &host) {


### PR DESCRIPTION
I met a compilation issue
```sh
/tmp/duckdb-iceberg/src/storage/authorization/sigv4.cpp: In static member function ‘static duckdb::unique_ptr<duckdb::IRCAuthorization> duckdb::SIGV4Authorization::FromAttachOptions(duckdb::IcebergAttachOptions&)’:
    /tmp/duckdb-iceberg/src/storage/authorization/sigv4.cpp:53:16: error: could not convert ‘result’ from ‘unique_ptr<duckdb::SIGV4Authorization,default_delete<duckdb::SIGV4Authorization>,[...]>’ to ‘unique_ptr<duckdb::IRCAuthorization,default_delete<duckdb::IRCAuthorization>,[...]>’
       53 |         return result;
          |                ^~~~~~
          |                |
          |                unique_ptr<duckdb::SIGV4Authorization,default_delete<duckdb::SIGV4Authorization>,[...]>
    [346/845] Building CXX object extension/iceberg/CMakeFiles/iceberg_extension.dir/src/storage/irc_catalog.cpp.o
```

Seems to be the same as https://github.com/duckdb/pg_duckdb/pull/456