### PR TITLE
get onelake  Iceberg catalog token using azure credential chain

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.2
     with:
       extension_name: iceberg
       duckdb_version: v1.4.2
@@ -25,7 +25,7 @@ jobs:
   duckdb-stable-deploy:
     name: Deploy extension binaries
     needs: duckdb-stable-build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@main
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.4.2
     secrets: inherit
     with:
       extension_name: iceberg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set(EXTENSION_SOURCES
     src/storage/authorization/sigv4.cpp
     src/storage/authorization/none.cpp
     src/storage/authorization/oauth2.cpp
+    src/storage/authorization/azure.cpp
     src/storage/iceberg_transaction_data.cpp
     src/storage/irc_authorization.cpp
     src/storage/irc_catalog.cpp
@@ -79,14 +80,34 @@ add_subdirectory(src/rest_catalog/objects)
 
 add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES} ${ALL_OBJECT_FILES})
 
+# Azure SDK requires C++14 or later
+set_target_properties(${EXTENSION_NAME} PROPERTIES
+    CXX_STANDARD 14
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+)
+
 set(PARAMETERS "-warnings")
 build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES} ${ALL_OBJECT_FILES})
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-    find_package(CURL REQUIRED)
-    find_package(AWSSDK REQUIRED COMPONENTS core sso sts)
-    include_directories(${CURL_INCLUDE_DIRS})
-endif()
+# Azure SDK requires C++14 or later
+set_target_properties(${TARGET_NAME}_loadable_extension PROPERTIES
+    CXX_STANDARD 14
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+)
+
+find_package(CURL REQUIRED)
+find_package(AWSSDK REQUIRED COMPONENTS core sso sts)
+
+# Azure SDK
+find_package(azure-identity-cpp CONFIG REQUIRED)
+find_package(azure-storage-blobs-cpp CONFIG REQUIRED)
+find_package(azure-storage-files-datalake-cpp CONFIG REQUIRED)
+set(HAVE_AZURE_SDK TRUE)
+add_compile_definitions(DUCKDB_ICEBERG_AZURE_SUPPORT=1)
+
+include_directories(${CURL_INCLUDE_DIRS})
 
 # Roaring is installed via vcpkg and used here
 find_package(roaring CONFIG REQUIRED)
@@ -95,20 +116,22 @@ find_package(roaring CONFIG REQUIRED)
 # overriding `TARGET_NAME`
 set(TARGET_NAME iceberg)
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-    # AWS SDK FROM vcpkg
-    target_include_directories(${EXTENSION_NAME}
-                            PUBLIC $<BUILD_INTERFACE:${AWSSDK_INCLUDE_DIRS}>)
-    target_link_libraries(${EXTENSION_NAME} PUBLIC ${AWSSDK_LINK_LIBRARIES})
-    target_include_directories(${TARGET_NAME}_loadable_extension
-                            PRIVATE $<BUILD_INTERFACE:${AWSSDK_INCLUDE_DIRS}>)
-    target_link_libraries(${TARGET_NAME}_loadable_extension
-                        ${AWSSDK_LINK_LIBRARIES})
+# AWS SDK FROM vcpkg
+target_include_directories(${EXTENSION_NAME}
+                        PUBLIC $<BUILD_INTERFACE:${AWSSDK_INCLUDE_DIRS}>)
+target_link_libraries(${EXTENSION_NAME} PUBLIC ${AWSSDK_LINK_LIBRARIES})
+target_include_directories(${TARGET_NAME}_loadable_extension
+                        PRIVATE $<BUILD_INTERFACE:${AWSSDK_INCLUDE_DIRS}>)
+target_link_libraries(${TARGET_NAME}_loadable_extension
+                    ${AWSSDK_LINK_LIBRARIES})
 
-    # Link dependencies into extension
-    target_link_libraries(${EXTENSION_NAME} PUBLIC ${CURL_LIBRARIES})
-    target_link_libraries(${TARGET_NAME}_loadable_extension ${CURL_LIBRARIES})
-endif()
+# Azure SDK FROM vcpkg
+target_link_libraries(${EXTENSION_NAME} PUBLIC Azure::azure-identity Azure::azure-storage-blobs Azure::azure-storage-files-datalake)
+target_link_libraries(${TARGET_NAME}_loadable_extension Azure::azure-identity Azure::azure-storage-blobs Azure::azure-storage-files-datalake)
+
+# Link dependencies into extension
+target_link_libraries(${EXTENSION_NAME} PUBLIC ${CURL_LIBRARIES})
+target_link_libraries(${TARGET_NAME}_loadable_extension ${CURL_LIBRARIES})
 
 # Link Roaring library
 target_link_libraries(${EXTENSION_NAME} PUBLIC roaring::roaring roaring::roaring-headers roaring::roaring-headers-cpp)

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -1,4 +1,6 @@
 # This file is included by DuckDB's build system. It specifies which extension to load
