### PR TITLE
Optimize manifest loading: parallel reads with file_size to avoid HEAD requests

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -30,16 +30,27 @@ string IcebergUtils::FileToString(const string &path, FileSystem &fs) {
 	// Table metadata is typically small (a few KB) and there is only one per query, so
 	// progressively reallocating the result string has minimal cost compared to the latency
 	// of an additional network request.
+	//
+	// We read directly into the result string's buffer to avoid an intermediate copy,
+	// growing the buffer 2x when space runs out (amortized O(1) per byte).
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
 	string result;
-	char buffer[32768];
+	idx_t capacity = 32768;
+	idx_t size = 0;
+	result.resize(capacity);
+
 	while (true) {
-		auto bytes_read = handle->Read(buffer, sizeof(buffer));
+		if (size == capacity) {
+			capacity *= 2;
+			result.resize(capacity);
+		}
+		auto bytes_read = handle->Read(&result[size], capacity - size);
 		if (bytes_read == 0) {
 			break;
 		}
-		result.append(buffer, bytes_read);
+		size += bytes_read;
 	}
+	result.resize(size);
 	return result;
 }
 


### PR DESCRIPTION
## Summary

This PR optimizes Iceberg manifest loading to significantly reduce query latency on object stores (S3, GCS, etc.) by:

- **Eliminating HEAD requests** - Pass `file_size` from manifest list entries via `OpenFileInfo` so the file system doesn't need to query file sizes
- **Parallel manifest loading** - Read all manifest files concurrently using `TaskExecutor` instead of sequentially
- **Lazy loading** - Only load manifests when data files are actually needed, preserving request count for metadata-only operations

## Changes

1. **Streaming read in FileToString** - Avoid `GetFileSize()` call (which triggers HEAD request) when reading `metadata.json` by using streaming 32KB buffer reads instead of pre-allocation

2. **OpenFileInfo through AvroScan** - Add infrastructure to pass file metadata (file_size, etag, last_modified) through the Avro scan pipeline via `function_info`

3. **file_size in IcebergTable::Load** - Use `manifest_length` from manifest list to avoid HEAD requests in metadata inspection functions

4. **Parallel manifest loading** - `ManifestReadTask` class reads manifests in parallel, each with its own `Connection` and transaction for thread-safe S3 secret access. Results are collected per-manifest to preserve ordering, then filtered and merged.