### PR TITLE
Unify request logic and enable no vended credentials

### DIFF
--- a/.github/workflows/Nessie_Testing.yml
+++ b/.github/workflows/Nessie_Testing.yml
@@ -22,6 +22,16 @@ jobs:
       PIP_BREAK_SYSTEM_PACKAGES: 1
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: 5e5d0e1cd7785623065e77eff011afdeec1a3574
+
       - name: Install nessie required packages
         shell: bash
         run: |
@@ -44,21 +54,11 @@ jobs:
           key: ${{ github.job }}
           save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
 
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11.1
-        with:
-          vcpkgGitCommitId: 5e5d0e1cd7785623065e77eff011afdeec1a3574
-
       - name: Start Nessie
         working-directory: nessie/docker
         run: |
           sed -i '/healthcheck/,/]/ s/\$/$$/g' catalog-auth-s3/docker-compose.yml
           docker-compose -f catalog-auth-s3/docker-compose.yml up -d
-
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: 'true'
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/Nessie_Testing.yml
+++ b/.github/workflows/Nessie_Testing.yml
@@ -33,9 +33,6 @@ jobs:
             make gcc-multilib \
             g++-multilib \
             libssl-dev \
-            wget \
-            openjdk-8-jdk \
-            zip \
             maven \
             unixodbc-dev \
             libc6-dev-i386 \
@@ -54,6 +51,19 @@ jobs:
           sudo apt-get install -y -qq tar pkg-config
           sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
+          
+      - name: Set up for Nessie
+        run: |
+          # install java
+          sudo apt install -y -qq openjdk-21-jre-headless
+          sudo apt install -y -qq openjdk-21-jdk-headless
+          sudo apt-get install -y -qq python3-venv
+          git clone https://github.com/projectnessie/nessie.git nessie
+
+      - name: Start Nessie
+        working-directory: nessie
+        run: |
+         docker-compose -f catalog-auth-s3/docker-compose.yml up -d
 
       - uses: actions/checkout@v4
         with:
@@ -75,21 +85,6 @@ jobs:
           STATIC_LIBCPP: 1
         run: |
           make release
-
-      - name: Set up for Nessie
-        run: |
-          # install java
-          # TODO: need a newer java version maybe?
-          sudo apt install -y -qq openjdk-21-jre-headless
-          sudo apt install -y -qq openjdk-21-jdk-headless
-          sudo apt-get install -y -qq python3-venv
-          git clone https://github.com/projectnessie/nessie.git nessie
-
-      - name: Start Nessie
-        working-directory: ./nessie
-        run: |
-          docker-compose -f catalog-auth-s3/docker-compose.yml up -d
-          
 
       - name: Wait for Nessie/Keycloak
         run: |

--- a/.github/workflows/Nessie_Testing.yml
+++ b/.github/workflows/Nessie_Testing.yml
@@ -22,6 +22,9 @@ jobs:
       PIP_BREAK_SYSTEM_PACKAGES: 1
 
     steps:
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Install required ubuntu packages
         run: |
           sudo apt-get update -y -qq
@@ -59,9 +62,6 @@ jobs:
           sudo apt install -y -qq openjdk-21-jdk-headless
           sudo apt-get install -y -qq python3-venv
           git clone https://github.com/projectnessie/nessie.git nessie
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
 
       - name: Start Nessie
         working-directory: nessie/docker

--- a/.github/workflows/Nessie_Testing.yml
+++ b/.github/workflows/Nessie_Testing.yml
@@ -22,12 +22,9 @@ jobs:
       PIP_BREAK_SYSTEM_PACKAGES: 1
 
     steps:
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Install nessie required packages
         shell: bash
-        run:
+        run: |
           # install docker
           sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
@@ -63,6 +60,9 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Build extension
         env:
           GEN: ninja
@@ -87,7 +87,7 @@ jobs:
 
       - name: Test with rest catalog
         env:
-          NESSIE_SERVER_AVAILABLE=1: 1
+          NESSIE_SERVER_AVAILABLE: 1
         run: |
           ./build/release/test/unittest "$PWD/test/*" --list-test-names-only || true
           ./build/release/test/unittest "$PWD/test/*"

--- a/.github/workflows/Nessie_Testing.yml
+++ b/.github/workflows/Nessie_Testing.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11.1
         with:
-          vcpkgGitCommitId: 5e5d0e1cd7785623065e77eff011afdeec1a3574
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
 
       - name: Install nessie required packages
         shell: bash
@@ -59,9 +59,6 @@ jobs:
         run: |
           sed -i '/healthcheck/,/]/ s/\$/$$/g' catalog-auth-s3/docker-compose.yml
           docker-compose -f catalog-auth-s3/docker-compose.yml up -d
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
 
       - name: Build extension
         env:

--- a/.github/workflows/Nessie_Testing.yml
+++ b/.github/workflows/Nessie_Testing.yml
@@ -64,9 +64,10 @@ jobs:
         uses: mxschmitt/action-tmate@v3
 
       - name: Start Nessie
-        working-directory: nessie
+        working-directory: nessie/docker
         run: |
-         docker-compose -f catalog-auth-s3/docker-compose.yml up -d
+          sed -i '/healthcheck/,/]/ s/\$/$$/g' catalog-auth-s3/docker-compose.yml
+          docker-compose -f catalog-auth-s3/docker-compose.yml up -d
 
       - uses: actions/checkout@v4
         with:
@@ -103,7 +104,6 @@ jobs:
             attempt=$((attempt + 1))
           done
           echo "Keycloak is healthy"
-
 
       - name: Test with rest catalog
         env:

--- a/.github/workflows/Nessie_Testing.yml
+++ b/.github/workflows/Nessie_Testing.yml
@@ -1,0 +1,116 @@
+name: Local Nessie Testing
+on: [push, pull_request,repository_dispatch]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  cancel-in-progress: true
+defaults:
+  run:
+    shell: bash
+
+env:
+  BASE_BRANCH: ${{ github.base_ref || (endsWith(github.ref, '_feature') && 'feature' || 'main') }}
+
+jobs:
+  rest:
+    name: Test against Nessie Catalog
+    runs-on: ubuntu-latest
+    env:
+      VCPKG_TARGET_TRIPLET: 'x64-linux-release'
+      GEN: ninja
+      VCPKG_FEATURE_FLAGS: "-binarycaching"
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+      PIP_BREAK_SYSTEM_PACKAGES: 1
+
+    steps:
+      - name: Install required ubuntu packages
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq software-properties-common
+          sudo add-apt-repository ppa:git-core/ppa
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq \
+            ninja-build \
+            make gcc-multilib \
+            g++-multilib \
+            libssl-dev \
+            wget \
+            openjdk-8-jdk \
+            zip \
+            maven \
+            unixodbc-dev \
+            libc6-dev-i386 \
+            lib32readline6-dev \
+            libssl-dev \
+            libcurl4-gnutls-dev \
+            libexpat1-dev \
+            gettext \
+            unzip \
+            build-essential \
+            checkinstall \
+            libffi-dev \
+            curl \
+            libz-dev \
+            openssh-client
+          sudo apt-get install -y -qq tar pkg-config
+          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+        continue-on-error: true
+
+      - name: Build extension
+        env:
+          GEN: ninja
+          STATIC_LIBCPP: 1
+        run: |
+          make release
+
+      - name: Set up for Nessie
+        run: |
+          # install java
+          # TODO: need a newer java version maybe?
+          sudo apt install -y -qq openjdk-21-jre-headless
+          sudo apt install -y -qq openjdk-21-jdk-headless
+          sudo apt-get install -y -qq python3-venv
+          git clone https://github.com/projectnessie/nessie.git nessie
+
+      - name: Start Nessie
+        working-directory: ./nessie
+        run: |
+          docker-compose -f catalog-auth-s3/docker-compose.yml up -d
+          
+
+      - name: Wait for Nessie/Keycloak
+        run: |
+          max_attempts=30
+          attempt=1
+          while ! curl -sf "http://localhost:8080/realms/master/.well-known/openid-configuration"; do
+            if [ $attempt -gt $max_attempts ]; then
+              echo "Keycloak failed to initialize after $max_attempts attempts"
+              exit 1
+            fi
+            echo "Waiting for Keycloak to initialize (attempt $attempt/$max_attempts)..."
+            sleep 5
+            attempt=$((attempt + 1))
+          done
+          echo "Keycloak is healthy"
+
+
+      - name: Test with rest catalog
+        env:
+          NESSIE_SERVER_AVAILABLE=1: 1
+        run: |
+          ./build/release/test/unittest "$PWD/test/*" --list-test-names-only || true
+          ./build/release/test/unittest "$PWD/test/*"
+

--- a/.github/workflows/Nessie_Testing.yml
+++ b/.github/workflows/Nessie_Testing.yml
@@ -60,6 +60,9 @@ jobs:
           sudo apt-get install -y -qq python3-venv
           git clone https://github.com/projectnessie/nessie.git nessie
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Start Nessie
         working-directory: nessie
         run: |

