### PR TITLE
Fix parquet parallel scans for one data file

### DIFF
--- a/src/iceberg_functions/iceberg_multi_file_list.cpp
+++ b/src/iceberg_functions/iceberg_multi_file_list.cpp
@@ -5,7 +5,6 @@
 #include "iceberg_logging.hpp"
 #include "iceberg_predicate.hpp"
 #include "iceberg_value.hpp"
-#include "../include/manifest_reader.hpp"
 #include "metadata/iceberg_manifest.hpp"
 #include "storage/iceberg_transaction.hpp"
 
@@ -237,7 +236,6 @@ FileExpandResult IcebergMultiFileList::GetExpandResult() const {
 	// always return multiple files, In the case there is only 1 data file,
 	// we only lose performance if it is small
 	return FileExpandResult::MULTIPLE_FILES;
-	return FileExpandResult::NO_FILES;
 }
 
 idx_t IcebergMultiFileList::GetTotalFileCount() const {


### PR DESCRIPTION
fixes https://github.com/duckdb/duckdb-iceberg/issues/419

The problem was that in the case of one manifest entry, we would return a file expand result of 1. This would in turn lead to 1 thread allocated for the parquet read. In case the parquet file was large, then duckdb would not be efficient reading it. If we always return multiple files, the only downside is allocating too many threads for a small read. This can also be fixed later on if it proves to become a problem