### PR TITLE
Fix create table sigv4

### DIFF
--- a/src/aws.cpp
+++ b/src/aws.cpp
@@ -149,11 +149,14 @@ unique_ptr<HTTPResponse> AWSInput::ExecuteRequest(ClientContext &context, Aws::H
 	if (resCode == Aws::Http::HttpResponseCode::REQUEST_NOT_MADE) {
 		D_ASSERT(response->HasClientError());
 		result->reason = response->GetClientErrorMessage();
+		throw HTTPException(*result, result->reason);
+	}
+	Aws::StringStream resBody;
+	resBody << response->GetResponseBody().rdbuf();
+	result->body = resBody.str();
+
+	if (static_cast<uint16_t>(result->status) > 400) {
 		result->success = false;
-	} else {
-		Aws::StringStream resBody;
-		resBody << response->GetResponseBody().rdbuf();
-		result->body = resBody.str();
 	}
 	return result;
 }

--- a/src/catalog_api.cpp
+++ b/src/catalog_api.cpp
@@ -83,7 +83,7 @@ bool IRCAPI::VerifySchemaExistence(ClientContext &context, IRCatalog &catalog, c
 	if (response->status == HTTPStatusCode::NotFound_404) {
 		return false;
 	}
-	throw HTTPException(*response, response->reason);
+	ThrowException(url, *response, response->reason);
 }
 
 bool IRCAPI::VerifyTableExistence(ClientContext &context, IRCatalog &catalog, const IRCSchemaEntry &schema,
@@ -107,7 +107,7 @@ bool IRCAPI::VerifyTableExistence(ClientContext &context, IRCatalog &catalog, co
 	if (response->status == HTTPStatusCode::NotFound_404) {
 		return false;
 	}
-	throw HTTPException(*response, response->reason);
+	ThrowException(url, *response, response->reason);
 }
 
 static unique_ptr<HTTPResponse> GetTableMetadata(ClientContext &context, IRCatalog &catalog,

--- a/test/sql/cloud/s3tables/test_create_table_s3tables.test
+++ b/test/sql/cloud/s3tables/test_create_table_s3tables.test
@@ -30,6 +30,8 @@ attach 'arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing' as s3_ca
     ENDPOINT_TYPE S3_TABLES
 );
 
+set ignore_error_messages
+
 statement ok
 create schema IF NOT EXISTS s3_catalog.test_create_schema;
 

--- a/test/sql/cloud/s3tables/test_direct_keys_s3tables.test
+++ b/test/sql/cloud/s3tables/test_direct_keys_s3tables.test
@@ -33,6 +33,8 @@ attach 'arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing' as my_da
     ENDPOINT_TYPE 'S3_Tables'
 );
 
+set ignore_error_messages
+
 query T nosort tables_1
 show all tables;
 ----

--- a/test/sql/cloud/s3tables/test_direct_keys_s3tables_no_endpoint_type.test
+++ b/test/sql/cloud/s3tables/test_direct_keys_s3tables_no_endpoint_type.test
@@ -34,6 +34,8 @@ attach 'arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing' as my_da
 	ENDPOINT 's3tables.us-east-2.amazonaws.com/iceberg'
 );
 
+set ignore_error_messages
+
 query T nosort tables_1
 show all tables;
 ----

--- a/test/sql/cloud/s3tables/test_insert_into_s3table.test
+++ b/test/sql/cloud/s3tables/test_insert_into_s3table.test
@@ -26,6 +26,8 @@ CREATE SECRET s1 (
   PROVIDER credential_chain
 );
 
+set ignore_error_messages
+
 statement ok
 attach 'arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing' as s3_catalog (
     TYPE ICEBERG,

--- a/test/sql/cloud/s3tables/test_logging_aws.test
+++ b/test/sql/cloud/s3tables/test_logging_aws.test
@@ -35,6 +35,8 @@ attach 'arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing' as s3_ca
     ENDPOINT_TYPE 'S3_TABLES'
 );
 
+set ignore_error_messages
+
 query I
 select count(*) from s3_catalog.tpch_sf1.region;
 ----

--- a/test/sql/cloud/s3tables/test_s3tables.test
+++ b/test/sql/cloud/s3tables/test_s3tables.test
@@ -32,8 +32,7 @@ attach 'arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing' as s3_ca
     ENDPOINT_TYPE 'S3_TABLES'
 );
 
-statement ok
-show all tables;
+set ignore_error_messages
 
 query I
 select count(*) > 20 from (show all tables);

--- a/test/sql/local/irc/test_use.test
+++ b/test/sql/local/irc/test_use.test
@@ -45,7 +45,7 @@ use my_datalake;
 Catalog Error: SET schema: No catalog + schema named "my_datalake" found.
 
 statement ok
-show all tables;
+select * from my_datalake.default.table_unpartitioned;
 
 # 'main' still doesn't exist
 statement error


### PR DESCRIPTION
fixes https://github.com/duckdblabs/duckdb-internal/issues/5833

Requests through aws and httplib are not consistent with what is a success and what is a failure. Using the httplib only 200 and 304_not_modified are considered "success", meanwhile a number of other 200 responses would be considered a failures (i.e 204_NoContent for head requests). I will make a separate PR to address this.

This PR just fixes the AWS requests so that anything in the range [200, 300) is a success, and anything >=400 is a failure. I'm pretty sure aws handles 300 responses internally. Also unsure how to get 100 responses.

Also fixes an issue with validating table existence. If a request fails because of a 400, we should make sure it's 404 and not 401_Unauthorized, or 402_BadRequest, or 403_Forbidden. Those are errors we should surface to the user and not return as a failed head attempt. That will return a "Table/Schema does not exist".

Only a 404 response should signify the schema/table has failed because the object doesn't exist. 

I'm working on cloud testing this again, cloud tests have been failing since there was a ton of data put on to R2 that I want to delete