--- a/.github/workflows/Nessie_Testing.yml
+++ b/.github/workflows/Nessie_Testing.yml
@@ -25,43 +25,32 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
 
-      - name: Install required ubuntu packages
-        run: |
-          sudo apt-get update -y -qq
-          sudo apt-get install -y -qq software-properties-common
-          sudo add-apt-repository ppa:git-core/ppa
-          sudo apt-get update -y -qq
-          sudo apt-get install -y -qq \
-            ninja-build \
-            make gcc-multilib \
-            g++-multilib \
-            libssl-dev \
-            maven \
-            unixodbc-dev \
-            libc6-dev-i386 \
-            lib32readline6-dev \
-            libssl-dev \
-            libcurl4-gnutls-dev \
-            libexpat1-dev \
-            gettext \
-            unzip \
-            build-essential \
-            checkinstall \
-            libffi-dev \
-            curl \
-            libz-dev \
-            openssh-client
-          sudo apt-get install -y -qq tar pkg-config
+      - name: Install nessie required packages
+        shell: bash
+        run:
+          # install docker
           sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
-          
-      - name: Set up for Nessie
-        run: |
           # install java
           sudo apt install -y -qq openjdk-21-jre-headless
           sudo apt install -y -qq openjdk-21-jdk-headless
           sudo apt-get install -y -qq python3-venv
           git clone https://github.com/projectnessie/nessie.git nessie
+
+      - name: Install Ninja
+        shell: bash
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build
+
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          key: ${{ github.job }}
+          save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgGitCommitId: 5e5d0e1cd7785623065e77eff011afdeec1a3574
 
       - name: Start Nessie
         working-directory: nessie/docker
@@ -73,15 +62,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'true'
-
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11.1
-        with:
-          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
-
-      - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@main
-        continue-on-error: true
 
       - name: Build extension
         env:

--- a/src/aws.cpp
+++ b/src/aws.cpp
@@ -194,7 +194,7 @@ unique_ptr<HTTPResponse> AWSInput::Request(HTTPRequestType request_type, ClientC
 	case HTTPRequestType::HTTP_HEAD:
 		return ExecuteRequest(context, Aws::Http::HttpMethod::HTTP_HEAD, headers);
 	default:
-		throw NotImplementedException("Cannot make this type of request");
+		throw NotImplementedException("Cannot make request of type %s", HTTPRequestTypeToString(request_type));
 	}
 }
 

--- a/src/aws.cpp
+++ b/src/aws.cpp
@@ -182,19 +182,19 @@ unique_ptr<HTTPResponse> AWSInput::ExecuteRequest(ClientContext &context, Aws::H
 	return result;
 }
 
