### PR TITLE
Add prefix for rest catalog

### DIFF
--- a/src/include/storage/irc_authorization.hpp
+++ b/src/include/storage/irc_authorization.hpp
@@ -15,6 +15,8 @@ struct IcebergAttachOptions {
 	string endpoint;
 	string warehouse;
 	string secret;
+	// optional prefix, if the catalog do not support prefix, we do not need to add this option.
+	string prefix;
 	string name;
 	// some catalogs do not yet support stage create
 	bool supports_stage_create = true;

--- a/src/storage/irc_catalog.cpp
+++ b/src/storage/irc_catalog.cpp
@@ -29,7 +29,7 @@ IRCatalog::IRCatalog(AttachedDatabase &db_p, AccessMode access_mode, unique_ptr<
                      IcebergAttachOptions &attach_options, const string &version)
     : Catalog(db_p), access_mode(access_mode), auth_handler(std::move(auth_handler)),
       warehouse(attach_options.warehouse), uri(attach_options.endpoint), version(version),
-      attach_options(attach_options) {
+      prefix((attach_options.prefix)), attach_options(attach_options) {
 	if (version.empty()) {
 		throw InternalException("version can not be empty");
 	}
@@ -280,9 +280,6 @@ void IRCatalog::AddS3TablesEndpoints() {
 }
 
 void IRCatalog::GetConfig(ClientContext &context, IcebergEndpointType &endpoint_type) {
-	// set the prefix to be empty. To get the config endpoint,
-	// we cannot add a default prefix.
-	D_ASSERT(prefix.empty());
 	auto catalog_config = IRCAPI::GetCatalogConfig(context, *this);
 
 	overrides = catalog_config.overrides;
@@ -468,6 +465,9 @@ unique_ptr<Catalog> IRCatalog::Attach(optional_ptr<StorageExtensionInfo> storage
 		} else if (lower_name == "purge_requested") {
 			attach_options.purge_requested = entry.second.DefaultCastAs(LogicalType::BOOLEAN).GetValue<bool>();
 			set_by_attach_options.insert("purge_requested");
+		} else if (lower_name == "prefix") {
+			attach_options.prefix = StringUtil::Lower(entry.second.ToString());
+			StringUtil::RTrim(attach_options.prefix);
 		} else {
 			attach_options.options.emplace(std::move(entry));
 		}

--- a/test/sql/local/irc/iceberg_catalog_prefix.test
+++ b/test/sql/local/irc/iceberg_catalog_prefix.test
@@ -1,0 +1,50 @@
+# name: test/sql/local/irc/iceberg_catalog_prefix.test
+# group: [irc]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+set logging_level='debug';
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+statement ok
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181',
+    PREFIX 'xxx'
+);
+
+statement error
+show all tables
+----
+HTTP Error: GET request to endpoint 'http://127.0.0.1:8181/v1/xxx/namespaces' returned an error response (HTTP 400). Reason: Bad Request
+
+
+
+
+


### PR DESCRIPTION
In our business, we provide a unified REST catalog service, different business lines use  catalog `prefix` to distinguish themselves.

so I want to add 'prefix' option for attach options, after  add  prefix , we use the following sql to attach iceberg
```
 ATTACH '' AS iceberg (TYPE ICEBERG, prefix 'xxx');
```
if the iceberg rest catalog do not support `prefix`, we use the attach as before

```
 ATTACH '' AS iceberg (TYPE ICEBERG);
```