### PR TITLE
[Dev] Make `IcebergTransactionData` and friends save for concurrent use.

### DIFF
--- a/src/include/storage/iceberg_table_information.hpp
+++ b/src/include/storage/iceberg_table_information.hpp
@@ -49,7 +49,6 @@ public:
 	void SetProperties(IcebergTransaction &transaction, const case_insensitive_map_t<string> &properties);
 	void RemoveProperties(IcebergTransaction &transaction, const vector<string> &properties);
 	void SetLocation(IcebergTransaction &transaction);
-	bool IsTransactionLocalTable(IcebergTransaction &transaction);
 	static string GetTableKey(const vector<string> &namespace_items, const string &table_name);
 	string GetTableKey() const;
 	// we pass the transaction, because we are only allowed to copy table information state provded by the catalog

--- a/src/include/storage/iceberg_transaction.hpp
+++ b/src/include/storage/iceberg_transaction.hpp
@@ -53,6 +53,7 @@ public:
 	void RecordTableRequest(const string &table_key, idx_t sequence_number, idx_t snapshot_id);
 	void RecordTableRequest(const string &table_key);
 	TableInfoCache GetTableRequestResult(const string &table_key);
+	IcebergTableInformation &GetTableInfoForTransaction(IcebergTableInformation &table_info);
 
 private:
 	void CleanupFiles();
@@ -83,18 +84,13 @@ public:
 
 	case_insensitive_set_t created_secrets;
 	case_insensitive_set_t looked_up_entries;
+	mutex lock;
 };
 
 template <typename Callback>
 void ApplyTableUpdate(IcebergTableInformation &table_info, IcebergTransaction &iceberg_transaction, Callback callback) {
-	if (table_info.IsTransactionLocalTable(iceberg_transaction)) {
-		callback(table_info);
-	} else {
-		iceberg_transaction.updated_tables.emplace(table_info.GetTableKey(), table_info.Copy(iceberg_transaction));
-		auto &updated_table = iceberg_transaction.updated_tables.at(table_info.GetTableKey());
-		updated_table.InitSchemaVersions();
-		callback(updated_table);
-	}
+	auto &updated_table = iceberg_transaction.GetTableInfoForTransaction(table_info);
+	callback(updated_table);
 }
 
 } // namespace duckdb

--- a/src/include/storage/iceberg_transaction_data.hpp
+++ b/src/include/storage/iceberg_transaction_data.hpp
@@ -24,7 +24,8 @@ public:
 	IcebergTransactionData(ClientContext &context, const IcebergTableInformation &table_info);
 
 public:
-	IcebergManifestFile CreateManifestFile(int64_t snapshot_id, sequence_number_t sequence_number,
+	IcebergManifestFile CreateManifestFile(lock_guard<mutex> &guard, int64_t snapshot_id,
+	                                       sequence_number_t sequence_number,
 	                                       const IcebergTableMetadata &table_metadata,
 	                                       IcebergManifestContentType manifest_content_type,
 	                                       vector<IcebergManifestEntry> &&data_files);
@@ -47,7 +48,7 @@ public:
 	void TableSetLocation();
 
 private:
-	void CacheExistingManifestList(const IcebergTableMetadata &metadata);
+	void CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata);
 
 public:
 	ClientContext &context;
@@ -66,6 +67,8 @@ public:
 	case_insensitive_map_t<string> transactional_delete_files;
 	//! Track the current row id for this transaction
 	int64_t next_row_id = 0;
+
+	mutex lock;
 };
 
 } // namespace duckdb