-unique_ptr<HTTPResponse> AWSInput::Request(HTTPRequestType request_type, ClientContext &context, HTTPHeaders &headers,
+unique_ptr<HTTPResponse> AWSInput::Request(RequestType request_type, ClientContext &context, HTTPHeaders &headers,
                                            const string &data) {
 	switch (request_type) {
-	case HTTPRequestType::HTTP_GET:
+	case RequestType::GET_REQUEST:
 		return ExecuteRequest(context, Aws::Http::HttpMethod::HTTP_GET, headers);
-	case HTTPRequestType::HTTP_POST:
+	case RequestType::POST_REQUEST:
 		return ExecuteRequest(context, Aws::Http::HttpMethod::HTTP_POST, headers, data);
-	case HTTPRequestType::HTTP_DELETE:
+	case RequestType::DELETE_REQUEST:
 		return ExecuteRequest(context, Aws::Http::HttpMethod::HTTP_DELETE, headers);
-	case HTTPRequestType::HTTP_HEAD:
+	case RequestType::HEAD_REQUEST:
 		return ExecuteRequest(context, Aws::Http::HttpMethod::HTTP_HEAD, headers);
 	default:
-		throw NotImplementedException("Cannot make request of type %s", HTTPRequestTypeToString(request_type));
+		throw NotImplementedException("Cannot make request of type %s", EnumUtil::ToString(request_type));
 	}
 }
 

--- a/src/common/api_utils.cpp
+++ b/src/common/api_utils.cpp
@@ -1,6 +1,7 @@
 #include "api_utils.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/http_util.hpp"
 #include "duckdb/common/exception/http_exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/client_data.hpp"
@@ -26,7 +27,7 @@ const string &APIUtils::GetCURLCertPath() {
 	return cert_path;
 }
 
-unique_ptr<HTTPResponse> APIUtils::Request(HTTPRequestType request_type, ClientContext &context,
+unique_ptr<HTTPResponse> APIUtils::Request(RequestType request_type, ClientContext &context,
                                            const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
                                            const string &data) {
 	auto &db = DatabaseInstance::GetDatabase(context);
@@ -37,27 +38,27 @@ unique_ptr<HTTPResponse> APIUtils::Request(HTTPRequestType request_type, ClientC
 	params = http_util.InitializeParameters(context, request_url);
 
 	switch (request_type) {
-	case HTTPRequestType::HTTP_GET: {
+	case RequestType::GET_REQUEST: {
 		GetRequestInfo get_request(request_url, headers, *params, nullptr, nullptr);
 		return http_util.Request(get_request);
 	}
-	case HTTPRequestType::HTTP_DELETE: {
+	case RequestType::DELETE_REQUEST: {
 		DeleteRequestInfo delete_request(request_url, headers, *params);
 		return http_util.Request(delete_request);
 	}
-	case HTTPRequestType::HTTP_POST: {
+	case RequestType::POST_REQUEST: {
 		PostRequestInfo post_request(request_url, headers, *params, reinterpret_cast<const_data_ptr_t>(data.data()),
 		                             data.size());
 		auto response = http_util.Request(post_request);
 		response->body = post_request.buffer_out;
 		return response;
 	}
-	case HTTPRequestType::HTTP_HEAD: {
+	case RequestType::HEAD_REQUEST: {
 		HeadRequestInfo head_request(request_url, headers, *params);
 		return http_util.Request(head_request);
 	}
 	default:
-		throw NotImplementedException("Cannot make request of type %s", HTTPRequestTypeToString(request_type));
+		throw NotImplementedException("Cannot make request of type %s", EnumUtil::ToString(request_type));
 	}
 }
 

--- a/src/common/api_utils.cpp
+++ b/src/common/api_utils.cpp
@@ -65,7 +65,7 @@ unique_ptr<HTTPResponse> APIUtils::Request(HTTPRequestType request_type, ClientC
 		return http_util.Request(head_request);
 	}
 	default:
-		throw NotImplementedException("This request type idk");
+		throw NotImplementedException("Cannot make request of type %s", HTTPRequestTypeToString(request_type));
 	}
 }
 

--- a/src/common/api_utils.cpp
+++ b/src/common/api_utils.cpp
@@ -26,14 +26,6 @@ const string &APIUtils::GetCURLCertPath() {
 	return cert_path;
 }
 
-static string AddHttpHostIfMissing(const string &url) {
-	auto lower_url = StringUtil::Lower(url);
-	if (StringUtil::StartsWith(lower_url, "http://") || StringUtil::StartsWith(lower_url, "https://")) {
-		return url;
-	}
-	return "http://" + url;
-}
-
 unique_ptr<HTTPResponse> APIUtils::Request(HTTPRequestType request_type, ClientContext &context,
                                            const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
                                            const string &data) {

--- a/src/common/api_utils.cpp
+++ b/src/common/api_utils.cpp
@@ -1,6 +1,5 @@
 #include "api_utils.hpp"
 
-#include "../include/storage/irc_authorization.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/exception/http_exception.hpp"
 #include "duckdb/common/string_util.hpp"

--- a/src/common/api_utils.cpp
+++ b/src/common/api_utils.cpp
@@ -1,4 +1,6 @@
 #include "api_utils.hpp"
+
+#include "../include/storage/irc_authorization.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/exception/http_exception.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -9,7 +11,6 @@
 #include <sys/stat.h>
 
 namespace duckdb {
-
 //! Grab the first path that exists, from a list of well-known locations
 static string SelectCURLCertPath() {
 	for (string &caFile : certFileLocations) {
@@ -34,91 +35,39 @@ static string AddHttpHostIfMissing(const string &url) {
 	return "http://" + url;
 }
 
-unique_ptr<HTTPResponse> APIUtils::DeleteRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder,
-                                                 const string &token) {
+unique_ptr<HTTPResponse> APIUtils::Request(HTTPRequestType request_type, ClientContext &context,
+                                           const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
+                                           const string &data) {
 	auto &db = DatabaseInstance::GetDatabase(context);
-
-	HTTPHeaders headers(db);
-	headers.Insert("X-Iceberg-Access-Delegation", "vended-credentials");
-	headers.Insert("Authorization", StringUtil::Format("Bearer %s", token));
-
-	string request_url = AddHttpHostIfMissing(endpoint_builder.GetURL());
-	auto &http_util = HTTPUtil::Get(db);
-	unique_ptr<HTTPParams> params;
-	params = http_util.InitializeParameters(context, request_url);
-
-	DeleteRequestInfo delete_request(request_url, headers, *params);
-	return http_util.Request(delete_request);
-}
-
-unique_ptr<HTTPResponse> APIUtils::PostRequest(ClientContext &context, const string &url, const string &post_data,
-                                               const unordered_map<string, string> &additional_headers,
-                                               const string &content_type, const string &token) {
-	auto &db = DatabaseInstance::GetDatabase(context);
-
-	string request_url = AddHttpHostIfMissing(url);
-
-	HTTPHeaders headers(db);
-	headers.Insert("X-Iceberg-Access-Delegation", "vended-credentials");
-	headers.Insert("Content-Type", StringUtil::Format("application/%s", content_type));
-	for (auto it : additional_headers) {
-		headers.Insert(it.first, it.second);
-	}
-	if (!token.empty()) {
-		headers.Insert("Authorization", StringUtil::Format("Bearer %s", token));
-	}
-
-	auto &http_util = HTTPUtil::Get(db);
-	unique_ptr<HTTPParams> params;
-	params = http_util.InitializeParameters(context, request_url);
-
-	PostRequestInfo post_request(request_url, headers, *params, reinterpret_cast<const_data_ptr_t>(post_data.data()),
-	                             post_data.size());
-	auto response = http_util.Request(post_request);
-	response->body = post_request.buffer_out;
-	return response;
-}
-
-unique_ptr<HTTPResponse> APIUtils::GetRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder,
-                                              const string &token) {
-	auto &db = DatabaseInstance::GetDatabase(context);
-
-	HTTPHeaders headers(db);
-	headers.Insert("X-Iceberg-Access-Delegation", "vended-credentials");
-	if (!token.empty()) {
-		headers.Insert("Authorization", StringUtil::Format("Bearer %s", token));
-	}
-
-	auto &http_util = HTTPUtil::Get(db);
-	unique_ptr<HTTPParams> params;
-
 	string request_url = AddHttpHostIfMissing(endpoint_builder.GetURL());
 
-	params = http_util.InitializeParameters(context, request_url);
-
-	GetRequestInfo get_request(request_url, headers, *params, nullptr, nullptr);
-	return http_util.Request(get_request);
-}
-
-unique_ptr<HTTPResponse> APIUtils::HeadRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder,
-                                               const string &token) {
-	auto &db = DatabaseInstance::GetDatabase(context);
-
-	HTTPHeaders headers(db);
-	headers.Insert("X-Iceberg-Access-Delegation", "vended-credentials");
-	if (!token.empty()) {
-		headers.Insert("Authorization", StringUtil::Format("Bearer %s", token));
-	}
-
 	auto &http_util = HTTPUtil::Get(db);
 	unique_ptr<HTTPParams> params;
-
-	string request_url = AddHttpHostIfMissing(endpoint_builder.GetURL());
-
 	params = http_util.InitializeParameters(context, request_url);
 
-	HeadRequestInfo head_request(request_url, headers, *params);
-	return http_util.Request(head_request);
+	switch (request_type) {
+	case HTTPRequestType::HTTP_GET: {
+		GetRequestInfo get_request(request_url, headers, *params, nullptr, nullptr);
+		return http_util.Request(get_request);
+	}
+	case HTTPRequestType::HTTP_DELETE: {
+		DeleteRequestInfo delete_request(request_url, headers, *params);
+		return http_util.Request(delete_request);
+	}
+	case HTTPRequestType::HTTP_POST: {
+		PostRequestInfo post_request(request_url, headers, *params, reinterpret_cast<const_data_ptr_t>(data.data()),
+		                             data.size());
+		auto response = http_util.Request(post_request);
+		response->body = post_request.buffer_out;
+		return response;
+	}
+	case HTTPRequestType::HTTP_HEAD: {
+		HeadRequestInfo head_request(request_url, headers, *params);
+		return http_util.Request(head_request);
+	}
+	default:
+		throw NotImplementedException("This request type idk");
+	}
 }
 
 } // namespace duckdb

--- a/src/common/url_utils.cpp
+++ b/src/common/url_utils.cpp
@@ -1,5 +1,4 @@
 #include "url_utils.hpp"
-#include "../include/url_utils.hpp"
 
 #include "duckdb/common/string_util.hpp"
 

--- a/src/common/url_utils.cpp
+++ b/src/common/url_utils.cpp
@@ -1,8 +1,15 @@
 #include "url_utils.hpp"
-
 #include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
+
+string AddHttpHostIfMissing(const string &url) {
+	auto lower_url = StringUtil::Lower(url);
+	if (StringUtil::StartsWith(lower_url, "http://") || StringUtil::StartsWith(lower_url, "https://")) {
+		return url;
+	}
+	return "http://" + url;
+}
 
 void IRCEndpointBuilder::AddPathComponent(const string &component) {
 	if (!component.empty()) {
@@ -54,22 +61,23 @@ string IRCEndpointBuilder::GetURL() const {
 }
 
 IRCEndpointBuilder IRCEndpointBuilder::FromURL(const string &url) {
+	auto url_with_http = AddHttpHostIfMissing(url);
 	auto ret = IRCEndpointBuilder();
-	size_t schemeEnd = url.find("://");
+	size_t schemeEnd = url_with_http.find("://");
 	if (schemeEnd == string::npos) {
 		throw InvalidInputException("Invalid URL: missing scheme");
 	}
-	string scheme = url.substr(0, schemeEnd);
+	string scheme = url_with_http.substr(0, schemeEnd);
 
 	// Start of host
 	size_t hostStart = schemeEnd + 3;
 
 	// Find where host ends (at first '/' after scheme)
-	size_t pathStart = url.find('/', hostStart);
-	ret.SetHost(url.substr(0, pathStart));
+	size_t pathStart = url_with_http.find('/', hostStart);
+	ret.SetHost(url_with_http.substr(0, pathStart));
 
 	// Extract path and split into components
-	string path = url.substr(pathStart + 1);
+	string path = url_with_http.substr(pathStart + 1);
 	size_t pos = 0;
 	string component = "";
 	while ((pos = path.find('/')) != string::npos) {
@@ -82,7 +90,6 @@ IRCEndpointBuilder IRCEndpointBuilder::FromURL(const string &url) {
 	if (!path.empty()) {
 		ret.path_components.push_back(path);
 	}
-	D_ASSERT(ret.GetURL() == url);
 	return ret;
 }
 

--- a/src/include/api_utils.hpp
+++ b/src/include/api_utils.hpp
@@ -13,6 +13,7 @@
 #include "url_utils.hpp"
 #include "aws.hpp"
 #include "duckdb/common/http_util.hpp"
+#include "storage/irc_authorization.hpp"
 
 namespace duckdb {
 
@@ -33,16 +34,10 @@ static string certFileLocations[] = {
 
 class APIUtils {
 public:
-	static unique_ptr<HTTPResponse> GetRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder,
-	                                           const string &token = "");
-	static unique_ptr<HTTPResponse> HeadRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder,
-	                                            const string &token = "");
-	static unique_ptr<HTTPResponse> DeleteRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder,
-	                                              const string &token = "");
-	static unique_ptr<HTTPResponse> PostRequest(ClientContext &context, const string &url, const string &post_data,
-	                                            const unordered_map<string, string> &additional_headers,
-	                                            const string &content_type = "x-www-form-urlencoded",
-	                                            const string &token = "");
+	static unique_ptr<HTTPResponse> Request(HTTPRequestType request_type, ClientContext &context,
+	                                        const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
+	                                        const string &data);
+
 	//! We use a singleton here to store the path, set by SelectCurlCertPath
 	static const string &GetCURLCertPath();
 };

--- a/src/include/api_utils.hpp
+++ b/src/include/api_utils.hpp
@@ -34,7 +34,7 @@ static string certFileLocations[] = {
 
 class APIUtils {
 public:
-	static unique_ptr<HTTPResponse> Request(HTTPRequestType request_type, ClientContext &context,
+	static unique_ptr<HTTPResponse> Request(RequestType request_type, ClientContext &context,
 	                                        const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
 	                                        const string &data);
 

--- a/src/include/aws.hpp
+++ b/src/include/aws.hpp
@@ -21,7 +21,7 @@ public:
 	}
 
 public:
-	unique_ptr<HTTPResponse> Request(HTTPRequestType request_type, ClientContext &context, HTTPHeaders &headers,
+	unique_ptr<HTTPResponse> Request(RequestType request_type, ClientContext &context, HTTPHeaders &headers,
 	                                 const string &data);
 
 #ifdef EMSCRIPTEN

--- a/src/include/aws.hpp
+++ b/src/include/aws.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "duckdb/common/http_util.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "storage/irc_authorization.hpp"
 
 #ifdef EMSCRIPTEN
 #else
@@ -19,17 +21,15 @@ public:
 	}
 
 public:
-	unique_ptr<HTTPResponse> GetRequest(ClientContext &context);
-	unique_ptr<HTTPResponse> HeadRequest(ClientContext &context);
-	unique_ptr<HTTPResponse> DeleteRequest(ClientContext &context);
-	unique_ptr<HTTPResponse> PostRequest(ClientContext &context, string post_body);
+	unique_ptr<HTTPResponse> Request(HTTPRequestType request_type, ClientContext &context, HTTPHeaders &headers,
+	                                 const string &data);
 
 #ifdef EMSCRIPTEN
 #else
-	unique_ptr<HTTPResponse> ExecuteRequest(ClientContext &context, Aws::Http::HttpMethod method,
-	                                        const string body = "", string content_type = "");
+	unique_ptr<HTTPResponse> ExecuteRequest(ClientContext &context, Aws::Http::HttpMethod method, HTTPHeaders &headers,
+	                                        const string &body = "");
 	std::shared_ptr<Aws::Http::HttpRequest> CreateSignedRequest(Aws::Http::HttpMethod method, const Aws::Http::URI &uri,
-	                                                            const string &body = "", string content_type = "");
+	                                                            HTTPHeaders &headers, const string &body = "");
 	Aws::Http::URI BuildURI();
 	Aws::Client::ClientConfiguration BuildClientConfig();
 #endif

--- a/src/include/metadata/iceberg_table_schema.hpp
+++ b/src/include/metadata/iceberg_table_schema.hpp
@@ -18,8 +18,7 @@ public:
 	static const IcebergColumnDefinition &GetFromColumnIndex(const vector<unique_ptr<IcebergColumnDefinition>> &columns,
 	                                                         const ColumnIndex &column_index, idx_t depth);
 
-	static void SchemaToJson(yyjson_mut_doc *doc, yyjson_mut_val *root_object,
-	                         const rest_api_objects::AddSchemaUpdate &update);
+	static void SchemaToJson(yyjson_mut_doc *doc, yyjson_mut_val *root_object, const rest_api_objects::Schema &schema);
 
 public:
 	int32_t schema_id;

--- a/src/include/metadata/iceberg_table_schema.hpp
+++ b/src/include/metadata/iceberg_table_schema.hpp
@@ -2,6 +2,7 @@
 
 #include "metadata/iceberg_column_definition.hpp"
 #include "rest_catalog/objects/schema.hpp"
+#include "rest_catalog/objects/add_schema_update.hpp"
 #include "duckdb/common/column_index.hpp"
 
 namespace duckdb {
@@ -17,10 +18,13 @@ public:
 	static const IcebergColumnDefinition &GetFromColumnIndex(const vector<unique_ptr<IcebergColumnDefinition>> &columns,
 	                                                         const ColumnIndex &column_index, idx_t depth);
 
-	static void SchemaToJson(yyjson_mut_doc *doc, yyjson_mut_val *root_object, const rest_api_objects::Schema &schema);
+	static void SchemaToJson(yyjson_mut_doc *doc, yyjson_mut_val *root_object,
+	                         const rest_api_objects::AddSchemaUpdate &update);
 
 public:
 	int32_t schema_id;
+	// Nessie Needs this for some reason.
+	idx_t last_column_id;
 	vector<unique_ptr<IcebergColumnDefinition>> columns;
 };
 

--- a/src/include/storage/authorization/none.hpp
+++ b/src/include/storage/authorization/none.hpp
@@ -13,7 +13,7 @@ public:
 
 public:
 	static unique_ptr<IRCAuthorization> FromAttachOptions(IcebergAttachOptions &input);
-	unique_ptr<HTTPResponse> Request(HTTPRequestType request_type, ClientContext &context,
+	unique_ptr<HTTPResponse> Request(RequestType request_type, ClientContext &context,
 	                                 const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
 	                                 const string &data = "") override;
 };

--- a/src/include/storage/authorization/none.hpp
+++ b/src/include/storage/authorization/none.hpp
@@ -13,11 +13,9 @@ public:
 
 public:
 	static unique_ptr<IRCAuthorization> FromAttachOptions(IcebergAttachOptions &input);
-	unique_ptr<HTTPResponse> GetRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder) override;
-	unique_ptr<HTTPResponse> HeadRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder) override;
-	unique_ptr<HTTPResponse> DeleteRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder) override;
-	unique_ptr<HTTPResponse> PostRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder,
-	                                     const string &body) override;
+	unique_ptr<HTTPResponse> Request(HTTPRequestType request_type, ClientContext &context,
+	                                 const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
+	                                 const string &data = "") override;
 };
 
 } // namespace duckdb

--- a/src/include/storage/authorization/oauth2.hpp
+++ b/src/include/storage/authorization/oauth2.hpp
@@ -15,7 +15,7 @@ public:
 
 public:
 	static unique_ptr<OAuth2Authorization> FromAttachOptions(ClientContext &context, IcebergAttachOptions &input);
-	unique_ptr<HTTPResponse> Request(HTTPRequestType request_type, ClientContext &context,
+	unique_ptr<HTTPResponse> Request(RequestType request_type, ClientContext &context,
 	                                 const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
 	                                 const string &data = "") override;
 	static string GetToken(ClientContext &context, const string &grant_type, const string &uri, const string &client_id,

--- a/src/include/storage/authorization/oauth2.hpp
+++ b/src/include/storage/authorization/oauth2.hpp
@@ -15,11 +15,9 @@ public:
 
 public:
 	static unique_ptr<OAuth2Authorization> FromAttachOptions(ClientContext &context, IcebergAttachOptions &input);
-	unique_ptr<HTTPResponse> GetRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder) override;
-	unique_ptr<HTTPResponse> HeadRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder) override;
-	unique_ptr<HTTPResponse> DeleteRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder) override;
-	unique_ptr<HTTPResponse> PostRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder,
-	                                     const string &body) override;
+	unique_ptr<HTTPResponse> Request(HTTPRequestType request_type, ClientContext &context,
+	                                 const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
+	                                 const string &data = "") override;
 	static string GetToken(ClientContext &context, const string &grant_type, const string &uri, const string &client_id,
 	                       const string &client_secret, const string &scope);
 	static void SetCatalogSecretParameters(CreateSecretFunction &function);

--- a/src/include/storage/authorization/oauth2.hpp
+++ b/src/include/storage/authorization/oauth2.hpp
@@ -34,7 +34,6 @@ public:
 
 	//! The user-supplied default region to add to the default secret
 	string default_region;
-
 	//! The (bearer) token retrieved
 	string token;
 };

--- a/src/include/storage/authorization/sigv4.hpp
+++ b/src/include/storage/authorization/sigv4.hpp
@@ -15,11 +15,9 @@ public:
 
 public:
 	static unique_ptr<IRCAuthorization> FromAttachOptions(IcebergAttachOptions &input);
-	unique_ptr<HTTPResponse> GetRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder) override;
-	unique_ptr<HTTPResponse> HeadRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder) override;
-	unique_ptr<HTTPResponse> DeleteRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder) override;
-	unique_ptr<HTTPResponse> PostRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder,
-	                                     const string &body) override;
+	unique_ptr<HTTPResponse> Request(HTTPRequestType request_type, ClientContext &context,
+	                                 const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
+	                                 const string &data = "") override;
 
 private:
 	AWSInput CreateAWSInput(ClientContext &context, const IRCEndpointBuilder &endpoint_builder);

