### PR TITLE
Support `CREATE IF NOT EXISTS`, and fix an issue causing empty snapshots to be created

### DIFF
--- a/src/iceberg_manifest.cpp
+++ b/src/iceberg_manifest.cpp
@@ -41,7 +41,6 @@ Value IcebergManifestEntry::ToDataFileStruct(const LogicalType &type) const {
 namespace manifest_file {
 
 static LogicalType PartitionStructType(IcebergTableInformation &table_info, const IcebergManifestFile &file) {
-	//! FIXME: do we validate this beforehand anywhere?
 	D_ASSERT(!file.data_files.empty());
 
 	auto &first_entry = file.data_files.front();
@@ -60,6 +59,7 @@ static LogicalType PartitionStructType(IcebergTableInformation &table_info, cons
 
 idx_t WriteToFile(IcebergTableInformation &table_info, const IcebergManifestFile &manifest_file, CopyFunction &copy,
                   DatabaseInstance &db, ClientContext &context) {
+	D_ASSERT(!manifest_file.data_files.empty());
 	auto &allocator = db.GetBufferManager().GetBufferAllocator();
 
 	//! We need to create an iceberg-schema for the manifest file, written in the metadata of the Avro file.

--- a/src/include/storage/iceberg_table_update.hpp
+++ b/src/include/storage/iceberg_table_update.hpp
@@ -35,6 +35,8 @@ enum class IcebergTableUpdateType : uint8_t {
 struct IcebergCommitState {
 	vector<IcebergManifest> manifests;
 	rest_api_objects::CommitTableRequest table_change;
+	bool added_snapshot = false;
+	int64_t new_snapshot_id;
 };
 
 struct IcebergTableUpdate {

--- a/src/include/storage/iceberg_table_update.hpp
+++ b/src/include/storage/iceberg_table_update.hpp
@@ -35,8 +35,6 @@ enum class IcebergTableUpdateType : uint8_t {
 struct IcebergCommitState {
 	vector<IcebergManifest> manifests;
 	rest_api_objects::CommitTableRequest table_change;
-	bool added_snapshot = false;
-	int64_t new_snapshot_id;
 };
 
 struct IcebergTableUpdate {

--- a/src/include/storage/irc_table_set.hpp
+++ b/src/include/storage/irc_table_set.hpp
@@ -21,7 +21,7 @@ public:
 	                                            const string &table_name);
 	optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const EntryLookupInfo &lookup);
 	void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
-	void CreateNewEntry(ClientContext &context, IRCatalog &catalog, IRCSchemaEntry &schema, CreateTableInfo &info);
+	bool CreateNewEntry(ClientContext &context, IRCatalog &catalog, IRCSchemaEntry &schema, CreateTableInfo &info);
 
 public:
 	void LoadEntries(ClientContext &context);

--- a/src/include/storage/table_update/iceberg_add_snapshot.hpp
+++ b/src/include/storage/table_update/iceberg_add_snapshot.hpp
@@ -26,7 +26,6 @@ public:
 
 public:
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) override;
-	rest_api_objects::TableUpdate CreateSetSnapshotRefUpdate();
 
 public:
 	IcebergManifestFile manifest_file;

--- a/src/storage/iceberg_insert.cpp
+++ b/src/storage/iceberg_insert.cpp
@@ -232,8 +232,10 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 	auto &table_info = irc_table.table_info;
 	auto &transaction = IRCTransaction::Get(context, table->catalog);
 
-	table_info.AddSnapshot(transaction, std::move(global_state.written_files));
-	transaction.MarkTableAsDirty(irc_table);
+	if (!global_state.written_files.empty()) {
+		table_info.AddSnapshot(transaction, std::move(global_state.written_files));
+		transaction.MarkTableAsDirty(irc_table);
+	}
 	return SinkFinalizeType::READY;
 }
 

--- a/src/storage/iceberg_table_information.cpp
+++ b/src/storage/iceberg_table_information.cpp
@@ -244,8 +244,8 @@ void IcebergTableInformation::InitTransactionData(IRCTransaction &transaction) {
 }
 
 void IcebergTableInformation::AddSnapshot(IRCTransaction &transaction, vector<IcebergManifestEntry> &&data_files) {
+	D_ASSERT(!data_files.empty());
 	InitTransactionData(transaction);
-
 	transaction_data->AddSnapshot(IcebergSnapshotOperationType::APPEND, std::move(data_files));
 }
 

--- a/src/storage/iceberg_transaction_data.cpp
+++ b/src/storage/iceberg_transaction_data.cpp
@@ -19,6 +19,8 @@ static int64_t NewSnapshotId() {
 
 void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
                                          vector<IcebergManifestEntry> &&data_files) {
+	D_ASSERT(!data_files.empty());
+
 	//! Generate a new snapshot id
 	auto &table_metadata = table_info.table_metadata;
 	auto snapshot_id = NewSnapshotId();

--- a/src/storage/irc_schema_entry.cpp
+++ b/src/storage/irc_schema_entry.cpp
@@ -37,7 +37,10 @@ optional_ptr<CatalogEntry> IRCSchemaEntry::CreateTable(IRCTransaction &irc_trans
 	auto &catalog = irc_transaction.GetCatalog();
 
 	// always posts to IRC catalog so we can get the metadata
-	tables.CreateNewEntry(context, catalog, *this, base_info);
+	if (!tables.CreateNewEntry(context, catalog, *this, base_info)) {
+		D_ASSERT(base_info.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT);
+		return nullptr;
+	}
 	auto lookup_info = EntryLookupInfo(CatalogType::TABLE_ENTRY, base_info.table);
 	auto entry = tables.GetEntry(context, lookup_info);
 	auto &ic_entry = entry->Cast<ICTableEntry>();

--- a/src/storage/irc_table_set.cpp
+++ b/src/storage/irc_table_set.cpp
@@ -70,13 +70,16 @@ void ICTableSet::LoadEntries(ClientContext &context) {
 	}
 }
 
-void ICTableSet::CreateNewEntry(ClientContext &context, IRCatalog &catalog, IRCSchemaEntry &schema,
+bool ICTableSet::CreateNewEntry(ClientContext &context, IRCatalog &catalog, IRCSchemaEntry &schema,
                                 CreateTableInfo &info) {
 	auto table_name = info.table;
 	if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
 		throw InvalidInputException("CREATE OR REPLACE not supported in DuckDB-Iceberg");
 	}
 	if (entries.find(table_name) != entries.end()) {
+		if (info.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
+			return false;
+		}
 		throw CatalogException("Table %s already exists", table_name.c_str());
 	}
 
@@ -113,6 +116,7 @@ void ICTableSet::CreateNewEntry(ClientContext &context, IRCatalog &catalog, IRCS
 		table_info.SetDefaultSortOrder(irc_transaction);
 		table_info.SetLocation(irc_transaction);
 	}
+	return true;
 }
 
 unique_ptr<ICTableInfo> ICTableSet::GetTableInfo(ClientContext &context, IRCSchemaEntry &schema,

--- a/src/storage/irc_transaction.cpp
+++ b/src/storage/irc_transaction.cpp
@@ -293,7 +293,7 @@ TableTransactionInfo IRCTransaction::GetTransactionRequest(ClientContext &contex
 				commit_state.table_change.requirements.push_back(
 				    CreateAssertRefSnapshotIdRequirement(*current_snapshot));
 			}
-			CreateSetSnapshotRefUpdate(commit_state.new_snapshot_id);
+			commit_state.table_change.updates.push_back(CreateSetSnapshotRefUpdate(commit_state.new_snapshot_id));
 		}
 
 		transaction.table_changes.push_back(std::move(table_change));

--- a/src/storage/table_update/iceberg_add_snapshot.cpp
+++ b/src/storage/table_update/iceberg_add_snapshot.cpp
@@ -37,11 +37,8 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 	D_ASSERT(avro_copy_p);
 	auto &avro_copy = avro_copy_p->Cast<CopyFunctionCatalogEntry>().function;
 
-	if (manifest_file.data_files.empty()) {
-		return;
-	}
-	commit_state.added_snapshot = true;
-	commit_state.new_snapshot_id = snapshot.snapshot_id;
+	D_ASSERT(!manifest_file.data_files.empty());
+
 	auto manifest_length = manifest_file::WriteToFile(table_info, manifest_file, avro_copy, db, context);
 	manifest.manifest_length = manifest_length;
 

--- a/test/sql/local/irc/create/test_create_table_as.test
+++ b/test/sql/local/irc/create/test_create_table_as.test
@@ -44,6 +44,15 @@ ATTACH '' AS my_datalake (
 statement ok
 use my_datalake.default;
 
+statement ok
+drop table if exists all_types_table_primitives_2;
+
+statement ok
+drop table if exists nested_types_2;
+
+statement ok
+drop table if exists fixed_array_table_as_list;
+
 # create primitive type table from test all types
 statement ok
 create table all_types_table_primitives_2 as select

--- a/test/sql/local/irc/test_create_if_not_exists.test
+++ b/test/sql/local/irc/test_create_if_not_exists.test
@@ -62,6 +62,14 @@ query III
 select * from my_datalake.default.a;
 ----
 
+# Now the table already exists, making the create a no-op
+statement ok
+CREATE TABLE IF NOT EXISTS my_datalake.default.a AS FROM my_datalake.default.empty_table WITH NO DATA;
+
+query III
+select * from my_datalake.default.a;
+----
+
 # FIXME:
 # This needs a DROP 'my_datalake.default.a' to make this test rerunnable.
 

--- a/test/sql/local/irc/test_create_if_not_exists.test
+++ b/test/sql/local/irc/test_create_if_not_exists.test
@@ -1,0 +1,67 @@
+# name: test/sql/local/irc/test_create_if_not_exists.test
+# group: [irc]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+
+statement ok
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181',
+    SUPPORT_NESTED_NAMESPACES true
+);
+
+# First in a transaction, to verify transaction-local tables and scans work
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+CREATE TABLE IF NOT EXISTS my_datalake.default.a AS FROM my_datalake.default.empty_table WITH NO DATA;
+
+query III
+select * from my_datalake.default.a;
+----
+
+statement ok
+ABORT;
+
+# Now outside of a transaction
+statement ok
+CREATE TABLE IF NOT EXISTS my_datalake.default.a AS FROM my_datalake.default.empty_table WITH NO DATA;
+
+query III
+select * from my_datalake.default.a;
+----
+
+# FIXME:
+# This needs a DROP 'my_datalake.default.a' to make this test rerunnable.
+


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/5755

We had an assertion that WriteToFile was never called with a snapshot with no datafiles, but this was never ensured. Now it is. Because of this I've changed how the "SetSnapshotRefUpdate" update is made.

As part of testing this, I noticed `IF NOT EXISTS` was being ignored, so I fixed that and added a test for it.