### PR TITLE
[Time Travel] Dont add transactional data to time-traveled scan

### DIFF
--- a/src/storage/catalog/iceberg_table_entry.cpp
+++ b/src/storage/catalog/iceberg_table_entry.cpp
@@ -209,7 +209,7 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 
 	auto iceberg_schema = metadata.GetSchemaFromId(schema_id);
 	auto scan_info = make_shared_ptr<IcebergScanInfo>(metadata.GetMetadataPath(), metadata, snapshot, *iceberg_schema);
-	if (table_info.transaction_data) {
+	if (table_info.transaction_data && snapshot_lookup.IsLatest()) {
 		scan_info->transaction_data = table_info.transaction_data.get();
 	}
 

--- a/test/sql/local/irc/delete/time_travel_after_uncommitted_delete.test
+++ b/test/sql/local/irc/delete/time_travel_after_uncommitted_delete.test
@@ -1,0 +1,123 @@
+# name: test/sql/local/irc/delete/time_travel_after_uncommitted_delete.test
+# description: test integration with iceberg catalog read
+# group: [delete]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+
+statement ok
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181'
+);
+
+
+statement ok
+drop table if exists my_datalake.default.tbl;
+
+statement ok
+create table my_datalake.default.tbl (
+	id INTEGER,
+	data VARCHAR
+) WITH (
+	'format-version' = 2
+);
+
+statement ok
+insert into my_datalake.default.tbl values
+	(1, 'a'),
+	(2, 'b'),
+	(3, 'c'),
+	(4, 'd'),
+	(5, 'e');
+
+query II
+select id, data from my_datalake.default.tbl order by id;
+----
+1	a
+2	b
+3	c
+4	d
+5	e
+
+statement ok
+set variable last_snapshot = (
+	select snapshot_id::BIGINT from iceberg_snapshots(
+		my_datalake.default.tbl
+	) order by timestamp_ms
+	offset 0 limit 1
+)
+
+query II
+select id, data from my_datalake.default.tbl AT (VERSION => getvariable('last_snapshot')) order by id;
+----
+1	a
+2	b
+3	c
+4	d
+5	e
+
+statement ok
+begin transaction
+
+# Create the first delete on the table
+statement ok
+DELETE FROM my_datalake.default.tbl
+WHERE id IN (2, 4);
+
+query II
+select id, data from my_datalake.default.tbl order by id;
+----
+1	a
+3	c
+5	e
+
+query II
+select id, data from my_datalake.default.tbl AT (VERSION => getvariable('last_snapshot')) order by id;
+----
+1	a
+2	b
+3	c
+4	d
+5	e
+
+statement ok
+abort
+
+query II
+select id, data from my_datalake.default.tbl order by id;
+----
+1	a
+2	b
+3	c
+4	d
+5	e


### PR DESCRIPTION
This PR fixes a problem identified as part of #728 

Solution is simple thankfully, we can just avoid setting the transaction data in the scan info if the snapshot lookup isn't `IsLatest()` (no explicit timestamp/snapshot-id)