### PR TITLE
[BUGFIX] use https on r2 gets. Path style access does not mean do not use ssl

### DIFF
--- a/src/storage/iceberg_table_information.cpp
+++ b/src/storage/iceberg_table_information.cpp
@@ -63,6 +63,8 @@ static void ParseConfigOptions(const case_insensitive_map_t<string> &config, cas
 	}
 	if (StringUtil::StartsWith(endpoint, "https://")) {
 		endpoint = endpoint.substr(8, string::npos);
+		// if there is an endpoint and the endpoiont has https, use ssl.
+		options["use_ssl"] = Value(true);
 	}
 	if (StringUtil::EndsWith(endpoint, "/")) {
 		endpoint = endpoint.substr(0, endpoint.size() - 1);

--- a/test/sql/cloud/r2_catalog/test_r2_attach_and_read.test
+++ b/test/sql/cloud/r2_catalog/test_r2_attach_and_read.test
@@ -32,4 +32,13 @@ attach '6b17833f308abc1e1cc343c552b51f51_r2-catalog' AS my_datalake (
 );
 
 statement ok
+pragma enable_logging('HTTP');
+
+statement ok
 select * from my_datalake.default.people;
+
+# no requests over http
+query I
+select count(*) from duckdb_logs_parsed('HTTP') where request.url like '%http://%';
+----
+0


### PR DESCRIPTION
if the provided endpoint starts with https:// set use_ssl to true reg…ardless of path_style_access trye

fixes https://github.com/duckdblabs/duckdb-internal/issues/5407