### PR TITLE
[Dev] CreateUpdate should be const so it can be retried safely

### DIFF
--- a/src/iceberg_manifest_list.cpp
+++ b/src/iceberg_manifest_list.cpp
@@ -15,16 +15,6 @@ const vector<IcebergManifestFile> &IcebergManifestList::GetManifestFilesConst() 
 	return manifest_entries;
 }
 
-void IcebergManifestList::WriteManifestListEntry(IcebergTableInformation &table_info, idx_t manifest_index,
-                                                 CopyFunction &avro_copy, DatabaseInstance &db,
-                                                 ClientContext &context) {
-	D_ASSERT(manifest_index < manifest_entries.size());
-	auto &manifest_file = manifest_entries[manifest_index];
-	auto manifest_length =
-	    manifest_file::WriteToFile(table_info.table_metadata, manifest_file.manifest_file, avro_copy, db, context);
-	manifest_file.manifest_length = manifest_length;
-}
-
 idx_t IcebergManifestList::GetManifestListEntriesCount() const {
 	return manifest_entries.size();
 }

--- a/src/include/metadata/iceberg_manifest_list.hpp
+++ b/src/include/metadata/iceberg_manifest_list.hpp
@@ -146,8 +146,6 @@ public:
 	}
 	idx_t GetManifestListEntriesCount() const;
 
-	void WriteManifestListEntry(IcebergTableInformation &table_info, idx_t manifest_index, CopyFunction &avro_copy,
-	                            DatabaseInstance &db, ClientContext &context);
 	void AddToManifestEntries(vector<IcebergManifestFile> &manifest_list_entries);
 	vector<IcebergManifestFile> GetManifestListEntries();
 

--- a/src/include/storage/iceberg_table_update.hpp
+++ b/src/include/storage/iceberg_table_update.hpp
@@ -46,7 +46,7 @@ public:
 	}
 
 public:
-	virtual void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) = 0;
+	virtual void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const = 0;
 
 public:
 	template <class TARGET>

--- a/src/include/storage/table_update/common.hpp
+++ b/src/include/storage/table_update/common.hpp
@@ -21,7 +21,7 @@ struct AddSchemaUpdate : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SCHEMA;
 
 	explicit AddSchemaUpdate(IcebergTableInformation &table_info);
-	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
+	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 
 	optional_ptr<IcebergTableSchema> table_schema = nullptr;
 };
@@ -37,28 +37,28 @@ struct AssignUUIDUpdate : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ASSIGN_UUID;
 
 	explicit AssignUUIDUpdate(IcebergTableInformation &table_info);
-	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
+	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 struct UpgradeFormatVersion : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::UPGRADE_FORMAT_VERSION;
 
 	explicit UpgradeFormatVersion(IcebergTableInformation &table_info);
-	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
+	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 struct SetCurrentSchema : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::UPGRADE_FORMAT_VERSION;
 
 	explicit SetCurrentSchema(IcebergTableInformation &table_info);
-	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
+	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 struct AddPartitionSpec : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::UPGRADE_FORMAT_VERSION;
 
 	explicit AddPartitionSpec(IcebergTableInformation &table_info);
-	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
+	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 struct AddSortOrder : public IcebergTableUpdate {
@@ -66,28 +66,28 @@ struct AddSortOrder : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SORT_ORDER;
 
 	explicit AddSortOrder(IcebergTableInformation &table_info);
-	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
+	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 struct SetDefaultSortOrder : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_DEFAULT_SORT_ORDER;
 
 	explicit SetDefaultSortOrder(IcebergTableInformation &table_info);
-	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
+	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 struct SetDefaultSpec : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_DEFAULT_SPEC;
 
 	explicit SetDefaultSpec(IcebergTableInformation &table_info);
-	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
+	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 struct SetProperties : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_PROPERTIES;
 
 	explicit SetProperties(IcebergTableInformation &table_info, case_insensitive_map_t<string> properties);
-	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
+	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 
 	case_insensitive_map_t<string> properties;
 };
@@ -96,7 +96,7 @@ struct RemoveProperties : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::REMOVE_PROPERTIES;
 
 	explicit RemoveProperties(IcebergTableInformation &table_info, vector<string> properties);
-	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
+	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 
 	vector<string> properties;
 };
@@ -105,7 +105,7 @@ struct SetLocation : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_LOCATION;
 
 	explicit SetLocation(IcebergTableInformation &table_info);
-	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
+	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 } // namespace duckdb

--- a/src/include/storage/table_update/iceberg_add_snapshot.hpp
+++ b/src/include/storage/table_update/iceberg_add_snapshot.hpp
@@ -25,7 +25,7 @@ public:
 	                   IcebergSnapshot &&snapshot);
 
 public:
-	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) override;
+	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 
 public:
 	IcebergManifestList manifest_list;

--- a/src/storage/table_update/common.cpp
+++ b/src/storage/table_update/common.cpp
@@ -30,7 +30,8 @@ AddSchemaUpdate::AddSchemaUpdate(IcebergTableInformation &table_info)
 	table_schema = table_info.table_metadata.schemas[current_schema_id];
 }
 
