### PR TITLE
[Dev] Add the `supports_pushdown_type` to disable pushing down `_row_id` filters

### DIFF
--- a/src/function/scan/iceberg_scan.cpp
+++ b/src/function/scan/iceberg_scan.cpp
@@ -65,16 +65,15 @@ BindInfo IcebergBindInfo(const optional_ptr<FunctionData> bind_data) {
 	return BindInfo(*file_list.table);
 }
 
-//! FIXME: needs v1.5.1, causes a crash on v1.5.0
-// static bool IcebergScanSupportsPushdownType(const FunctionData &bind_data_p, idx_t column_id) {
-//	// Don't push down filters on the _row_id virtual column
-//	if (column_id == COLUMN_IDENTIFIER_ROW_ID) {
-//		return false;
-//	}
+static bool IcebergScanSupportsPushdownType(const FunctionData &bind_data_p, idx_t column_id) {
+	// Don't push down filters on the _row_id virtual column
+	if (column_id == COLUMN_IDENTIFIER_ROW_ID) {
+		return false;
+	}
 
-//	// Default behavior for other columns
-//	return true;
-//}
+	// Default behavior for other columns
+	return true;
+}
 
 TableFunctionSet IcebergFunctions::GetIcebergScanFunction(ExtensionLoader &loader) {
 	// The iceberg_scan function is constructed by grabbing the parquet scan from the Catalog, then injecting the
@@ -98,7 +97,7 @@ TableFunctionSet IcebergFunctions::GetIcebergScanFunction(ExtensionLoader &loade
 		function.get_bind_info = IcebergBindInfo;
 		function.get_virtual_columns = IcebergVirtualColumns;
 		function.get_partition_stats = IcebergMultiFileReader::IcebergGetPartitionStats;
-		// function.supports_pushdown_type = IcebergScanSupportsPushdownType;
+		function.supports_pushdown_type = IcebergScanSupportsPushdownType;
 
 		// Schema param is just confusing here
 		function.named_parameters.erase("schema");

--- a/test/sql/local/irc_any_catalog/reads/partitioned_reads/truncate/truncate_bigint.test
+++ b/test/sql/local/irc_any_catalog/reads/partitioned_reads/truncate/truncate_bigint.test
@@ -1,4 +1,4 @@
-# name: test/sql/local/partitioning/truncate/truncate_bigint.test
+# name: test/sql/local/irc_any_catalog/reads/partitioned_reads/truncate/truncate_bigint.test
 # group: [truncate]
 
 require avro

--- a/test/sql/local/irc_any_catalog/reads/partitioned_reads/truncate/truncate_binary.test
+++ b/test/sql/local/irc_any_catalog/reads/partitioned_reads/truncate/truncate_binary.test
@@ -1,4 +1,4 @@
-# name: test/sql/local/partitioning/truncate/truncate_binary.test
+# name: test/sql/local/irc_any_catalog/reads/partitioned_reads/truncate/truncate_binary.test
 # group: [truncate]
 
 require avro

--- a/test/sql/local/irc_any_catalog/reads/partitioned_reads/truncate/truncate_decimal.test
+++ b/test/sql/local/irc_any_catalog/reads/partitioned_reads/truncate/truncate_decimal.test
@@ -1,4 +1,4 @@
-# name: test/sql/local/partitioning/truncate/truncate_decimal.test
+# name: test/sql/local/irc_any_catalog/reads/partitioned_reads/truncate/truncate_decimal.test
 # group: [truncate]
 
 require avro

--- a/test/sql/local/irc_any_catalog/reads/partitioned_reads/truncate/truncate_varchar.test
+++ b/test/sql/local/irc_any_catalog/reads/partitioned_reads/truncate/truncate_varchar.test
@@ -1,4 +1,4 @@
-# name: test/sql/local/partitioning/truncate/truncate_varchar.test
+# name: test/sql/local/irc_any_catalog/reads/partitioned_reads/truncate/truncate_varchar.test
 # group: [truncate]
 
 require avro


### PR DESCRIPTION
This PR is a follow up to #745 