### PR TITLE
Add geometry support simple

### DIFF
--- a/src/catalog/rest/api/iceberg_type.cpp
+++ b/src/catalog/rest/api/iceberg_type.cpp
@@ -58,6 +58,8 @@ string IcebergTypeHelper::LogicalTypeToIcebergType(const LogicalType &type) {
 		return "map";
 	case LogicalTypeId::VARIANT:
 		return "variant";
+	case LogicalTypeId::GEOMETRY:
+		return "geometry";
 	default:
 		throw InvalidInputException("Column type %s is not a valid Iceberg Type.", LogicalTypeIdToString(type.id()));
 	}

--- a/src/core/metadata/schema/iceberg_column_definition.cpp
+++ b/src/core/metadata/schema/iceberg_column_definition.cpp
@@ -174,6 +174,10 @@ LogicalType IcebergColumnDefinition::ParsePrimitiveTypeString(const string &type
 	if (type_str == "variant") {
 		return LogicalType::VARIANT();
 	}
+	if (type_str == "geometry") {
+		// Geometry is an Iceberg v3 type stored as WKB binary in parquet
+		return LogicalType::GEOMETRY();
+	}
 	throw InvalidConfigurationException("Unrecognized primitive type: %s", type_str);
 }
 
@@ -202,6 +206,7 @@ bool IcebergColumnDefinition::IsIcebergPrimitiveType() const {
 	case LogicalTypeId::TIMESTAMP:
 	case LogicalTypeId::TIMESTAMP_TZ:
 	case LogicalTypeId::VARIANT:
+	case LogicalTypeId::GEOMETRY:
 		return true;
 	default:
 		return false;

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -307,10 +307,6 @@ void IcebergInsertGlobalState::AddFiles(DataChunk &chunk, const string &table_na
 				continue;
 			}
 			auto &column_info = *column_info_p;
-			if (column_info.type.id() == LogicalTypeId::GEOMETRY) {
-				//! Geometry columns have no meaningful min/max bounds
-				continue;
-			}
 			auto stats = ParseColumnStats(column_info.type, col_stats, context);
 
 			// a map type cannot violate not null constraints.

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -307,6 +307,10 @@ void IcebergInsertGlobalState::AddFiles(DataChunk &chunk, const string &table_na
 				continue;
 			}
 			auto &column_info = *column_info_p;
+			if (column_info.type.id() == LogicalTypeId::GEOMETRY) {
+				//! Geometry columns have no meaningful min/max bounds
+				continue;
+			}
 			auto stats = ParseColumnStats(column_info.type, col_stats, context);
 
 			// a map type cannot violate not null constraints.

--- a/test/configs/lakekeeper.json
+++ b/test/configs/lakekeeper.json
@@ -24,7 +24,8 @@
         "test/sql/local/irc_any_catalog/delete/delete_table.test",
         "test/sql/local/irc_any_catalog/reads/test_read_partitioned_table_type_promotion.test",
         "test/sql/local/irc_any_catalog/create/default/test_create_default_blob.test",
-        "test/sql/local/irc_any_catalog/test_basic_variant.test"
+        "test/sql/local/irc_any_catalog/test_basic_variant.test",
+        "test/sql/local/irc_any_catalog/insert/test_create_geometry_type.test"
       ]
     },
     {

--- a/test/configs/nessie.json
+++ b/test/configs/nessie.json
@@ -42,6 +42,7 @@
         "test/sql/local/irc_any_catalog/create/default/test_create_default_uuid.test",
         "test/sql/local/irc_any_catalog/create/default/test_create_default_time.test",
         "test/sql/local/irc_any_catalog/create/test_create_default.test",
+        "test/sql/local/irc_any_catalog/insert/test_create_geometry_type.test",
         "test/sql/local/irc_any_catalog/other_engines/test_create_partitioned_tables.test",
         "test/sql/local/irc_any_catalog/update/update_with_default.test"
       ]

