### PR TITLE
Support GCS OAuth tokens in IRC vended credentials

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -33,7 +33,7 @@ endif ()
 endif()
 
 duckdb_extension_load(httpfs
-        GIT_URL https://github.com/duckdb/duckdb-httpfs
-        GIT_TAG da2821906eb42f7255d969be3e073bc1b45a71a8
-        INCLUDE_DIR extension/httpfs/include
+        GIT_URL https://github.com/danklynn/duckdb-httpfs
+        GIT_TAG d5a7a2b06d4b6dc5e98cd19748d1dbe3cd9c5aa6
 )
+

--- a/src/storage/iceberg_table_information.cpp
+++ b/src/storage/iceberg_table_information.cpp
@@ -15,8 +15,46 @@ const string &IcebergTableInformation::BaseFilePath() const {
 	return load_table_result.metadata.location;
 }
 
-static void ParseConfigOptions(const case_insensitive_map_t<string> &config, case_insensitive_map_t<Value> &options) {
-	//! Set of recognized config parameters and the duckdb secret option that matches it.
+static string DetectStorageType(const string &location) {
+	// Detect storage type from the location URL
+	if (StringUtil::StartsWith(location, "gs://") || 
+	    StringUtil::Contains(location, "storage.googleapis.com")) {
+		return "gcs";
+	} else if (StringUtil::StartsWith(location, "s3://") || 
+	           StringUtil::StartsWith(location, "s3a://")) {
+		return "s3";
+	} else if (StringUtil::StartsWith(location, "abfs://") || 
+	           StringUtil::StartsWith(location, "az://")) {
+		return "azure";
+	}
+	// Default to s3 for backward compatibility
+	return "s3";
+}
+
+static void ParseGCSConfigOptions(const case_insensitive_map_t<string> &config, case_insensitive_map_t<Value> &options) {
+	//! Set of recognized GCS config parameters and the duckdb secret option that matches it.
+	static const case_insensitive_map_t<string> gcs_config_to_option = {
+		{"gcs.oauth2.token", "bearer_token"},
+		{"gcs.bearer-token", "bearer_token"},
+		{"gcs.access-token", "bearer_token"},
+		{"gcs.endpoint", "endpoint"},
+		{"gcs.project-id", "project_id"},
+		// Map common OAuth2 patterns
+		{"oauth2.token", "bearer_token"},
+		{"bearer_token", "bearer_token"},
+		{"access_token", "bearer_token"}
+	};
+	
+	for (auto &entry : config) {
+		auto it = gcs_config_to_option.find(entry.first);
+		if (it != gcs_config_to_option.end()) {
+			options[it->second] = entry.second;
+		}
+	}
+}
+
+static void ParseS3ConfigOptions(const case_insensitive_map_t<string> &config, case_insensitive_map_t<Value> &options) {
+	//! Set of recognized S3 config parameters and the duckdb secret option that matches it.
 	static const case_insensitive_map_t<string> config_to_option = {{"s3.access-key-id", "key_id"},
 	                                                                {"s3.secret-access-key", "secret"},
 	                                                                {"s3.session-token", "session_token"},
@@ -25,14 +63,26 @@ static void ParseConfigOptions(const case_insensitive_map_t<string> &config, cas
 	                                                                {"client.region", "region"},
 	                                                                {"s3.endpoint", "endpoint"}};
 
-	if (config.empty()) {
-		return;
-	}
 	for (auto &entry : config) {
 		auto it = config_to_option.find(entry.first);
 		if (it != config_to_option.end()) {
 			options[it->second] = entry.second;
 		}
+	}
+}
+
+static void ParseConfigOptions(const case_insensitive_map_t<string> &config, case_insensitive_map_t<Value> &options, 
+                               const string &storage_type = "s3") {
+	if (config.empty()) {
+		return;
+	}
+	
+	// Parse storage-specific config options
+	if (storage_type == "gcs") {
+		ParseGCSConfigOptions(config, options);
+	} else {
+		// Default to S3 parsing for backward compatibility
+		ParseS3ConfigOptions(config, options);
 	}
 
 	auto it = config.find("s3.path-style-access");
@@ -105,18 +155,28 @@ IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(ClientConte
 		}
 	}
 
+	// Detect storage type from metadata location
+	const auto &metadata_location = load_table_result.metadata.location;
+	string storage_type = DetectStorageType(metadata_location);
+	
+	// If storage is GCS and we have a bearer token from catalog OAuth2 auth
+	if (storage_type == "gcs" && catalog.auth_handler->type == IRCAuthorizationType::OAUTH2) {
+		auto &oauth2_auth = catalog.auth_handler->Cast<OAuth2Authorization>();
+		if (!oauth2_auth.token.empty()) {
+			// Use catalog's OAuth2 token for storage access
+			user_defaults["bearer_token"] = oauth2_auth.token;
+		}
+	}
+	
 	// Mapping from config key to a duckdb secret option
-
 	case_insensitive_map_t<Value> config_options;
 	//! TODO: apply the 'defaults' retrieved from the /v1/config endpoint
 	config_options.insert(user_defaults.begin(), user_defaults.end());
 
 	if (load_table_result.has_config) {
 		auto &config = load_table_result.config;
-		ParseConfigOptions(config, config_options);
+		ParseConfigOptions(config, config_options, storage_type);
 	}
-
-	const auto &metadata_location = load_table_result.metadata.location;
 
 	if (load_table_result.has_storage_credentials) {
 		auto &storage_credentials = load_table_result.storage_credentials;
@@ -133,12 +193,12 @@ IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(ClientConte
 			create_secret_input.scope.push_back(ignore_credential_prefix ? metadata_location : credential.prefix);
 			create_secret_input.name = StringUtil::Format("%s_%d_%s", secret_base_name, index, credential.prefix);
 
-			create_secret_input.type = "s3";
+			create_secret_input.type = storage_type;
 			create_secret_input.provider = "config";
 			create_secret_input.storage_type = "memory";
 			create_secret_input.options = config_options;
 
-			ParseConfigOptions(credential.config, create_secret_input.options);
+			ParseConfigOptions(credential.config, create_secret_input.options, storage_type);
 			//! TODO: apply the 'overrides' retrieved from the /v1/config endpoint
 			result.storage_credentials.push_back(create_secret_input);
 		}
@@ -154,7 +214,7 @@ IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(ClientConte
 		//! TODO: apply the 'overrides' retrieved from the /v1/config endpoint
 		config.options = config_options;
 		config.name = secret_base_name;
-		config.type = "s3";
+		config.type = storage_type;
 		config.provider = "config";
 		config.storage_type = "memory";
 	}


### PR DESCRIPTION
Apache Polaris returns an OAuth2 bearer token for GCS tables like so:

```json
{
  "metadata-location": "gs://my-bucket/warehouse/table/metadata.json",
  "config": {
    "gcs.oauth2.token": "ya29.a0AfH6SMBx..."
  }
}
```

This PR adds support for passing these bearer tokens through to GCS. This commit depends upon functionality added to the httpfs extension here:

https://github.com/danklynn/duckdb-httpfs/commit/d5a7a2b06d4b6dc5e98cd19748d1dbe3cd9c5aa6

It will compile if you comment out https loading from `out_of_tree_extensions.cmake` in the duckdb submodule, but this can be resolved once this PR is merged:

https://github.com/duckdb/duckdb-httpfs/pull/93