### PR TITLE
Disable drops of all types with `CASCADE` for now

### DIFF
--- a/src/storage/irc_catalog.cpp
+++ b/src/storage/irc_catalog.cpp
@@ -109,6 +109,9 @@ optional_ptr<CatalogEntry> IRCatalog::CreateSchema(CatalogTransaction transactio
 }
 
 void IRCatalog::DropSchema(ClientContext &context, DropInfo &info) {
+	if (info.cascade) {
+		throw NotImplementedException("DROP SCHEMA <schema_name> CASCADE is not supported currently");
+	}
 	vector<string> namespace_items;
 	auto namespace_identifier = IRCAPI::ParseSchemaName(info.name);
 	namespace_items.push_back(IRCAPI::GetEncodedSchemaName(namespace_identifier));

--- a/src/storage/irc_catalog.cpp
+++ b/src/storage/irc_catalog.cpp
@@ -110,7 +110,8 @@ optional_ptr<CatalogEntry> IRCatalog::CreateSchema(CatalogTransaction transactio
 
 void IRCatalog::DropSchema(ClientContext &context, DropInfo &info) {
 	if (info.cascade) {
-		throw NotImplementedException("DROP SCHEMA <schema_name> CASCADE is not supported currently");
+		throw NotImplementedException(
+		    "DROP SCHEMA <schema_name> CASCADE is not supported for Iceberg schemas currently");
 	}
 	vector<string> namespace_items;
 	auto namespace_identifier = IRCAPI::ParseSchemaName(info.name);

--- a/src/storage/irc_schema_entry.cpp
+++ b/src/storage/irc_schema_entry.cpp
@@ -72,6 +72,9 @@ void IRCSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
 	if (table_info_it == tables.entries.end()) {
 		throw InvalidInputException("Table %s does not exist");
 	}
+	if (info.cascade) {
+		throw NotImplementedException("DROP TABLE <table_name> CASCADE is not supported currently");
+	}
 	auto &table_entry = table_info_it->second;
 	auto lookupInfo = EntryLookupInfo(CatalogType::TABLE_ENTRY, table_name);
 	auto catalog_transaction = CatalogTransaction::GetSystemCatalogTransaction(context);

--- a/src/storage/irc_schema_entry.cpp
+++ b/src/storage/irc_schema_entry.cpp
@@ -73,7 +73,7 @@ void IRCSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
 		throw InvalidInputException("Table %s does not exist");
 	}
 	if (info.cascade) {
-		throw NotImplementedException("DROP TABLE <table_name> CASCADE is not supported currently");
+		throw NotImplementedException("DROP TABLE <table_name> CASCADE is not supported for Iceberg tables currently");
 	}
 	auto &table_entry = table_info_it->second;
 	auto lookupInfo = EntryLookupInfo(CatalogType::TABLE_ENTRY, table_name);

--- a/test/sql/local/irc/test_cascade.test
+++ b/test/sql/local/irc/test_cascade.test
@@ -1,0 +1,45 @@
+# name: test/sql/local/irc/test_cascade.test
+# group: [irc]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require aws
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+CREATE SECRET local_catalog_secret (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+statement ok
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181'
+);
+
+statement error
+DROP SCHEMA my_datalake.default CASCADE;
+----
+Not implemented Error: DROP SCHEMA <schema_name> CASCADE is not supported currently
+
+statement error
+DROP TABLE my_datalake.default.empty_table CASCADE;
+----
+Not implemented Error: DROP TABLE <table_name> CASCADE is not supported currently

--- a/test/sql/local/irc/test_cascade.test
+++ b/test/sql/local/irc/test_cascade.test
@@ -37,9 +37,9 @@ ATTACH '' AS my_datalake (
 statement error
 DROP SCHEMA my_datalake.default CASCADE;
 ----
-Not implemented Error: DROP SCHEMA <schema_name> CASCADE is not supported currently
+Not implemented Error: DROP SCHEMA <schema_name> CASCADE is not supported for Iceberg schemas currently
 
 statement error
 DROP TABLE my_datalake.default.empty_table CASCADE;
 ----
-Not implemented Error: DROP TABLE <table_name> CASCADE is not supported currently
+Not implemented Error: DROP TABLE <table_name> CASCADE is not supported for Iceberg tables currently


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/5754

The actual functionality can be implemented later, for now I think it's important to block off all avenues that are not behaving correctly