### PR TITLE
[Dev] Fix test that was silently being skipped due to `require` problems

### DIFF
--- a/test/sql/local/iceberg_scans/big_query_read.test
+++ b/test/sql/local/iceberg_scans/big_query_read.test
@@ -1,11 +1,11 @@
 # name: test/sql/local/iceberg_scans/big_query_read.test
 # group: [iceberg_scans]
 
+require avro
+
 require parquet
 
 require iceberg
-
-require avro
 
 query III
 select * from iceberg_scan('data/persistent/big_query_error');


### PR DESCRIPTION
`avro` has to be required first, `iceberg` will fail if that's not the case
This is a bug in the unittester (of core, duckdb/duckdb), but we're working around it here first