### PR TITLE
Autodetect endpoint type (for s3 tables)

### DIFF
--- a/src/storage/irc_catalog.cpp
+++ b/src/storage/irc_catalog.cpp
@@ -470,9 +470,16 @@ unique_ptr<Catalog> IRCatalog::Attach(optional_ptr<StorageExtensionInfo> storage
 		}
 	}
 	IcebergEndpointType endpoint_type = IcebergEndpointType::INVALID;
+	bool endpoint_set = false;
 	//! Then check any if the 'endpoint_type' is set, for any well known catalogs
 	if (!endpoint_type_string.empty()) {
 		endpoint_type = EndpointTypeFromString(endpoint_type_string);
+		endpoint_set = true;
+	} else if (StringUtil::StartsWith(info.path, "arn:aws:s3tables:")) {
+		endpoint_type = IcebergEndpointType::AWS_S3TABLES;
+		endpoint_set = true;
+	}
+	if (endpoint_set) {
 		switch (endpoint_type) {
 		case IcebergEndpointType::AWS_GLUE: {
 			GlueAttach(context, attach_options);

--- a/test/sql/cloud/s3tables/test_s3tables.test
+++ b/test/sql/cloud/s3tables/test_s3tables.test
@@ -27,6 +27,12 @@ CREATE SECRET s3table_secret (
 );
 
 statement ok
+ATTACH 'iceberg:arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing';
+
+statement ok
+DETACH iceberg-testing;
+
+statement ok
 attach 'arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing' as s3_catalog (
     TYPE ICEBERG,
     ENDPOINT_TYPE 'S3_TABLES'


### PR DESCRIPTION
This is something I bumped against, unsure if this patch is making stuff simpler or restricting design space.

Basically, in case of s3 tables, we don't need to specify extra parameters, so all relevant data that's needed can be extracted from the DB path, like:
```sql
--- current
ATTACH 'arn:aws:s3tables:<region>:<user_id>:bucket/<bucket_name>' (TYPE iceberg, ENDPOINT_TYPE 's3_tables');
--- equivalent to
ATTACH 'iceberg:arn:aws:s3tables:<region>:<user_id>:bucket/<bucket_name>' (ENDPOINT_TYPE 's3_tables');
--- with proposed changeset that makes ENDPOINT_TYPE derived from path:
ATTACH 'iceberg:arn:aws:s3tables:<region>:<user_id>:bucket/<bucket_name>';
```

Again, not sure if this improves or add confusion, given other iceberg `ATTACH` will require parameters to be present.
Open for discussion.