### PR TITLE
Upgrade openssl version

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -31,7 +31,7 @@
 	"overrides": [
 		{
 			"name": "openssl",
-			"version": "3.0.8"
+			"version": "3.5.2"
 		}
 	]
 }


### PR DESCRIPTION
Hi team, I'm suffering link error when compiling the extension.
(I feel weird, since vcpkg is supposed to be hermetic from my understanding.)

Error message:
```sh
[ 90%] Building CXX object extension/parquet/CMakeFiles/parquet_loadable_extension.dir/parquet_timestamp.cpp.o 
/usr/bin/ld: ../../vcpkg_installed/arm64-linux/lib/libs2n.a(s2n_hash.c.o): in function s2n_evp_hash_digest': s2n_hash.c:(.text+0x1128): undefined reference to EVP_MD_CTX_get_size_ex' 
collect2: error: ld returned 1 exit status gmake[3]: *** [tools/shell/CMakeFiles/shell.dir/build.make:232: duckdb] 
Error 1 gmake[2]: *** [CMakeFiles/Makefile2:9789: tools/shell/CMakeFiles/shell.dir/all] 
Error 2 gmake[2]: *** Waiting for unfinished jobs....
```

The command I'm using
```sh
 VCPKG_TOOLCHAIN_PATH='/tmp/vcpkg/scripts/buildsystems/vcpkg.cmake' make reldebug -j 10
```

I checked the symbol, seems it exists for higher version of openssl
```sh
# Check local openssl symbol
vscode ➜ /tmp/duckdb_iceberg (hjiang/upgrade-openssl) $ pkg-config --modversion openssl 2>/dev/null || echo "no pkg-config"
3.5.1
vscode ➜ /tmp/duckdb_iceberg (hjiang/upgrade-openssl) $ nm -D /usr/lib/*/libcrypto.so* | grep -E 'EVP_MD_CTX_get_size_ex' || true
0000000000223fa4 T EVP_MD_CTX_get_size_ex@@OPENSSL_3.4.0
0000000000223fa4 T EVP_MD_CTX_get_size_ex@@OPENSSL_3.4.0
```

I tried to upgrade openssl to a higher version, which works on my end.
Let me know if you think it's a valid change, thank you!