### PR TITLE
[Dev] Refactor internals of `IcebergTransaction`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(EXTENSION_SOURCES
 	src/catalog/rest/transaction/iceberg_transaction_data.cpp
 	src/catalog/rest/transaction/iceberg_transaction_manager.cpp
 	src/catalog/rest/transaction/iceberg_transaction.cpp
+	src/catalog/rest/transaction/iceberg_transaction_update.cpp
 	src/common/iceberg_utils.cpp
 	src/core/deletes/iceberg_deletion_vector.cpp
 	src/core/deletes/iceberg_equality_delete.cpp

--- a/src/catalog/rest/catalog_entry/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/iceberg_schema_entry.cpp
@@ -15,6 +15,7 @@
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
 #include "catalog/rest/api/iceberg_type.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_update.hpp"
 
 namespace duckdb {
 
@@ -46,8 +47,8 @@ bool IcebergSchemaEntry::HandleCreateConflict(CatalogTransaction &transaction, C
 		// FIXME: With Snapshot operation type overwrite, you can handle create or replace for tables.
 		auto &iceberg_transaction = GetICTransaction(transaction);
 		auto table_key = IcebergTableInformation::GetTableKey(namespace_items, entry_name);
-		auto deleted_table_entry = iceberg_transaction.deleted_tables.find(table_key);
-		if (deleted_table_entry != iceberg_transaction.deleted_tables.end()) {
+		auto latest_state = iceberg_transaction.GetLatestTableState(table_key);
+		if (latest_state && latest_state->status == IcebergTableStatus::DROPPED) {
 			auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 			vector<string> qualified_name = {ic_catalog.GetName()};
 			qualified_name.insert(qualified_name.end(), namespace_items.begin(), namespace_items.end());
@@ -67,7 +68,7 @@ bool IcebergSchemaEntry::HandleCreateConflict(CatalogTransaction &transaction, C
 		return false;
 	}
 	default:
-		throw InternalException("DuckDB-Iceberg, Unsupported conflict type: %s", EnumUtil::ToString(on_conflict));
+		throw NotImplementedException("DuckDB-Iceberg, Unsupported conflict type: %s", EnumUtil::ToString(on_conflict));
 	}
 	return true;
 }
@@ -115,13 +116,11 @@ void IcebergSchemaEntry::DropEntry(ClientContext &context, DropInfo &info, bool 
 		// Add the table to the transaction's deleted_tables
 		auto &transaction = IcebergTransaction::Get(context, catalog).Cast<IcebergTransaction>();
 		auto &table_info = table_info_it->second;
-		auto table_key = table_info->GetTableKey();
-		transaction.deleted_tables.emplace(table_key, table_info->Copy());
-		D_ASSERT(transaction.deleted_tables.count(table_key) > 0);
-		auto &deleted_table_info = transaction.deleted_tables.at(table_key);
+		auto &table = transaction.DeleteTable(*table_info);
+		//! FIXME: what?
 		// must init schema versions after copy. Schema versions have a pointer to IcebergTableInformation
 		// if the IcebergTableInformation is moved, then the pointer is no longer valid.
-		deleted_table_info.InitSchemaVersions();
+		table.InitSchemaVersions();
 	}
 }
 
@@ -267,14 +266,10 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 	}
 	auto &table_entry = catalog_entry->Cast<IcebergTableEntry>();
 	auto &catalog_table_info = table_entry.table_info;
-	auto emplace_res =
-	    irc_transaction.updated_tables.emplace(catalog_table_info.GetTableKey(), catalog_table_info.Copy());
-	auto &updated_table = emplace_res.first->second;
-	auto &transaction_data = updated_table.GetOrCreateTransactionData(irc_transaction);
-	if (emplace_res.second) {
-		updated_table.InitSchemaVersions();
-	}
 
+	auto &alter = irc_transaction.GetOrCreateAlter();
+	auto &updated_table = alter.GetOrInitializeTable(catalog_table_info);
+	auto &transaction_data = updated_table.GetOrCreateTransactionData(irc_transaction);
 	auto &current_schema = updated_table.table_metadata.GetLatestSchema();
 
 	switch (alter_table_info.alter_table_type) {

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -545,9 +545,8 @@ IcebergTableInformation IcebergTableInformation::Copy(IcebergTransaction &iceber
 		return ret;
 	}
 	IcebergSnapshotScanInfo snapshot_info;
-	try {
-		snapshot_info = ret.table_metadata.GetSnapshot(snapshot_lookup);
-	} catch (InvalidConfigurationException &e) {
+	snapshot_info = ret.table_metadata.GetSnapshot(snapshot_lookup);
+	if (!snapshot_info.snapshot) {
 		throw TransactionException("Table %s is already outdated. Please restart your transaction", GetTableKey());
 	}
 

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -21,6 +21,7 @@
 #include "catalog/rest/storage/authorization/oauth2.hpp"
 #include "catalog/rest/catalog_entry/iceberg_schema_entry.hpp"
 #include "core/metadata/partition/iceberg_partition_spec.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_update.hpp"
 
 namespace duckdb {
 
@@ -204,12 +205,9 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 	}
 
 	auto key = IcebergTableInformation::GetTableKey(schema.namespace_items, info.table);
-	auto emplace_res =
-	    iceberg_transaction.updated_tables.emplace(key, IcebergTableInformation(catalog, schema, info.table));
-	if (!emplace_res.second) {
-		throw InternalException("Table %s was already created somehow?", key);
-	}
-	auto &table_info = emplace_res.first->second;
+	auto &alter_update = iceberg_transaction.GetOrCreateAlter();
+	auto &table_info = alter_update.CreateTable(key, IcebergTableInformation(catalog, schema, info.table));
+	// auto &table_info = emplace_res.first->second;
 	auto &table_metadata = table_info.table_metadata;
 	auto table_entry = make_uniq<IcebergTableEntry>(table_info, catalog, schema, info, 0);
 	auto table_ptr = table_entry.get();
@@ -290,22 +288,20 @@ optional_ptr<CatalogEntry> IcebergTableSet::GetEntry(ClientContext &context, con
 	lock_guard<mutex> l(entry_lock);
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
-	const auto table_name = lookup.GetEntryName();
+	const auto &table_name = lookup.GetEntryName();
 	// first check transaction entries
 	auto table_key = IcebergTableInformation::GetTableKey(schema.namespace_items, table_name);
-	// Check if table has been deleted within in the transaction.
-	if (iceberg_transaction.deleted_tables.count(table_key) > 0) {
-		return nullptr;
-	}
-	// Check if the table has been updated within the transaction
-	{
-		auto it = iceberg_transaction.updated_tables.find(table_key);
-		if (it != iceberg_transaction.updated_tables.end()) {
-			auto &table_info = it->second;
-			auto snapshot_lookup = GetSnapshotLookup(table_info, context, lookup);
-			return table_info.GetSchemaVersion(snapshot_lookup, context);
+	auto latest_state = iceberg_transaction.GetLatestTableState(table_key);
+	if (latest_state) {
+		if (latest_state->status == IcebergTableStatus::DROPPED) {
+			// If table has been deleted within the transaction, return null
+			return nullptr;
 		}
+		auto &table_info = latest_state->table.get();
+		auto snapshot_lookup = GetSnapshotLookup(table_info, context, lookup);
+		return table_info.GetSchemaVersion(snapshot_lookup, context);
 	}
+
 	auto previous_request_info = iceberg_transaction.GetTableRequestResult(table_key);
 	if (previous_request_info.exists) {
 		// transaction has already looked up this table, find it in entries
@@ -336,7 +332,6 @@ optional_ptr<CatalogEntry> IcebergTableSet::GetEntry(ClientContext &context, con
 	}
 
 	iceberg_transaction.tables[table_key] = entry->second;
-
 	IcebergSnapshotLookup snapshot_lookup;
 
 	bool is_time_travel = lookup.GetAtClause();

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -24,8 +24,13 @@
 #include "planning/metadata_io/avro/avro_scan.hpp"
 #include "iceberg_logging.hpp"
 #include "catalog/rest/api/table_update.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_update.hpp"
 
 namespace duckdb {
+
+IcebergTransactionTableState::IcebergTransactionTableState(IcebergTableInformation &table, IcebergTableSource source)
+    : table(table), source(source), status(IcebergTableStatus::ALIVE) {
+}
 
 IcebergTransaction::IcebergTransaction(IcebergCatalog &ic_catalog, TransactionManager &manager, ClientContext &context)
     : Transaction(manager, context), db(*context.db), catalog(ic_catalog), access_mode(ic_catalog.access_mode) {
@@ -296,10 +301,11 @@ static bool NeedsAssertSchemaId(const IcebergTransactionData &transaction_data,
 	return initial_schema_id != table_info.table_metadata.GetCurrentSchemaId();
 }
 
-TableTransactionInfo IcebergTransaction::GetTransactionRequest(ClientContext &context) {
+TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactionAlterUpdate &alter_update,
+                                                               ClientContext &context) {
 	TableTransactionInfo info;
 	auto &transaction = info.request;
-	for (auto &updated_table : updated_tables) {
+	for (auto &updated_table : alter_update.updated_tables) {
 		auto &table_info = updated_table.second;
 		if (!table_info.transaction_data) {
 			continue;
@@ -365,26 +371,8 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(ClientContext &co
 	return info;
 }
 
-IcebergTableInformation &IcebergTransaction::GetTableInfoForTransaction(IcebergTableInformation &table_info) {
-	lock_guard<mutex> guard(lock);
-
-	auto table_key = table_info.GetTableKey();
-	auto it = updated_tables.find(table_key);
-	if (it != updated_tables.end()) {
-		return it->second;
-	}
-	auto emplace_res = updated_tables.emplace(table_key, table_info.Copy(*this));
-	auto &updated_table = emplace_res.first->second;
-	if (emplace_res.second) {
-		updated_table.InitSchemaVersions();
-		auto client_context = context.lock();
-		updated_table.transaction_data = make_uniq<IcebergTransactionData>(*client_context, updated_table);
-	}
-	return updated_table;
-}
-
 void IcebergTransaction::Commit() {
-	if (updated_tables.empty() && deleted_tables.empty() && created_schemas.empty() && deleted_schemas.empty()) {
+	if (transaction_updates.empty() && created_schemas.empty() && deleted_schemas.empty()) {
 		return;
 	}
 
@@ -399,8 +387,22 @@ void IcebergTransaction::Commit() {
 
 	try {
 		DoSchemaCreates(*temp_con_context);
-		DoTableUpdates(*temp_con_context);
-		DoTableDeletes(*temp_con_context);
+		for (auto &transaction_update : transaction_updates) {
+			auto &type = transaction_update->type;
+			switch (type) {
+			case IcebergTransactionUpdateType::ALTER: {
+				auto &alter_update = transaction_update->Cast<IcebergTransactionAlterUpdate>();
+				DoTableUpdates(alter_update, *temp_con_context);
+			}
+			case IcebergTransactionUpdateType::DELETE: {
+				auto &delete_update = transaction_update->Cast<IcebergTransactionDeleteUpdate>();
+				DoTableDeletes(delete_update, *temp_con_context);
+			}
+			default:
+				throw InternalException("IcebergTransactionUpdateType (%d) not implemented",
+				                        static_cast<uint8_t>(type));
+			};
+		}
 		DoSchemaDeletes(*temp_con_context);
 	} catch (std::exception &ex) {
 		ErrorData error(ex);
@@ -413,9 +415,9 @@ void IcebergTransaction::Commit() {
 	temp_con.Rollback();
 }
 
-void IcebergTransaction::DoTableUpdates(ClientContext &context) {
-	if (!updated_tables.empty()) {
-		auto transaction_info = GetTransactionRequest(context);
+void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context) {
+	if (!alter_update.updated_tables.empty()) {
+		auto transaction_info = GetTransactionRequest(alter_update, context);
 		auto &transaction = transaction_info.request;
 
 		// if there are no new tables, we can post to the transactions/commit endpoint
@@ -442,28 +444,27 @@ void IcebergTransaction::DoTableUpdates(ClientContext &context) {
 				                          table_change.identifier.name, transaction_json);
 			}
 		}
-		updated_tables.clear();
+		// updated_tables.clear();
 		DropSecrets(context);
 	}
 }
 
-void IcebergTransaction::DoTableDeletes(ClientContext &context) {
+void IcebergTransaction::DoTableDeletes(IcebergTransactionDeleteUpdate &delete_update, ClientContext &context) {
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
-	for (auto &deleted_table : deleted_tables) {
-		auto &table = deleted_table.second;
-		auto schema_key = table.schema.name;
-		auto table_key = table.GetTableKey();
-		auto table_name = table.name;
-		IRCAPI::CommitTableDelete(context, catalog, table.schema.namespace_items, table.name);
-		// remove the load table result
-		ic_catalog.RemoveLoadTableResult(table_key);
-		// remove the table entry from the catalog
-		auto &schema_entry = ic_catalog.schemas.GetEntry(schema_key).Cast<IcebergSchemaEntry>();
-		DropInfo drop_info;
-		drop_info.name = table_name;
-		drop_info.if_not_found = OnEntryNotFound::RETURN_NULL;
-		schema_entry.DropEntry(context, drop_info, true);
-	}
+	auto &table = delete_update.table;
+	auto schema_key = table.schema.name;
+	auto table_key = table.GetTableKey();
+	auto table_name = table.name;
+	IRCAPI::CommitTableDelete(context, catalog, table.schema.namespace_items, table.name);
+	// remove the load table result
+	//! FIXME: this can very easily be problematic
+	ic_catalog.RemoveLoadTableResult(table_key);
+	// remove the table entry from the catalog
+	auto &schema_entry = ic_catalog.schemas.GetEntry(schema_key).Cast<IcebergSchemaEntry>();
+	DropInfo drop_info;
+	drop_info.name = table_name;
+	drop_info.if_not_found = OnEntryNotFound::RETURN_NULL;
+	schema_entry.DropEntry(context, drop_info, true);
 }
 
 void IcebergTransaction::DoSchemaCreates(ClientContext &context) {
@@ -510,31 +511,38 @@ void IcebergTransaction::CleanupFiles() {
 	temp_con.BeginTransaction();
 	auto &temp_con_context = temp_con.context;
 	auto &fs = FileSystem::GetFileSystem(*temp_con_context);
-	for (auto &up_table : updated_tables) {
-		auto &table = up_table.second;
-		if (!table.transaction_data) {
-			// error occurred before transaction data was initialized
-			// this can happen during table creation with table schema that cannot convert to
-			// an iceberg table schema due to type incompatabilities
+
+	for (auto &transaction_update : transaction_updates) {
+		if (transaction_update->type != IcebergTransactionUpdateType::ALTER) {
 			continue;
 		}
-		auto &transaction_data = table.transaction_data;
-		for (auto &update : transaction_data->updates) {
-			if (update->type != IcebergTableUpdateType::ADD_SNAPSHOT) {
+		auto &alter_update = transaction_update->Cast<IcebergTransactionAlterUpdate>();
+		for (auto &up_table : alter_update.updated_tables) {
+			auto &table = up_table.second;
+			if (!table.transaction_data) {
+				// error occurred before transaction data was initialized
+				// this can happen during table creation with table schema that cannot convert to
+				// an iceberg table schema due to type incompatabilities
 				continue;
 			}
-			// we need to recreate the keys in the current context.
-			auto &ic_table_entry = table.GetLatestSchema(*temp_con_context)->Cast<IcebergTableEntry>();
-			ic_table_entry.PrepareIcebergScanFromEntry(*temp_con_context);
+			auto &transaction_data = table.transaction_data;
+			for (auto &update : transaction_data->updates) {
+				if (update->type != IcebergTableUpdateType::ADD_SNAPSHOT) {
+					continue;
+				}
+				// we need to recreate the keys in the current context.
+				auto &ic_table_entry = table.GetLatestSchema(*temp_con_context)->Cast<IcebergTableEntry>();
+				ic_table_entry.PrepareIcebergScanFromEntry(*temp_con_context);
 
-			auto &add_snapshot = update->Cast<IcebergAddSnapshot>();
-			const auto manifest_list_entries = add_snapshot.GetManifestFiles();
-			for (const auto &manifest : manifest_list_entries) {
-				for (auto &manifest_entry : manifest.manifest_entries) {
-					auto &data_file = manifest_entry.data_file;
-					if (fs.TryRemoveFile(data_file.file_path)) {
-						DUCKDB_LOG(*temp_con_context, IcebergLogType,
-						           "Iceberg Transaction Cleanup, deleted 'data_file': '%s'", data_file.file_path);
+				auto &add_snapshot = update->Cast<IcebergAddSnapshot>();
+				const auto manifest_list_entries = add_snapshot.GetManifestFiles();
+				for (const auto &manifest : manifest_list_entries) {
+					for (auto &manifest_entry : manifest.manifest_entries) {
+						auto &data_file = manifest_entry.data_file;
+						if (fs.TryRemoveFile(data_file.file_path)) {
+							DUCKDB_LOG(*temp_con_context, IcebergLogType,
+							           "Iceberg Transaction Cleanup, deleted 'data_file': '%s'", data_file.file_path);
+						}
 					}
 				}
 			}
@@ -571,6 +579,57 @@ bool IcebergTransaction::StartedBefore(timestamp_t timestamp_ms) const {
 	auto meta_transaction_start = meta_transaction.GetCurrentTransactionStartTimestamp();
 	auto start = Timestamp::GetEpochMs(meta_transaction_start);
 	return start < timestamp_ms.value;
+}
+
+optional_ptr<IcebergTransactionTableState> IcebergTransaction::GetLatestTableState(const string &table_key) {
+	auto it = current_table_data.find(table_key);
+	if (it == current_table_data.end()) {
+		return nullptr;
+	}
+	return it->second;
+}
+
+IcebergTransactionTableState &IcebergTransaction::SetLatestTableState(IcebergTableInformation &table,
+                                                                      IcebergTableSource source) {
+	auto table_key = table.GetTableKey();
+	auto it = current_table_data.find(table_key);
+	if (it == current_table_data.end()) {
+		it = current_table_data.emplace(table_key, IcebergTransactionTableState(table, source)).first;
+		return it->second;
+	}
+	auto &state = it->second;
+	state.table = table;
+	state.source = source;
+	return state;
+}
+
+IcebergTransactionAlterUpdate &IcebergTransaction::GetOrCreateAlter() {
+	if (transaction_updates.empty() || transaction_updates.back()->type != IcebergTransactionUpdateType::ALTER) {
+		auto alter_p = make_uniq<IcebergTransactionAlterUpdate>(*this);
+		auto &alter = *alter_p;
+		transaction_updates.push_back(std::move(alter_p));
+		return alter;
+	}
+	return transaction_updates.back()->Cast<IcebergTransactionAlterUpdate>();
+}
+
+IcebergTableInformation &IcebergTransaction::DeleteTable(const IcebergTableInformation &table) {
+	auto table_key = table.GetTableKey();
+	auto state = GetLatestTableState(table_key);
+	if (!state) {
+		throw InternalException("Attempting to delete a table (%s) that was never recorded in the transaction",
+		                        table_key);
+	}
+	state->status = IcebergTableStatus::DROPPED;
+	transaction_updates.push_back(make_uniq<IcebergTransactionDeleteUpdate>(*this, state->table));
+	return state->table;
+}
+
+void ApplyTableUpdate(IcebergTableInformation &table_info, IcebergTransaction &iceberg_transaction,
+                      const std::function<void(IcebergTableInformation &)> &callback) {
+	auto &alter = iceberg_transaction.GetOrCreateAlter();
+	auto &updated_table = alter.GetOrInitializeTable(table_info);
+	callback(updated_table);
 }
 
 } // namespace duckdb

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -393,10 +393,12 @@ void IcebergTransaction::Commit() {
 			case IcebergTransactionUpdateType::ALTER: {
 				auto &alter_update = transaction_update->Cast<IcebergTransactionAlterUpdate>();
 				DoTableUpdates(alter_update, *temp_con_context);
+				break;
 			}
 			case IcebergTransactionUpdateType::DELETE: {
 				auto &delete_update = transaction_update->Cast<IcebergTransactionDeleteUpdate>();
 				DoTableDeletes(delete_update, *temp_con_context);
+				break;
 			}
 			default:
 				throw InternalException("IcebergTransactionUpdateType (%d) not implemented",
@@ -613,12 +615,11 @@ IcebergTransactionAlterUpdate &IcebergTransaction::GetOrCreateAlter() {
 	return transaction_updates.back()->Cast<IcebergTransactionAlterUpdate>();
 }
 
-IcebergTableInformation &IcebergTransaction::DeleteTable(const IcebergTableInformation &table) {
+IcebergTableInformation &IcebergTransaction::DeleteTable(IcebergTableInformation &table) {
 	auto table_key = table.GetTableKey();
 	auto state = GetLatestTableState(table_key);
 	if (!state) {
-		throw InternalException("Attempting to delete a table (%s) that was never recorded in the transaction",
-		                        table_key);
+		state = SetLatestTableState(table, IcebergTableSource::EXTERNAL);
 	}
 	state->status = IcebergTableStatus::DROPPED;
 	transaction_updates.push_back(make_uniq<IcebergTransactionDeleteUpdate>(*this, state->table));

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -453,7 +453,7 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 
 void IcebergTransaction::DoTableDeletes(IcebergTransactionDeleteUpdate &delete_update, ClientContext &context) {
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
-	auto &table = delete_update.table;
+	auto &table = delete_update.deleted_table;
 	auto schema_key = table.schema.name;
 	auto table_key = table.GetTableKey();
 	auto table_name = table.name;
@@ -618,12 +618,18 @@ IcebergTransactionAlterUpdate &IcebergTransaction::GetOrCreateAlter() {
 IcebergTableInformation &IcebergTransaction::DeleteTable(IcebergTableInformation &table) {
 	auto table_key = table.GetTableKey();
 	auto state = GetLatestTableState(table_key);
-	if (!state) {
-		state = SetLatestTableState(table, IcebergTableSource::EXTERNAL);
+
+	unique_ptr<IcebergTransactionDeleteUpdate> delete_update;
+	if (state) {
+		delete_update = make_uniq<IcebergTransactionDeleteUpdate>(*this, state->table);
+	} else {
+		delete_update = make_uniq<IcebergTransactionDeleteUpdate>(*this, table);
+		auto &deleted_table = delete_update->deleted_table;
+		state = SetLatestTableState(deleted_table, IcebergTableSource::TRANSACTION);
 	}
+	transaction_updates.push_back(std::move(delete_update));
 	state->status = IcebergTableStatus::DROPPED;
-	transaction_updates.push_back(make_uniq<IcebergTransactionDeleteUpdate>(*this, state->table));
-	return state->table;
+	return state->table.get();
 }
 
 void ApplyTableUpdate(IcebergTableInformation &table_info, IcebergTransaction &iceberg_transaction,

--- a/src/catalog/rest/transaction/iceberg_transaction_update.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_update.cpp
@@ -1,0 +1,49 @@
+#include "catalog/rest/transaction/iceberg_transaction_update.hpp"
+#include "catalog/rest/transaction/iceberg_transaction.hpp"
+
+namespace duckdb {
+
+IcebergTransactionUpdate::IcebergTransactionUpdate(IcebergTransaction &transaction, IcebergTransactionUpdateType type)
+    : transaction(transaction), type(type) {
+}
+IcebergTransactionUpdate::~IcebergTransactionUpdate() {
+}
+
+IcebergTransactionAlterUpdate::IcebergTransactionAlterUpdate(IcebergTransaction &transaction)
+    : IcebergTransactionUpdate(transaction, TYPE) {
+}
+IcebergTransactionAlterUpdate::~IcebergTransactionAlterUpdate() {
+}
+
+IcebergTableInformation &IcebergTransactionAlterUpdate::GetOrInitializeTable(const IcebergTableInformation &table) {
+	auto table_key = table.GetTableKey();
+	auto it = updated_tables.find(table_key);
+	if (it == updated_tables.end()) {
+		it = updated_tables.emplace(table_key, table.Copy()).first;
+		it->second.InitSchemaVersions();
+	}
+
+	transaction.SetLatestTableState(it->second, IcebergTableSource::TRANSACTION);
+	return it->second;
+}
+
+IcebergTableInformation &IcebergTransactionAlterUpdate::CreateTable(const string &table_key,
+                                                                    IcebergTableInformation &&table) {
+	auto emplace_res = updated_tables.emplace(table_key, std::move(table));
+	if (!emplace_res.second) {
+		throw InternalException("Table %s was already created somehow?", table_key);
+	}
+
+	transaction.current_table_data.emplace(
+	    table_key, IcebergTransactionTableState(emplace_res.first->second, IcebergTableSource::TRANSACTION));
+	return emplace_res.first->second;
+}
+
+IcebergTransactionDeleteUpdate::IcebergTransactionDeleteUpdate(IcebergTransaction &transaction,
+                                                               const IcebergTableInformation &table)
+    : IcebergTransactionUpdate(transaction, TYPE), table(table) {
+}
+IcebergTransactionDeleteUpdate::~IcebergTransactionDeleteUpdate() {
+}
+
+} // namespace duckdb

--- a/src/catalog/rest/transaction/iceberg_transaction_update.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_update.cpp
@@ -19,7 +19,7 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::GetOrInitializeTable(con
 	auto table_key = table.GetTableKey();
 	auto it = updated_tables.find(table_key);
 	if (it == updated_tables.end()) {
-		it = updated_tables.emplace(table_key, table.Copy()).first;
+		it = updated_tables.emplace(table_key, table.Copy(transaction)).first;
 		it->second.InitSchemaVersions();
 	}
 
@@ -41,7 +41,7 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::CreateTable(const string
 
 IcebergTransactionDeleteUpdate::IcebergTransactionDeleteUpdate(IcebergTransaction &transaction,
                                                                const IcebergTableInformation &table)
-    : IcebergTransactionUpdate(transaction, TYPE), table(table) {
+    : IcebergTransactionUpdate(transaction, TYPE), deleted_table(table.Copy(transaction)) {
 }
 IcebergTransactionDeleteUpdate::~IcebergTransactionDeleteUpdate() {
 }

--- a/src/function/metadata/iceberg_table_properties_functions.cpp
+++ b/src/function/metadata/iceberg_table_properties_functions.cpp
@@ -160,14 +160,15 @@ static void SetIcebergTablePropertiesFunction(ClientContext &context, TableFunct
 
 	auto iceberg_table = bind_data.iceberg_table;
 	auto &table_info = iceberg_table->table_info;
+
 	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
-	iceberg_transaction.updated_tables.emplace(table_info.GetTableKey(), table_info.Copy(iceberg_transaction));
-	auto &entry = iceberg_transaction.updated_tables.at(table_info.GetTableKey());
-	auto &transaction_data = entry.GetOrCreateTransactionData(iceberg_transaction);
+	ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
+		auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
+		transaction_data.TableSetProperties(bind_data.properties);
+	});
 
 	auto schema = iceberg_table->schema.name;
 	auto table_name = iceberg_table->name;
-	transaction_data.TableSetProperties(bind_data.properties);
 	global_state.properties_set = true;
 	// set success output, failure happens during transaction commit.
 	FlatVector::GetData<int64_t>(output.data[0])[0] = bind_data.properties.size();
@@ -190,12 +191,13 @@ static void RemoveIcebergTablePropertiesFunction(ClientContext &context, TableFu
 	auto iceberg_table = bind_data.iceberg_table;
 	auto &table_info = iceberg_table->table_info;
 	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
-	iceberg_transaction.updated_tables.emplace(table_info.GetTableKey(), table_info.Copy(iceberg_transaction));
-	auto &entry = iceberg_transaction.updated_tables.at(table_info.GetTableKey());
-	auto &transaction_data = entry.GetOrCreateTransactionData(iceberg_transaction);
+	ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
+		auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
+		transaction_data.TableRemoveProperties(bind_data.remove_properties);
+	});
+
 	auto schema = iceberg_table->schema.name;
 	auto table_name = iceberg_table->name;
-	transaction_data.TableRemoveProperties(bind_data.remove_properties);
 	global_state.properties_removed = true;
 	// set success output, failure happens during transaction commit.
 	FlatVector::GetData<int64_t>(output.data[0])[0] = bind_data.properties.size();

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -79,7 +79,7 @@ public:
 	IcebergTransactionTableState &SetLatestTableState(IcebergTableInformation &table, IcebergTableSource source);
 	bool StartedBefore(timestamp_t timestamp_ms) const;
 	IcebergTransactionAlterUpdate &GetOrCreateAlter();
-	IcebergTableInformation &DeleteTable(const IcebergTableInformation &table);
+	IcebergTableInformation &DeleteTable(IcebergTableInformation &table);
 
 private:
 	void CleanupFiles();

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -8,6 +8,9 @@ namespace duckdb {
 class IcebergCatalog;
 class IcebergSchemaEntry;
 class IcebergTableEntry;
+struct IcebergTransactionUpdate;
+struct IcebergTransactionAlterUpdate;
+struct IcebergTransactionDeleteUpdate;
 
 struct TableTransactionInfo {
 	TableTransactionInfo() {};
@@ -30,6 +33,25 @@ struct TableInfoCache {
 	bool exists;
 };
 
+enum class IcebergTableStatus : uint8_t { ALIVE, DROPPED };
+
+enum class IcebergTableSource : uint8_t {
+	//! Loaded from external source
+	EXTERNAL,
+	//! Version that exists within the transaction
+	TRANSACTION
+};
+
+struct IcebergTransactionTableState {
+public:
+	IcebergTransactionTableState(IcebergTableInformation &table, IcebergTableSource source);
+
+public:
+	reference<IcebergTableInformation> table;
+	IcebergTableSource source;
+	IcebergTableStatus status;
+};
+
 class IcebergTransaction : public Transaction {
 public:
 	IcebergTransaction(IcebergCatalog &ic_catalog, TransactionManager &manager, ClientContext &context);
@@ -43,18 +65,21 @@ public:
 	AccessMode GetAccessMode() const {
 		return access_mode;
 	}
-	void DoTableUpdates(ClientContext &context);
-	void DoTableDeletes(ClientContext &context);
+	void DoTableUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
+	void DoTableDeletes(IcebergTransactionDeleteUpdate &delete_update, ClientContext &context);
 	void DoSchemaCreates(ClientContext &context);
 	void DoSchemaDeletes(ClientContext &context);
 	IcebergCatalog &GetCatalog();
 	void DropSecrets(ClientContext &context);
-	TableTransactionInfo GetTransactionRequest(ClientContext &context);
+	TableTransactionInfo GetTransactionRequest(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
 	void RecordTableRequest(const string &table_key, idx_t sequence_number, idx_t snapshot_id);
 	void RecordTableRequest(const string &table_key);
 	TableInfoCache GetTableRequestResult(const string &table_key);
-	IcebergTableInformation &GetTableInfoForTransaction(IcebergTableInformation &table_info);
+	optional_ptr<IcebergTransactionTableState> GetLatestTableState(const string &table_key);
+	IcebergTransactionTableState &SetLatestTableState(IcebergTableInformation &table, IcebergTableSource source);
 	bool StartedBefore(timestamp_t timestamp_ms) const;
+	IcebergTransactionAlterUpdate &GetOrCreateAlter();
+	IcebergTableInformation &DeleteTable(const IcebergTableInformation &table);
 
 private:
 	void CleanupFiles();
@@ -73,16 +98,15 @@ private:
 public:
 	//! Tables referenced by this transaction that have to stay alive for the duration of the transaction.
 	case_insensitive_map_t<shared_ptr<IcebergTableInformation>> tables;
-	//! tables that have been created in this transaction
-	//! tables are hashed by catalog_name.table name
-	//! Tables that have been updated in this transaction, to be rewritten on commit.
-	case_insensitive_map_t<IcebergTableInformation> updated_tables;
-	//! tables that have been deleted in this transaction, to be deleted on commit.
-	case_insensitive_map_t<IcebergTableInformation> deleted_tables;
+	vector<unique_ptr<IcebergTransactionUpdate>> transaction_updates;
+	//! The latest state of a table (either points into 'transaction_updates' or 'tables')
+	case_insensitive_map_t<IcebergTransactionTableState> current_table_data;
+
 	unordered_set<string> created_schemas;
 	unordered_set<string> deleted_schemas;
 
 	bool called_list_schemas = false;
+	//! Set of schemas that this transaction has listed tables for
 	case_insensitive_set_t listed_schemas;
 
 	case_insensitive_set_t created_secrets;
@@ -90,10 +114,7 @@ public:
 	mutex lock;
 };
 
-template <typename Callback>
-void ApplyTableUpdate(IcebergTableInformation &table_info, IcebergTransaction &iceberg_transaction, Callback callback) {
-	auto &updated_table = iceberg_transaction.GetTableInfoForTransaction(table_info);
-	callback(updated_table);
-}
+void ApplyTableUpdate(IcebergTableInformation &table_info, IcebergTransaction &iceberg_transaction,
+                      const std::function<void(IcebergTableInformation &)> &callback);
 
 } // namespace duckdb

--- a/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
@@ -68,7 +68,7 @@ public:
 	virtual ~IcebergTransactionDeleteUpdate() override;
 
 public:
-	const IcebergTableInformation &table;
+	IcebergTableInformation deleted_table;
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+
+namespace duckdb {
+
+class IcebergTransaction;
+
+enum class IcebergTransactionUpdateType : uint8_t { ALTER, DELETE };
+
+struct IcebergTransactionUpdate {
+public:
+	IcebergTransactionUpdate(IcebergTransaction &transaction, IcebergTransactionUpdateType type);
+	virtual ~IcebergTransactionUpdate();
+
+public:
+	template <class TARGET>
+	TARGET &Cast() {
+		if (type != TARGET::TYPE) {
+			throw InternalException(
+			    "Failed to cast IcebergTransactionUpdate to type - IcebergTransactionUpdate type mismatch");
+		}
+		return reinterpret_cast<TARGET &>(*this);
+	}
+
+	template <class TARGET>
+	const TARGET &Cast() const {
+		if (type != TARGET::TYPE) {
+			throw InternalException(
+			    "Failed to cast IcebergTransactionUpdate to type - IcebergTransactionUpdate type mismatch");
+		}
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+
+public:
+	IcebergTransaction &transaction;
+	IcebergTransactionUpdateType type;
+};
+
+//! Update a table with a regular alter
+struct IcebergTransactionAlterUpdate : public IcebergTransactionUpdate {
+public:
+	static constexpr const IcebergTransactionUpdateType TYPE = IcebergTransactionUpdateType::ALTER;
+
+public:
+	IcebergTransactionAlterUpdate(IcebergTransaction &transaction);
+	virtual ~IcebergTransactionAlterUpdate() override;
+
+public:
+	IcebergTableInformation &CreateTable(const string &table_key, IcebergTableInformation &&table);
+	IcebergTableInformation &GetOrInitializeTable(const IcebergTableInformation &table);
+
+public:
+	//! All the tables touched in this atomic block
+	case_insensitive_map_t<IcebergTableInformation> updated_tables;
+};
+
+//! Drop a table
+struct IcebergTransactionDeleteUpdate : public IcebergTransactionUpdate {
+public:
+	static constexpr const IcebergTransactionUpdateType TYPE = IcebergTransactionUpdateType::DELETE;
+
+public:
+	IcebergTransactionDeleteUpdate(IcebergTransaction &transaction, const IcebergTableInformation &table);
+	virtual ~IcebergTransactionDeleteUpdate() override;
+
+public:
+	const IcebergTableInformation &table;
+};
+
+} // namespace duckdb

--- a/test/sql/local/irc_any_catalog/transactions/test_transactional_updates.test
+++ b/test/sql/local/irc_any_catalog/transactions/test_transactional_updates.test
@@ -35,7 +35,7 @@ drop table if exists my_datalake.default.multi_transaction_update;
 statement ok
 create table my_datalake.default.multi_transaction_update (a int, b int);
 
-# make sure the table has a snapshot id to start
+# Insert 0,0
 statement ok
 insert into my_datalake.default.multi_transaction_update select 0, 0;
 
@@ -45,23 +45,36 @@ begin
 statement ok con2
 begin
 
+# Insert 2,2
 statement ok con2
 insert into my_datalake.default.multi_transaction_update select 2, 2;
 
 statement ok con2
 commit
 
-# con1 should only see data from con1 and before (from transaction start of con1)
+# con1 doesn't see 2,2 yet
 query II con1
 select * from my_datalake.default.multi_transaction_update;
 ----
 0	0
 
+# con1 updates 0 to 50 for column a (doesn't affect row inserted by con2)
 statement ok con1
 update my_datalake.default.multi_transaction_update set a = 50;
 
-# con1 should error. con1 cannot update the table since the last snapshot it saw was the 1, 1 insert.
+query II con1
+select * from my_datalake.default.multi_transaction_update;
+----
+50	0
+
 statement error con1
 commit;
 ----
-<REGEX>:.*TransactionContext Error:.*Conflict.*
+<REGEX>:.*Requirement failed: branch main has changed:.*
+
+# con1 UPDATE didn't go through
+query II
+select * from my_datalake.default.multi_transaction_update order by all
+----
+0	0
+2	2

--- a/test/sql/local/irc_any_catalog/transactions/test_transactional_updates.test
+++ b/test/sql/local/irc_any_catalog/transactions/test_transactional_updates.test
@@ -70,7 +70,7 @@ select * from my_datalake.default.multi_transaction_update;
 statement error con1
 commit;
 ----
-<REGEX>:.*Requirement failed: branch main has changed:.*
+<REGEX>:.*TransactionContext Error: Failed to commit:.*
 
 # con1 UPDATE didn't go through
 query II


### PR DESCRIPTION
### Limitation

Previously the internals of `IcebergTransaction` consisted of:
```c++
case_insensitive_map_t<IcebergTableInformation> updated_tables;
case_insensitive_map_t<IcebergTableInformation> deleted_tables;
```

Renaming and deleting tables use a different endpoint than other alters.
This makes renaming and recreating tables within a transaction impossible, as it would be impossible to discern which updates should be applied before and after a rename/delete.

### Refactor

To fix this, the following change was made:
```c++
vector<unique_ptr<IcebergTransactionUpdate>> transaction_updates;
case_insensitive_map_t<IcebergTransactionTableState> current_table_data;
```
`transaction_updates` represents a block of 1 or more alters that can be applied atomically (within the same endpoint)
`current_table_data` is a struct representing the current state of a table, with a reference to the `IcebergTableInformation` that currently applies to the latest state.

### IcebergTransactionTableState

```c++
enum class IcebergTableStatus : uint8_t { ALIVE, DROPPED };

enum class IcebergTableSource : uint8_t {
	//! Loaded from external source
	EXTERNAL,
	//! Version that exists within the transaction
	TRANSACTION
};

struct IcebergTransactionTableState {
public:
	IcebergTransactionTableState(IcebergTableInformation &table, IcebergTableSource source);

public:
	reference<IcebergTableInformation> table;
	IcebergTableSource source;
	IcebergTableStatus status;
};
```

### IcebergTransactionUpdate

```c++
//! Update a table with a regular alter
struct IcebergTransactionAlterUpdate : public IcebergTransactionUpdate {
public:
	static constexpr const IcebergTransactionUpdateType TYPE = IcebergTransactionUpdateType::ALTER;

public:
	IcebergTransactionAlterUpdate(IcebergTransaction &transaction);
	virtual ~IcebergTransactionAlterUpdate() override;

public:
	IcebergTableInformation &CreateTable(const string &table_key, IcebergTableInformation &&table);
	IcebergTableInformation &GetOrInitializeTable(const IcebergTableInformation &table);

public:
	//! All the tables touched in this atomic block
	case_insensitive_map_t<IcebergTableInformation> updated_tables;
};
```

```c++
//! Drop a table
struct IcebergTransactionDeleteUpdate : public IcebergTransactionUpdate {
public:
	static constexpr const IcebergTransactionUpdateType TYPE = IcebergTransactionUpdateType::DELETE;

public:
	IcebergTransactionDeleteUpdate(IcebergTransaction &transaction, const IcebergTableInformation &table);
	virtual ~IcebergTransactionDeleteUpdate() override;

public:
	const IcebergTableInformation &table;
};
```