### PR TITLE
Avoid needs for explicit casts in interpreting AT clause

### DIFF
--- a/src/iceberg_snapshot_lookup.cpp
+++ b/src/iceberg_snapshot_lookup.cpp
@@ -15,17 +15,11 @@ IcebergSnapshotLookup IcebergSnapshotLookup::FromAtClause(optional_ptr<BoundAtCl
 		throw InvalidInputException("NULL values can not be used as the 'unit' of a time travel clause");
 	}
 	if (StringUtil::CIEquals(unit, "version")) {
-		if (value.type().id() != LogicalTypeId::BIGINT) {
-			throw InvalidInputException("'version' has to be provided as a BIGINT value");
-		}
 		result.snapshot_source = SnapshotSource::FROM_ID;
-		result.snapshot_id = value.GetValue<int64_t>();
+		result.snapshot_id = value.DefaultCastAs(LogicalType::BIGINT).GetValue<int64_t>();
 	} else if (StringUtil::CIEquals(unit, "timestamp")) {
-		if (value.type().id() != LogicalTypeId::TIMESTAMP) {
-			throw InvalidInputException("'timestamp' has to be provided as a TIMESTAMP value");
-		}
 		result.snapshot_source = SnapshotSource::FROM_TIMESTAMP;
-		result.snapshot_timestamp = value.GetValue<timestamp_t>();
+		result.snapshot_timestamp = value.DefaultCastAs(LogicalType::TIMESTAMP).GetValue<timestamp_t>();
 	} else {
 		throw InvalidInputException(
 		    "Unit '%s' for time travel is not valid, supported options are 'version' and 'timestamp'", unit);

--- a/test/sql/local/iceberg_scans/iceberg_scan_schema_evo_timetravel.test
+++ b/test/sql/local/iceberg_scans/iceberg_scan_schema_evo_timetravel.test
@@ -52,3 +52,52 @@ from
 	my_datalake.default.pyspark_iceberg_table_v2 AT (VERSION => getvariable('last_snapshot')) WHERE schema_evol_added_col_1 IS NOT NULL;
 ----
 685
+
+query I
+select
+	count(schema_evol_added_col_1)
+from
+	my_datalake.default.pyspark_iceberg_table_v2 AT (TIMESTAMP => now()::TIMESTAMP) WHERE schema_evol_added_col_1 IS NOT NULL;
+----
+685
+
+query I
+select
+	count(schema_evol_added_col_1)
+from
+	my_datalake.default.pyspark_iceberg_table_v2 AT (TIMESTAMP => now()) WHERE schema_evol_added_col_1 IS NOT NULL;
+----
+685
+
+statement error
+select
+	count(schema_evol_added_col_1)
+from
+	my_datalake.default.pyspark_iceberg_table_v2 AT (TIMESTAMP => 'hi there') WHERE schema_evol_added_col_1 IS NOT NULL;
+----
+Invalid Input Error: Failed to cast value
+
+statement error
+select
+	count(schema_evol_added_col_1)
+from
+	my_datalake.default.pyspark_iceberg_table_v2 AT (VERSION => 'hi there') WHERE schema_evol_added_col_1 IS NOT NULL;
+----
+Invalid Input Error: Failed to cast value
+
+statement error
+select
+	count(schema_evol_added_col_1)
+from
+	my_datalake.default.pyspark_iceberg_table_v2 AT (VERSION => 1) WHERE schema_evol_added_col_1 IS NOT NULL;
+----
+Invalid Configuration Error: Could not find snapshot with id 1
+
+statement error
+select
+	count(schema_evol_added_col_1)
+from
+	my_datalake.default.pyspark_iceberg_table_v2 AT (VERSION => 1.0) WHERE schema_evol_added_col_1 IS NOT NULL;
+----
+Invalid Configuration Error: Could not find snapshot with id 1
+


### PR DESCRIPTION
Currenty `AT (TIMESTAMP => now())` will not work, requiring explicit cast like `AT (TIMESTAMP => now()::TIMESTAMP)`, and similar for passing integers or doubles to `VERSION`, I think this is just nicer / more user friendly.