### PR TITLE
[Dev] Disable IcebergScan serialization

### DIFF
--- a/src/iceberg_functions/iceberg_scan.cpp
+++ b/src/iceberg_functions/iceberg_scan.cpp
@@ -41,6 +41,11 @@ static void AddNamedParameters(TableFunction &fun) {
 	fun.named_parameters["snapshot_from_id"] = LogicalType::UBIGINT;
 }
 
+static void IcebergScanSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data,
+                                 const TableFunction &function) {
+	throw NotImplementedException("IcebergScan serialization not implemented");
+}
+
 TableFunctionSet IcebergFunctions::GetIcebergScanFunction(ExtensionLoader &loader) {
 	// The iceberg_scan function is constructed by grabbing the parquet scan from the Catalog, then injecting the
 	// IcebergMultiFileReader into it to create a Iceberg-based multi file read
@@ -55,8 +60,9 @@ TableFunctionSet IcebergFunctions::GetIcebergScanFunction(ExtensionLoader &loade
 
 		// Unset all of these: they are either broken, very inefficient.
 		// TODO: implement/fix these
-		function.serialize = nullptr;
+		function.serialize = IcebergScanSerialize;
 		function.deserialize = nullptr;
+
 		function.statistics = nullptr;
 		function.table_scan_progress = nullptr;
 		function.get_bind_info = nullptr;


### PR DESCRIPTION
Throw an exception, instead of setting the method to null.

If we the method is null, the system tries to use a fallback for serialization, which fails because the `parameters` ends up empty (somehow? I couldn't find a logical explanation for that)

This takes after DuckLake, which uses the same logic.