### PR TITLE
Disable inserting NULL into columns marked NOT NULL

### DIFF
--- a/scripts/data_generators/tests/table_with_deletes/__init__.py
+++ b/scripts/data_generators/tests/table_with_deletes/__init__.py
@@ -1,7 +1,5 @@
 from scripts.data_generators.tests.base import IcebergTest
 import pathlib
-import tempfile
-import duckdb
 
 
 @IcebergTest.register()
@@ -9,14 +7,3 @@ class Test(IcebergTest):
     def __init__(self):
         path = pathlib.PurePath(__file__)
         super().__init__(path.parent.name)
-
-        # Create a temporary directory
-        self.tempdir = pathlib.Path(tempfile.mkdtemp())
-        self.parquet_file = self.tempdir / "tmp.parquet"
-
-        duckdb_con = duckdb.connect()
-        duckdb_con.execute("call dbgen(sf=0.01)")
-        duckdb_con.execute(f"copy lineitem to '{self.parquet_file}' (FORMAT PARQUET)")
-
-    def setup(self, con):
-        con.con.read.parquet(self.parquet_file.as_posix()).createOrReplaceTempView('parquet_file_view')

--- a/scripts/data_generators/tests/table_with_deletes/__init__.py
+++ b/scripts/data_generators/tests/table_with_deletes/__init__.py
@@ -1,5 +1,7 @@
 from scripts.data_generators.tests.base import IcebergTest
 import pathlib
+import tempfile
+import duckdb
 
 
 @IcebergTest.register()
@@ -7,3 +9,14 @@ class Test(IcebergTest):
     def __init__(self):
         path = pathlib.PurePath(__file__)
         super().__init__(path.parent.name)
+
+        # Create a temporary directory
+        self.tempdir = pathlib.Path(tempfile.mkdtemp())
+        self.parquet_file = self.tempdir / "tmp.parquet"
+
+        duckdb_con = duckdb.connect()
+        duckdb_con.execute("call dbgen(sf=0.01)")
+        duckdb_con.execute(f"copy lineitem to '{self.parquet_file}' (FORMAT PARQUET)")
+
+    def setup(self, con):
+        con.con.read.parquet(self.parquet_file.as_posix()).createOrReplaceTempView('parquet_file_view')

--- a/scripts/data_generators/tests/test_not_null/__init__.py
+++ b/scripts/data_generators/tests/test_not_null/__init__.py
@@ -1,21 +1,8 @@
 from scripts.data_generators.tests.base import IcebergTest
 import pathlib
-import tempfile
-import duckdb
-
 
 @IcebergTest.register()
 class Test(IcebergTest):
     def __init__(self):
         path = pathlib.PurePath(__file__)
         super().__init__(path.parent.name)
-
-        # Create a temporary directory
-        self.tempdir = pathlib.Path(tempfile.mkdtemp())
-        self.parquet_file = self.tempdir / "tmp.parquet"
-
-        duckdb_con = duckdb.connect()
-        duckdb_con.execute(f"copy lineitem to '{self.parquet_file}' (FORMAT PARQUET)")
-
-    def setup(self, con):
-        con.con.read.parquet(self.parquet_file.as_posix()).createOrReplaceTempView('parquet_file_view')

--- a/scripts/data_generators/tests/test_not_null/__init__.py
+++ b/scripts/data_generators/tests/test_not_null/__init__.py
@@ -1,0 +1,21 @@
+from scripts.data_generators.tests.base import IcebergTest
+import pathlib
+import tempfile
+import duckdb
+
+
+@IcebergTest.register()
+class Test(IcebergTest):
+    def __init__(self):
+        path = pathlib.PurePath(__file__)
+        super().__init__(path.parent.name)
+
+        # Create a temporary directory
+        self.tempdir = pathlib.Path(tempfile.mkdtemp())
+        self.parquet_file = self.tempdir / "tmp.parquet"
+
+        duckdb_con = duckdb.connect()
+        duckdb_con.execute(f"copy lineitem to '{self.parquet_file}' (FORMAT PARQUET)")
+
+    def setup(self, con):
+        con.con.read.parquet(self.parquet_file.as_posix()).createOrReplaceTempView('parquet_file_view')

--- a/scripts/data_generators/tests/test_not_null/q00.sql
+++ b/scripts/data_generators/tests/test_not_null/q00.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE TABLE default.test_not_null (
+    id INT,
+    name STRING NOT NULL,
+    address STRUCT<
+        street: STRING NOT NULL,
+        city: STRING NOT NULL,
+        zip: STRING NOT NULL
+    >,
+    phone_numbers ARRAY<STRING>,
+    metadata MAP<STRING, STRING>
+);

--- a/scripts/data_generators/tests/test_not_null/q01.sql
+++ b/scripts/data_generators/tests/test_not_null/q01.sql
@@ -1,0 +1,7 @@
+INSERT INTO default.test_not_null VALUES (
+    1,
+    'Alice',
+    NAMED_STRUCT('street', '123 Main St', 'city', 'Metropolis', 'zip', '12345'),
+    ARRAY('123-456-7890', '987-654-3210'),
+    MAP('age', '30', 'membership', 'gold')
+);

