### PR TITLE
[Filter Pushdown] Enable filter pushdown for the `IN` filter

### DIFF
--- a/test/sql/local/partitioning/in_filter.test
+++ b/test/sql/local/partitioning/in_filter.test
@@ -1,0 +1,50 @@
+# name: test/sql/local/partitioning/in_filter.test
+# group: [partitioning]
+
+require httpfs
+
+require avro
+
+require parquet
+
+require iceberg
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+statement ok
+CALL enable_logging('Iceberg');
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+statement ok
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181'
+);
+
+statement ok
+select
+	*
+from
+	my_datalake.default.lineitem_partitioned_l_shipmode
+where
+	l_shipmode in ('RAIL', 'FOB');
+
+query I
+select count(*) FROM duckdb_logs() where type = 'Iceberg' and message.contains('data_file')
+----
+4


### PR DESCRIPTION
We turn it into a compare_equal check for all values in the in filter, returning true as soon as one of the values matches.