--- a/test/sql/cloud/snowflake/test_snowflake_gemoetry_type.test
+++ b/test/sql/cloud/snowflake/test_snowflake_gemoetry_type.test
@@ -1,0 +1,86 @@
+# name: test/sql/cloud/snowflake/test_snowflake_geometry_type.test
+# description: test integration with iceberg catalog read
+# group: [snowflake]
+
+require-env ICEBERG_SNOWFLAKE_REMOTE_AVAILABLE
+
+require-env SNOWFLAKE_KEY_ID_S3
+
+require-env SNOWFLAKE_SECRET_KEY_S3
+
+require-env SNOWFLAKE_CATALOG_URI_GCS
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+
+statement ok
+create secret polaris_secret (
+	TYPE ICEBERG,
+	CLIENT_ID '${SNOWFLAKE_KEY_ID_S3}',
+	CLIENT_SECRET '${SNOWFLAKE_SECRET_KEY_S3}',
+	ENDPOINT '${SNOWFLAKE_CATALOG_URI_GCS}'
+);
+
+statement ok
+attach 's3-catalog' as my_datalake (
+	type ICEBERG,
+	ENDPOINT '${SNOWFLAKE_CATALOG_URI_GCS}'
+);
+
+
+# this table is made up of many geometry points, inserted one at a time, 
+# meaning there are many manifest files that store the upper and lower bound information
+# of the geometry type
+# INSERT INTO geometry_test SELECT 1, 'min_min_point', TO_GEOMETRY('POINT (-180 -90)', 4326);
+# INSERT INTO geometry_test SELECT 2, 'max_max_point', TO_GEOMETRY('POINT (180 90)',   4326);
+# INSERT INTO geometry_test SELECT 3, 'min_max_point', TO_GEOMETRY('POINT (-180 90)', 4326) ;
+# INSERT INTO geometry_test SELECT 4, 'max_min_point', TO_GEOMETRY('POINT (180 -90)', 4326);
+# INSERT INTO geometry_test SELECT 5,  'north_pole',            TO_GEOMETRY('POINT(0 90)', 4326);
+# INSERT INTO geometry_test SELECT 6,  'south_pole',            TO_GEOMETRY('POINT(0 -90)', 4326);
+# INSERT INTO geometry_test SELECT 7,  'origin',                TO_GEOMETRY('POINT(0 0)', 4326);
+# INSERT INTO geometry_test SELECT 8,  'antimeridian_pos',      TO_GEOMETRY('POINT(180 0)', 4326);
+# INSERT INTO geometry_test SELECT 9,  'antimeridian_neg',      TO_GEOMETRY('POINT(-180 0)', 4326);
+# INSERT INTO geometry_test SELECT 10, 'antimeridian_crossing', TO_GEOMETRY('LINESTRING(170 10, -170 10)', 4326);
+# INSERT INTO geometry_test SELECT 11, 'full_world_polygon',       TO_GEOMETRY('POLYGON ((-180 -90, 180 -90, 180 90, -180 90, -180 -90))', 4326);
+# INSERT INTO geometry_test SELECT 12, 'near_degenerate_polygon',  TO_GEOMETRY('POLYGON ((45 45, 45.0000001 45, 45.0000001 45.0000001, 45 45))', 4326);
+# INSERT INTO geometry_test SELECT 13, 'equatorial_linestring',    TO_GEOMETRY('LINESTRING (-180 0, 180 0)', 4326);
+# INSERT INTO geometry_test SELECT 14, 'meridian_linestring',      TO_GEOMETRY('LINESTRING (0 -90, 0 90)', 4326);
+# INSERT INTO geometry_test SELECT 15, 'multipoint_extremes',   TO_GEOMETRY('MULTIPOINT ((-180 -90), (0 0), (180 90))', 4326);
+# INSERT INTO geometry_test SELECT 16, 'polygon_with_hole',     TO_GEOMETRY('POLYGON ((-10 -10, 10 -10, 10 10, -10 10, -10 -10), (-5 -5, 5 -5, 5 5, -5 5, -5 -5))', 4326);
+# INSERT INTO geometry_test SELECT 17, 'point_3d_high_z',       TO_GEOMETRY('POINT Z (45 45 8849)', 4326);
+# INSERT INTO geometry_test SELECT 18, 'point_3d_low_z',        TO_GEOMETRY('POINT Z (30 30 -11034)', 4326);
+# INSERT INTO geometry_test SELECT 20, 'empty_collection',      TO_GEOMETRY('GEOMETRYCOLLECTION EMPTY', 4326);
+# INSERT INTO geometry_test SELECT 19, 'null_geom',  NULL;
+query III
+select * from my_datalake.default.geometry_test;
+----
+1	min_min_point	POINT (-180 -90)
+2	max_max_point	POINT (180 90)
+3	min_max_point	POINT (-180 90)
+4	max_min_point	POINT (180 -90)
+5	north_pole	POINT (0 90)
+6	south_pole	POINT (0 -90)
+7	origin	POINT (0 0)
+8	antimeridian_pos	POINT (180 0)
+9	antimeridian_neg	POINT (-180 0)
+10	antimeridian_crossing	LINESTRING (170 10, -170 10)
+11	full_world_polygon	POLYGON ((-180 -90, 180 -90, 180 90, -180 90, -180 -90))
+12	near_degenerate_polygon	POLYGON ((45 45, 45.0000001 45, 45.0000001 45.0000001, 45 45))
+13	equatorial_linestring	LINESTRING (-180 0, 180 0)
+14	meridian_linestring	LINESTRING (0 -90, 0 90)
+15	multipoint_extremes	MULTIPOINT (-180 -90, 0 0, 180 90)
+16	polygon_with_hole	POLYGON ((-10 -10, 10 -10, 10 10, -10 10, -10 -10), (-5 -5, 5 -5, 5 5, -5 5, -5 -5))
+17	point_3d_high_z	POINT Z (45 45 8849)
+18	point_3d_low_z	POINT Z (30 30 -11034)
+19	null_geom	NULL
+20	empty_collection	NULL

