### PR TITLE
[Dev] Pass the `IcebergTableInformation` around as a const reference

### DIFF
--- a/src/include/storage/iceberg_table_information.hpp
+++ b/src/include/storage/iceberg_table_information.hpp
@@ -46,8 +46,8 @@ public:
 	void AddSortOrder(IcebergTransaction &transaction);
 	void SetDefaultSortOrder(IcebergTransaction &transaction);
 	void SetDefaultSpec(IcebergTransaction &transaction);
-	void SetProperties(IcebergTransaction &transaction, case_insensitive_map_t<string> properties);
-	void RemoveProperties(IcebergTransaction &transaction, vector<string> properties);
+	void SetProperties(IcebergTransaction &transaction, const case_insensitive_map_t<string> &properties);
+	void RemoveProperties(IcebergTransaction &transaction, const vector<string> &properties);
 	void SetLocation(IcebergTransaction &transaction);
 	bool IsTransactionLocalTable(IcebergTransaction &transaction);
 	static string GetTableKey(const vector<string> &namespace_items, const string &table_name);

--- a/src/include/storage/iceberg_table_requirement.hpp
+++ b/src/include/storage/iceberg_table_requirement.hpp
@@ -20,7 +20,7 @@ enum class IcebergTableRequirementType : uint8_t {
 
 struct IcebergTableRequirement {
 public:
-	IcebergTableRequirement(IcebergTableRequirementType type, IcebergTableInformation &table_info)
+	IcebergTableRequirement(IcebergTableRequirementType type, const IcebergTableInformation &table_info)
 	    : type(type), table_info(table_info) {
 	}
 	virtual ~IcebergTableRequirement() {
@@ -40,7 +40,7 @@ public:
 
 public:
 	IcebergTableRequirementType type;
-	IcebergTableInformation &table_info;
+	const IcebergTableInformation &table_info;
 };
 
 } // namespace duckdb

--- a/src/include/storage/iceberg_table_update.hpp
+++ b/src/include/storage/iceberg_table_update.hpp
@@ -49,7 +49,7 @@ public:
 
 struct IcebergTableUpdate {
 public:
-	IcebergTableUpdate(IcebergTableUpdateType type, IcebergTableInformation &table_info);
+	IcebergTableUpdate(IcebergTableUpdateType type, const IcebergTableInformation &table_info);
 	virtual ~IcebergTableUpdate() {
 	}
 
@@ -67,7 +67,7 @@ public:
 
 public:
 	IcebergTableUpdateType type;
-	IcebergTableInformation &table_info;
+	const IcebergTableInformation &table_info;
 };
 
 } // namespace duckdb

