### PR TITLE
Overwrite as default for snapshot operations

### DIFF
--- a/scripts/api.yaml
+++ b/scripts/api.yaml
@@ -2441,6 +2441,7 @@ components:
           properties:
             operation:
               type: string
+              default: "overwrite"
               enum: ["append", "replace", "overwrite", "delete"]
           additionalProperties:
             type: string

--- a/scripts/parse_openapi_spec.py
+++ b/scripts/parse_openapi_spec.py
@@ -22,6 +22,7 @@ class Property:
         self.any_of: List[Property] = []
         self.one_of: List[Property] = []
         self.nullable: Optional[bool] = None
+        self.default = None
 
     def is_string(self):
         if self.type != Property.Type.PRIMITIVE:
@@ -159,6 +160,7 @@ class ResponseObjectsGenerator:
         # default to 'object' (see 'AssertViewUUID')
         property_type = spec.get('type', 'object')
         nullable = spec.get('nullable', None)
+        default = spec.get('default', None)
 
         one_of = spec.get('oneOf')
         all_of = spec.get('allOf')
@@ -181,6 +183,7 @@ class ResponseObjectsGenerator:
             exit(1)
 
         result.nullable = nullable
+        result.default = default
 
         if one_of:
             if property_type != 'object':

--- a/src/rest_catalog/objects/snapshot.cpp
+++ b/src/rest_catalog/objects/snapshot.cpp
@@ -30,7 +30,7 @@ string Snapshot::Object2::TryFromJSON(yyjson_val *obj) {
 	string error;
 	auto operation_val = yyjson_obj_get(obj, "operation");
 	if (!operation_val) {
-		operation = "overwrite"; // assume overwrite as default value
+		operation = "overwrite";
 	} else {
 		if (yyjson_is_str(operation_val)) {
 			operation = yyjson_get_str(operation_val);


### PR DESCRIPTION
This would fix https://github.com/duckdb/duckdb-iceberg/issues/412

It's similar to the fix made in [py-iceberg](https://github.com/apache/iceberg-python/pull/1263).

I also wanted to emit a warning like py-iceberg does, but I couldn't find out how this would be done in duckdb,
if this is wanted, please guide me how this could be implemented.

