### PR TITLE
Fix Cloud tests. Modify what responses to `/namespaces` return false

### DIFF
--- a/test/sql/cloud/glue/test_create_table_glue.test
+++ b/test/sql/cloud/glue/test_create_table_glue.test
@@ -18,6 +18,8 @@ require httpfs
 
 require aws
 
+set ignore_error_messages
+
 statement ok
 CREATE SECRET (
   TYPE S3,

--- a/test/sql/cloud/glue/test_direct_keys_glue.test
+++ b/test/sql/cloud/glue/test_direct_keys_glue.test
@@ -18,6 +18,8 @@ require httpfs
 
 require aws
 
+set ignore_error_messages
+
 statement ok
 CREATE SECRET s1 (
       TYPE S3,

--- a/test/sql/cloud/glue/test_direct_keys_glue_no_endpoint_type.test
+++ b/test/sql/cloud/glue/test_direct_keys_glue_no_endpoint_type.test
@@ -18,6 +18,8 @@ require httpfs
 
 require aws
 
+set ignore_error_messages
+
 # test using keys directory
 statement ok
 CREATE SECRET s1 (

--- a/test/sql/cloud/glue/test_glue.test
+++ b/test/sql/cloud/glue/test_glue.test
@@ -18,6 +18,8 @@ require httpfs
 
 require aws
 
+set ignore_error_messages
+
 statement ok
 CREATE SECRET glue_secret (
     TYPE S3,
@@ -74,5 +76,5 @@ attach '840140254803:incorrect/pyiceberg-blog-bucket' as no_s3tables (
 statement error
 select * from no_s3tables.my_namesepace.my_table;
 ----
-Catalog not found
+<REGEX>:.*HTTP Error: GET request to endpoint.*404.*
 

--- a/test/sql/cloud/glue/test_insert_glue.test
+++ b/test/sql/cloud/glue/test_insert_glue.test
@@ -20,6 +20,8 @@ require httpfs
 
 require aws
 
+set ignore_error_messages
+
 statement ok
 CREATE SECRET (
     TYPE S3,

--- a/test/sql/cloud/r2_catalog/test_r2_attach_and_read.test
+++ b/test/sql/cloud/r2_catalog/test_r2_attach_and_read.test
@@ -31,6 +31,8 @@ attach '6b17833f308abc1e1cc343c552b51f51_r2-catalog' AS my_datalake (
     ENDPOINT 'https://catalog.cloudflarestorage.com/6b17833f308abc1e1cc343c552b51f51/r2-catalog'
 );
 
+set ignore_error_messages
+
 statement ok
 CALL enable_logging('HTTP');
 

--- a/test/sql/cloud/r2_catalog/test_r2_create_table.test
+++ b/test/sql/cloud/r2_catalog/test_r2_create_table.test
@@ -30,6 +30,8 @@ attach '6b17833f308abc1e1cc343c552b51f51_r2-catalog' AS my_datalake (
     ENDPOINT 'https://catalog.cloudflarestorage.com/6b17833f308abc1e1cc343c552b51f51/r2-catalog'
 );
 
+set ignore_error_messages
+
 statement ok
 create schema IF NOT EXISTS my_datalake.test_create;
 

--- a/test/sql/cloud/r2_catalog/test_r2_inserts.test
+++ b/test/sql/cloud/r2_catalog/test_r2_inserts.test
@@ -30,6 +30,8 @@ attach '6b17833f308abc1e1cc343c552b51f51_r2-catalog' AS my_datalake (
     ENDPOINT 'https://catalog.cloudflarestorage.com/6b17833f308abc1e1cc343c552b51f51/r2-catalog'
 );
 
+set ignore_error_messages
+
 query IIII
 select * from my_datalake.test_inserts.basic_insert_test order by id;
 ----

--- a/test/sql/cloud/r2_catalog/test_r2_pagination.test
+++ b/test/sql/cloud/r2_catalog/test_r2_pagination.test
@@ -31,6 +31,8 @@ attach '6b17833f308abc1e1cc343c552b51f51_iceberg-catalog-test' AS my_datalake (
     support_nested_namespaces true
 );
 
+set ignore_error_messages
+
 query I
 select count(*) from (show all tables);
 ----

--- a/test/sql/cloud/s3tables/test_logging_aws.test
+++ b/test/sql/cloud/s3tables/test_logging_aws.test
@@ -44,7 +44,8 @@ select count(*) from s3_catalog.tpch_sf1.region;
 
 # make sure we log calls to IRC
 query II
-select request.url, request.type from duckdb_logs_parsed('HTTP') where request.type = 'GET' and request.url like '%/iceberg-testing/namespaces/%'
+select request.url, request.type from duckdb_logs_parsed('HTTP') where request.type in ('GET', 'HEAD') and request.url like '%/iceberg-testing/namespaces/%'
 ----
-https://s3tables.us-east-2.amazonaws.com/iceberg/v1/arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing/namespaces/tpch_sf1/tables	GET
+https://s3tables.us-east-2.amazonaws.com/iceberg/v1/arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing/namespaces/tpch_sf1	HEAD
+https://s3tables.us-east-2.amazonaws.com/iceberg/v1/arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing/namespaces/tpch_sf1/tables/region	HEAD
 https://s3tables.us-east-2.amazonaws.com/iceberg/v1/arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing/namespaces/tpch_sf1/tables/region	GET

--- a/test/sql/cloud/test_aws_secret_type.test
+++ b/test/sql/cloud/test_aws_secret_type.test
@@ -36,6 +36,8 @@ attach '840140254803:s3tablescatalog/duckdblabs-iceberg-testing' as glue_catalog
     ENDPOINT_TYPE 'GLUE'
 );
 
+set ignore_error_messages
+
 statement ok
 attach 'arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing' as s3_catalog (
     TYPE ICEBERG,

--- a/test/sql/cloud/test_glue_catalog_with_other_tables.test
+++ b/test/sql/cloud/test_glue_catalog_with_other_tables.test
@@ -30,6 +30,7 @@ attach '840140254803' as glue_catalog (
   AUTHORIZATION_TYPE 'sigv4'
 );
 
+set ignore_error_messages
 
 statement ok
 show all tables;

--- a/test/sql/cloud/test_multiple_catalogs.test
+++ b/test/sql/cloud/test_multiple_catalogs.test
@@ -18,6 +18,8 @@ require httpfs
 
 require aws
 
+set ignore_error_messages
+
 statement ok
 CREATE SECRET s3table_secret (
     TYPE s3,

--- a/test/sql/cloud/test_use.test
+++ b/test/sql/cloud/test_use.test
@@ -33,6 +33,8 @@ attach '840140254803:s3tablescatalog/pyiceberg-blog-bucket' as glue_lake (
     ENDPOINT_TYPE 'GLUE'
 );
 
+set ignore_error_messages
+
 statement ok
 use glue_lake.myblognamespace;
 


### PR DESCRIPTION
AWS requests would log every request as a GET request. This was incorrect and has now been fixed. 

Also, when running `VerifyNamespaceExistence`, we would only return false if the response was 404. Via cloud testing I have found that some other catalogs return other responses. To avoid surfacing unnecessary http response codes to users, I have decided to expand the scope of what responses merit a logical "This table does not exist" response. 

I have noticed in particular with the Glue catalog that responses are inconsistent with what the iceberg rests api spec defined.

Also added `set ignore_error_messages` for a lot more of the cloud tests.