--- a/src/storage/catalog/iceberg_table_entry.cpp
+++ b/src/storage/catalog/iceberg_table_entry.cpp
@@ -249,7 +249,12 @@ virtual_column_map_t IcebergTableEntry::VirtualColumns() {
 
 vector<column_t> IcebergTableEntry::GetRowIdColumns() const {
 	vector<column_t> result;
-	result.push_back(COLUMN_IDENTIFIER_ROW_ID);
+	auto &table_metadata = table_info.table_metadata;
+	if (table_metadata.iceberg_version >= 3) {
+		//! Project the _row_id column as part of the row-id-columns
+		result.push_back(COLUMN_IDENTIFIER_ROW_ID);
+	}
+
 	result.push_back(MultiFileReader::COLUMN_IDENTIFIER_FILENAME);
 	result.push_back(MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER);
 	return result;

--- a/src/storage/iceberg_delete.cpp
+++ b/src/storage/iceberg_delete.cpp
@@ -422,17 +422,23 @@ PhysicalOperator &IcebergCatalog::PlanDelete(ClientContext &context, PhysicalPla
 	if (op.return_chunk) {
 		throw BinderException("RETURNING clause not yet supported for deletion from Iceberg table");
 	}
+	auto &ic_table_entry = op.table.Cast<IcebergTableEntry>();
+	auto iceberg_version = ic_table_entry.table_info.table_metadata.iceberg_version;
+	if (iceberg_version < 2) {
+		throw NotImplementedException("Delete from Iceberg V%d tables",
+		                              ic_table_entry.table_info.table_metadata.iceberg_version);
+	}
 
 	vector<idx_t> row_id_indexes;
 	// we only push 2 columns for positional deletes
-	for (idx_t i = 0; i < 2; i++) {
-		auto &bound_ref = op.expressions[1 + i]->Cast<BoundReferenceExpression>();
-		row_id_indexes.push_back(bound_ref.index);
+	idx_t column_offset = 0;
+	if (iceberg_version >= 3) {
+		//! The row ids of the table contain the _row_id column, which we're not interested in
+		column_offset = 1;
 	}
-	auto &ic_table_entry = op.table.Cast<IcebergTableEntry>();
-	if (ic_table_entry.table_info.table_metadata.iceberg_version < 2) {
-		throw NotImplementedException("Delete from Iceberg V%d tables",
-		                              ic_table_entry.table_info.table_metadata.iceberg_version);
+	for (idx_t i = 0; i < 2; i++) {
+		auto &bound_ref = op.expressions[column_offset + i]->Cast<BoundReferenceExpression>();
+		row_id_indexes.push_back(bound_ref.index);
 	}
 
 	auto allows_positional_deletes =

--- a/src/storage/iceberg_insert.cpp
+++ b/src/storage/iceberg_insert.cpp
@@ -9,8 +9,8 @@
 #include "utils/iceberg_type.hpp"
 #include "duckdb/catalog/catalog_entry/copy_function_catalog_entry.hpp"
 #include "duckdb/main/client_data.hpp"
-#include "duckdb/planner/operator/logical_copy_to_file.hpp"
 #include "duckdb/execution/physical_operator_states.hpp"
+#include "duckdb/planner/operator/logical_copy_to_file.hpp"
 #include "duckdb/planner/operator/logical_insert.hpp"
 #include "duckdb/planner/operator/logical_create_table.hpp"
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
@@ -294,11 +294,15 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 	auto &transaction = IcebergTransaction::Get(context, table->catalog);
 	auto &iceberg_transaction = transaction.Cast<IcebergTransaction>();
 
-	lock_guard<mutex> guard(global_state.lock);
-	if (!global_state.written_files.empty()) {
-		ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
-			tbl.AddSnapshot(transaction, std::move(global_state.written_files));
-		});
+	vector<IcebergManifestEntry> written_files;
+	{
+		lock_guard<mutex> guard(global_state.lock);
+		written_files = std::move(global_state.written_files);
+	}
+
+	if (!written_files.empty()) {
+		ApplyTableUpdate(table_info, iceberg_transaction,
+		                 [&](IcebergTableInformation &tbl) { tbl.AddSnapshot(transaction, std::move(written_files)); });
 	}
 	return SinkFinalizeType::READY;
 }

--- a/src/storage/iceberg_table_information.cpp
+++ b/src/storage/iceberg_table_information.cpp
@@ -375,6 +375,7 @@ IcebergTableInformation::IcebergTableInformation(IcebergCatalog &catalog, Iceber
 }
 
 void IcebergTableInformation::InitTransactionData(IcebergTransaction &transaction) {
+	lock_guard<mutex> guard(transaction.lock);
 	if (!transaction_data) {
 		auto context = transaction.context.lock();
 		transaction_data = make_uniq<IcebergTransactionData>(*context, *this);
@@ -457,15 +458,6 @@ void IcebergTableInformation::RemoveProperties(IcebergTransaction &transaction, 
 void IcebergTableInformation::SetLocation(IcebergTransaction &transaction) {
 	InitTransactionData(transaction);
 	transaction_data->TableSetLocation();
-}
-
-bool IcebergTableInformation::IsTransactionLocalTable(IcebergTransaction &transaction) {
-	for (auto &tbl : transaction.updated_tables) {
-		if (tbl.first == GetTableKey()) {
-			return true;
-		}
-	}
-	return false;
 }
 
 } // namespace duckdb

--- a/src/storage/iceberg_transaction.cpp
+++ b/src/storage/iceberg_transaction.cpp
@@ -343,6 +343,19 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(ClientContext &co
 	return info;
 }
 
+IcebergTableInformation &IcebergTransaction::GetTableInfoForTransaction(IcebergTableInformation &table_info) {
+	lock_guard<mutex> guard(lock);
+
+	auto table_key = table_info.GetTableKey();
+	auto it = updated_tables.find(table_key);
+	if (it != updated_tables.end()) {
+		return it->second;
+	}
+	auto &updated_table = updated_tables.emplace(table_key, table_info.Copy(*this)).first->second;
+	updated_table.InitSchemaVersions();
+	return updated_table;
+}
+
 void IcebergTransaction::Commit() {
 	if (updated_tables.empty() && deleted_tables.empty() && created_schemas.empty() && deleted_schemas.empty()) {
 		return;

--- a/src/storage/iceberg_transaction_data.cpp
+++ b/src/storage/iceberg_transaction_data.cpp
@@ -74,7 +74,50 @@ static void AddToMetrics(IcebergSnapshot::metrics_map_t &metrics, const IcebergM
 	}
 }
 
-IcebergManifestFile IcebergTransactionData::CreateManifestFile(int64_t snapshot_id, sequence_number_t sequence_number,
+void IcebergTransactionData::CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata) {
+	if (!alters.empty()) {
+		return;
+	}
+
+	auto current_snapshot = metadata.GetLatestSnapshot();
+	if (!current_snapshot) {
+		return;
+	}
+	auto &snapshot = *current_snapshot;
+
+	auto &manifest_list_path = snapshot.manifest_list;
+	//! Read the manifest list
+	auto scan = AvroScan::ScanManifestList(snapshot, metadata, context, manifest_list_path);
+	auto manifest_list_reader = make_uniq<manifest_list::ManifestListReader>(*scan);
+	while (!manifest_list_reader->Finished()) {
+		manifest_list_reader->Read(STANDARD_VECTOR_SIZE, existing_manifest_list);
+	}
+
+	if (metadata.iceberg_version < 3) {
+		return;
+	}
+
+	//! Deal with upgraded tables, if the snapshot originated from V2
+	for (auto &manifest_file : existing_manifest_list) {
+		if (manifest_file.content != IcebergManifestContentType::DATA) {
+			continue;
+		}
+		if (manifest_file.has_first_row_id) {
+			continue;
+		}
+		if (snapshot.has_first_row_id) {
+			throw InternalException("Table is corrupted, snapshot has 'first-row-id' but not all 'manifest_file' "
+			                        "entries have a 'first_row_id'");
+		}
+		manifest_file.has_first_row_id = true;
+		manifest_file.first_row_id = next_row_id;
+		next_row_id += manifest_file.added_rows_count;
+		next_row_id += manifest_file.existing_rows_count;
+	}
+}
+
+IcebergManifestFile IcebergTransactionData::CreateManifestFile(lock_guard<mutex> &guard, int64_t snapshot_id,
+                                                               sequence_number_t sequence_number,
                                                                const IcebergTableMetadata &table_metadata,
                                                                IcebergManifestContentType manifest_content_type,
                                                                vector<IcebergManifestEntry> &&manifest_entries) {
@@ -135,6 +178,7 @@ IcebergManifestFile IcebergTransactionData::CreateManifestFile(int64_t snapshot_
 		}
 		}
 
+		//! FIXME: these should be inherited - left NULL - for newly added data
 		manifest_entry.sequence_number = sequence_number;
 		manifest_entry.snapshot_id = snapshot_id;
 		manifest_entry.partition_spec_id = manifest_file.partition_spec_id;
@@ -153,21 +197,22 @@ IcebergManifestFile IcebergTransactionData::CreateManifestFile(int64_t snapshot_
 void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
                                          vector<IcebergManifestEntry> &&data_files,
                                          case_insensitive_map_t<IcebergManifestDeletes> &&altered_manifests) {
-	D_ASSERT(!data_files.empty());
+	//! NOTE: Lock has to be held to make sure the rows are assigned the correct row ids
+	lock_guard<mutex> guard(lock);
 
 	//! Generate a new snapshot id
 	auto &table_metadata = table_info.table_metadata;
-
-	CacheExistingManifestList(table_metadata);
 	auto last_sequence_number = table_metadata.last_sequence_number;
+
+	CacheExistingManifestList(guard, table_metadata);
 	if (!alters.empty()) {
 		auto &last_alter = alters.back().get();
 		last_sequence_number = last_alter.snapshot.sequence_number;
 	}
 
 	auto snapshot_id = NewSnapshotId();
-	auto sequence_number = last_sequence_number + 1;
-	auto first_row_id = next_row_id;
+	const auto sequence_number = last_sequence_number + 1;
+	const auto first_row_id = next_row_id;
 
 	//! Construct the manifest list
 	auto manifest_list_uuid = UUID::ToString(UUID::GenerateRandomUUID());
@@ -185,8 +230,8 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 	default:
 		throw NotImplementedException("Cannot have use snapshot operation type REPLACE or OVERWRITE here");
 	};
-	auto manifest_file =
-	    CreateManifestFile(snapshot_id, sequence_number, table_metadata, manifest_content_type, std::move(data_files));
+	auto manifest_file = CreateManifestFile(guard, snapshot_id, sequence_number, table_metadata, manifest_content_type,
+	                                        std::move(data_files));
 
 	//! Construct the snapshot
 	IcebergSnapshot new_snapshot;
@@ -196,6 +241,7 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 	new_snapshot.schema_id = table_metadata.current_schema_id;
 	new_snapshot.manifest_list = manifest_list_path;
 	new_snapshot.timestamp_ms = Timestamp::GetEpochMs(Timestamp::GetCurrentTimestamp());
+
 	new_snapshot.has_parent_snapshot = table_metadata.has_current_snapshot || !alters.empty();
 	if (new_snapshot.has_parent_snapshot) {
 		if (!alters.empty()) {
@@ -235,74 +281,35 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 	updates.push_back(std::move(add_snapshot));
 }
 
-void IcebergTransactionData::CacheExistingManifestList(const IcebergTableMetadata &metadata) {
-	if (!alters.empty()) {
-		return;
-	}
-
-	auto current_snapshot = metadata.GetLatestSnapshot();
-	if (!current_snapshot) {
-		return;
-	}
-	auto &snapshot = *current_snapshot;
-
-	auto &manifest_list_path = snapshot.manifest_list;
-	//! Read the manifest list
-	auto scan = AvroScan::ScanManifestList(snapshot, metadata, context, manifest_list_path);
-	auto manifest_list_reader = make_uniq<manifest_list::ManifestListReader>(*scan);
-	while (!manifest_list_reader->Finished()) {
-		manifest_list_reader->Read(STANDARD_VECTOR_SIZE, existing_manifest_list);
-	}
-
-	if (metadata.iceberg_version < 3) {
-		return;
-	}
-
-	//! Deal with upgraded tables, if the snapshot originated from V2
-	for (auto &manifest_file : existing_manifest_list) {
-		if (manifest_file.content != IcebergManifestContentType::DATA) {
-			continue;
-		}
-		if (manifest_file.has_first_row_id) {
-			continue;
-		}
-		if (snapshot.has_first_row_id) {
-			throw InternalException("Table is corrupted, snapshot has 'first-row-id' but not all 'manifest_file' "
-			                        "entries have a 'first_row_id'");
-		}
-		manifest_file.has_first_row_id = true;
-		manifest_file.first_row_id = next_row_id;
-		next_row_id += manifest_file.added_rows_count;
-		next_row_id += manifest_file.existing_rows_count;
-	}
-}
-
 void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&delete_files,
                                                vector<IcebergManifestEntry> &&data_files,
                                                case_insensitive_map_t<IcebergManifestDeletes> &&altered_manifests) {
+	//! NOTE: Lock has to be held to make sure the rows are assigned the correct row ids
+	lock_guard<mutex> guard(lock);
+
 	//! Generate a new snapshot id
 	auto &table_metadata = table_info.table_metadata;
 	auto last_sequence_number = table_metadata.last_sequence_number;
 
-	CacheExistingManifestList(table_metadata);
+	CacheExistingManifestList(guard, table_metadata);
 	if (!alters.empty()) {
 		auto &last_alter = alters.back().get();
 		last_sequence_number = last_alter.snapshot.sequence_number;
 	}
 
 	auto snapshot_id = NewSnapshotId();
-	auto sequence_number = last_sequence_number + 1;
-	auto first_row_id = next_row_id;
+	const auto sequence_number = last_sequence_number + 1;
+	const auto first_row_id = next_row_id;
 
 	//! Construct the manifest list
 	auto manifest_list_uuid = UUID::ToString(UUID::GenerateRandomUUID());
 	auto manifest_list_path =
 	    table_metadata.GetMetadataPath() + "/snap-" + std::to_string(snapshot_id) + "-" + manifest_list_uuid + ".avro";
 
-	auto delete_manifest_file = CreateManifestFile(snapshot_id, sequence_number, table_metadata,
+	auto delete_manifest_file = CreateManifestFile(guard, snapshot_id, sequence_number, table_metadata,
 	                                               IcebergManifestContentType::DELETE, std::move(delete_files));
 	// Add a manifest_file for the new insert data
-	auto data_manifest_file = CreateManifestFile(snapshot_id, sequence_number, table_metadata,
+	auto data_manifest_file = CreateManifestFile(guard, snapshot_id, sequence_number, table_metadata,
 	                                             IcebergManifestContentType::DATA, std::move(data_files));
 
 	//! Construct the snapshot


### PR DESCRIPTION
This PR is extracted from #788 

Summary:
- `IcebergTableInformation` uses a lock to ensure `IcebergTransactionData` is only created once.
- `IcebergTransactionData` uses a lock to ensure that during the creation of a new `IcebergSnapshot` the state isn't altered.
- `_row_id` is added for V3 tables, make sure it's only added to the `get_row_id_columns` result for >= V3 tables