### PR TITLE
load avro when committing first snapshot

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -18,8 +18,7 @@ duckdb_extension_load(ducklake
 duckdb_extension_load(avro
 	LOAD_TESTS
 	GIT_URL https://github.com/duckdb/duckdb-avro
-	GIT_TAG 0d7af391bd0aa201b2bdcfb994b7a575ad810155
-	APPLY_PATCHES
+	GIT_TAG 0c97a61781f63f8c5444cf3e0c6881ecbaa9fe13
 )
 
 if (NOT EMSCRIPTEN)

--- a/src/storage/table_update/iceberg_add_snapshot.cpp
+++ b/src/storage/table_update/iceberg_add_snapshot.cpp
@@ -6,6 +6,8 @@
 #include "duckdb/parser/parsed_data/copy_info.hpp"
 #include "duckdb/execution/execution_context.hpp"
 #include "duckdb/parallel/thread_context.hpp"
+#include "duckdb/main/extension_helper.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/caching_file_system.hpp"
 
@@ -46,6 +48,7 @@ rest_api_objects::TableUpdate IcebergAddSnapshot::CreateSetSnapshotRefUpdate() {
 
 void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
 	// load avro so we can get
+	auto &instance = DatabaseInstance::GetDatabase(context);
 	ExtensionHelper::AutoLoadExtension(instance, "avro");
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);

--- a/src/storage/table_update/iceberg_add_snapshot.cpp
+++ b/src/storage/table_update/iceberg_add_snapshot.cpp
@@ -45,6 +45,8 @@ rest_api_objects::TableUpdate IcebergAddSnapshot::CreateSetSnapshotRefUpdate() {
 }
 
 void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
+	// load avro so we can get
+	ExtensionHelper::AutoLoadExtension(instance, "avro");
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);
 	auto &schema = system_catalog.GetSchema(data, DEFAULT_SCHEMA);


### PR DESCRIPTION
Interesting bug when creating a table, since no snapshot exists, the block 
```
if (current_snapshot) {
...
	auto scan = make_uniq<AvroScan>("IcebergManifestList", context, manifest_list_path);
...
}
```
at IRCTransaction::GettransactionRequest is never hit. Which also means avro has not been loaded (since we also have not read any tables yet).


Then when we create the update, we try to get the copy function for avro, but avro has not yet been loaded. 
Not sure if this is the best fix. I remember we wanted to load avro on extension load, but there were conflicts with spatial. @Maxxen do you know if these are fixed yet? 

Otherwise I think this should be pretty safe for now.
fixes https://github.com/duckdb/duckdb-iceberg/issues/382