-void AddSchemaUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
+void AddSchemaUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
+                                   IcebergCommitState &commit_state) const {
 	commit_state.table_change.updates.push_back(rest_api_objects::TableUpdate());
 	auto &update = commit_state.table_change.updates.back();
 	update.has_add_schema_update = true;
@@ -50,7 +51,8 @@ AssignUUIDUpdate::AssignUUIDUpdate(IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA, table_info) {
 }
 
-void AssignUUIDUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
+void AssignUUIDUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
+                                    IcebergCommitState &commit_state) const {
 	commit_state.table_change.updates.push_back(rest_api_objects::TableUpdate());
 	auto &update = commit_state.table_change.updates.back();
 	update.has_assign_uuidupdate = true;
@@ -77,7 +79,7 @@ UpgradeFormatVersion::UpgradeFormatVersion(IcebergTableInformation &table_info)
 }
 
 void UpgradeFormatVersion::CreateUpdate(DatabaseInstance &db, ClientContext &context,
-                                        IcebergCommitState &commit_state) {
+                                        IcebergCommitState &commit_state) const {
 	commit_state.table_change.updates.push_back(rest_api_objects::TableUpdate());
 	auto &req = commit_state.table_change.updates.back();
 	req.has_upgrade_format_version_update = true;
@@ -90,7 +92,8 @@ SetCurrentSchema::SetCurrentSchema(IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_CURRENT_SCHEMA, table_info) {
 }
 
-void SetCurrentSchema::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
+void SetCurrentSchema::CreateUpdate(DatabaseInstance &db, ClientContext &context,
+                                    IcebergCommitState &commit_state) const {
 	commit_state.table_change.updates.push_back(rest_api_objects::TableUpdate());
 	auto &req = commit_state.table_change.updates.back();
 	req.has_set_current_schema_update = true;
@@ -103,7 +106,8 @@ AddPartitionSpec::AddPartitionSpec(IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::ADD_PARTITION_SPEC, table_info) {
 }
 
-void AddPartitionSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
+void AddPartitionSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context,
+                                    IcebergCommitState &commit_state) const {
 	commit_state.table_change.updates.push_back(rest_api_objects::TableUpdate());
 	auto &req = commit_state.table_change.updates.back();
 	req.has_add_partition_spec_update = true;
@@ -130,7 +134,7 @@ AddSortOrder::AddSortOrder(IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::ADD_SORT_ORDER, table_info) {
 }
 
-void AddSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
+void AddSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const {
 	commit_state.table_change.updates.push_back(rest_api_objects::TableUpdate());
 	auto &req = commit_state.table_change.updates.back();
 	req.has_add_sort_order_update = true;
@@ -159,7 +163,8 @@ SetDefaultSortOrder::SetDefaultSortOrder(IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SORT_ORDER, table_info) {
 }
 
-void SetDefaultSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
+void SetDefaultSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context,
+                                       IcebergCommitState &commit_state) const {
 	commit_state.table_change.updates.push_back(rest_api_objects::TableUpdate());
 	auto &req = commit_state.table_change.updates.back();
 	req.has_set_default_sort_order_update = true;
@@ -173,7 +178,8 @@ SetDefaultSpec::SetDefaultSpec(IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SPEC, table_info) {
 }
 
-void SetDefaultSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
+void SetDefaultSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context,
+                                  IcebergCommitState &commit_state) const {
 	commit_state.table_change.updates.push_back(rest_api_objects::TableUpdate());
 	auto &req = commit_state.table_change.updates.back();
 	req.has_set_default_spec_update = true;
@@ -186,7 +192,7 @@ SetProperties::SetProperties(IcebergTableInformation &table_info, case_insensiti
     : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES, table_info), properties(properties) {
 }
 
-void SetProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
+void SetProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const {
 	commit_state.table_change.updates.push_back(rest_api_objects::TableUpdate());
 	auto &req = commit_state.table_change.updates.back();
 	req.has_set_properties_update = true;
@@ -198,7 +204,8 @@ RemoveProperties::RemoveProperties(IcebergTableInformation &table_info, vector<s
     : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES, table_info), properties(properties) {
 }
 
-void RemoveProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
+void RemoveProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context,
+                                    IcebergCommitState &commit_state) const {
 	commit_state.table_change.updates.push_back(rest_api_objects::TableUpdate());
 	auto &req = commit_state.table_change.updates.back();
 	req.has_remove_properties_update = true;
@@ -210,7 +217,7 @@ SetLocation::SetLocation(IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_LOCATION, table_info) {
 }
 
-void SetLocation::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) {
+void SetLocation::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const {
 	commit_state.table_change.updates.push_back(rest_api_objects::TableUpdate());
 	auto &req = commit_state.table_change.updates.back();
 	req.has_set_location_update = true;


### PR DESCRIPTION
This PR fixes an issue found internally, and makes a small step towards retry functionality for failed catalog commits