### PR TITLE
[Dev] Fix problem that was causing files of committed tables to be deleted in multi-table transactions

### DIFF
--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -370,8 +370,8 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 			update.CreateUpdate(db, context, commit_state);
 		}
 
+		info.table_requests.emplace(updated_table.first, transaction.table_changes.size());
 		transaction.table_changes.push_back(std::move(table_change));
-		info.table_requests.emplace(updated_table.first, transaction.table_changes.back());
 	}
 	return info;
 }
@@ -448,7 +448,7 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 			         catalog.supported_urls.end());
 			// each table change will make a separate request
 			for (auto &it : transaction_info.table_requests) {
-				auto &table_change = it.second.get();
+				auto &table_change = transaction.table_changes[it.second];
 				D_ASSERT(table_change.has_identifier);
 				auto transaction_json = ConstructTableUpdateJSON(table_change);
 				IRCAPI::CommitTableUpdate(context, catalog, table_change.identifier._namespace.value,

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -306,6 +306,10 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 	TableTransactionInfo info;
 	auto &transaction = info.request;
 	for (auto &updated_table : alter_update.updated_tables) {
+		if (alter_update.committed_tables.count(updated_table.first)) {
+			//! Table is already committed
+			continue;
+		}
 		auto &table_info = updated_table.second;
 		if (!table_info.transaction_data) {
 			continue;
@@ -367,6 +371,7 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 		}
 
 		transaction.table_changes.push_back(std::move(table_change));
+		info.table_requests.emplace(updated_table.first, transaction.table_changes.back());
 	}
 	return info;
 }
@@ -435,15 +440,20 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 			CommitTransactionToJSON(doc, root_object, transaction);
 			auto transaction_json = JsonDocToString(std::move(doc_p));
 			IRCAPI::CommitMultiTableUpdate(context, catalog, transaction_json);
+			for (auto &it : alter_update.updated_tables) {
+				alter_update.committed_tables.insert(it.first);
+			}
 		} else {
 			D_ASSERT(catalog.supported_urls.find("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}") !=
 			         catalog.supported_urls.end());
 			// each table change will make a separate request
-			for (auto &table_change : transaction.table_changes) {
+			for (auto &it : transaction_info.table_requests) {
+				auto &table_change = it.second.get();
 				D_ASSERT(table_change.has_identifier);
 				auto transaction_json = ConstructTableUpdateJSON(table_change);
 				IRCAPI::CommitTableUpdate(context, catalog, table_change.identifier._namespace.value,
 				                          table_change.identifier.name, transaction_json);
+				alter_update.committed_tables.insert(it.first);
 			}
 		}
 		// updated_tables.clear();
@@ -520,6 +530,10 @@ void IcebergTransaction::CleanupFiles() {
 		}
 		auto &alter_update = transaction_update->Cast<IcebergTransactionAlterUpdate>();
 		for (auto &up_table : alter_update.updated_tables) {
+			if (alter_update.committed_tables.count(up_table.first)) {
+				//! Successively committed, no need to roll back
+				continue;
+			}
 			auto &table = up_table.second;
 			if (!table.transaction_data) {
 				// error occurred before transaction data was initialized

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -16,7 +16,7 @@ struct TableTransactionInfo {
 	TableTransactionInfo() {};
 
 	rest_api_objects::CommitTransactionRequest request;
-	case_insensitive_map_t<reference<rest_api_objects::CommitTableRequest>> table_requests;
+	case_insensitive_map_t<idx_t> table_requests;
 
 	// if a table is created with assert create, we cannot use the
 	// transactions/commit endpoint. Instead we iterate through each table

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -16,6 +16,8 @@ struct TableTransactionInfo {
 	TableTransactionInfo() {};
 
 	rest_api_objects::CommitTransactionRequest request;
+	case_insensitive_map_t<reference<rest_api_objects::CommitTableRequest>> table_requests;
+
 	// if a table is created with assert create, we cannot use the
 	// transactions/commit endpoint. Instead we iterate through each table
 	// update and update each table individually

--- a/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
@@ -56,6 +56,8 @@ public:
 public:
 	//! All the tables touched in this atomic block
 	case_insensitive_map_t<IcebergTableInformation> updated_tables;
+	//! The tables successively committed (used if multi-table commit isn't available)
+	case_insensitive_set_t committed_tables;
 };
 
 //! Drop a table

--- a/test/python/test_spark_read.py
+++ b/test/python/test_spark_read.py
@@ -116,9 +116,11 @@ requires_iceberg_server = pytest.mark.skipif(
 @requires_iceberg_server
 class TestSparkRead:
     def test_spark_read_insert_test(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select * from default.insert_test order by col1, col2, col3
-        """)
+        """
+        )
         res = df.collect()
         assert res == [
             Row(col1=datetime.date(2010, 6, 11), col2=42, col3='test'),
@@ -130,9 +132,11 @@ class TestSparkRead:
         ]
 
     def test_spark_read_duckdb_table(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select * from default.duckdb_written_table order by a
-            """)
+            """
+        )
         res = df.collect()
         assert res == [
             Row(a=0),
@@ -148,9 +152,11 @@ class TestSparkRead:
         ]
 
     def test_spark_read_table_with_deletes(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select * from default.duckdb_deletes_for_other_engines order by a
-            """)
+            """
+        )
         res = df.collect()
         assert res == [
             Row(a=1),
@@ -166,9 +172,11 @@ class TestSparkRead:
         ]
 
     def test_spark_read_upper_and_lower_bounds(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select * from default.lower_upper_bounds_test;
-            """)
+            """
+        )
         res = df.collect()
         assert len(res) == 3
         assert res == [
@@ -211,9 +219,11 @@ class TestSparkRead:
         ]
 
     def test_spark_read_infinities(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select * from default.test_infinities;
-            """)
+            """
+        )
         res = df.collect()
         assert len(res) == 2
         assert res == [
@@ -222,9 +232,11 @@ class TestSparkRead:
         ]
 
     def test_duckdb_written_nested_types(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select * from default.duckdb_nested_types;
-            """)
+            """
+        )
         res = df.collect()
         assert len(res) == 1
         assert res == [
@@ -240,9 +252,11 @@ class TestSparkRead:
     @pytest.mark.requires_spark(">=4.0")
     def test_duckdb_written_deletion_vectors(self, spark_con):
         # requires test_delete_consolidation_transactional.test to run
-        res = spark_con.sql("""
+        res = spark_con.sql(
+            """
             select * from default.write_v3_update_and_delete order by all
-            """).collect()
+            """
+        ).collect()
         assert (
             str(res)
             == "[Row(id=1, data='a'), Row(id=2, data='b_u1'), Row(id=3, data='c'), Row(id=4, data='d_u1'), Row(id=5, data='e')]"
@@ -256,9 +270,11 @@ class TestSparkRead:
             assert bytes(actual.value) == value_bytes
             assert bytes(actual.metadata) == metadata_bytes
 
-        res = spark_con.sql("""
+        res = spark_con.sql(
+            """
             select * from default.my_variant_tbl order by b
-            """).collect()
+            """
+        ).collect()
 
         row = res[0]
         assert row.b == 42
@@ -277,9 +293,11 @@ class TestSparkRead:
 
     @pytest.mark.requires_spark(">=4.0")
     def test_duckdb_written_row_lineage(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select _last_updated_sequence_number, _row_id, * from default.duckdb_row_lineage order by _row_id;
-            """)
+            """
+        )
         res = df.collect()
         print(res)
         assert res == [
@@ -295,9 +313,11 @@ class TestSparkRead:
     @pytest.mark.skip(reason="Failures due to unclear Spark behavior regarding row ids")
     @pytest.mark.requires_spark(">=4.0")
     def test_spark_read_row_lineage_from_upgraded(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select _last_updated_sequence_number, _row_id, * from default.row_lineage_test_upgraded_insert order by id;
-            """)
+            """
+        )
         res = df.collect()
         assert res == [
             Row(_last_updated_sequence_number=5, _row_id=3, id=1, data='replaced'),
@@ -311,9 +331,11 @@ class TestSparkRead:
     @pytest.mark.requires_spark(">=4.0")
     @pytest.mark.skip(reason="Failures due to unclear Spark behavior regarding row ids")
     def test_spark_read_row_lineage_from_upgraded_by_duckdb(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select _last_updated_sequence_number, _row_id, * from default.row_lineage_test_upgraded order by id;
-            """)
+            """
+        )
         res = df.collect()
         assert res == [
             Row(_last_updated_sequence_number=8, _row_id=3, id=2, data='replaced_again'),

--- a/test/sql/local/irc_any_catalog/transactions/test_multi_table_commit_integrity.test
+++ b/test/sql/local/irc_any_catalog/transactions/test_multi_table_commit_integrity.test
@@ -60,11 +60,11 @@ statement ok con1
 insert into my_datalake.default.cleanup_new_tbl values (1, 'from_con1');
 
 # ---------------------------------------------------------------------------
-# con2: INSERT into tbl_0 to create a 409 conflict for con1
+# con2: INSERT into tbl_10 to create a 409 conflict for con1
 # ---------------------------------------------------------------------------
 
 statement ok con2
-insert into my_datalake.default.cleanup_tbl_0 values (2, 'from_con2');
+insert into my_datalake.default.cleanup_tbl_10 values (2, 'from_con2');
 
 # ---------------------------------------------------------------------------
 # con1: commit — per-table fallback loop.
@@ -94,14 +94,24 @@ select * from my_datalake.default.cleanup_tbl_0;
 # All other tables should be readable with just their seed data.
 # If CleanupFiles() deleted data files for already-committed tables,
 # these queries will fail with HTTP 404 / IO errors.
-loop i 1 20
+loop i 0 20
 
-query IT
-select * from my_datalake.default.cleanup_tbl_${i} order by id;
+onlyif i=10
+continue
+
+query I
+select id from my_datalake.default.cleanup_tbl_${i} where val = 'seed' order by id;
 ----
-0	seed
+0
 
 endloop
+
+# Verify that the commit to tbl_10 failed
+query IT
+select * from my_datalake.default.cleanup_tbl_10 order by id;
+----
+0	seed
+2	from_con2
 
 # ---------------------------------------------------------------------------
 # Cleanup

--- a/test/sql/local/irc_any_catalog/transactions/test_multi_table_commit_integrity.test
+++ b/test/sql/local/irc_any_catalog/transactions/test_multi_table_commit_integrity.test
@@ -1,0 +1,118 @@
+# name: test/sql/local/irc_any_catalog/transactions/test_multi_table_commit_integrity.test
+# group: [transactions]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require-env SECRETS_CREATED_AND_CATALOG_ATTACHED
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+set threads=1;
+
+# ---------------------------------------------------------------------------
+# Setup: create and seed 20 existing tables
+# ---------------------------------------------------------------------------
+
+loop i 0 20
+
+statement ok
+drop table if exists my_datalake.default.cleanup_tbl_${i};
+
+statement ok
+create table my_datalake.default.cleanup_tbl_${i} (id int, val varchar);
+
+statement ok
+insert into my_datalake.default.cleanup_tbl_${i} values (0, 'seed');
+
+endloop
+
+statement ok
+drop table if exists my_datalake.default.cleanup_new_tbl;
+
+# ---------------------------------------------------------------------------
+# con1: begin transaction, INSERT into all 20 tables, CREATE TABLE 
+# (forces has_assert_create -> per-table commit fallback loop)
+# ---------------------------------------------------------------------------
+
+statement ok con1
+begin
+
+loop i 0 20
+
+statement ok con1
+insert into my_datalake.default.cleanup_tbl_${i} values (1, 'from_con1');
+
+endloop
+
+statement ok con1
+create table my_datalake.default.cleanup_new_tbl (id int, val varchar);
+
+statement ok con1
+insert into my_datalake.default.cleanup_new_tbl values (1, 'from_con1');
+
+# ---------------------------------------------------------------------------
+# con2: INSERT into tbl_0 to create a 409 conflict for con1
+# ---------------------------------------------------------------------------
+
+statement ok con2
+insert into my_datalake.default.cleanup_tbl_0 values (2, 'from_con2');
+
+# ---------------------------------------------------------------------------
+# con1: commit — per-table fallback loop.
+# Some tables commit before tbl_0 hits 409. CleanupFiles() then deletes
+# data files for ALL tables, corrupting the already-committed ones.
+# ---------------------------------------------------------------------------
+
+statement error con1
+commit
+----
+<REGEX>:.*
+
+# ---------------------------------------------------------------------------
+# Verification: every table should still be readable.
+#
+# If CleanupFiles() deleted data files for already-committed tables,
+# these queries will fail with IO errors — proving the data corruption.
+# ---------------------------------------------------------------------------
+
+# tbl_0 is the conflicted table — con1's insert was rejected.
+# It should still be readable (not corrupted). Con2's insert may or may not
+# be visible depending on catalog cache state, so we just verify it doesn't
+# throw an IO error.
+statement ok
+select * from my_datalake.default.cleanup_tbl_0;
+
+# All other tables should be readable with just their seed data.
+# If CleanupFiles() deleted data files for already-committed tables,
+# these queries will fail with HTTP 404 / IO errors.
+loop i 1 20
+
+query IT
+select * from my_datalake.default.cleanup_tbl_${i} order by id;
+----
+0	seed
+
+endloop
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+loop i 0 20
+
+statement ok
+drop table if exists my_datalake.default.cleanup_tbl_${i};
+
+endloop
+
+statement ok
+drop table if exists my_datalake.default.cleanup_new_tbl;


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/8889

This is arguably not correct behavior, as we break atomicity, but now we don't delete files of tables that successfully committed, if the commit of another table triggered a ROLLBACK.