--- a/test/sql/cloud/snowflake/test_snowflake_gemoetry_type.test
+++ b/test/sql/cloud/snowflake/test_snowflake_gemoetry_type.test
@@ -1,4 +1,4 @@
-# name: test/sql/cloud/snowflake/test_snowflake_geometry_type.test
+# name: test/sql/cloud/snowflake/test_snowflake_gemoetry_type.test
 # description: test integration with iceberg catalog read
 # group: [snowflake]
 
@@ -34,7 +34,8 @@ create secret polaris_secret (
 statement ok
 attach 's3-catalog' as my_datalake (
 	type ICEBERG,
-	ENDPOINT '${SNOWFLAKE_CATALOG_URI_GCS}'
+	ENDPOINT '${SNOWFLAKE_CATALOG_URI_GCS}',
+	DEFAULT_REGION 'eu-west-2'
 );
 
 
@@ -62,7 +63,7 @@ attach 's3-catalog' as my_datalake (
 # INSERT INTO geometry_test SELECT 20, 'empty_collection',      TO_GEOMETRY('GEOMETRYCOLLECTION EMPTY', 4326);
 # INSERT INTO geometry_test SELECT 19, 'null_geom',  NULL;
 query III
-select * from my_datalake.default.geometry_test;
+select * from my_datalake.default.geometry_test order by all;
 ----
 1	min_min_point	POINT (-180 -90)
 2	max_max_point	POINT (180 90)

--- a/test/sql/local/irc_any_catalog/insert/test_create_geometry_type.test
+++ b/test/sql/local/irc_any_catalog/insert/test_create_geometry_type.test
@@ -29,6 +29,9 @@ statement ok
 drop table if exists my_datalake.default.geometry_list;
 
 statement ok
+drop table if exists my_datalake.default.geometry_in_struct;
+
+statement ok
 create table my_datalake.default.geometry_type (goe_type GEOMETRY) with ('format-version'='3');
 
 statement ok
@@ -51,3 +54,15 @@ query I
 select * from my_datalake.default.geometry_list;
 ----
 ['POINT (1 2)', 'LINESTRING (0 0, 1 1)']
+
+statement ok
+create table my_datalake.default.geometry_in_struct (geo_struct STRUCT(label VARCHAR, geom GEOMETRY)) with ('format-version'='3');
+
+statement ok
+insert into my_datalake.default.geometry_in_struct VALUES ({'label': 'point', 'geom': 'POINT(1 2)'::GEOMETRY}), ({'label': 'line', 'geom': 'LINESTRING(0 0, 1 1)'::GEOMETRY});
+
+query I
+select * from my_datalake.default.geometry_in_struct;
+----
+{'label': point, 'geom': 'POINT (1 2)'}
+{'label': line, 'geom': 'LINESTRING (0 0, 1 1)'}

--- a/test/sql/local/irc_any_catalog/insert/test_create_geometry_type.test
+++ b/test/sql/local/irc_any_catalog/insert/test_create_geometry_type.test
@@ -1,0 +1,53 @@
+# name: test/sql/local/irc_any_catalog/insert/test_create_geometry_type.test
+# group: [insert]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require-env SECRETS_CREATED_AND_CATALOG_ATTACHED
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+statement ok
+drop table if exists my_datalake.default.geometry_type;
+
+statement ok
+drop table if exists my_datalake.default.geometry_list;
+
+statement ok
+create table my_datalake.default.geometry_type (goe_type GEOMETRY) with ('format-version'='3');
+
+statement ok
+insert into my_datalake.default.geometry_type VALUES ('POINT(1 2)'::GEOMETRY), ('LINESTRING Z (5 5 5, 10 10 10)'::GEOMETRY);
+
+query I
+select * from my_datalake.default.geometry_type;
+----
+POINT (1 2)
+LINESTRING Z (5 5 5, 10 10 10)
+
+
+statement ok
+create table my_datalake.default.geometry_list (geo_type_list GEOMETRY[]) with ('format-version'='3');
+
+statement ok
+insert into my_datalake.default.geometry_list VALUES (ARRAY['POINT(1 2)'::GEOMETRY, 'LINESTRING(0 0, 1 1)'::GEOMETRY]);
+
+query I
+select * from my_datalake.default.geometry_list;
+----
+['POINT (1 2)', 'LINESTRING (0 0, 1 1)']


### PR DESCRIPTION
This adds geometry type support to DuckDB-Iceberg.

I still want to add tests with other engines to make sure there is compatibility. It's been pretty tough getting sedonaDB to work, but I'll get there. 

This PR doesn't add support for upper bound and lower bounds for the geometry type. That is something we will add later.

This includes a cloud test to read from snowflake created geoemtry types. 
I have manually tested that snowflake can read duckdb created geometry types, except for an empty collection https://github.com/duckdblabs/duckdb-internal/issues/8847. The issue there is interesting though, since it leads me to believe that snowflake is scanning the parquet files when registering an iceberg table (which there is no reason to do that)