--- a/src/storage/create_table/iceberg_create_table_request.cpp
+++ b/src/storage/create_table/iceberg_create_table_request.cpp
@@ -117,9 +117,7 @@ shared_ptr<IcebergTableSchema> IcebergCreateTableRequest::CreateIcebergSchema(co
 					continue;
 				}
 				auto &not_null_constraint = constraint->Cast<NotNullConstraint>();
-				auto break_here = column.pos;
-				auto wat = not_null_constraint.index.index;
-				if (not_null_constraint.index.index == column.pos) {
+				if (not_null_constraint.index.IsValid() && not_null_constraint.index.index == column.pos) {
 					required = true;
 				}
 			}

--- a/src/storage/iceberg_insert.cpp
+++ b/src/storage/iceberg_insert.cpp
@@ -150,16 +150,6 @@ static IcebergColumnStats ParseColumnStats(const vector<Value> col_stats) {
 	return column_stats;
 }
 
-struct IcebergColumnDef {
-
-	IcebergColumnDef(string nested_name, optional_ptr<IcebergColumnDefinition> col_def_) : nested_name(nested_name) {
-		column_def = col_def_;
-	}
-	//! nested column name separated by "."
-	string nested_name;
-	optional_ptr<IcebergColumnDefinition> column_def;
-};
-
 static void AddToColDefMap(case_insensitive_map_t<optional_ptr<IcebergColumnDefinition>> &name_to_coldef,
                            string col_name_prefix, optional_ptr<IcebergColumnDefinition> column_def) {
 	string column_name = column_def->name;

--- a/src/storage/iceberg_insert.cpp
+++ b/src/storage/iceberg_insert.cpp
@@ -205,12 +205,12 @@ static void AddWrittenFiles(IcebergInsertGlobalState &global_state, DataChunk &c
 			auto &col_stats = MapValue::GetChildren(struct_children[1]);
 			auto column_names = ParseQuotedList(col_name, '.');
 			auto stats = ParseColumnStats(col_stats);
-			string normalized_col_name = StringUtil::Join(column_names, ".");
+			auto normalized_col_name = StringUtil::Join(column_names, ".");
 
 			auto ic_column_info = column_info.find(normalized_col_name);
 			D_ASSERT(ic_column_info != column_info.end());
 			if (ic_column_info->second->required && stats.has_null_count && stats.null_count > 0) {
-				throw ConstraintException("NOT NULL constraint failed: %s.%s boop", table->name, normalized_col_name);
+				throw ConstraintException("NOT NULL constraint failed: %s.%s", table->name, normalized_col_name);
 			}
 
 			//! TODO: convert 'stats' into 'data_file.lower_bounds', upper_bounds, value_counts, null_value_counts,

--- a/src/storage/iceberg_insert.cpp
+++ b/src/storage/iceberg_insert.cpp
@@ -6,7 +6,6 @@
 #include "metadata/iceberg_column_definition.hpp"
 
 #include "iceberg_multi_file_list.hpp"
-#include "../include/metadata/iceberg_column_definition.hpp"
 
 #include "duckdb/common/sort/partition_state.hpp"
 #include "duckdb/catalog/catalog_entry/copy_function_catalog_entry.hpp"
@@ -198,7 +197,6 @@ static void AddWrittenFiles(IcebergInsertGlobalState &global_state, DataChunk &c
 
 		// extract the column stats
 		auto column_stats = chunk.GetValue(4, r);
-
 		auto &map_children = MapValue::GetChildren(column_stats);
 
 		global_state.insert_count += data_file.record_count;
@@ -222,8 +220,7 @@ static void AddWrittenFiles(IcebergInsertGlobalState &global_state, DataChunk &c
 			auto ic_column_info = column_info.find(normalized_col_name);
 			D_ASSERT(ic_column_info != column_info.end());
 			if (ic_column_info->second->required && stats.has_null_count && stats.null_count > 0) {
-				throw InvalidInputException("Column %s is marked required. Cannot Insert NULL values",
-				                            normalized_col_name);
+				throw ConstraintException("NOT NULL constraint failed: %s.%s boop", table->name, normalized_col_name);
 			}
 
 			//! TODO: convert 'stats' into 'data_file.lower_bounds', upper_bounds, value_counts, null_value_counts,

--- a/test/sql/local/irc/create/test_create_table_not_null.test
+++ b/test/sql/local/irc/create/test_create_table_not_null.test
@@ -1,0 +1,61 @@
+# name: test/sql/local/irc/create/test_create_table_not_null.test
+# description: test create table
+# group: [create]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+set logging_level='debug'
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+
+statement ok
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181'
+);
+
+statement ok
+use my_datalake.default;
+
+statement ok
+drop table if exists table_with_null_reqs;
+
+statement ok
+create table table_with_null_reqs (
+	a varchar,
+	b int NOT NULL
+);
+
+statement error
+insert into table_with_null_reqs values ('value', NULL);
+----
+<REGEX>:.*NOT NULL constraint failed.*table_with_null_reqs.b.*
+
+statement ok
+insert into table_with_null_reqs values ('value', 5);

--- a/test/sql/local/irc/insert/test_insert_into_null_columns.test
+++ b/test/sql/local/irc/insert/test_insert_into_null_columns.test
@@ -59,7 +59,7 @@ insert into my_datalake.default.test_not_null VALUES (
 	MAP {'age': '30', 'membership': 'gold'}
 );
 ----
-<REGEX>:.*Constraint Error.*
+<REGEX>:.*Constraint Error.*NOT NULL.*
 
 # cannot insert NULL into primitive type marked NOT NULL
 statement error
@@ -71,4 +71,4 @@ insert into my_datalake.default.test_not_null VALUES (
 	MAP {'age': '30', 'membership': 'gold'}
 );
 ----
-<REGEX>:.*Constraint Error.*
+<REGEX>:.*Constraint Error.*NOT NULL.*

--- a/test/sql/local/irc/insert/test_insert_into_null_columns.test
+++ b/test/sql/local/irc/insert/test_insert_into_null_columns.test
@@ -40,7 +40,12 @@ ATTACH '' AS my_datalake (
 );
 
 statement error
-insert into my_datalake.default.test_not_null VALUES (NULL, NULL);
+insert into my_datalake.default.test_not_null VALUES (
+	1,
+	'NULL nested type',
+	{'street': NULL, 'city': 'Metropolis', 'zip': '12345'},
+	['123-456-7890', '987-654-3210']::VARCHAR[],
+	MAP {'age': '30', 'membership': 'gold'}
+);
 ----
 <REGEX>:.*Invalid Input Error.*
-

--- a/test/sql/local/irc/insert/test_insert_into_null_columns.test
+++ b/test/sql/local/irc/insert/test_insert_into_null_columns.test
@@ -59,7 +59,7 @@ insert into my_datalake.default.test_not_null VALUES (
 	MAP {'age': '30', 'membership': 'gold'}
 );
 ----
-<REGEX>:.*Invalid Input Error.*
+<REGEX>:.*Constraint Error.*
 
 # cannot insert NULL into primitive type marked NOT NULL
 statement error
@@ -71,4 +71,4 @@ insert into my_datalake.default.test_not_null VALUES (
 	MAP {'age': '30', 'membership': 'gold'}
 );
 ----
-<REGEX>:.*Invalid Input Error.*
+<REGEX>:.*Constraint Error.*

--- a/test/sql/local/irc/insert/test_insert_into_null_columns.test
+++ b/test/sql/local/irc/insert/test_insert_into_null_columns.test
@@ -1,0 +1,46 @@
+# name: test/sql/local/irc/insert/test_insert_into_null_columns.test
+# group: [insert]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+set logging_level='debug'
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+
+statement ok
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181'
+);
+
+statement error
+insert into my_datalake.default.test_not_null VALUES (NULL, NULL);
+----
+<REGEX>:.*Invalid Input Error.*
+

--- a/test/sql/local/irc/insert/test_insert_into_null_columns.test
+++ b/test/sql/local/irc/insert/test_insert_into_null_columns.test
@@ -39,11 +39,34 @@ ATTACH '' AS my_datalake (
     ENDPOINT 'http://127.0.0.1:8181'
 );
 
+# first test that we can insert nested types
+statement ok
+insert into my_datalake.default.test_not_null VALUES (
+	1,
+	'NULL nested type',
+	{'street': 'duck street', 'city': 'Metropolis', 'zip': '12345'},
+	['123-456-7890', '987-654-3210']::VARCHAR[],
+	MAP {'age': '30', 'membership': 'gold'}
+);
+
+# cannot insert null into a nested type that is required
 statement error
 insert into my_datalake.default.test_not_null VALUES (
 	1,
 	'NULL nested type',
 	{'street': NULL, 'city': 'Metropolis', 'zip': '12345'},
+	['123-456-7890', '987-654-3210']::VARCHAR[],
+	MAP {'age': '30', 'membership': 'gold'}
+);
+----
+<REGEX>:.*Invalid Input Error.*
+
+# cannot insert NULL into primitive type marked NOT NULL
+statement error
+insert into my_datalake.default.test_not_null VALUES (
+	1,
+	NULL,
+	{'street': 'duck street', 'city': 'swan city', 'zip': '12345'},
 	['123-456-7890', '987-654-3210']::VARCHAR[],
 	MAP {'age': '30', 'membership': 'gold'}
 );


### PR DESCRIPTION
Tests structs and primitive types. Have not yet figured out how create a map type with a `NOT NULL` requirement for lists and maps. I've stepped through the code though, and we should still throw an error in these cases