### PR TITLE
[Dev] Fix compilation warning, bundle some logic into a function

### DIFF
--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -30,9 +30,9 @@ namespace duckdb {
 IcebergCatalog::IcebergCatalog(AttachedDatabase &db_p, AccessMode access_mode,
                                unique_ptr<IcebergAuthorization> auth_handler, IcebergAttachOptions &attach_options,
                                const string &default_schema)
-    : Catalog(db_p), access_mode(access_mode), auth_handler(std::move(auth_handler)),
-      warehouse(attach_options.warehouse), uri(attach_options.endpoint), version("v1"), attach_options(attach_options),
-      default_schema(default_schema), schemas(*this), metadata_cache() {
+    : Catalog(db_p), access_mode(access_mode), auth_handler(std::move(auth_handler)), uri(attach_options.endpoint),
+      version("v1"), attach_options(attach_options), default_schema(default_schema),
+      warehouse(attach_options.warehouse), schemas(*this), metadata_cache() {
 }
 
 IcebergCatalog::~IcebergCatalog() = default;

--- a/src/core/deletes/iceberg_equality_delete.cpp
+++ b/src/core/deletes/iceberg_equality_delete.cpp
@@ -18,20 +18,10 @@ static void InitializeFromOtherChunk(DataChunk &target, DataChunk &other, const 
 	target.InitializeEmpty(types);
 }
 
-void IcebergMultiFileList::ScanEqualityDeleteFile(const IcebergManifestEntry &manifest_entry, DataChunk &result_p,
-                                                  vector<MultiFileColumnDefinition> &local_columns,
-                                                  const vector<MultiFileColumnDefinition> &global_columns,
-                                                  const vector<ColumnIndex> &column_indexes) const {
-	auto &data_file = manifest_entry.data_file;
-	D_ASSERT(!data_file.equality_ids.empty());
-	D_ASSERT(result_p.ColumnCount() == local_columns.size());
-
-	auto count = result_p.size();
-	if (count == 0) {
-		return;
-	}
-
-	//! Map from column_id to 'local_columns' index, to figure out which columns from the 'result_p' are relevant here
+static void ColumnsReferencedByEqualityIds(DataChunk &source, DataChunk &result,
+                                           const vector<MultiFileColumnDefinition> &local_columns,
+                                           const vector<int32_t> &equality_ids) {
+	//! Map from column_id to 'local_columns' index, to figure out which columns from the 'source' are relevant here
 	unordered_map<int32_t, column_t> id_to_column;
 	for (column_t i = 0; i < local_columns.size(); i++) {
 		auto &col = local_columns[i];
@@ -40,11 +30,30 @@ void IcebergMultiFileList::ScanEqualityDeleteFile(const IcebergManifestEntry &ma
 	}
 
 	vector<column_t> column_ids;
-	DataChunk result;
-	for (auto id : data_file.equality_ids) {
+	for (auto id : equality_ids) {
 		D_ASSERT(id_to_column.count(id));
 		column_ids.push_back(id_to_column[id]);
 	}
+	//! Take only the relevant columns from the source
+	InitializeFromOtherChunk(result, source, column_ids);
+	result.ReferenceColumns(source, column_ids);
+}
+
+void IcebergMultiFileList::ScanEqualityDeleteFile(const IcebergManifestEntry &manifest_entry, DataChunk &source,
+                                                  vector<MultiFileColumnDefinition> &local_columns,
+                                                  const vector<MultiFileColumnDefinition> &global_columns,
+                                                  const vector<ColumnIndex> &column_indexes) const {
+	auto &data_file = manifest_entry.data_file;
+	D_ASSERT(!data_file.equality_ids.empty());
+	D_ASSERT(source.ColumnCount() == local_columns.size());
+
+	auto count = source.size();
+	if (count == 0) {
+		return;
+	}
+
+	DataChunk result;
+	ColumnsReferencedByEqualityIds(source, result, local_columns, data_file.equality_ids);
 
 	//! Get or create the equality delete data for this sequence number
 	auto it = equality_delete_data.find(manifest_entry.sequence_number);
@@ -86,10 +95,6 @@ void IcebergMultiFileList::ScanEqualityDeleteFile(const IcebergManifestEntry &ma
 		auto result_id = equality_id_to_result_id.emplace(field_id, new_result_id).first->second;
 		global_id_to_result_id[global_column_id] = result_id;
 	}
-
-	//! Take only the relevant columns from the result
-	InitializeFromOtherChunk(result, result_p, column_ids);
-	result.ReferenceColumns(result_p, column_ids);
 	deletes.files.emplace_back(data_file.partition_info, manifest_entry.partition_spec_id);
 	auto &rows = deletes.files.back().rows;
 	rows.resize(count);


### PR DESCRIPTION
- `warehouse` was initialized in the wrong order in the initializer list.
- bundled some logic in `ScanEqualityDeleteFile` into a function to reduce the cognitive load of the method.