+
+# Load only avro (required dependency for iceberg)
 if (NOT EMSCRIPTEN)
 duckdb_extension_load(avro
 		LOAD_TESTS
@@ -12,21 +14,3 @@ duckdb_extension_load(iceberg
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
     LOAD_TESTS
 )
-
-if (NOT EMSCRIPTEN)
-duckdb_extension_load(tpch)
-duckdb_extension_load(icu)
-duckdb_extension_load(ducklake
-        LOAD_TESTS
-        GIT_URL https://github.com/duckdb/ducklake
-        GIT_TAG f134ad86f2f6e7cdf4133086c38ecd9c48f1a772
-)
-
-if (NOT MINGW)
-    duckdb_extension_load(aws
-            LOAD_TESTS
-            GIT_URL https://github.com/duckdb/duckdb-aws
-            GIT_TAG 18803d5e55b9f9f6dda5047d0fdb4f4238b6801d
-    )
-endif()
-endif()

--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -16,6 +16,7 @@
 #include "duckdb/main/extension_helper.hpp"
 #include "storage/authorization/oauth2.hpp"
 #include "storage/authorization/sigv4.hpp"
+#include "storage/authorization/azure.hpp"
 #include "iceberg_utils.hpp"
 #include "iceberg_logging.hpp"
 
@@ -73,9 +74,17 @@ static void LoadInternal(ExtensionLoader &loader) {
 	secret_type.default_provider = "config";
 
 	loader.RegisterSecretType(secret_type);
+
 	CreateSecretFunction secret_function = {"iceberg", "config", OAuth2Authorization::CreateCatalogSecretFunction};
 	OAuth2Authorization::SetCatalogSecretParameters(secret_function);
 	loader.RegisterFunction(secret_function);
+
+#if DUCKDB_ICEBERG_AZURE_SUPPORT
+	CreateSecretFunction azure_secret_function = {"iceberg", "credential_chain",
+	                                              AzureAuthorization::CreateCatalogSecretFunction};
+	AzureAuthorization::SetCatalogSecretParameters(azure_secret_function);
+	loader.RegisterFunction(azure_secret_function);
+#endif
 
 	auto &log_manager = instance.GetLogManager();
 	log_manager.RegisterLogType(make_uniq<IcebergLogType>());

--- a/src/include/storage/authorization/azure.hpp
+++ b/src/include/storage/authorization/azure.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "storage/irc_authorization.hpp"
+
+namespace duckdb {
+
+class AzureAuthorization : public IRCAuthorization {
+public:
+	static constexpr const IRCAuthorizationType TYPE = IRCAuthorizationType::AZURE;
+
+public:
+	AzureAuthorization();
+	AzureAuthorization(const string &account_name, const string &chain);
+
+public:
+	static unique_ptr<AzureAuthorization> FromAttachOptions(ClientContext &context, IcebergAttachOptions &input);
+	unique_ptr<HTTPResponse> Request(RequestType request_type, ClientContext &context,
+	                                 const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
+	                                 const string &data = "") override;
+	static void SetCatalogSecretParameters(CreateSecretFunction &function);
+	static unique_ptr<BaseSecret> CreateCatalogSecretFunction(ClientContext &context, CreateSecretInput &input);
+
+public:
+	string account_name;
+	string chain;
+	//! The (bearer) token retrieved from Azure CLI or other credential chain
+	string token;
+};
+
+} // namespace duckdb

--- a/src/include/storage/irc_authorization.hpp
+++ b/src/include/storage/irc_authorization.hpp
@@ -9,7 +9,7 @@ namespace duckdb {
 
 enum class IcebergEndpointType : uint8_t { AWS_S3TABLES, AWS_GLUE, INVALID };
 
-enum class IRCAuthorizationType : uint8_t { OAUTH2, SIGV4, NONE, INVALID };
+enum class IRCAuthorizationType : uint8_t { OAUTH2, SIGV4, AZURE, NONE, INVALID };
 
 enum class IRCAccessDelegationMode : uint8_t { NONE, VENDED_CREDENTIALS };
 

--- a/src/storage/authorization/azure.cpp
+++ b/src/storage/authorization/azure.cpp
@@ -1,0 +1,237 @@
+#include "storage/authorization/azure.hpp"
+#include "storage/irc_catalog.hpp"
+#include "api_utils.hpp"
+#include "iceberg_logging.hpp"
+#include "duckdb/common/exception/http_exception.hpp"
+
+#if DUCKDB_ICEBERG_AZURE_SUPPORT
+#include <azure/core/credentials/token_credential_options.hpp>
+#include <azure/core/http/policies/policy.hpp>
+#include <azure/identity/azure_cli_credential.hpp>
+#include <azure/identity/chained_token_credential.hpp>
+#endif
+
+namespace duckdb {
+
+namespace {
+
+static const case_insensitive_map_t<LogicalType> &IcebergAzureSecretOptions() {
+	static const case_insensitive_map_t<LogicalType> options {
+	    {"account_name", LogicalType::VARCHAR},
+	    {"chain", LogicalType::VARCHAR},
+	    {"endpoint", LogicalType::VARCHAR}};
+	return options;
+}
+
+#if DUCKDB_ICEBERG_AZURE_SUPPORT
+static Azure::Core::Credentials::TokenCredentialOptions GetTokenCredentialOptions() {
+	Azure::Core::Credentials::TokenCredentialOptions options;
+	return options;
+}
+
+static std::shared_ptr<Azure::Core::Credentials::TokenCredential>
+CreateChainedTokenCredential(const string &chain) {
+	auto credential_options = GetTokenCredentialOptions();
+
+	auto chain_list = StringUtil::Split(chain, ';');
+	Azure::Identity::ChainedTokenCredential::Sources sources;
+	for (const auto &item : chain_list) {
+		if (item == "cli") {
+			sources.push_back(std::make_shared<Azure::Identity::AzureCliCredential>(credential_options));
+		} else {
+			throw InvalidInputException("Unknown credential provider found: " + item);
+		}
+	}
+	return std::make_shared<Azure::Identity::ChainedTokenCredential>(sources);
+}
+
+static string GetTokenFromCredential(std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential) {
+	Azure::Core::Credentials::TokenRequestContext token_request_context;
+	token_request_context.Scopes = {"https://storage.azure.com/.default"};
+
+	try {
+		auto token = credential->GetToken(token_request_context, Azure::Core::Context());
+		return token.Token;
+	} catch (const std::exception &ex) {
+		throw InvalidConfigurationException("Failed to retrieve Azure token: %s", ex.what());
+	}
+}
+#endif
+
+} // namespace
+
+AzureAuthorization::AzureAuthorization() : IRCAuthorization(IRCAuthorizationType::AZURE) {
+}
+
+AzureAuthorization::AzureAuthorization(const string &account_name, const string &chain)
+    : IRCAuthorization(IRCAuthorizationType::AZURE), account_name(account_name), chain(chain) {
+}
+
+unique_ptr<AzureAuthorization> AzureAuthorization::FromAttachOptions(ClientContext &context,
+                                                                     IcebergAttachOptions &input) {
+	auto result = make_uniq<AzureAuthorization>();
+
+	unordered_map<string, Value> remaining_options;
+	case_insensitive_map_t<Value> create_secret_options;
+	string secret;
+
+	static const unordered_set<string> recognized_create_secret_options {
+	    "account_name", "chain", "endpoint"};
+
+	for (auto &entry : input.options) {
+		auto lower_name = StringUtil::Lower(entry.first);
+		if (lower_name == "secret") {
+			secret = entry.second.ToString();
+		} else if (recognized_create_secret_options.count(lower_name)) {
+			create_secret_options.emplace(std::move(entry));
+		} else {
+			remaining_options.emplace(std::move(entry));
+		}
+	}
+
+	unique_ptr<SecretEntry> iceberg_secret;
+	if (create_secret_options.empty()) {
+		iceberg_secret = IRCatalog::GetIcebergSecret(context, secret);
+		if (!iceberg_secret) {
+			if (!secret.empty()) {
+				throw InvalidConfigurationException("No ICEBERG secret by the name of '%s' could be found", secret);
+			} else {
+				throw InvalidConfigurationException(
+				    "AUTHORIZATION_TYPE is 'azure', yet no 'secret' was provided, and no account_name+chain were "
+				    "provided. Please provide one of the listed options or change the 'authorization_type'.");
+			}
+		}
+		auto &kv_iceberg_secret = dynamic_cast<const KeyValueSecret &>(*iceberg_secret->secret);
+		auto endpoint_from_secret = kv_iceberg_secret.TryGetValue("endpoint");
+		if (input.endpoint.empty()) {
+			if (endpoint_from_secret.IsNull()) {
+				throw InvalidConfigurationException(
+				    "No 'endpoint' was given to attach, and no 'endpoint' could be retrieved from the ICEBERG secret!");
+			}
+			DUCKDB_LOG(context, IcebergLogType, "'endpoint' is inferred from the ICEBERG secret '%s'",
+			           iceberg_secret->secret->GetName());
+			input.endpoint = endpoint_from_secret.ToString();
+		}
+
+		auto account_name_val = kv_iceberg_secret.TryGetValue("account_name");
+		if (!account_name_val.IsNull()) {
+			result->account_name = account_name_val.ToString();
+		}
+
+		auto chain_val = kv_iceberg_secret.TryGetValue("chain");
+		if (!chain_val.IsNull()) {
+			result->chain = chain_val.ToString();
+		}
+
+		auto token_val = kv_iceberg_secret.TryGetValue("token");
+		if (!token_val.IsNull()) {
+			result->token = token_val.ToString();
+		}
+	} else {
+		if (!secret.empty()) {
+			set<string> option_names;
+			for (auto &entry : create_secret_options) {
+				option_names.insert(entry.first);
+			}
+			throw InvalidConfigurationException(
+			    "Both 'secret' and the following Azure option(s) were given: %s. These are mutually exclusive",
+			    StringUtil::Join(option_names, ", "));
+		}
+		CreateSecretInput create_secret_input;
+		if (!input.endpoint.empty()) {
+			create_secret_options["endpoint"] = input.endpoint;
+		}
+		create_secret_input.options = std::move(create_secret_options);
+		auto new_secret = AzureAuthorization::CreateCatalogSecretFunction(context, create_secret_input);
+		auto &kv_iceberg_secret = dynamic_cast<KeyValueSecret &>(*new_secret);
+
+		auto account_name_val = kv_iceberg_secret.TryGetValue("account_name");
+		if (!account_name_val.IsNull()) {
+			result->account_name = account_name_val.ToString();
+		}
+
+		auto chain_val = kv_iceberg_secret.TryGetValue("chain");
+		if (!chain_val.IsNull()) {
+			result->chain = chain_val.ToString();
+		}
+
+		auto token_val = kv_iceberg_secret.TryGetValue("token");
+		if (!token_val.IsNull()) {
+			result->token = token_val.ToString();
+		}
+	}
+
+	if (result->token.empty()) {
+		throw HTTPException(StringUtil::Format("Failed to retrieve Azure token from credential chain '%s'",
+		                                       result->chain));
+	}	input.options = std::move(remaining_options);
+	return result;
+}
+
+unique_ptr<BaseSecret> AzureAuthorization::CreateCatalogSecretFunction(ClientContext &context,
+                                                                       CreateSecretInput &input) {
+	vector<string> prefix_paths;
+	auto result = make_uniq<KeyValueSecret>(prefix_paths, "iceberg", "credential_chain", input.name);
+	result->redact_keys = {"token"};
+
+	auto &accepted_parameters = IcebergAzureSecretOptions();
+
+	for (const auto &named_param : input.options) {
+		auto &param_name = named_param.first;
+		auto it = accepted_parameters.find(param_name);
+		if (it != accepted_parameters.end()) {
+			result->secret_map[param_name] = named_param.second.ToString();
+		} else {
+			throw InvalidInputException("Unknown named parameter passed to CreateAzureIcebergSecretFunction: %s", param_name);
+		}
+	}
+
+	auto token_it = result->secret_map.find("token");
+	if (token_it != result->secret_map.end()) {
+		return std::move(result);
+	}
+
+	auto account_name_it = result->secret_map.find("account_name");
+	if (account_name_it == result->secret_map.end()) {
+		throw InvalidConfigurationException(
+		    "Missing required parameter 'account_name' for authorization_type 'azure' with credential_chain provider");
+	}
+
+	auto chain_it = result->secret_map.find("chain");
+	string chain = "cli";
+	if (chain_it != result->secret_map.end()) {
+		chain = chain_it->second.ToString();
+	} else {
+		result->secret_map["chain"] = chain;
+	}
+
+	if (!StringUtil::CIEquals(chain, "cli")) {
+		throw InvalidInputException(
+		    "Unsupported option ('%s') for 'chain', only supports 'cli' currently", chain);
+	}
+
+#if DUCKDB_ICEBERG_AZURE_SUPPORT
+	auto credential = CreateChainedTokenCredential(chain);
+	result->secret_map["token"] = GetTokenFromCredential(credential);
+#else
+	throw NotImplementedException("Azure support is not available on this platform. Please rebuild with Azure SDK support.");
+#endif
+
+	return std::move(result);
+}
+
+unique_ptr<HTTPResponse> AzureAuthorization::Request(RequestType request_type, ClientContext &context,
+                                                     const IRCEndpointBuilder &endpoint_builder, HTTPHeaders &headers,
+                                                     const string &data) {
+	if (!token.empty()) {
+		headers.Insert("Authorization", StringUtil::Format("Bearer %s", token));
+	}
+	return APIUtils::Request(request_type, context, endpoint_builder, this->client, headers, data);
+}
+
+void AzureAuthorization::SetCatalogSecretParameters(CreateSecretFunction &function) {
+	auto &options = IcebergAzureSecretOptions();
+	function.named_parameters.insert(options.begin(), options.end());
+}
+
+} // namespace duckdb

--- a/src/storage/iceberg_table_information.cpp
+++ b/src/storage/iceberg_table_information.cpp
@@ -9,6 +9,7 @@
 #include "storage/irc_authorization.hpp"
 #include "storage/authorization/oauth2.hpp"
 #include "storage/authorization/sigv4.hpp"
+#include "storage/authorization/azure.hpp"
 #include "storage/authorization/none.hpp"
 
 namespace duckdb {
@@ -138,6 +139,14 @@ IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(ClientConte
 		auto &oauth2_auth = catalog.auth_handler->Cast<OAuth2Authorization>();
 		if (!oauth2_auth.default_region.empty()) {
 			user_defaults["region"] = oauth2_auth.default_region;
+		}
+	} else if (catalog.auth_handler->type == IRCAuthorizationType::AZURE) {
+		auto &azure_auth = catalog.auth_handler->Cast<AzureAuthorization>();
+		if (!azure_auth.account_name.empty()) {
+			user_defaults["account_name"] = azure_auth.account_name;
+		}
+		if (!azure_auth.token.empty()) {
+			user_defaults["access_token"] = azure_auth.token;
 		}
 	}
 

--- a/src/storage/irc_authorization.cpp
+++ b/src/storage/irc_authorization.cpp
@@ -8,6 +8,7 @@ namespace duckdb {
 IRCAuthorizationType IRCAuthorization::TypeFromString(const string &type) {
 	static const case_insensitive_map_t<IRCAuthorizationType> mapping {{"oauth2", IRCAuthorizationType::OAUTH2},
 	                                                                   {"sigv4", IRCAuthorizationType::SIGV4},
+	                                                                   {"azure", IRCAuthorizationType::AZURE},
 	                                                                   {"none", IRCAuthorizationType::NONE}};
 
 	for (auto it : mapping) {

--- a/src/storage/irc_catalog.cpp
+++ b/src/storage/irc_catalog.cpp
@@ -18,6 +18,7 @@
 #include "storage/irc_authorization.hpp"
 #include "storage/authorization/oauth2.hpp"
 #include "storage/authorization/sigv4.hpp"
+#include "storage/authorization/azure.hpp"
 #include "storage/authorization/none.hpp"
 
 using namespace duckdb_yyjson;
@@ -523,6 +524,10 @@ unique_ptr<Catalog> IRCatalog::Attach(optional_ptr<StorageExtensionInfo> storage
 	}
 	case IRCAuthorizationType::SIGV4: {
 		auth_handler = SIGV4Authorization::FromAttachOptions(attach_options);
+		break;
+	}
+	case IRCAuthorizationType::AZURE: {
+		auth_handler = AzureAuthorization::FromAttachOptions(context, attach_options);
 		break;
 	}
 	case IRCAuthorizationType::NONE: {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,6 +5,9 @@
 		"curl",
 		"openssl",
 		"roaring",
+		"azure-identity-cpp",
+		"azure-storage-blobs-cpp",
+		"azure-storage-files-datalake-cpp",
 		{
 			"name": "aws-sdk-cpp",
 			"features": [


### PR DESCRIPTION
trying to implement this : https://github.com/duckdb/duckdb-iceberg/issues/499 , i tested manually by running the extension in my laptop using -unsigned and creating this new iceberg secret

```
CREATE or replace PERSISTENT SECRET onelake_iceberg
       (TYPE iceberg,PROVIDER credential_chain, CHAIN 'cli',ACCOUNT_NAME 'onelake');
```


Let me know if I am on the right track, as you will notice, the code is AI generated :) 


<img width="956" height="575" alt="image" src="https://github.com/user-attachments/assets/da49b904-b1c0-4ea9-9afe-a4255110d969" />
