### PR TITLE
Backport #628 to v1.4-andium

### DIFF
--- a/src/storage/irc_catalog.cpp
+++ b/src/storage/irc_catalog.cpp
@@ -240,7 +240,7 @@ void IRCatalog::AddDefaultSupportedEndpoints() {
 	// Rename a table from one identifier to another.
 	supported_urls.insert("POST /v1/{prefix}/tables/rename");
 	// commit updates to multiple tables in an atomic transaction
-	supported_urls.insert("POST /v1/{prefix}/transactions/commit)");
+	supported_urls.insert("POST /v1/{prefix}/transactions/commit");
 }
 
 void IRCatalog::AddS3TablesEndpoints() {
@@ -268,7 +268,7 @@ void IRCatalog::AddS3TablesEndpoints() {
 	// Rename a table from one identifier to another.
 	supported_urls.insert("POST /v1/{prefix}/tables/rename");
 	// commit updates to multiple tables in an atomic transaction
-	supported_urls.insert("POST /v1/{prefix}/transactions/commit)");
+	supported_urls.insert("POST /v1/{prefix}/transactions/commit");
 }
 
 void IRCatalog::GetConfig(ClientContext &context, IcebergEndpointType &endpoint_type) {


### PR DESCRIPTION
Not sure if https://github.com/duckdb/duckdb-iceberg/pull/628 is backport-able given that it changes the endpoint used on table commit in common cases, but putting this PR up in case