--- a/src/include/storage/authorization/sigv4.hpp
+++ b/src/include/storage/authorization/sigv4.hpp
@@ -15,7 +15,7 @@ public:
 
 public:
 	static unique_ptr<IRCAuthorization> FromAttachOptions(IcebergAttachOptions &input);
-	unique_ptr<HTTPResponse> Request(HTTPRequestType request_type, ClientContext &context,
+	unique_ptr<HTTPResponse> Request(RequestType request_type, ClientContext &context,
 	                                 const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
 	                                 const string &data = "") override;
 

--- a/src/include/storage/irc_authorization.hpp
+++ b/src/include/storage/irc_authorization.hpp
@@ -13,10 +13,6 @@ enum class IRCAuthorizationType : uint8_t { OAUTH2, SIGV4, NONE, INVALID };
 
 enum class IRCAccessDelegationMode : uint8_t { NONE, VENDED_CREDENTIALS };
 
-enum class HTTPRequestType : uint8_t { HTTP_GET, HTTP_POST, HTTP_PUT, HTTP_DELETE, HTTP_HEAD };
-
-string HTTPRequestTypeToString(HTTPRequestType request_type);
-
 struct IcebergAttachOptions {
 	string endpoint;
 	string warehouse;
@@ -45,7 +41,7 @@ public:
 	static IRCAuthorizationType TypeFromString(const string &type);
 
 public:
-	virtual unique_ptr<HTTPResponse> Request(HTTPRequestType request_type, ClientContext &context,
+	virtual unique_ptr<HTTPResponse> Request(RequestType request_type, ClientContext &context,
 	                                         const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
 	                                         const string &data = "") = 0;
 

--- a/src/include/storage/irc_authorization.hpp
+++ b/src/include/storage/irc_authorization.hpp
@@ -15,6 +15,23 @@ enum class IRCAccessDelegationMode : uint8_t { NONE, VENDED_CREDENTIALS };
 
 enum class HTTPRequestType : uint8_t { HTTP_GET, HTTP_POST, HTTP_PUT, HTTP_DELETE, HTTP_HEAD };
 
+static string HTTPRequestTypeToString(HTTPRequestType request_type) {
+	switch (request_type) {
+	case HTTPRequestType::HTTP_GET:
+		return "GET";
+	case HTTPRequestType::HTTP_POST:
+		return "POST";
+	case HTTPRequestType::HTTP_PUT:
+		return "PUT";
+	case HTTPRequestType::HTTP_DELETE:
+		return "DELETE";
+	case HTTPRequestType::HTTP_HEAD:
+		return "HEAD";
+	default:
+		throw InternalException("Unrecognized HTTP request type");
+	}
+}
+
 struct IcebergAttachOptions {
 	string endpoint;
 	string warehouse;

--- a/src/include/storage/irc_authorization.hpp
+++ b/src/include/storage/irc_authorization.hpp
@@ -15,22 +15,7 @@ enum class IRCAccessDelegationMode : uint8_t { NONE, VENDED_CREDENTIALS };
 
 enum class HTTPRequestType : uint8_t { HTTP_GET, HTTP_POST, HTTP_PUT, HTTP_DELETE, HTTP_HEAD };
 
-static string HTTPRequestTypeToString(HTTPRequestType request_type) {
-	switch (request_type) {
-	case HTTPRequestType::HTTP_GET:
-		return "GET";
-	case HTTPRequestType::HTTP_POST:
-		return "POST";
-	case HTTPRequestType::HTTP_PUT:
-		return "PUT";
-	case HTTPRequestType::HTTP_DELETE:
-		return "DELETE";
-	case HTTPRequestType::HTTP_HEAD:
-		return "HEAD";
-	default:
-		throw InternalException("Unrecognized HTTP request type");
-	}
-}
+string HTTPRequestTypeToString(HTTPRequestType request_type);
 
 struct IcebergAttachOptions {
 	string endpoint;

--- a/src/include/storage/irc_authorization.hpp
+++ b/src/include/storage/irc_authorization.hpp
@@ -13,6 +13,8 @@ enum class IRCAuthorizationType : uint8_t { OAUTH2, SIGV4, NONE, INVALID };
 
 enum class IRCAccessDelegationMode : uint8_t { NONE, VENDED_CREDENTIALS };
 
+enum class HTTPRequestType : uint8_t { HTTP_GET, HTTP_POST, HTTP_PUT, HTTP_DELETE, HTTP_HEAD };
+
 struct IcebergAttachOptions {
 	string endpoint;
 	string warehouse;
@@ -41,13 +43,9 @@ public:
 	static IRCAuthorizationType TypeFromString(const string &type);
 
 public:
-	virtual unique_ptr<HTTPResponse> GetRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder) = 0;
-	virtual unique_ptr<HTTPResponse> HeadRequest(ClientContext &context,
-	                                             const IRCEndpointBuilder &endpoint_builder) = 0;
-	virtual unique_ptr<HTTPResponse> DeleteRequest(ClientContext &context,
-	                                               const IRCEndpointBuilder &endpoint_builder) = 0;
-	virtual unique_ptr<HTTPResponse> PostRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder,
-	                                             const string &body) = 0;
+	virtual unique_ptr<HTTPResponse> Request(HTTPRequestType request_type, ClientContext &context,
+	                                         const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
+	                                         const string &data = "") = 0;
 
 public:
 	template <class TARGET>

--- a/src/include/storage/irc_authorization.hpp
+++ b/src/include/storage/irc_authorization.hpp
@@ -11,6 +11,8 @@ enum class IcebergEndpointType : uint8_t { AWS_S3TABLES, AWS_GLUE, INVALID };
 
 enum class IRCAuthorizationType : uint8_t { OAUTH2, SIGV4, NONE, INVALID };
 
+enum class IRCAccessDelegationMode : uint8_t { NONE, VENDED_CREDENTIALS };
+
 struct IcebergAttachOptions {
 	string endpoint;
 	string warehouse;
@@ -23,7 +25,7 @@ struct IcebergAttachOptions {
 	bool support_nested_namespaces = false;
 	// in rest api spec, purge requested defaults to false.
 	bool purge_requested = false;
-
+	IRCAccessDelegationMode access_mode = IRCAccessDelegationMode::VENDED_CREDENTIALS;
 	IRCAuthorizationType authorization_type = IRCAuthorizationType::INVALID;
 	unordered_map<string, Value> options;
 };

--- a/src/include/url_utils.hpp
+++ b/src/include/url_utils.hpp
@@ -9,10 +9,13 @@
 #pragma once
 
 #include "duckdb/common/string.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/unordered_map.hpp"
 
 namespace duckdb {
+
+string AddHttpHostIfMissing(const string &url);
 
 class IRCEndpointBuilder {
 public:

--- a/src/include/url_utils.hpp
+++ b/src/include/url_utils.hpp
@@ -26,6 +26,7 @@ public:
 	const unordered_map<string, string> GetParams() const;
 
 	string GetURL() const;
+	static IRCEndpointBuilder FromURL(const string &url);
 
 	//! path components when querying. Like namespaces/tables etc.
 	vector<string> path_components;

--- a/src/metadata/iceberg_table_schema.cpp
+++ b/src/metadata/iceberg_table_schema.cpp
@@ -2,6 +2,7 @@
 
 #include "iceberg_metadata.hpp"
 #include "iceberg_utils.hpp"
+#include "yyjson.hpp"
 #include "rest_catalog/objects/list.hpp"
 
 namespace duckdb {
@@ -120,10 +121,10 @@ static void AddUnnamedField(yyjson_mut_doc *doc, yyjson_mut_val *field_obj, rest
 }
 
 void IcebergTableSchema::SchemaToJson(yyjson_mut_doc *doc, yyjson_mut_val *root_object,
-                                      const rest_api_objects::Schema &schema) {
+                                      const rest_api_objects::AddSchemaUpdate &update) {
 	yyjson_mut_obj_add_strcpy(doc, root_object, "type", "struct");
 	auto fields_arr = yyjson_mut_obj_add_arr(doc, root_object, "fields");
-
+	auto &schema = update.schema;
 	// populate the fields
 	for (auto &field : schema.struct_type.fields) {
 		auto field_obj = yyjson_mut_arr_add_obj(doc, fields_arr);

--- a/src/metadata/iceberg_table_schema.cpp
+++ b/src/metadata/iceberg_table_schema.cpp
@@ -2,7 +2,6 @@
 
 #include "iceberg_metadata.hpp"
 #include "iceberg_utils.hpp"
-#include "yyjson.hpp"
 #include "rest_catalog/objects/list.hpp"
 
 namespace duckdb {
@@ -121,10 +120,9 @@ static void AddUnnamedField(yyjson_mut_doc *doc, yyjson_mut_val *field_obj, rest
 }
 
 void IcebergTableSchema::SchemaToJson(yyjson_mut_doc *doc, yyjson_mut_val *root_object,
-                                      const rest_api_objects::AddSchemaUpdate &update) {
+                                      const rest_api_objects::Schema &schema) {
 	yyjson_mut_obj_add_strcpy(doc, root_object, "type", "struct");
 	auto fields_arr = yyjson_mut_obj_add_arr(doc, root_object, "fields");
-	auto &schema = update.schema;
 	// populate the fields
 	for (auto &field : schema.struct_type.fields) {
 		auto field_obj = yyjson_mut_arr_add_obj(doc, fields_arr);

--- a/src/storage/authorization/none.cpp
+++ b/src/storage/authorization/none.cpp
@@ -1,5 +1,6 @@
 #include "storage/authorization/none.hpp"
 #include "api_utils.hpp"
+#include "../../include/api_utils.hpp"
 #include "storage/irc_catalog.hpp"
 
 namespace duckdb {
@@ -12,26 +13,10 @@ unique_ptr<IRCAuthorization> NoneAuthorization::FromAttachOptions(IcebergAttachO
 	return std::move(result);
 }
 
-unique_ptr<HTTPResponse> NoneAuthorization::GetRequest(ClientContext &context,
-                                                       const IRCEndpointBuilder &endpoint_builder) {
-	return APIUtils::GetRequest(context, endpoint_builder, "");
-}
-
-unique_ptr<HTTPResponse> NoneAuthorization::HeadRequest(ClientContext &context,
-                                                        const IRCEndpointBuilder &endpoint_builder) {
-	return APIUtils::HeadRequest(context, endpoint_builder, "");
-}
-
-unique_ptr<HTTPResponse> NoneAuthorization::DeleteRequest(ClientContext &context,
-                                                          const IRCEndpointBuilder &endpoint_builder) {
-	return APIUtils::DeleteRequest(context, endpoint_builder, "");
-}
-
-unique_ptr<HTTPResponse>
-NoneAuthorization::PostRequest(ClientContext &context, const IRCEndpointBuilder &endpoint_builder, const string &body) {
-	auto url = endpoint_builder.GetURL();
-	unordered_map<string, string> empty_headers;
-	return APIUtils::PostRequest(context, url, body, empty_headers, "json", "");
+unique_ptr<HTTPResponse> NoneAuthorization::Request(HTTPRequestType request_type, ClientContext &context,
+                                                    const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
+                                                    const string &data) {
+	return APIUtils::Request(request_type, context, endpoint_builder, headers, data);
 }
 
 } // namespace duckdb

--- a/src/storage/authorization/none.cpp
+++ b/src/storage/authorization/none.cpp
@@ -1,6 +1,5 @@
 #include "storage/authorization/none.hpp"
 #include "api_utils.hpp"
-#include "../../include/api_utils.hpp"
 #include "storage/irc_catalog.hpp"
 
 namespace duckdb {

--- a/src/storage/authorization/none.cpp
+++ b/src/storage/authorization/none.cpp
@@ -12,7 +12,7 @@ unique_ptr<IRCAuthorization> NoneAuthorization::FromAttachOptions(IcebergAttachO
 	return std::move(result);
 }
 
-unique_ptr<HTTPResponse> NoneAuthorization::Request(HTTPRequestType request_type, ClientContext &context,
+unique_ptr<HTTPResponse> NoneAuthorization::Request(RequestType request_type, ClientContext &context,
                                                     const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
                                                     const string &data) {
 	return APIUtils::Request(request_type, context, endpoint_builder, headers, data);

--- a/src/storage/authorization/oauth2.cpp
+++ b/src/storage/authorization/oauth2.cpp
@@ -131,7 +131,8 @@ unique_ptr<OAuth2Authorization> OAuth2Authorization::FromAttachOptions(ClientCon
 	Value token;
 
 	static const unordered_set<string> recognized_create_secret_options {
-	    "oauth2_scope", "oauth2_server_uri", "oauth2_grant_type", "token", "client_id", "client_secret"};
+	    "oauth2_scope", "oauth2_server_uri", "oauth2_grant_type",     "token",
+	    "client_id",    "client_secret",     "access_delegation_mode"};
 
 	for (auto &entry : input.options) {
 		auto lower_name = StringUtil::Lower(entry.first);

--- a/src/storage/authorization/oauth2.cpp
+++ b/src/storage/authorization/oauth2.cpp
@@ -73,7 +73,7 @@ string OAuth2Authorization::GetToken(ClientContext &context, const string &grant
 	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> doc;
 	try {
 		auto endpoint_builder = IRCEndpointBuilder::FromURL(uri);
-		auto response = APIUtils::Request(HTTPRequestType::HTTP_POST, context, endpoint_builder, headers, post_data);
+		auto response = APIUtils::Request(RequestType::POST_REQUEST, context, endpoint_builder, headers, post_data);
 		doc = std::unique_ptr<yyjson_doc, YyjsonDocDeleter>(ICUtils::api_result_to_doc(response->body));
 	} catch (std::exception &ex) {
 		ErrorData error(ex);
@@ -258,7 +258,7 @@ unique_ptr<BaseSecret> OAuth2Authorization::CreateCatalogSecretFunction(ClientCo
 	return std::move(result);
 }
 
-unique_ptr<HTTPResponse> OAuth2Authorization::Request(HTTPRequestType request_type, ClientContext &context,
+unique_ptr<HTTPResponse> OAuth2Authorization::Request(RequestType request_type, ClientContext &context,
                                                       const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
                                                       const string &data) {
 	if (!token.empty()) {

--- a/src/storage/authorization/sigv4.cpp
+++ b/src/storage/authorization/sigv4.cpp
@@ -102,7 +102,7 @@ AWSInput SIGV4Authorization::CreateAWSInput(ClientContext &context, const IRCEnd
 	return aws_input;
 }
 
-unique_ptr<HTTPResponse> SIGV4Authorization::Request(HTTPRequestType request_type, ClientContext &context,
+unique_ptr<HTTPResponse> SIGV4Authorization::Request(RequestType request_type, ClientContext &context,
                                                      const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
                                                      const string &data) {
 	auto aws_input = CreateAWSInput(context, endpoint_builder);

--- a/src/storage/authorization/sigv4.cpp
+++ b/src/storage/authorization/sigv4.cpp
@@ -1,6 +1,5 @@
 #include "storage/authorization/sigv4.hpp"
 #include "api_utils.hpp"
-#include "../../include/storage/irc_authorization.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "storage/irc_catalog.hpp"
 

--- a/src/storage/authorization/sigv4.cpp
+++ b/src/storage/authorization/sigv4.cpp
@@ -1,5 +1,7 @@
 #include "storage/authorization/sigv4.hpp"
 #include "api_utils.hpp"
+#include "../../include/storage/irc_authorization.hpp"
+#include "duckdb/main/client_context.hpp"
 #include "storage/irc_catalog.hpp"
 
 namespace duckdb {
@@ -101,29 +103,11 @@ AWSInput SIGV4Authorization::CreateAWSInput(ClientContext &context, const IRCEnd
 	return aws_input;
 }
 
-unique_ptr<HTTPResponse> SIGV4Authorization::PostRequest(ClientContext &context,
-                                                         const IRCEndpointBuilder &endpoint_builder,
-                                                         const string &body) {
-	AWSInput aws_input = CreateAWSInput(context, endpoint_builder);
-	return aws_input.PostRequest(context, body);
-}
-
-unique_ptr<HTTPResponse> SIGV4Authorization::GetRequest(ClientContext &context,
-                                                        const IRCEndpointBuilder &endpoint_builder) {
-	AWSInput aws_input = CreateAWSInput(context, endpoint_builder);
-	return aws_input.GetRequest(context);
-}
-
-unique_ptr<HTTPResponse> SIGV4Authorization::HeadRequest(ClientContext &context,
-                                                         const IRCEndpointBuilder &endpoint_builder) {
-	AWSInput aws_input = CreateAWSInput(context, endpoint_builder);
-	return aws_input.HeadRequest(context);
-}
-
-unique_ptr<HTTPResponse> SIGV4Authorization::DeleteRequest(ClientContext &context,
-                                                           const IRCEndpointBuilder &endpoint_builder) {
-	AWSInput aws_input = CreateAWSInput(context, endpoint_builder);
-	return aws_input.DeleteRequest(context);
+unique_ptr<HTTPResponse> SIGV4Authorization::Request(HTTPRequestType request_type, ClientContext &context,
+                                                     const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
+                                                     const string &data) {
+	auto aws_input = CreateAWSInput(context, endpoint_builder);
+	return aws_input.Request(request_type, context, headers, data);
 }
 
 } // namespace duckdb

--- a/src/storage/iceberg_table_information.cpp
+++ b/src/storage/iceberg_table_information.cpp
@@ -194,12 +194,6 @@ IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(ClientConte
 		config.storage_type = "memory";
 	}
 
-	if (result.config->options.find("key_id") == result.config->options.end()) {
-		auto wat = 0;
-		result.config->options["key_id"] = "minioadmin";
-		result.config->options["secret"] = "minioadmin";
-	}
-
 	return result;
 }
 

--- a/src/storage/iceberg_table_information.cpp
+++ b/src/storage/iceberg_table_information.cpp
@@ -194,6 +194,12 @@ IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(ClientConte
 		config.storage_type = "memory";
 	}
 
+	if (result.config->options.find("key_id") == result.config->options.end()) {
+		auto wat = 0;
+		result.config->options["key_id"] = "minioadmin";
+		result.config->options["secret"] = "minioadmin";
+	}
+
 	return result;
 }
 

--- a/src/storage/irc_authorization.cpp
+++ b/src/storage/irc_authorization.cpp
@@ -1,3 +1,4 @@
+#include "../include/storage/irc_authorization.hpp"
 #include "storage/irc_authorization.hpp"
 #include "api_utils.hpp"
 #include "storage/authorization/oauth2.hpp"
@@ -21,6 +22,23 @@ IRCAuthorizationType IRCAuthorization::TypeFromString(const string &type) {
 	}
 	throw InvalidConfigurationException("'authorization_type' '%s' is not supported, valid options are: %s", type,
 	                                    StringUtil::Join(accepted_options, ", "));
+}
+
+string HTTPRequestTypeToString(HTTPRequestType request_type) {
+	switch (request_type) {
+	case HTTPRequestType::HTTP_GET:
+		return "GET";
+	case HTTPRequestType::HTTP_POST:
+		return "POST";
+	case HTTPRequestType::HTTP_PUT:
+		return "PUT";
+	case HTTPRequestType::HTTP_DELETE:
+		return "DELETE";
+	case HTTPRequestType::HTTP_HEAD:
+		return "HEAD";
+	default:
+		throw InternalException("Unrecognized HTTP request type");
+	}
 }
 
 } // namespace duckdb

--- a/src/storage/irc_authorization.cpp
+++ b/src/storage/irc_authorization.cpp
@@ -24,21 +24,4 @@ IRCAuthorizationType IRCAuthorization::TypeFromString(const string &type) {
 	                                    StringUtil::Join(accepted_options, ", "));
 }
 
-string HTTPRequestTypeToString(HTTPRequestType request_type) {
-	switch (request_type) {
-	case HTTPRequestType::HTTP_GET:
-		return "GET";
-	case HTTPRequestType::HTTP_POST:
-		return "POST";
-	case HTTPRequestType::HTTP_PUT:
-		return "PUT";
-	case HTTPRequestType::HTTP_DELETE:
-		return "DELETE";
-	case HTTPRequestType::HTTP_HEAD:
-		return "HEAD";
-	default:
-		throw InternalException("Unrecognized HTTP request type");
-	}
-}
-
 } // namespace duckdb

--- a/src/storage/irc_catalog.cpp
+++ b/src/storage/irc_catalog.cpp
@@ -435,6 +435,7 @@ unique_ptr<Catalog> IRCatalog::Attach(optional_ptr<StorageExtensionInfo> storage
 
 	string endpoint_type_string;
 	string authorization_type_string;
+	string access_mode_string;
 
 	IcebergAttachOptions attach_options;
 	attach_options.warehouse = info.path;
@@ -454,6 +455,8 @@ unique_ptr<Catalog> IRCatalog::Attach(optional_ptr<StorageExtensionInfo> storage
 			endpoint_type_string = StringUtil::Lower(entry.second.ToString());
 		} else if (lower_name == "authorization_type") {
 			authorization_type_string = StringUtil::Lower(entry.second.ToString());
+		} else if (lower_name == "access_delegation_mode") {
+			access_mode_string = StringUtil::Lower(entry.second.ToString());
 		} else if (lower_name == "endpoint") {
 			attach_options.endpoint = StringUtil::Lower(entry.second.ToString());
 			StringUtil::RTrim(attach_options.endpoint, "/");
@@ -500,6 +503,17 @@ unique_ptr<Catalog> IRCatalog::Attach(optional_ptr<StorageExtensionInfo> storage
 			throw InvalidConfigurationException("'authorization_type' can not be combined with 'endpoint_type'");
 		}
 		attach_options.authorization_type = IRCAuthorization::TypeFromString(authorization_type_string);
+	}
+	if (!access_mode_string.empty()) {
+		if (access_mode_string == "vended_credentials") {
+			attach_options.access_mode = IRCAccessDelegationMode::VENDED_CREDENTIALS;
+		} else if (access_mode_string == "none") {
+			attach_options.access_mode = IRCAccessDelegationMode::NONE;
+		} else {
+			throw InvalidInputException(
+			    "Unrecognized access mode '%s'. Supported options are 'vended_credentials' and 'none'",
+			    access_mode_string);
+		}
 	}
 	if (attach_options.authorization_type == IRCAuthorizationType::INVALID) {
 		attach_options.authorization_type = IRCAuthorizationType::OAUTH2;

--- a/src/storage/irc_table_entry.cpp
+++ b/src/storage/irc_table_entry.cpp
@@ -85,6 +85,12 @@ string ICTableEntry::PrepareIcebergScanFromEntry(ClientContext &context) const {
 			                {"endpoint", endpoint}};
 		}
 		(void)secret_manager.CreateSecret(context, info);
+		// if there is no key_id, secret, or token in the info. log that vended credentials has not worked
+		if (info.options.find("key_id") == info.options.end() && info.options.find("secret") == info.options.end() &&
+		    info.options.find("token") == info.options.end()) {
+			DUCKDB_LOG_INFO(context, "Failed to create valid secret from Vendend Credentials for table '%s'",
+			                table_info.name);
+		}
 	}
 
 	for (auto &info : table_credentials.storage_credentials) {

--- a/src/storage/irc_table_entry.cpp
+++ b/src/storage/irc_table_entry.cpp
@@ -42,7 +42,6 @@ string ICTableEntry::PrepareIcebergScanFromEntry(ClientContext &context) const {
 
 	if (ic_catalog.attach_options.access_mode != IRCAccessDelegationMode::VENDED_CREDENTIALS) {
 		return table_info.load_table_result.metadata_location;
-		;
 	}
 	// Get Credentials from IRC API
 	auto table_credentials = table_info.GetVendedCredentials(context);

--- a/src/storage/irc_table_entry.cpp
+++ b/src/storage/irc_table_entry.cpp
@@ -52,8 +52,6 @@ string ICTableEntry::PrepareIcebergScanFromEntry(ClientContext &context) const {
 		size_t metadata_pos = lc_storage_location.find("metadata");
 		if (metadata_pos != string::npos) {
 			info.scope = {load_result.metadata_location.substr(0, metadata_pos)};
-		} else {
-			throw InvalidInputException("Substring not found");
 		}
 
 		if (StringUtil::StartsWith(ic_catalog.uri, "glue")) {

--- a/src/storage/irc_transaction.cpp
+++ b/src/storage/irc_transaction.cpp
@@ -11,6 +11,7 @@
 #include "storage/table_update/iceberg_add_snapshot.hpp"
 #include "storage/table_create/iceberg_create_table_request.hpp"
 #include "catalog_utils.hpp"
+#include "yyjson.hpp"
 #include "duckdb/storage/table/update_state.hpp"
 
 namespace duckdb {
@@ -118,8 +119,9 @@ void CommitTableToJSON(yyjson_mut_doc *doc, yyjson_mut_val *root_object,
 			auto &ref_update = update.add_schema_update;
 			//! updates[...].action
 			yyjson_mut_obj_add_strcpy(doc, update_json, "action", ref_update.action.c_str());
+			yyjson_mut_obj_add_uint(doc, update_json, "last-column-id", update.add_schema_update.last_column_id);
 			auto schema_json = yyjson_mut_obj_add_obj(doc, update_json, "schema");
-			IcebergTableSchema::SchemaToJson(doc, schema_json, update.add_schema_update.schema);
+			IcebergTableSchema::SchemaToJson(doc, schema_json, update.add_schema_update);
 		} else if (update.has_set_current_schema_update) {
 			auto update_json = yyjson_mut_arr_add_obj(doc, updates_array);
 			auto &ref_update = update.set_current_schema_update;

--- a/src/storage/irc_transaction.cpp
+++ b/src/storage/irc_transaction.cpp
@@ -11,7 +11,6 @@
 #include "storage/table_update/iceberg_add_snapshot.hpp"
 #include "storage/table_create/iceberg_create_table_request.hpp"
 #include "catalog_utils.hpp"
-#include "yyjson.hpp"
 #include "duckdb/storage/table/update_state.hpp"
 
 namespace duckdb {
@@ -121,7 +120,7 @@ void CommitTableToJSON(yyjson_mut_doc *doc, yyjson_mut_val *root_object,
 			yyjson_mut_obj_add_strcpy(doc, update_json, "action", ref_update.action.c_str());
 			yyjson_mut_obj_add_uint(doc, update_json, "last-column-id", update.add_schema_update.last_column_id);
 			auto schema_json = yyjson_mut_obj_add_obj(doc, update_json, "schema");
-			IcebergTableSchema::SchemaToJson(doc, schema_json, update.add_schema_update);
+			IcebergTableSchema::SchemaToJson(doc, schema_json, update.add_schema_update.schema);
 		} else if (update.has_set_current_schema_update) {
 			auto update_json = yyjson_mut_arr_add_obj(doc, updates_array);
 			auto &ref_update = update.set_current_schema_update;

--- a/src/storage/table_update/common.cpp
+++ b/src/storage/table_update/common.cpp
@@ -37,8 +37,11 @@ void AddSchemaUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 	auto current_schema_id = table_info.load_table_result.metadata.current_schema_id;
 	auto &schema = table_info.table_metadata.schemas[current_schema_id];
 	update.add_schema_update.schema = CopySchema(*schema.get());
-	update.add_schema_update.has_last_column_id = true;
-	update.add_schema_update.last_column_id = table_info.load_table_result.metadata.last_column_id;
+	// last column id is technically deprecated, but some catalogs still use it (nessie).
+	if (table_info.load_table_result.metadata.has_last_column_id) {
+		update.add_schema_update.has_last_column_id = true;
+		update.add_schema_update.last_column_id = table_info.load_table_result.metadata.last_column_id;
+	}
 }
 
 AssignUUIDUpdate::AssignUUIDUpdate(IcebergTableInformation &table_info)

--- a/src/storage/table_update/common.cpp
+++ b/src/storage/table_update/common.cpp
@@ -37,6 +37,8 @@ void AddSchemaUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 	auto current_schema_id = table_info.load_table_result.metadata.current_schema_id;
 	auto &schema = table_info.table_metadata.schemas[current_schema_id];
 	update.add_schema_update.schema = CopySchema(*schema.get());
+	update.add_schema_update.has_last_column_id = true;
+	update.add_schema_update.last_column_id = table_info.load_table_result.metadata.last_column_id;
 }
 
 AssignUUIDUpdate::AssignUUIDUpdate(IcebergTableInformation &table_info)

--- a/test/sql/local/irc/test_nessie.test
+++ b/test/sql/local/irc/test_nessie.test
@@ -2,7 +2,7 @@
 # description: test nessie integration
 # group: [irc]
 
-require-env ICEBERG_SERVER_AVAILABLE
+# require-env NESSIE_SERVER_AVAILABLE
 
 require avro
 
@@ -14,6 +14,15 @@ require httpfs
 
 require aws
 
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'minioadmin',
+    SECRET 'minioadmin',
+    ENDPOINT '127.0.0.1:9002',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
 
 statement ok
 create secret my_secret (
@@ -22,7 +31,7 @@ create secret my_secret (
     CLIENT_SECRET 's3cr3t',
     OAUTH2_SCOPE 'catalog sign',
     OAUTH2_SERVER_URI 'http://127.0.0.1:8080/realms/iceberg/protocol/openid-connect/token'
-  );
+);
 
 
 statement ok
@@ -30,14 +39,22 @@ attach '' as my_datalake (
     type ICEBERG,
     ENDPOINT 'http://127.0.0.1:19120/iceberg/',
     SECRET 'my_secret'
-  );
-
-# statement ok
-# create table if not exist my_datalake.default.t1 (a int);
-
-# statement ok
-# insert into my_datalake.default.t1 select range a from range(10);
-
+);
 
 statement ok
-create table my_datalake.default.t2 as select range a from range(100);
+create schema if not exists my_datalake.default;
+
+statement ok
+create table if not exists my_datalake.default.t1 (a int);
+
+statement ok
+insert into my_datalake.default.t1 select range a from range(10);
+
+statement ok
+create table my_datalake.default.t2 as select range a from range(1000);
+
+statement ok
+drop table my_datalake.default.t2;
+
+statement ok
+drop table my_datalake.default.t1;

--- a/test/sql/local/irc/test_nessie.test
+++ b/test/sql/local/irc/test_nessie.test
@@ -14,8 +14,10 @@ require httpfs
 
 require aws
 
+set ignore_error_messages
+
 statement ok
-CREATE SECRET (
+CREATE SECRET storage_secret (
     TYPE S3,
     KEY_ID 'minioadmin',
     SECRET 'minioadmin',
@@ -33,11 +35,11 @@ create secret my_secret (
     OAUTH2_SERVER_URI 'http://127.0.0.1:8080/realms/iceberg/protocol/openid-connect/token'
 );
 
-
 statement ok
 attach '' as my_datalake (
     type ICEBERG,
     ENDPOINT 'http://127.0.0.1:19120/iceberg/',
+    ACCESS_DELEGATION_MODE 'none',
     SECRET 'my_secret'
 );
 
@@ -51,10 +53,39 @@ statement ok
 insert into my_datalake.default.t1 select range a from range(10);
 
 statement ok
-create table my_datalake.default.t2 as select range a from range(1000);
+create table if not exists my_datalake.default.t2 as select range a from range(1000);
 
 statement ok
-drop table my_datalake.default.t2;
+drop table if exists my_datalake.default.t2;
 
 statement ok
-drop table my_datalake.default.t1;
+drop table if exists my_datalake.default.t1;
+
+statement ok
+detach my_datalake;
+
+statement ok
+drop secret storage_secret;
+
+# test with nessie vending credentials
+# vending credentials is default
+statement ok
+attach '' as my_datalake (
+    type ICEBERG,
+    ENDPOINT 'http://127.0.0.1:19120/iceberg/',
+    SECRET 'my_secret'
+);
+
+statement ok
+create schema if not exists my_datalake.new_schema;
+
+statement ok
+drop table if exists my_datalake.new_schema.table_1;
+
+statement error
+create table my_datalake.new_schema.table_1 as select range a from range(100);
+----
+<REGEX>:.*HTTP Error: Unable to connect.*Forbidden.*403.*
+
+statement ok
+drop schema my_datalake.new_schema;

--- a/test/sql/local/irc/test_nessie.test
+++ b/test/sql/local/irc/test_nessie.test
@@ -77,6 +77,9 @@ attach '' as my_datalake (
 );
 
 statement ok
+call enable_logging();
+
+statement ok
 create schema if not exists my_datalake.new_schema;
 
 statement ok
@@ -86,6 +89,11 @@ statement error
 create table my_datalake.new_schema.table_1 as select range a from range(100);
 ----
 <REGEX>:.*HTTP Error: Unable to connect.*Forbidden.*403.*
+
+query I
+select message from duckdb_logs() where message like '%Failed%';
+----
+Failed to create valid secret from Vendend Credentials for table 'table_1'
 
 statement ok
 drop schema my_datalake.new_schema;

--- a/test/sql/local/irc/test_nessie.test
+++ b/test/sql/local/irc/test_nessie.test
@@ -1,0 +1,43 @@
+# name: test/sql/local/irc/test_nessie.test
+# description: test nessie integration
+# group: [irc]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require aws
+
+
+statement ok
+create secret my_secret (
+    TYPE ICEBERG,
+    CLIENT_ID 'client1',
+    CLIENT_SECRET 's3cr3t',
+    OAUTH2_SCOPE 'catalog sign',
+    OAUTH2_SERVER_URI 'http://127.0.0.1:8080/realms/iceberg/protocol/openid-connect/token'
+  );
+
+
+statement ok
+attach '' as my_datalake (
+    type ICEBERG,
+    ENDPOINT 'http://127.0.0.1:19120/iceberg/',
+    SECRET 'my_secret'
+  );
+
+# statement ok
+# create table if not exist my_datalake.default.t1 (a int);
+
+# statement ok
+# insert into my_datalake.default.t1 select range a from range(10);
+
+
+statement ok
+create table my_datalake.default.t2 as select range a from range(100);

--- a/test/sql/local/irc/test_nessie.test
+++ b/test/sql/local/irc/test_nessie.test
@@ -2,7 +2,7 @@
 # description: test nessie integration
 # group: [irc]
 
-# require-env NESSIE_SERVER_AVAILABLE
+require-env NESSIE_SERVER_AVAILABLE
 
 require avro
 

--- a/test/sql/local/irc/test_nessie.test
+++ b/test/sql/local/irc/test_nessie.test
@@ -2,7 +2,7 @@
 # description: test nessie integration
 # group: [irc]
 
-require-env NESSIE_SERVER_AVAILABLE
+# require-env NESSIE_SERVER_AVAILABLE
 
 require avro
 
@@ -34,6 +34,16 @@ create secret my_secret (
     OAUTH2_SCOPE 'catalog sign',
     OAUTH2_SERVER_URI 'http://127.0.0.1:8080/realms/iceberg/protocol/openid-connect/token'
 );
+
+statement error
+attach '' as my_datalake (
+    type ICEBERG,
+    ENDPOINT 'http://127.0.0.1:19120/iceberg/',
+    ACCESS_DELEGATION_MODE 'blah',
+    SECRET 'my_secret'
+);
+----
+<REGEX>:.*Unrecognized access mode.*Supported options are 'vended_credentials' and 'none'.*
 
 statement ok
 attach '' as my_datalake (


### PR DESCRIPTION
This PR tackles a couple of things

fixes https://github.com/duckdb/duckdb-iceberg/issues/494
fixes https://github.com/duckdb/duckdb-iceberg/issues/450

Nessie seems to support vending credentials, but doesn't actually return a key-id and secret, which is annoying. Instead of implementing a workaround in the attach options by adding a `storage_key_id` and `storage_secret` I decided to implement disabling of vended credentials. This lead me down a rabbit hole of realizing we do not have fine grain access to headers when making requests to an Iceberg catalog. All header/authorization logic was scattered throughout multiple api_util/aws/none.cpp files and multiple Http request functions with the names GetRequest,HeadRequest,DeleteRequest, and PostRequest. This has all now been unified into `Request` and you can pass the request type. 

In addition you can pass the request headers from catalog_api.cpp, so if you know exactly what url you are hitting, you can also selectively choose what http headers to include in the request. With this change, we no longer pass a Vended-Credentials header for every single request, now we only pass it for GetRequests.

This will also make it easier to implement PUT requests if we ever need to.

To get Nessie working locally now, you can attach without vended credentials, and create your own storage secret.

See the test file or here below
```
CREATE SECRET storage_secret (
    TYPE S3,
    KEY_ID 'minioadmin',
    SECRET 'minioadmin',
    ENDPOINT '127.0.0.1:9002',
    URL_STYLE 'path',
    USE_SSL 0
);
create secret my_secret (
    TYPE ICEBERG,
    CLIENT_ID 'client1',
    CLIENT_SECRET 's3cr3t',
    OAUTH2_SCOPE 'catalog sign',
    OAUTH2_SERVER_URI 'http://127.0.0.1:8080/realms/iceberg/protocol/openid-connect/token'
);
attach '' as my_datalake (
    type ICEBERG,
    ENDPOINT 'http://127.0.0.1:19120/iceberg/',
    ACCESS_DELEGATION_MODE 'none',
    SECRET 'my_secret'
);
```