--- a/src/include/storage/iceberg_transaction_data.hpp
+++ b/src/include/storage/iceberg_transaction_data.hpp
@@ -21,11 +21,11 @@ struct IcebergCreateTableRequest;
 
 struct IcebergTransactionData {
 public:
-	IcebergTransactionData(ClientContext &context, IcebergTableInformation &table_info);
+	IcebergTransactionData(ClientContext &context, const IcebergTableInformation &table_info);
 
 public:
 	IcebergManifestFile CreateManifestFile(int64_t snapshot_id, sequence_number_t sequence_number,
-	                                       IcebergTableMetadata &table_metadata,
+	                                       const IcebergTableMetadata &table_metadata,
 	                                       IcebergManifestContentType manifest_content_type,
 	                                       vector<IcebergManifestEntry> &&data_files);
 	void AddSnapshot(IcebergSnapshotOperationType operation, vector<IcebergManifestEntry> &&data_files,
@@ -42,8 +42,8 @@ public:
 	void TableAddSortOrder();
 	void TableSetDefaultSortOrder();
 	void TableSetDefaultSpec();
-	void TableSetProperties(case_insensitive_map_t<string> properties);
-	void TableRemoveProperties(vector<string> properties);
+	void TableSetProperties(const case_insensitive_map_t<string> &properties);
+	void TableRemoveProperties(const vector<string> &properties);
 	void TableSetLocation();
 
 private:
@@ -51,7 +51,7 @@ private:
 
 public:
 	ClientContext &context;
-	IcebergTableInformation &table_info;
+	const IcebergTableInformation &table_info;
 	//! schema updates etc.
 	vector<unique_ptr<IcebergTableUpdate>> updates;
 	//! has the table been deleted in the current transaction

--- a/src/include/storage/table_create/iceberg_create_table_request.hpp
+++ b/src/include/storage/table_create/iceberg_create_table_request.hpp
@@ -22,9 +22,9 @@ struct IcebergCreateTableRequest {
 	explicit IcebergCreateTableRequest(const IcebergTableInformation &table_info);
 
 public:
-	static shared_ptr<IcebergTableSchema> CreateIcebergSchema(const IcebergTableEntry *table_entry);
+	static shared_ptr<IcebergTableSchema> CreateIcebergSchema(const IcebergTableEntry &table_entry);
 	string CreateTableToJSON(std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p);
-	static void PopulateSchema(yyjson_mut_doc *doc, yyjson_mut_val *schema_json, IcebergTableSchema &schema);
+	static void PopulateSchema(yyjson_mut_doc *doc, yyjson_mut_val *schema_json, const IcebergTableSchema &schema);
 
 private:
 	const IcebergTableInformation &table_info;

--- a/src/include/storage/table_update/common.hpp
+++ b/src/include/storage/table_update/common.hpp
@@ -20,44 +20,44 @@ struct IcebergTableInformation;
 struct AddSchemaUpdate : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SCHEMA;
 
-	explicit AddSchemaUpdate(IcebergTableInformation &table_info);
+	explicit AddSchemaUpdate(const IcebergTableInformation &table_info);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 
-	optional_ptr<IcebergTableSchema> table_schema = nullptr;
+	optional_ptr<const IcebergTableSchema> table_schema = nullptr;
 };
 
 struct AssertCreateRequirement : public IcebergTableRequirement {
 	static constexpr const IcebergTableRequirementType TYPE = IcebergTableRequirementType::ASSERT_CREATE;
 
-	explicit AssertCreateRequirement(IcebergTableInformation &table_info);
+	explicit AssertCreateRequirement(const IcebergTableInformation &table_info);
 	void CreateRequirement(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
 };
 
 struct AssignUUIDUpdate : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ASSIGN_UUID;
 
-	explicit AssignUUIDUpdate(IcebergTableInformation &table_info);
+	explicit AssignUUIDUpdate(const IcebergTableInformation &table_info);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 struct UpgradeFormatVersion : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::UPGRADE_FORMAT_VERSION;
 
-	explicit UpgradeFormatVersion(IcebergTableInformation &table_info);
+	explicit UpgradeFormatVersion(const IcebergTableInformation &table_info);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 struct SetCurrentSchema : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::UPGRADE_FORMAT_VERSION;
 
-	explicit SetCurrentSchema(IcebergTableInformation &table_info);
+	explicit SetCurrentSchema(const IcebergTableInformation &table_info);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 struct AddPartitionSpec : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::UPGRADE_FORMAT_VERSION;
 
-	explicit AddPartitionSpec(IcebergTableInformation &table_info);
+	explicit AddPartitionSpec(const IcebergTableInformation &table_info);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
@@ -65,28 +65,28 @@ struct AddSortOrder : public IcebergTableUpdate {
 	static constexpr const int64_t DEFAULT_SORT_ORDER_ID = 0;
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SORT_ORDER;
 
-	explicit AddSortOrder(IcebergTableInformation &table_info);
+	explicit AddSortOrder(const IcebergTableInformation &table_info);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 struct SetDefaultSortOrder : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_DEFAULT_SORT_ORDER;
 
-	explicit SetDefaultSortOrder(IcebergTableInformation &table_info);
+	explicit SetDefaultSortOrder(const IcebergTableInformation &table_info);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 struct SetDefaultSpec : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_DEFAULT_SPEC;
 
-	explicit SetDefaultSpec(IcebergTableInformation &table_info);
+	explicit SetDefaultSpec(const IcebergTableInformation &table_info);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 struct SetProperties : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_PROPERTIES;
 
-	explicit SetProperties(IcebergTableInformation &table_info, case_insensitive_map_t<string> properties);
+	explicit SetProperties(const IcebergTableInformation &table_info, const case_insensitive_map_t<string> &properties);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 
 	case_insensitive_map_t<string> properties;
@@ -95,7 +95,7 @@ struct SetProperties : public IcebergTableUpdate {
 struct RemoveProperties : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::REMOVE_PROPERTIES;
 
-	explicit RemoveProperties(IcebergTableInformation &table_info, vector<string> properties);
+	explicit RemoveProperties(const IcebergTableInformation &table_info, const vector<string> &properties);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 
 	vector<string> properties;
@@ -104,7 +104,7 @@ struct RemoveProperties : public IcebergTableUpdate {
 struct SetLocation : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_LOCATION;
 
-	explicit SetLocation(IcebergTableInformation &table_info);
+	explicit SetLocation(const IcebergTableInformation &table_info);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 

--- a/src/include/storage/table_update/iceberg_add_snapshot.hpp
+++ b/src/include/storage/table_update/iceberg_add_snapshot.hpp
@@ -22,7 +22,7 @@ struct IcebergAddSnapshot : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SNAPSHOT;
 
 public:
-	IcebergAddSnapshot(IcebergTableInformation &table_info, const string &manifest_list_path,
+	IcebergAddSnapshot(const IcebergTableInformation &table_info, const string &manifest_list_path,
 	                   IcebergSnapshot &&snapshot);
 
 public:

--- a/src/storage/catalog/iceberg_table_set.cpp
+++ b/src/storage/catalog/iceberg_table_set.cpp
@@ -202,7 +202,7 @@ bool IcebergTableSet::CreateNewEntry(ClientContext &context, IcebergCatalog &cat
 	auto table_entry = make_uniq<IcebergTableEntry>(table_info, catalog, schema, info);
 	auto table_ptr = table_entry.get();
 	table_entry->table_info.schema_versions[0] = std::move(table_entry);
-	table_ptr->table_info.table_metadata.schemas[0] = IcebergCreateTableRequest::CreateIcebergSchema(table_ptr);
+	table_ptr->table_info.table_metadata.schemas[0] = IcebergCreateTableRequest::CreateIcebergSchema(*table_ptr);
 	table_ptr->table_info.table_metadata.current_schema_id = 0;
 	table_ptr->table_info.table_metadata.schemas[0]->schema_id = 0;
 	table_ptr->table_info.table_metadata.iceberg_version = iceberg_version.GetIndex();

--- a/src/storage/create_table/iceberg_create_table_request.cpp
+++ b/src/storage/create_table/iceberg_create_table_request.cpp
@@ -20,9 +20,9 @@ IcebergCreateTableRequest::IcebergCreateTableRequest(const IcebergTableInformati
     : table_info(table_info) {
 }
 
-static void AddUnnamedField(yyjson_mut_doc *doc, yyjson_mut_val *field_obj, IcebergColumnDefinition &column);
+static void AddUnnamedField(yyjson_mut_doc *doc, yyjson_mut_val *field_obj, const IcebergColumnDefinition &column);
 
-static void AddNamedField(yyjson_mut_doc *doc, yyjson_mut_val *field_obj, IcebergColumnDefinition &column) {
+static void AddNamedField(yyjson_mut_doc *doc, yyjson_mut_val *field_obj, const IcebergColumnDefinition &column) {
 	yyjson_mut_obj_add_strcpy(doc, field_obj, "name", column.name.c_str());
 	yyjson_mut_obj_add_uint(doc, field_obj, "id", column.id);
 	if (column.type.id() != LogicalTypeId::VARIANT && column.type.IsNested()) {
@@ -35,7 +35,7 @@ static void AddNamedField(yyjson_mut_doc *doc, yyjson_mut_val *field_obj, Iceber
 	yyjson_mut_obj_add_bool(doc, field_obj, "required", column.required);
 }
 
-static void AddUnnamedField(yyjson_mut_doc *doc, yyjson_mut_val *field_obj, IcebergColumnDefinition &column) {
+static void AddUnnamedField(yyjson_mut_doc *doc, yyjson_mut_val *field_obj, const IcebergColumnDefinition &column) {
 	D_ASSERT(column.type.IsNested());
 	switch (column.type.id()) {
 	case LogicalTypeId::STRUCT: {
@@ -91,22 +91,22 @@ static void AddUnnamedField(yyjson_mut_doc *doc, yyjson_mut_val *field_obj, Iceb
 	}
 }
 
-shared_ptr<IcebergTableSchema> IcebergCreateTableRequest::CreateIcebergSchema(const IcebergTableEntry *table_entry) {
+shared_ptr<IcebergTableSchema> IcebergCreateTableRequest::CreateIcebergSchema(const IcebergTableEntry &table_entry) {
 	auto schema = make_shared_ptr<IcebergTableSchema>();
 	// should this be a different schema id?
-	schema->schema_id = table_entry->table_info.table_metadata.current_schema_id;
+	schema->schema_id = table_entry.table_info.table_metadata.current_schema_id;
 
 	// TODO: this can all be refactored out
 	//  this makes the IcebergTableSchema, and we use that to dump data to JSON.
 	//  we can just directly dump it to json.
-	auto column_iterator = table_entry->GetColumns().Logical();
+	auto column_iterator = table_entry.GetColumns().Logical();
 	idx_t field_id = 1;
 
 	auto next_field_id = [&field_id]() -> idx_t {
 		return field_id++;
 	};
 
-	auto &constraints = table_entry->GetConstraints();
+	auto &constraints = table_entry.GetConstraints();
 	for (auto column = column_iterator.begin(); column != column_iterator.end(); ++column) {
 		auto name = (*column).Name();
 		// check if there is a not null constraint
@@ -140,7 +140,7 @@ shared_ptr<IcebergTableSchema> IcebergCreateTableRequest::CreateIcebergSchema(co
 }
 
 void IcebergCreateTableRequest::PopulateSchema(yyjson_mut_doc *doc, yyjson_mut_val *schema_json,
-                                               IcebergTableSchema &schema) {
+                                               const IcebergTableSchema &schema) {
 	yyjson_mut_obj_add_strcpy(doc, schema_json, "type", "struct");
 	auto fields_arr = yyjson_mut_obj_add_arr(doc, schema_json, "fields");
 

--- a/src/storage/iceberg_table_information.cpp
+++ b/src/storage/iceberg_table_information.cpp
@@ -446,11 +446,11 @@ void IcebergTableInformation::SetDefaultSpec(IcebergTransaction &transaction) {
 	transaction_data->TableSetDefaultSpec();
 }
 void IcebergTableInformation::SetProperties(IcebergTransaction &transaction,
-                                            case_insensitive_map_t<string> properties) {
+                                            const case_insensitive_map_t<string> &properties) {
 	InitTransactionData(transaction);
 	transaction_data->TableSetProperties(properties);
 }
-void IcebergTableInformation::RemoveProperties(IcebergTransaction &transaction, vector<string> properties) {
+void IcebergTableInformation::RemoveProperties(IcebergTransaction &transaction, const vector<string> &properties) {
 	InitTransactionData(transaction);
 	transaction_data->TableRemoveProperties(properties);
 }

--- a/src/storage/iceberg_table_update.cpp
+++ b/src/storage/iceberg_table_update.cpp
@@ -7,7 +7,7 @@ IcebergCommitState::IcebergCommitState(const IcebergTableInformation &table_info
     : table_info(table_info), context(context) {
 }
 
-IcebergTableUpdate::IcebergTableUpdate(IcebergTableUpdateType type, IcebergTableInformation &table_info)
+IcebergTableUpdate::IcebergTableUpdate(IcebergTableUpdateType type, const IcebergTableInformation &table_info)
     : type(type), table_info(table_info) {
 }
 

--- a/src/storage/iceberg_transaction_data.cpp
+++ b/src/storage/iceberg_transaction_data.cpp
@@ -15,7 +15,7 @@
 
 namespace duckdb {
 
-IcebergTransactionData::IcebergTransactionData(ClientContext &context, IcebergTableInformation &table_info)
+IcebergTransactionData::IcebergTransactionData(ClientContext &context, const IcebergTableInformation &table_info)
     : context(context), table_info(table_info), is_deleted(false) {
 	if (table_info.table_metadata.has_next_row_id) {
 		next_row_id = table_info.table_metadata.next_row_id;
@@ -75,7 +75,7 @@ static void AddToMetrics(IcebergSnapshot::metrics_map_t &metrics, const IcebergM
 }
 
 IcebergManifestFile IcebergTransactionData::CreateManifestFile(int64_t snapshot_id, sequence_number_t sequence_number,
-                                                               IcebergTableMetadata &table_metadata,
+                                                               const IcebergTableMetadata &table_metadata,
                                                                IcebergManifestContentType manifest_content_type,
                                                                vector<IcebergManifestEntry> &&manifest_entries) {
 	//! create manifest file path
@@ -387,11 +387,11 @@ void IcebergTransactionData::TableSetDefaultSpec() {
 	updates.push_back(make_uniq<SetDefaultSpec>(table_info));
 }
 
-void IcebergTransactionData::TableSetProperties(case_insensitive_map_t<string> properties) {
+void IcebergTransactionData::TableSetProperties(const case_insensitive_map_t<string> &properties) {
 	updates.push_back(make_uniq<SetProperties>(table_info, properties));
 }
 
-void IcebergTransactionData::TableRemoveProperties(vector<string> properties) {
+void IcebergTransactionData::TableRemoveProperties(const vector<string> &properties) {
 	updates.push_back(make_uniq<RemoveProperties>(table_info, properties));
 }
 

--- a/src/storage/table_update/common.cpp
+++ b/src/storage/table_update/common.cpp
@@ -5,7 +5,7 @@
 
 namespace duckdb {
 
-static rest_api_objects::Schema CopySchema(IcebergTableSchema &schema) {
+static rest_api_objects::Schema CopySchema(const IcebergTableSchema &schema) {
 	// the rest api objects are currently not copyable. Without having to modify generated code
 	//  the easiest way to copy for now is to write the schema to string, then parse it again
 	std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
@@ -21,13 +21,17 @@ static rest_api_objects::Schema CopySchema(IcebergTableSchema &schema) {
 	return rest_api_objects::Schema::FromJSON(val);
 }
 
-AddSchemaUpdate::AddSchemaUpdate(IcebergTableInformation &table_info)
+AddSchemaUpdate::AddSchemaUpdate(const IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA, table_info) {
 	auto current_schema_id = table_info.table_metadata.current_schema_id;
 	if (table_info.table_metadata.schemas.find(current_schema_id) == table_info.table_metadata.schemas.end()) {
 		throw InvalidConfigurationException("cannot assign a current schema id for a schema that does not yet exist");
 	};
-	table_schema = table_info.table_metadata.schemas[current_schema_id];
+	auto it = table_info.table_metadata.schemas.find(current_schema_id);
+	if (it == table_info.table_metadata.schemas.end()) {
+		throw InternalException("(AddSchemaUpdate) Could not find schema with id: %d", current_schema_id);
+	}
+	table_schema = it->second.get();
 }
 
 void AddSchemaUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -38,7 +42,11 @@ void AddSchemaUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 	update.add_schema_update.has_action = true;
 	update.add_schema_update.action = "add-schema";
 	auto &current_schema = table_info.table_metadata.GetLatestSchema();
-	auto &schema = table_info.table_metadata.schemas[current_schema.schema_id];
+	auto it = table_info.table_metadata.schemas.find(current_schema.schema_id);
+	if (it == table_info.table_metadata.schemas.end()) {
+		throw InternalException("(AddSchemaUpdate) Couldn't find schema with id: %d", current_schema.schema_id);
+	}
+	auto &schema = it->second;
 	update.add_schema_update.schema = CopySchema(*schema.get());
 	// last column id is technically deprecated, but some catalogs still use it (nessie).
 	if (table_info.table_metadata.HasLastColumnId()) {
@@ -47,7 +55,7 @@ void AddSchemaUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 	}
 }
 
-AssignUUIDUpdate::AssignUUIDUpdate(IcebergTableInformation &table_info)
+AssignUUIDUpdate::AssignUUIDUpdate(const IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA, table_info) {
 }
 
@@ -62,7 +70,7 @@ void AssignUUIDUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	update.assign_uuidupdate.uuid = table_info.table_metadata.table_uuid;
 }
 
-AssertCreateRequirement::AssertCreateRequirement(IcebergTableInformation &table_info)
+AssertCreateRequirement::AssertCreateRequirement(const IcebergTableInformation &table_info)
     : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_CREATE, table_info) {
 }
 
@@ -74,7 +82,7 @@ void AssertCreateRequirement::CreateRequirement(DatabaseInstance &db, ClientCont
 	req.has_assert_create = true;
 }
 
-UpgradeFormatVersion::UpgradeFormatVersion(IcebergTableInformation &table_info)
+UpgradeFormatVersion::UpgradeFormatVersion(const IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::UPGRADE_FORMAT_VERSION, table_info) {
 }
 
@@ -88,7 +96,7 @@ void UpgradeFormatVersion::CreateUpdate(DatabaseInstance &db, ClientContext &con
 	req.upgrade_format_version_update.format_version = table_info.table_metadata.iceberg_version;
 }
 
-SetCurrentSchema::SetCurrentSchema(IcebergTableInformation &table_info)
+SetCurrentSchema::SetCurrentSchema(const IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_CURRENT_SCHEMA, table_info) {
 }
 
@@ -102,7 +110,7 @@ void SetCurrentSchema::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	req.set_current_schema_update.schema_id = table_info.table_metadata.current_schema_id;
 }
 
-AddPartitionSpec::AddPartitionSpec(IcebergTableInformation &table_info)
+AddPartitionSpec::AddPartitionSpec(const IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::ADD_PARTITION_SPEC, table_info) {
 }
 
@@ -130,7 +138,7 @@ void AddPartitionSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	}
 }
 
-AddSortOrder::AddSortOrder(IcebergTableInformation &table_info)
+AddSortOrder::AddSortOrder(const IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::ADD_SORT_ORDER, table_info) {
 }
 
@@ -159,7 +167,7 @@ void AddSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context, Ic
 	}
 }
 
-SetDefaultSortOrder::SetDefaultSortOrder(IcebergTableInformation &table_info)
+SetDefaultSortOrder::SetDefaultSortOrder(const IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SORT_ORDER, table_info) {
 }
 
@@ -174,7 +182,7 @@ void SetDefaultSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &cont
 	req.set_default_sort_order_update.sort_order_id = table_info.table_metadata.GetLatestSortOrder().sort_order_id;
 }
 
-SetDefaultSpec::SetDefaultSpec(IcebergTableInformation &table_info)
+SetDefaultSpec::SetDefaultSpec(const IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SPEC, table_info) {
 }
 
@@ -188,7 +196,8 @@ void SetDefaultSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 	req.set_default_spec_update.spec_id = 0;
 }
 
-SetProperties::SetProperties(IcebergTableInformation &table_info, case_insensitive_map_t<string> properties)
+SetProperties::SetProperties(const IcebergTableInformation &table_info,
+                             const case_insensitive_map_t<string> &properties)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES, table_info), properties(properties) {
 }
 
@@ -200,7 +209,7 @@ void SetProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context, I
 	req.set_properties_update.updates = properties;
 }
 
-RemoveProperties::RemoveProperties(IcebergTableInformation &table_info, vector<string> properties)
+RemoveProperties::RemoveProperties(const IcebergTableInformation &table_info, const vector<string> &properties)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES, table_info), properties(properties) {
 }
 
@@ -213,7 +222,7 @@ void RemoveProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	req.remove_properties_update.removals = properties;
 }
 
-SetLocation::SetLocation(IcebergTableInformation &table_info)
+SetLocation::SetLocation(const IcebergTableInformation &table_info)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_LOCATION, table_info) {
 }
 

--- a/src/storage/table_update/iceberg_add_snapshot.cpp
+++ b/src/storage/table_update/iceberg_add_snapshot.cpp
@@ -14,7 +14,7 @@
 
 namespace duckdb {
 
-IcebergAddSnapshot::IcebergAddSnapshot(IcebergTableInformation &table_info, const string &manifest_list_path,
+IcebergAddSnapshot::IcebergAddSnapshot(const IcebergTableInformation &table_info, const string &manifest_list_path,
                                        IcebergSnapshot &&snapshot)
     : IcebergTableUpdate(IcebergTableUpdateType::ADD_SNAPSHOT, table_info), manifest_list(manifest_list_path),
       snapshot(std::move(snapshot)) {
@@ -141,7 +141,7 @@ IcebergManifestList IcebergAddSnapshot::ConstructManifestList(CopyFunction &avro
 	return new_manifest_list;
 }
 
-static IcebergManifestFile WriteManifestListEntry(IcebergTableInformation &table_info,
+static IcebergManifestFile WriteManifestListEntry(const IcebergTableInformation &table_info,
                                                   const IcebergManifestFile &manifest_file, CopyFunction &avro_copy,
                                                   DatabaseInstance &db, ClientContext &context) {
 	auto manifest_length =

--- a/test/sql/local/irc_custom_setup/test_set_properties_on_local_files.test
+++ b/test/sql/local/irc_custom_setup/test_set_properties_on_local_files.test
@@ -1,5 +1,5 @@
 # name: test/sql/local/irc_custom_setup/test_set_properties_on_local_files.test
-# group: [table_properties]
+# group: [irc_custom_setup]
 
 require-env ICEBERG_SERVER_AVAILABLE
 


### PR DESCRIPTION
Some more "const-thread" pulling, related to #742 

This one is more of a formality, logically the `IcebergTableInformation` should be const because it's shared by potentially many connections, any alterations made have to be stored in the `IcebergTransactionData` until the transaction is committed.