### PR TITLE
Load avro on extension load

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -18,8 +18,7 @@ duckdb_extension_load(ducklake
 duckdb_extension_load(avro
 	LOAD_TESTS
 	GIT_URL https://github.com/duckdb/duckdb-avro
-	GIT_TAG 0d7af391bd0aa201b2bdcfb994b7a575ad810155
-	APPLY_PATCHES
+	GIT_TAG 0c97a61781f63f8c5444cf3e0c6881ecbaa9fe13
 )
 
 if (NOT EMSCRIPTEN)

--- a/src/avro_scan.cpp
+++ b/src/avro_scan.cpp
@@ -11,9 +11,6 @@
 namespace duckdb {
 
 AvroScan::AvroScan(const string &scan_name, ClientContext &context, const string &path) : path(path), context(context) {
-	auto &instance = DatabaseInstance::GetDatabase(context);
-	ExtensionHelper::AutoLoadExtension(instance, "avro");
-
 	auto &system_catalog = Catalog::GetSystemCatalog(instance);
 	auto data = CatalogTransaction::GetSystemTransaction(instance);
 	auto &schema = system_catalog.GetSchema(data, DEFAULT_SCHEMA);

--- a/src/avro_scan.cpp
+++ b/src/avro_scan.cpp
@@ -11,6 +11,7 @@
 namespace duckdb {
 
 AvroScan::AvroScan(const string &scan_name, ClientContext &context, const string &path) : path(path), context(context) {
+	auto &instance = DatabaseInstance::GetDatabase(context);
 	auto &system_catalog = Catalog::GetSystemCatalog(instance);
 	auto data = CatalogTransaction::GetSystemTransaction(instance);
 	auto &schema = system_catalog.GetSchema(data, DEFAULT_SCHEMA);

--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -37,10 +37,14 @@ public:
 
 static void LoadInternal(ExtensionLoader &loader) {
 	auto &instance = loader.GetDatabaseInstance();
-	ExtensionHelper::AutoLoadExtension(instance, "parquet");
+	ExtensionHelper::AutoLoadExtension(instance, "parquet")
+	ExtensionHelper::AutoLoadExtension(instance, "avro");
 
 	if (!instance.ExtensionIsLoaded("parquet")) {
 		throw MissingExtensionException("The iceberg extension requires the parquet extension to be loaded!");
+	}
+	if (!instance.ExtensionIsLoaded("avro")) {
+		throw MissingExtensionException("The iceberg extension requires the avro extension to be loaded!");
 	}
 
 	auto &config = DBConfig::GetConfig(instance);

--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -37,7 +37,7 @@ public:
 
 static void LoadInternal(ExtensionLoader &loader) {
 	auto &instance = loader.GetDatabaseInstance();
-	ExtensionHelper::AutoLoadExtension(instance, "parquet")
+	ExtensionHelper::AutoLoadExtension(instance, "parquet");
 	ExtensionHelper::AutoLoadExtension(instance, "avro");
 
 	if (!instance.ExtensionIsLoaded("parquet")) {

--- a/src/storage/table_update/iceberg_add_snapshot.cpp
+++ b/src/storage/table_update/iceberg_add_snapshot.cpp
@@ -6,6 +6,8 @@
 #include "duckdb/parser/parsed_data/copy_info.hpp"
 #include "duckdb/execution/execution_context.hpp"
 #include "duckdb/parallel/thread_context.hpp"
+#include "duckdb/main/extension_helper.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/caching_file_system.hpp"
 
@@ -46,6 +48,7 @@ rest_api_objects::TableUpdate IcebergAddSnapshot::CreateSetSnapshotRefUpdate() {
 
 void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
 	// load avro so we can get
+	auto &instance = DatabaseInstance::GetDatabase(context);
 	ExtensionHelper::AutoLoadExtension(instance, "avro");
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);

--- a/src/storage/table_update/iceberg_add_snapshot.cpp
+++ b/src/storage/table_update/iceberg_add_snapshot.cpp
@@ -47,7 +47,6 @@ rest_api_objects::TableUpdate IcebergAddSnapshot::CreateSetSnapshotRefUpdate() {
 }
 
 void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
-	// load avro so we can get
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);
 	auto &schema = system_catalog.GetSchema(data, DEFAULT_SCHEMA);

--- a/src/storage/table_update/iceberg_add_snapshot.cpp
+++ b/src/storage/table_update/iceberg_add_snapshot.cpp
@@ -48,8 +48,6 @@ rest_api_objects::TableUpdate IcebergAddSnapshot::CreateSetSnapshotRefUpdate() {
 
 void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
 	// load avro so we can get
-	auto &instance = DatabaseInstance::GetDatabase(context);
-	ExtensionHelper::AutoLoadExtension(instance, "avro");
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);
 	auto &schema = system_catalog.GetSchema(data, DEFAULT_SCHEMA);

--- a/src/storage/table_update/iceberg_add_snapshot.cpp
+++ b/src/storage/table_update/iceberg_add_snapshot.cpp
@@ -45,6 +45,8 @@ rest_api_objects::TableUpdate IcebergAddSnapshot::CreateSetSnapshotRefUpdate() {
 }
 
 void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
+	// load avro so we can get
+	ExtensionHelper::AutoLoadExtension(instance, "avro");
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);
 	auto &schema = system_catalog.GetSchema(data, DEFAULT_SCHEMA);


### PR DESCRIPTION
Just load avro on extension load
Could supersede https://github.com/duckdb/duckdb-iceberg/pull/452, but want to check if conflicts with spatial are resolved first. Status of that is in https://github.com/Tmonster/duckdb/pull/247