### PR TITLE
[Dev] Remove `manifest_file_path` from `IcebergManifestEntry`

### DIFF
--- a/src/core/deletes/iceberg_deletion_vector.cpp
+++ b/src/core/deletes/iceberg_deletion_vector.cpp
@@ -65,7 +65,7 @@ bool CRC32::table_initialized = false;
 
 } // namespace
 
-shared_ptr<IcebergDeletionVectorData> IcebergDeletionVectorData::FromBlob(const IcebergManifestEntry &entry,
+shared_ptr<IcebergDeletionVectorData> IcebergDeletionVectorData::FromBlob(const BoundIcebergManifestEntry &entry,
                                                                           data_ptr_t blob_start, idx_t blob_length) {
 	//! https://iceberg.apache.org/puffin-spec/#deletion-vector-v1-blob-type
 
@@ -168,7 +168,7 @@ void IcebergMultiFileList::ScanPuffinFile(const BoundIcebergManifestEntry &bound
 	}
 	//! NOTE: assign, don't emplace, deletion vectors take priority over any remaining positional delete files
 	positional_delete_data[data_file.referenced_data_file] =
-	    IcebergDeletionVectorData::FromBlob(entry, buffer_data, length);
+	    IcebergDeletionVectorData::FromBlob(bound_entry, buffer_data, length);
 }
 
 idx_t IcebergDeletionVector::Filter(row_t start_row_index, idx_t count, SelectionVector &result_sel) {

--- a/src/core/deletes/iceberg_positional_delete.cpp
+++ b/src/core/deletes/iceberg_positional_delete.cpp
@@ -12,7 +12,7 @@ void IcebergPositionalDeleteData::ToSet(set<idx_t> &out) const {
 }
 
 static optional_ptr<IcebergPositionalDeleteData>
-TryGetOrCreate(case_insensitive_map_t<shared_ptr<IcebergDeleteData>> &deletes, const IcebergManifestEntry &entry,
+TryGetOrCreate(case_insensitive_map_t<shared_ptr<IcebergDeleteData>> &deletes, const BoundIcebergManifestEntry &entry,
                const string &file_path) {
 	auto it = deletes.find(file_path);
 	if (it == deletes.end()) {
@@ -28,7 +28,6 @@ TryGetOrCreate(case_insensitive_map_t<shared_ptr<IcebergDeleteData>> &deletes, c
 
 void IcebergMultiFileList::ScanPositionalDeleteFile(const BoundIcebergManifestEntry &bound_entry,
                                                     DataChunk &result) const {
-	auto &entry = bound_entry.entry;
 	//! FIXME: might want to check the 'columns' of the 'reader' to check, field-ids are:
 	auto names = FlatVector::GetData<string_t>(result.data[0]);  //! 2147483546
 	auto row_ids = FlatVector::GetData<int64_t>(result.data[1]); //! 2147483545
@@ -39,7 +38,7 @@ void IcebergMultiFileList::ScanPositionalDeleteFile(const BoundIcebergManifestEn
 	}
 	reference<string_t> current_file_path = names[0];
 	auto initial_key = current_file_path.get().GetString();
-	auto deletes = TryGetOrCreate(positional_delete_data, entry, initial_key);
+	auto deletes = TryGetOrCreate(positional_delete_data, bound_entry, initial_key);
 
 	for (idx_t i = 0; i < count; i++) {
 		auto &name = names[i];
@@ -48,7 +47,7 @@ void IcebergMultiFileList::ScanPositionalDeleteFile(const BoundIcebergManifestEn
 		if (name != current_file_path.get()) {
 			current_file_path = name;
 			auto key = current_file_path.get().GetString();
-			deletes = TryGetOrCreate(positional_delete_data, entry, key);
+			deletes = TryGetOrCreate(positional_delete_data, bound_entry, key);
 		}
 		if (!deletes) {
 			continue;

--- a/src/core/metadata/manifest/iceberg_manifest_list.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest_list.cpp
@@ -51,7 +51,6 @@ IcebergManifestListEntry IcebergManifestListEntry::CreateFromEntries(FileSystem 
 
 	//! Add the files to the manifest
 	for (auto &manifest_entry : manifest_entries) {
-		manifest_entry.manifest_file_path = manifest_file_path;
 		auto &data_file = manifest_entry.data_file;
 		if (data_file.content == IcebergManifestEntryContentType::DATA) {
 			//! FIXME: this is required because we don't apply inheritance to uncommitted manifests

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -99,7 +99,8 @@ void IcebergDelete::WriteDeletionVectorFile(ClientContext &context, IcebergDelet
 
 	// Build deletion vector data
 	IcebergManifestEntry unused;
-	auto dv_data = make_shared_ptr<IcebergDeletionVectorData>(unused);
+	BoundIcebergManifestEntry bound_unused(0, unused);
+	auto dv_data = make_shared_ptr<IcebergDeletionVectorData>(bound_unused);
 
 	// Group row indices by high 32 bits
 	for (auto row_idx : sorted_deletes) {
@@ -214,12 +215,14 @@ void IcebergDelete::WritePositionalDeleteFile(ClientContext &context, IcebergDel
 	global_state.written_files.emplace(filename, std::move(delete_file));
 }
 
-static void PopulateAlteredManifests(case_insensitive_map_t<IcebergManifestDeletes> &out,
+static void PopulateAlteredManifests(const IcebergMultiFileList &multi_file_list,
+                                     case_insensitive_map_t<IcebergManifestDeletes> &out,
                                      IcebergDeleteData &delete_data, const string &referenced_data_file) {
-	for (auto &entry_p : delete_data.entries) {
-		auto &entry = entry_p.get();
-		auto &manifest_file = out[entry.manifest_file_path];
-		auto it = manifest_file.altered_data_files.emplace(entry.data_file.file_path, delete_data.type).first;
+	for (auto &bound_entry : delete_data.entries) {
+		auto &entry = bound_entry.entry;
+		auto &manifest_file = multi_file_list.GetManifestFileForEntry(bound_entry, IcebergManifestContentType::DELETE);
+		auto &altered_manifest_file = out[manifest_file.manifest_path];
+		auto it = altered_manifest_file.altered_data_files.emplace(entry.data_file.file_path, delete_data.type).first;
 		auto &delete_file = it->second;
 		delete_file.referenced_data_files.push_back(referenced_data_file);
 	}
@@ -248,7 +251,7 @@ void IcebergDelete::FlushDeletes(IcebergTransaction &transaction, ClientContext 
 			auto it = multi_file_list.positional_delete_data.find(filename);
 			if (it != multi_file_list.positional_delete_data.end()) {
 				auto &delete_data = *it->second;
-				PopulateAlteredManifests(global_state.altered_manifests, delete_data, filename);
+				PopulateAlteredManifests(multi_file_list, global_state.altered_manifests, delete_data, filename);
 				delete_data.ToSet(sorted_deletes);
 			}
 		}

--- a/src/include/core/deletes/iceberg_delete_data.hpp
+++ b/src/include/core/deletes/iceberg_delete_data.hpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/multi_file/multi_file_data.hpp"
 #include "core/metadata/manifest/iceberg_manifest.hpp"
+#include "planning/metadata_io/manifest/bound_iceberg_manifest_entry.hpp"
 
 namespace duckdb {
 
@@ -9,7 +10,7 @@ enum class IcebergDeleteType : uint8_t { POSITIONAL_DELETE, DELETION_VECTOR };
 
 struct IcebergDeleteData {
 public:
-	IcebergDeleteData(IcebergDeleteType type, const IcebergManifestEntry &entry) : type(type) {
+	IcebergDeleteData(IcebergDeleteType type, const BoundIcebergManifestEntry &entry) : type(type) {
 		entries.push_back(entry);
 	}
 	virtual ~IcebergDeleteData() {
@@ -22,7 +23,7 @@ public:
 public:
 	IcebergDeleteType type;
 	//! The manifest entry(s) that created this delete data
-	vector<reference<const IcebergManifestEntry>> entries;
+	vector<BoundIcebergManifestEntry> entries;
 };
 
 } // namespace duckdb

--- a/src/include/core/deletes/iceberg_deletion_vector.hpp
+++ b/src/include/core/deletes/iceberg_deletion_vector.hpp
@@ -8,14 +8,14 @@ namespace duckdb {
 
 struct IcebergDeletionVectorData : public enable_shared_from_this<IcebergDeletionVectorData>, IcebergDeleteData {
 public:
-	IcebergDeletionVectorData(const IcebergManifestEntry &entry)
+	IcebergDeletionVectorData(const BoundIcebergManifestEntry &entry)
 	    : IcebergDeleteData(IcebergDeleteType::DELETION_VECTOR, entry) {
 	}
 	virtual ~IcebergDeletionVectorData() override {
 	}
 
 public:
-	static shared_ptr<IcebergDeletionVectorData> FromBlob(const IcebergManifestEntry &entry, data_ptr_t blob_start,
+	static shared_ptr<IcebergDeletionVectorData> FromBlob(const BoundIcebergManifestEntry &entry, data_ptr_t blob_start,
 	                                                      idx_t blob_length);
 	vector<data_t> ToBlob() const;
 

--- a/src/include/core/deletes/iceberg_positional_delete.hpp
+++ b/src/include/core/deletes/iceberg_positional_delete.hpp
@@ -7,7 +7,7 @@ namespace duckdb {
 
 struct IcebergPositionalDeleteData : public enable_shared_from_this<IcebergPositionalDeleteData>, IcebergDeleteData {
 public:
-	IcebergPositionalDeleteData(const IcebergManifestEntry &entry)
+	IcebergPositionalDeleteData(const BoundIcebergManifestEntry &entry)
 	    : IcebergDeleteData(IcebergDeleteType::POSITIONAL_DELETE, entry) {
 	}
 	virtual ~IcebergPositionalDeleteData() override {

--- a/src/include/core/metadata/manifest/iceberg_manifest.hpp
+++ b/src/include/core/metadata/manifest/iceberg_manifest.hpp
@@ -91,7 +91,6 @@ public:
 	IcebergManifestEntryStatusType status;
 	bool has_snapshot_id = false;
 	int64_t snapshot_id;
-	string manifest_file_path;
 	IcebergDataFile data_file;
 
 public:

--- a/src/include/planning/metadata_io/avro/iceberg_avro_multi_file_reader.hpp
+++ b/src/include/planning/metadata_io/avro/iceberg_avro_multi_file_reader.hpp
@@ -23,9 +23,6 @@ public:
 
 struct IcebergAvroMultiFileReader : public MultiFileReader {
 public:
-	static constexpr column_t MANIFEST_FILE_PATH_FIELD_ID = UINT64_C(10000000000000000002);
-
-public:
 	IcebergAvroMultiFileReader(shared_ptr<TableFunctionInfo> function_info) : function_info(std::move(function_info)) {
 	}
 
@@ -34,11 +31,6 @@ public:
 	                                         const FileGlobInput &glob_input) override;
 	bool Bind(MultiFileOptions &options, MultiFileList &files, vector<LogicalType> &return_types, vector<string> &names,
 	          MultiFileReaderBindData &bind_data) override;
-	unique_ptr<Expression>
-	GetVirtualColumnExpression(ClientContext &context, MultiFileReaderData &reader_data,
-	                           const vector<MultiFileColumnDefinition> &local_columns, idx_t &column_id,
-	                           const LogicalType &type, MultiFileLocalIndex local_idx,
-	                           optional_ptr<MultiFileColumnDefinition> &global_column_reference) override;
 	void FinalizeChunk(ClientContext &context, const MultiFileBindData &bind_data, BaseFileReader &reader,
 	                   const MultiFileReaderData &reader_data, DataChunk &input_chunk, DataChunk &output_chunk,
 	                   ExpressionExecutor &executor, optional_ptr<MultiFileReaderGlobalState> global_state) override;

--- a/src/planning/metadata_io/avro/avro_scan.cpp
+++ b/src/planning/metadata_io/avro/avro_scan.cpp
@@ -58,23 +58,6 @@ AvroScan::AvroScan(const string &path, ClientContext &context, shared_ptr<Iceber
 		column_ids.push_back(i);
 	}
 
-	if (!is_manifest_list) {
-		const ManifestFileVirtualColumn columns[] = {
-		    {IcebergAvroMultiFileReader::MANIFEST_FILE_PATH_FIELD_ID, "manifest_file_path", LogicalType::VARCHAR}};
-		const idx_t columns_size = sizeof(columns) / sizeof(ManifestFileVirtualColumn);
-		auto &multi_file_bind_data = bind_data->Cast<MultiFileBindData>();
-
-		virtual_column_map_t result;
-		for (idx_t i = 0; i < columns_size; i++) {
-			auto &column = columns[i];
-			result.emplace(column.id, TableColumn(column.name, column.type));
-			column_ids.push_back(column.id);
-			return_types.push_back(column.type);
-			return_names.push_back(column.name);
-		}
-		multi_file_bind_data.virtual_columns = result;
-	}
-
 	TableFunctionInitInput input(bind_data.get(), column_ids, vector<idx_t>(), nullptr);
 	global_state = avro_scan->init_global(context, input);
 }

--- a/src/planning/metadata_io/avro/iceberg_avro_multi_file_reader.cpp
+++ b/src/planning/metadata_io/avro/iceberg_avro_multi_file_reader.cpp
@@ -11,7 +11,6 @@
 #include "planning/metadata_io/manifest_list/iceberg_manifest_list_reader.hpp"
 
 namespace duckdb {
-constexpr column_t IcebergAvroMultiFileReader::MANIFEST_FILE_PATH_FIELD_ID;
 
 unique_ptr<MultiFileReader> IcebergAvroMultiFileReader::CreateInstance(const TableFunction &table) {
 	return make_uniq<IcebergAvroMultiFileReader>(table.function_info);
@@ -523,25 +522,6 @@ void IcebergAvroMultiFileReader::FinalizeChunk(ClientContext &context, const Mul
 		throw InternalException("AvroScanInfoType not implemented");
 	}
 	return;
-}
-
-unique_ptr<Expression> IcebergAvroMultiFileReader::GetVirtualColumnExpression(
-    ClientContext &context, MultiFileReaderData &reader_data, const vector<MultiFileColumnDefinition> &local_columns,
-    idx_t &column_id, const LogicalType &type, MultiFileLocalIndex local_idx,
-    optional_ptr<MultiFileColumnDefinition> &global_column_reference) {
-	if (column_id == MANIFEST_FILE_PATH_FIELD_ID) {
-		if (!reader_data.file_to_be_opened.extended_info) {
-			throw InternalException("Extended info not found for manifest_file_path column");
-		}
-		auto &options = reader_data.file_to_be_opened.extended_info->options;
-		auto entry = options.find("manifest_file_path");
-		if (entry == options.end()) {
-			throw InternalException("'manifest_file_path' not set when initializing the FileList");
-		}
-		return make_uniq<BoundConstantExpression>(entry->second);
-	}
-	return MultiFileReader::GetVirtualColumnExpression(context, reader_data, local_columns, column_id, type, local_idx,
-	                                                   global_column_reference);
 }
 
 unique_ptr<MultiFileReaderGlobalState> IcebergAvroMultiFileReader::InitializeGlobalState(

--- a/src/planning/metadata_io/manifest/iceberg_manifest_reader.cpp
+++ b/src/planning/metadata_io/manifest/iceberg_manifest_reader.cpp
@@ -108,8 +108,6 @@ void ManifestReader::ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &
 
 	auto &data_file = chunk.data[vector_index++];
 
-	auto &manifest_file_path = chunk.data[vector_index++];
-
 	idx_t entry_index = 0;
 	auto &data_file_entries = StructVector::GetEntries(data_file);
 	optional_ptr<Vector> content;
@@ -152,7 +150,6 @@ void ManifestReader::ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &
 
 	auto sequence_number_data = FlatVector::GetData<int64_t>(sequence_number);
 	auto file_sequence_number_data = FlatVector::GetData<int64_t>(file_sequence_number);
-	auto manifest_file_path_data = FlatVector::GetData<string_t>(manifest_file_path);
 
 	auto &sort_order_id_validity = FlatVector::Validity(sort_order_id);
 	auto sort_order_id_data = FlatVector::GetData<int32_t>(sort_order_id);
@@ -244,7 +241,6 @@ void ManifestReader::ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &
 		if (entry.has_snapshot_id) {
 			entry.snapshot_id = snapshot_id_data[index];
 		}
-		entry.manifest_file_path = manifest_file_path_data[index].GetString();
 		for (auto &it : partition_vectors) {
 			auto field_id = it.first;
 			auto &partition_vector = it.second.get();


### PR DESCRIPTION
Use the `BoundIcebergManifestEntry` to get the `IcebergManifestFile`'s `manifest_path` when required, instead of baking this into the `IcebergManifestEntry`