### PR TITLE
Fix races / ownership problems in `MetadataCacheValue` expiration

### DIFF
--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -219,40 +219,28 @@ IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(ClientConte
 	auto schema_component = IRCPathComponent::NamespaceComponent(schema.namespace_items);
 	auto key = schema_component.encoded + "." + name;
 	{
-		// get cache lock when accessing load table result cache
-		lock_guard<std::mutex> cache_lock(catalog.GetMetadataCacheLock());
-		auto cached_table_result = catalog.TryGetValidCachedLoadTableResult(key, cache_lock, false);
-		D_ASSERT(cached_table_result);
-		auto &load_table_result = *cached_table_result->load_table_result;
-		if (load_table_result.has_config) {
-			auto &config = load_table_result.config;
-			ParseConfigOptions(config, config_options, context, storage_type);
-		}
+		ParseConfigOptions(config, config_options, context, storage_type);
 
-		if (load_table_result.has_storage_credentials) {
-			auto &storage_credentials = load_table_result.storage_credentials;
+		//! If there is only one credential listed, we don't really care about the prefix,
+		//! we can use the table_location instead.
+		const bool ignore_credential_prefix = storage_credentials.size() == 1;
+		for (idx_t index = 0; index < storage_credentials.size(); index++) {
+			auto &credential = storage_credentials[index];
+			CreateSecretInput create_secret_input;
+			create_secret_input.on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
+			create_secret_input.persist_type = SecretPersistType::TEMPORARY;
 
-			//! If there is only one credential listed, we don't really care about the prefix,
-			//! we can use the table_location instead.
-			const bool ignore_credential_prefix = storage_credentials.size() == 1;
-			for (idx_t index = 0; index < storage_credentials.size(); index++) {
-				auto &credential = storage_credentials[index];
-				CreateSecretInput create_secret_input;
-				create_secret_input.on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
-				create_secret_input.persist_type = SecretPersistType::TEMPORARY;
+			create_secret_input.scope.push_back(ignore_credential_prefix ? table_location : credential.prefix);
+			create_secret_input.name = StringUtil::Format("%s_%d_%s", secret_base_name, index, credential.prefix);
 
-				create_secret_input.scope.push_back(ignore_credential_prefix ? table_location : credential.prefix);
-				create_secret_input.name = StringUtil::Format("%s_%d_%s", secret_base_name, index, credential.prefix);
+			create_secret_input.type = storage_type;
+			create_secret_input.provider = "config";
+			create_secret_input.storage_type = "memory";
+			create_secret_input.options = config_options;
 
-				create_secret_input.type = storage_type;
-				create_secret_input.provider = "config";
-				create_secret_input.storage_type = "memory";
-				create_secret_input.options = config_options;
-
-				ParseConfigOptions(credential.config, create_secret_input.options, context, storage_type);
-				//! TODO: apply the 'overrides' retrieved from the /v1/config endpoint
-				result.storage_credentials.push_back(create_secret_input);
-			}
+			ParseConfigOptions(credential.config, create_secret_input.options, context, storage_type);
+			//! TODO: apply the 'overrides' retrieved from the /v1/config endpoint
+			result.storage_credentials.push_back(create_secret_input);
 		}
 	}
 
@@ -332,8 +320,7 @@ int64_t IcebergTableInformation::GetExistingSpecId(IcebergPartitionSpec &spec) {
 				fields_match = false;
 				break;
 			}
-			auto existing_partition_col_transform =
-			    existing_spec.second.fields[field_index].transform.RawType();
+			auto existing_partition_col_transform = existing_spec.second.fields[field_index].transform.RawType();
 			auto new_spec_col_transform = spec.fields[field_index].transform.RawType();
 			if (existing_partition_col_transform != new_spec_col_transform) {
 				fields_match = false;
@@ -546,12 +533,11 @@ IcebergTableInformation IcebergTableInformation::Copy() const {
 	auto ret = IcebergTableInformation(catalog, schema, name);
 	auto table_key = ret.GetTableKey();
 	{
-		lock_guard<std::mutex> cache_lock(catalog.GetMetadataCacheLock());
-		auto cached_result = catalog.TryGetValidCachedLoadTableResult(table_key, cache_lock, false);
+		lock_guard<std::mutex> cache_lock(catalog.table_request_cache.Lock());
+		auto cached_result = catalog.table_request_cache.Get(table_key, cache_lock, false);
 		D_ASSERT(cached_result);
 		auto &cached_table_result = *cached_result->load_table_result;
-		ret.table_metadata = IcebergTableMetadata::FromTableMetadata(cached_table_result.metadata);
-		ret.table_metadata.latest_metadata_json = cached_table_result.metadata_location;
+		ret.InitializeFromLoadTableResult(cached_table_result);
 	}
 	return ret;
 }
@@ -595,6 +581,23 @@ IcebergTransactionData &IcebergTableInformation::GetOrCreateTransactionData(Iceb
 		transaction_data = make_uniq<IcebergTransactionData>(*context, *this);
 	}
 	return *transaction_data;
+}
+
+void IcebergTableInformation::InitializeFromLoadTableResult(
+    const rest_api_objects::LoadTableResult &load_table_result) {
+	table_metadata = IcebergTableMetadata::FromTableMetadata(load_table_result.metadata);
+	config = load_table_result.config;
+	storage_credentials.clear();
+	for (auto &credential : load_table_result.storage_credentials) {
+		storage_credentials.push_back(credential);
+	}
+	latest_metadata_json = load_table_result.metadata_location;
+
+	auto &schemas = table_metadata.GetSchemas();
+	D_ASSERT(!schemas.empty());
+	for (auto &table_schema : schemas) {
+		CreateSchemaVersion(*table_schema.second);
+	}
 }
 
 } // namespace duckdb

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -218,30 +218,29 @@ IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(ClientConte
 	config_options.insert(user_defaults.begin(), user_defaults.end());
 	auto schema_component = IRCPathComponent::NamespaceComponent(schema.namespace_items);
 	auto key = schema_component.encoded + "." + name;
-	{
-		ParseConfigOptions(config, config_options, context, storage_type);
 
-		//! If there is only one credential listed, we don't really care about the prefix,
-		//! we can use the table_location instead.
-		const bool ignore_credential_prefix = storage_credentials.size() == 1;
-		for (idx_t index = 0; index < storage_credentials.size(); index++) {
-			auto &credential = storage_credentials[index];
-			CreateSecretInput create_secret_input;
-			create_secret_input.on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
-			create_secret_input.persist_type = SecretPersistType::TEMPORARY;
+	ParseConfigOptions(config, config_options, context, storage_type);
 
-			create_secret_input.scope.push_back(ignore_credential_prefix ? table_location : credential.prefix);
-			create_secret_input.name = StringUtil::Format("%s_%d_%s", secret_base_name, index, credential.prefix);
+	//! If there is only one credential listed, we don't really care about the prefix,
+	//! we can use the table_location instead.
+	const bool ignore_credential_prefix = storage_credentials.size() == 1;
+	for (idx_t index = 0; index < storage_credentials.size(); index++) {
+		auto &credential = storage_credentials[index];
+		CreateSecretInput create_secret_input;
+		create_secret_input.on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
+		create_secret_input.persist_type = SecretPersistType::TEMPORARY;
 
-			create_secret_input.type = storage_type;
-			create_secret_input.provider = "config";
-			create_secret_input.storage_type = "memory";
-			create_secret_input.options = config_options;
+		create_secret_input.scope.push_back(ignore_credential_prefix ? table_location : credential.prefix);
+		create_secret_input.name = StringUtil::Format("%s_%d_%s", secret_base_name, index, credential.prefix);
 
-			ParseConfigOptions(credential.config, create_secret_input.options, context, storage_type);
-			//! TODO: apply the 'overrides' retrieved from the /v1/config endpoint
-			result.storage_credentials.push_back(create_secret_input);
-		}
+		create_secret_input.type = storage_type;
+		create_secret_input.provider = "config";
+		create_secret_input.storage_type = "memory";
+		create_secret_input.options = config_options;
+
+		ParseConfigOptions(credential.config, create_secret_input.options, context, storage_type);
+		//! TODO: apply the 'overrides' retrieved from the /v1/config endpoint
+		result.storage_credentials.push_back(create_secret_input);
 	}
 
 	if (result.storage_credentials.empty() && !config_options.empty()) {

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -536,7 +536,7 @@ IcebergTableInformation IcebergTableInformation::Copy() const {
 		auto cached_result = catalog.table_request_cache.Get(table_key, cache_lock, false);
 		D_ASSERT(cached_result);
 		auto &cached_table_result = *cached_result->load_table_result;
-		ret.InitializeFromLoadTableResult(cached_table_result);
+		ret.InitializeFromLoadTableResult(cached_table_result, false);
 	}
 	return ret;
 }
@@ -582,8 +582,8 @@ IcebergTransactionData &IcebergTableInformation::GetOrCreateTransactionData(Iceb
 	return *transaction_data;
 }
 
-void IcebergTableInformation::InitializeFromLoadTableResult(
-    const rest_api_objects::LoadTableResult &load_table_result) {
+void IcebergTableInformation::InitializeFromLoadTableResult(const rest_api_objects::LoadTableResult &load_table_result,
+                                                            bool initialize_schemas) {
 	table_metadata = IcebergTableMetadata::FromTableMetadata(load_table_result.metadata);
 	config = load_table_result.config;
 	storage_credentials.clear();
@@ -592,10 +592,12 @@ void IcebergTableInformation::InitializeFromLoadTableResult(
 	}
 	latest_metadata_json = load_table_result.metadata_location;
 
-	auto &schemas = table_metadata.GetSchemas();
-	D_ASSERT(!schemas.empty());
-	for (auto &table_schema : schemas) {
-		CreateSchemaVersion(*table_schema.second);
+	if (initialize_schemas) {
+		auto &schemas = table_metadata.GetSchemas();
+		D_ASSERT(!schemas.empty());
+		for (auto &table_schema : schemas) {
+			CreateSchemaVersion(*table_schema.second);
+		}
 	}
 }
 

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -32,7 +32,8 @@ IcebergCatalog::IcebergCatalog(AttachedDatabase &db_p, AccessMode access_mode,
                                const string &default_schema)
     : Catalog(db_p), access_mode(access_mode), auth_handler(std::move(auth_handler)), uri(attach_options.endpoint),
       version("v1"), attach_options(attach_options), default_schema(default_schema),
-      warehouse(attach_options.warehouse), schemas(*this), metadata_cache() {
+      warehouse(attach_options.warehouse), schemas(*this) {
+	table_request_cache.SetMaxTableStaleness(attach_options.max_table_staleness_micros);
 }
 
 IcebergCatalog::~IcebergCatalog() = default;
@@ -66,53 +67,6 @@ optional_ptr<SchemaCatalogEntry> IcebergCatalog::LookupSchema(CatalogTransaction
 	}
 
 	return reinterpret_cast<SchemaCatalogEntry *>(entry.get());
-}
-
-void IcebergCatalog::StoreLoadTableResult(const string &table_key,
-                                          unique_ptr<const rest_api_objects::LoadTableResult> load_table_result) {
-	std::lock_guard<std::mutex> g(metadata_cache_mutex);
-	// erase load table result if it exists.
-	if (metadata_cache.find(table_key) != metadata_cache.end()) {
-		metadata_cache.erase(table_key);
-	}
-	// If max_table_staleness_minutes is not set, use a time in the past so cache is always expired
-	system_clock::time_point expires_at;
-	if (attach_options.max_table_staleness_micros.IsValid()) {
-		expires_at =
-		    system_clock::now() + std::chrono::microseconds(attach_options.max_table_staleness_micros.GetIndex());
-	} else {
-		expires_at = system_clock::time_point::min();
-	}
-	auto val = make_uniq<MetadataCacheValue>(expires_at, std::move(load_table_result));
-	metadata_cache.emplace(table_key, std::move(val));
-}
-
-std::mutex &IcebergCatalog::GetMetadataCacheLock() {
-	return metadata_cache_mutex;
-}
-
-optional_ptr<MetadataCacheValue> IcebergCatalog::TryGetValidCachedLoadTableResult(const string &table_key,
-                                                                                  lock_guard<std::mutex> &lock,
-                                                                                  bool validate_cache) {
-	(void)lock;
-	auto it = metadata_cache.find(table_key);
-	if (it == metadata_cache.end()) {
-		return nullptr;
-	}
-	auto &cached_value = *it->second;
-	if (validate_cache && system_clock::now() > cached_value.expires_at) {
-		// cached value has expired
-		return nullptr;
-	}
-	return &cached_value;
-}
-
-void IcebergCatalog::RemoveLoadTableResult(const string &table_key) {
-	std::lock_guard<std::mutex> g(metadata_cache_mutex);
-	if (metadata_cache.find(table_key) == metadata_cache.end()) {
-		throw InternalException("Attempting to remove table information that was never stored");
-	}
-	metadata_cache.erase(table_key);
 }
 
 optional_ptr<CatalogEntry> IcebergCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -28,12 +28,11 @@ using namespace duckdb_yyjson;
 namespace duckdb {
 
 IcebergCatalog::IcebergCatalog(AttachedDatabase &db_p, AccessMode access_mode,
-                               unique_ptr<IcebergAuthorization> auth_handler, IcebergAttachOptions &attach_options,
+                               unique_ptr<IcebergAuthorization> auth_handler, IcebergAttachOptions &attach_options_p,
                                const string &default_schema)
-    : Catalog(db_p), access_mode(access_mode), auth_handler(std::move(auth_handler)), uri(attach_options.endpoint),
-      version("v1"), attach_options(attach_options), default_schema(default_schema),
-      warehouse(attach_options.warehouse), schemas(*this) {
-	table_request_cache.SetMaxTableStaleness(attach_options.max_table_staleness_micros);
+    : Catalog(db_p), access_mode(access_mode), auth_handler(std::move(auth_handler)), uri(attach_options_p.endpoint),
+      version("v1"), attach_options(attach_options_p), default_schema(default_schema),
+      warehouse(attach_options.warehouse), schemas(*this), table_request_cache(attach_options) {
 }
 
 IcebergCatalog::~IcebergCatalog() = default;

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -38,16 +38,11 @@ bool IcebergTableSet::FillEntry(ClientContext &context, IcebergTableInformation 
 
 	// Only check cache if MAX_TABLE_STALENESS option is set
 	if (ic_catalog.attach_options.max_table_staleness_micros.IsValid()) {
-		lock_guard<std::mutex> cache_lock(ic_catalog.GetMetadataCacheLock());
-		auto cached_result = ic_catalog.TryGetValidCachedLoadTableResult(table_key, cache_lock);
+		lock_guard<mutex> cache_lock(ic_catalog.table_request_cache.Lock());
+		auto cached_result = ic_catalog.table_request_cache.Get(table_key, cache_lock);
 		if (cached_result) {
 			// Use the cached result instead of making a new request
-			table.table_metadata = IcebergTableMetadata::FromLoadTableResult(*cached_result->load_table_result);
-			auto &schemas = table.table_metadata.GetSchemas();
-			D_ASSERT(!schemas.empty());
-			for (auto &table_schema : schemas) {
-				table.CreateSchemaVersion(*table_schema.second);
-			}
+			table.InitializeFromLoadTableResult(*cached_result->load_table_result);
 			return true;
 		}
 	}
@@ -71,20 +66,13 @@ bool IcebergTableSet::FillEntry(ClientContext &context, IcebergTableInformation 
 		    StringUtil::Format("GetTableInformation endpoint returned response code %s with message \"%s\"",
 		                       EnumUtil::ToString(get_table_result.status_), get_table_result.error_._error.message));
 	}
-	ic_catalog.StoreLoadTableResult(table_key, std::move(get_table_result.result_));
+	ic_catalog.table_request_cache.SetOrOverwrite(context, table_key, std::move(get_table_result.result_));
 	{
-		lock_guard<std::mutex> cache_lock(ic_catalog.GetMetadataCacheLock());
-		auto cached_table_result = ic_catalog.TryGetValidCachedLoadTableResult(table_key, cache_lock, false);
+		lock_guard<std::mutex> cache_lock(ic_catalog.table_request_cache.Lock());
+		auto cached_table_result = ic_catalog.table_request_cache.Get(table_key, cache_lock, false);
 		D_ASSERT(cached_table_result);
 		auto &load_table_result = *cached_table_result->load_table_result;
-		table.table_metadata = IcebergTableMetadata::FromLoadTableResult(load_table_result);
-	}
-	auto &schemas = table.table_metadata.GetSchemas();
-
-	//! It should be impossible to have a metadata file without any schema
-	D_ASSERT(!schemas.empty());
-	for (auto &table_schema : schemas) {
-		table.CreateSchemaVersion(*table_schema.second);
+		table.InitializeFromLoadTableResult(load_table_result);
 	}
 	return true;
 }
@@ -245,10 +233,10 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 	auto load_table_result =
 	    make_uniq<const rest_api_objects::LoadTableResult>(IRCAPI::CommitNewTable(context, catalog, *table_ptr));
 
-	catalog.StoreLoadTableResult(key, std::move(load_table_result));
+	catalog.table_request_cache.SetOrOverwrite(context, key, std::move(load_table_result));
 	{
-		lock_guard<std::mutex> cache_lock(catalog.GetMetadataCacheLock());
-		auto cached_table_result = catalog.TryGetValidCachedLoadTableResult(key, cache_lock, false);
+		lock_guard<mutex> cache_lock(catalog.table_request_cache.Lock());
+		auto cached_table_result = catalog.table_request_cache.Get(key, cache_lock, false);
 		D_ASSERT(cached_table_result);
 		auto &load_table_result = cached_table_result->load_table_result;
 		table_metadata = IcebergTableMetadata::FromTableMetadata(load_table_result->metadata);

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -239,7 +239,7 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 		auto cached_table_result = catalog.table_request_cache.Get(key, cache_lock, false);
 		D_ASSERT(cached_table_result);
 		auto &load_table_result = cached_table_result->load_table_result;
-		table_metadata = IcebergTableMetadata::FromTableMetadata(load_table_result->metadata);
+		table_info.InitializeFromLoadTableResult(*load_table_result, false);
 	}
 
 	// if we stage created the table, we add an assert create

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -469,8 +469,7 @@ void IcebergTransaction::DoTableDeletes(IcebergTransactionDeleteUpdate &delete_u
 	auto table_name = table.name;
 	IRCAPI::CommitTableDelete(context, catalog, table.schema.namespace_items, table.name);
 	// remove the load table result
-	//! FIXME: this can very easily be problematic
-	ic_catalog.RemoveLoadTableResult(table_key);
+	ic_catalog.table_request_cache.Expire(context, table_key);
 	// remove the table entry from the catalog
 	auto &schema_entry = ic_catalog.schemas.GetEntry(schema_key).Cast<IcebergSchemaEntry>();
 	DropInfo drop_info;

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -585,6 +585,7 @@ TableInfoCache IcebergTransaction::GetTableRequestResult(const string &table_key
 }
 
 IcebergTransaction &IcebergTransaction::Get(ClientContext &context, Catalog &catalog) {
+	D_ASSERT(catalog.GetCatalogType() == "iceberg");
 	return Transaction::Get(context, catalog).Cast<IcebergTransaction>();
 }
 

--- a/src/common/iceberg_utils.cpp
+++ b/src/common/iceberg_utils.cpp
@@ -150,7 +150,7 @@ string IcebergUtils::GetStorageLocation(ClientContext &context, const string &in
 				throw InvalidInputException("Table %s is not an Iceberg table", input);
 			}
 			auto &table_entry = catalog_entry->Cast<IcebergTableEntry>();
-			storage_location = table_entry.table_info.table_metadata.GetLatestMetadataJson();
+			storage_location = table_entry.table_info.latest_metadata_json;
 			// Prepare Iceberg Scan from entry will create the secret needed to access the table
 			table_entry.PrepareIcebergScanFromEntry(context);
 			break;

--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -336,13 +336,6 @@ rest_api_objects::TableMetadata IcebergTableMetadata::Parse(const string &path, 
 	return rest_api_objects::TableMetadata::FromJSON(root);
 }
 
-IcebergTableMetadata
-IcebergTableMetadata::FromLoadTableResult(const rest_api_objects::LoadTableResult &load_table_result) {
-	auto res = FromTableMetadata(load_table_result.metadata);
-	res.latest_metadata_json = load_table_result.metadata_location;
-	return res;
-}
-
 IcebergTableMetadata IcebergTableMetadata::FromTableMetadata(const rest_api_objects::TableMetadata &table_metadata) {
 	IcebergTableMetadata res;
 
@@ -426,10 +419,6 @@ IcebergTableMetadata IcebergTableMetadata::FromTableMetadata(const rest_api_obje
 
 const case_insensitive_map_t<string> &IcebergTableMetadata::GetTableProperties() const {
 	return table_properties;
-}
-
-const string &IcebergTableMetadata::GetLatestMetadataJson() const {
-	return latest_metadata_json;
 }
 
 const string &IcebergTableMetadata::GetLocation() const {

--- a/src/core/metadata/manifest/iceberg_manifest.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest.cpp
@@ -59,8 +59,7 @@ map<idx_t, LogicalType> IcebergDataFile::GetFieldIdToTypeMapping(const IcebergSn
 			}
 			auto &column_id = it->second;
 			auto &column = IcebergTableSchema::GetFromColumnIndex(schema.columns, column_id, 0);
-			partition_field_id_to_type.emplace(field.partition_field_id,
-			                                   field.transform.GetBoundsType(column.type));
+			partition_field_id_to_type.emplace(field.partition_field_id, field.transform.GetBoundsType(column.type));
 		}
 	}
 	return partition_field_id_to_type;

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -542,8 +542,8 @@ static unique_ptr<Expression> GetBucketExpression(ClientContext &context, Iceber
 	auto col_type = GetSourceColumnType(copy_input, field.source_id);
 
 	vector<unique_ptr<Expression>> children;
-	children.push_back(make_uniq<BoundConstantExpression>(
-	    Value::INTEGER(static_cast<int32_t>(field.transform.GetBucketModulo()))));
+	children.push_back(
+	    make_uniq<BoundConstantExpression>(Value::INTEGER(static_cast<int32_t>(field.transform.GetBucketModulo()))));
 	children.push_back(CreateColumnReference(copy_input, col_type, col_idx));
 
 	ErrorData error;
@@ -562,8 +562,8 @@ static unique_ptr<Expression> GetTruncateExpression(ClientContext &context, Iceb
 	auto col_type = GetSourceColumnType(copy_input, field.source_id);
 
 	vector<unique_ptr<Expression>> children;
-	children.push_back(make_uniq<BoundConstantExpression>(
-	    Value::INTEGER(static_cast<int32_t>(field.transform.GetTruncateWidth()))));
+	children.push_back(
+	    make_uniq<BoundConstantExpression>(Value::INTEGER(static_cast<int32_t>(field.transform.GetTruncateWidth()))));
 	children.push_back(CreateColumnReference(copy_input, col_type, col_idx));
 
 	ErrorData error;

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -6,6 +6,7 @@
 #include "core/metadata/manifest/iceberg_manifest.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
+#include "rest_catalog/objects/storage_credential.hpp"
 
 namespace duckdb {
 class IcebergTableSchema;
@@ -17,6 +18,18 @@ struct IcebergManifestEntry;
 struct IRCAPITableCredentials {
 	unique_ptr<CreateSecretInput> config;
 	vector<CreateSecretInput> storage_credentials;
+};
+
+struct IcebergTableStorageCredential {
+public:
+	IcebergTableStorageCredential(const rest_api_objects::StorageCredential &storage_credential) {
+		prefix = storage_credential.prefix;
+		config = storage_credential.config;
+	}
+
+public:
+	string prefix;
+	case_insensitive_map_t<string> config;
 };
 
 struct IcebergTableInformation {
@@ -52,6 +65,7 @@ public:
 	IcebergSnapshotLookup GetSnapshotLookup(ClientContext &context) const;
 	bool TableIsEmpty(const IcebergSnapshotLookup &snapshot_lookup) const;
 	bool HasTransactionUpdates() const;
+	void InitializeFromLoadTableResult(const rest_api_objects::LoadTableResult &load_table_result);
 
 public:
 	IcebergCatalog &catalog;
@@ -59,6 +73,10 @@ public:
 	string name;
 	string table_id;
 	IcebergTableMetadata table_metadata;
+	case_insensitive_map_t<string> config;
+	vector<IcebergTableStorageCredential> storage_credentials;
+	// when loading table metadata, store the path to the metadata.json for extension functions like iceberg_metadata()
+	string latest_metadata_json;
 
 	unordered_map<int32_t, unique_ptr<IcebergTableEntry>> schema_versions;
 	// dummy entry to hold existence of a table, but no schema versions

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -65,7 +65,8 @@ public:
 	IcebergSnapshotLookup GetSnapshotLookup(ClientContext &context) const;
 	bool TableIsEmpty(const IcebergSnapshotLookup &snapshot_lookup) const;
 	bool HasTransactionUpdates() const;
-	void InitializeFromLoadTableResult(const rest_api_objects::LoadTableResult &load_table_result);
+	void InitializeFromLoadTableResult(const rest_api_objects::LoadTableResult &load_table_result,
+	                                   bool initialize_schemas = true);
 
 public:
 	IcebergCatalog &catalog;

--- a/src/include/catalog/rest/iceberg_catalog.hpp
+++ b/src/include/catalog/rest/iceberg_catalog.hpp
@@ -36,7 +36,7 @@ public:
 
 class LoadTableResultCache {
 public:
-	LoadTableResultCache() {
+	LoadTableResultCache(IcebergAttachOptions &attach_options) : attach_options(attach_options) {
 	}
 
 public:
@@ -66,8 +66,9 @@ public:
 
 		// If max_table_staleness_minutes is not set, use a time in the past so cache is always expired
 		system_clock::time_point expires_at;
-		if (max_table_staleness_micros.IsValid()) {
-			expires_at = system_clock::now() + std::chrono::microseconds(max_table_staleness_micros.GetIndex());
+		if (attach_options.max_table_staleness_micros.IsValid()) {
+			expires_at =
+			    system_clock::now() + std::chrono::microseconds(attach_options.max_table_staleness_micros.GetIndex());
 		} else {
 			expires_at = system_clock::time_point::min();
 		}
@@ -90,12 +91,9 @@ public:
 		}
 		tables.erase(it);
 	}
-	void SetMaxTableStaleness(optional_idx micros) {
-		max_table_staleness_micros = micros;
-	}
 
 private:
-	optional_idx max_table_staleness_micros;
+	IcebergAttachOptions &attach_options;
 	mutex lock;
 	case_insensitive_map_t<MetadataCacheValue> tables;
 };

--- a/src/include/catalog/rest/iceberg_catalog.hpp
+++ b/src/include/catalog/rest/iceberg_catalog.hpp
@@ -79,17 +79,7 @@ public:
 	void Expire(ClientContext &context, const string &table_key) {
 		auto &meta_transaction = MetaTransaction::Get(context);
 		lock_guard<mutex> guard(lock);
-		auto it = tables.find(table_key);
-		if (it == tables.end()) {
-			//! Entry doesn't exist anymore
-			return;
-		}
-		auto &entry = it->second;
-		if (entry.creator != meta_transaction.global_transaction_id) {
-			//! The entry we made is no longer the latest version, can't expire
-			return;
-		}
-		tables.erase(it);
+		tables.erase(table_key);
 	}
 
 private:

--- a/src/include/catalog/rest/iceberg_catalog.hpp
+++ b/src/include/catalog/rest/iceberg_catalog.hpp
@@ -80,6 +80,16 @@ public:
 		auto &meta_transaction = MetaTransaction::Get(context);
 		lock_guard<mutex> guard(lock);
 		tables.erase(table_key);
+		auto it = tables.find(table_key);
+		if (it == tables.end()) {
+			//! Entry doesn't exist anymore
+			return;
+		}
+		auto &entry = it->second;
+		if (entry.creator != meta_transaction.global_transaction_id) {
+			//! The entry we made is no longer the latest version, can't expire
+			return;
+		}
 	}
 
 private:

--- a/src/include/catalog/rest/iceberg_catalog.hpp
+++ b/src/include/catalog/rest/iceberg_catalog.hpp
@@ -7,6 +7,7 @@
 #include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "duckdb/storage/storage_extension.hpp"
 #include "duckdb/common/http_util.hpp"
+#include "duckdb/transaction/meta_transaction.hpp"
 
 #include "catalog/rest/api/url_utils.hpp"
 #include "catalog/rest/iceberg_schema_set.hpp"
@@ -19,14 +20,84 @@ class IcebergSchemaEntry;
 
 class MetadataCacheValue {
 public:
-	const system_clock::time_point expires_at;
-	unique_ptr<const rest_api_objects::LoadTableResult> load_table_result;
+	MetadataCacheValue(transaction_t creator, const system_clock::time_point expires_at,
+	                   unique_ptr<const rest_api_objects::LoadTableResult> load_table_result)
+	    : creator(creator), expires_at(expires_at), load_table_result(std::move(load_table_result)) {
+	}
 
 public:
-	MetadataCacheValue(const system_clock::time_point expires_at,
-	                   unique_ptr<const rest_api_objects::LoadTableResult> load_table_result)
-	    : expires_at(expires_at), load_table_result(std::move(load_table_result)) {
+	//! Store the id of the transaction that added the entry
+	transaction_t creator;
+	//! The timestamp until when this entry is valid
+	const system_clock::time_point expires_at;
+	//! The payload of the cache entry
+	unique_ptr<const rest_api_objects::LoadTableResult> load_table_result;
+};
+
+class LoadTableResultCache {
+public:
+	LoadTableResultCache() {
 	}
+
+public:
+	mutex &Lock() {
+		return lock;
+	}
+
+	//! NOTE: lock needs to be held by the caller until the result goes out of scope
+	optional_ptr<MetadataCacheValue> Get(const string &table_key, lock_guard<mutex> &lock, bool validate_cache = true) {
+		(void)lock;
+		auto it = tables.find(table_key);
+		if (it == tables.end()) {
+			return nullptr;
+		}
+		auto &entry = it->second;
+		if (validate_cache && system_clock::now() > entry.expires_at) {
+			// cached value has expired
+			return nullptr;
+		}
+		return entry;
+	}
+	void SetOrOverwrite(ClientContext &context, const string &table_key,
+	                    unique_ptr<const rest_api_objects::LoadTableResult> load_table_result) {
+		lock_guard<mutex> guard(lock);
+		// erase load table result if it exists.
+		tables.erase(table_key);
+
+		// If max_table_staleness_minutes is not set, use a time in the past so cache is always expired
+		system_clock::time_point expires_at;
+		if (max_table_staleness_micros.IsValid()) {
+			expires_at = system_clock::now() + std::chrono::microseconds(max_table_staleness_micros.GetIndex());
+		} else {
+			expires_at = system_clock::time_point::min();
+		}
+		auto &meta_transaction = MetaTransaction::Get(context);
+		tables.emplace(table_key, MetadataCacheValue(meta_transaction.global_transaction_id, expires_at,
+		                                             std::move(load_table_result)));
+	}
+	void Expire(ClientContext &context, const string &table_key) {
+		auto &meta_transaction = MetaTransaction::Get(context);
+		lock_guard<mutex> guard(lock);
+		auto it = tables.find(table_key);
+		if (it == tables.end()) {
+			//! Entry doesn't exist anymore
+			return;
+		}
+		auto &entry = it->second;
+		if (entry.creator != meta_transaction.global_transaction_id) {
+			//! The entry we made is no longer the latest version, can't expire
+			return;
+		}
+		tables.erase(it);
+	}
+	void SetMaxTableStaleness(optional_idx micros) {
+		max_table_staleness_micros = micros;
+	}
+
+private:
+	optional_idx max_table_staleness_micros;
+	mutex lock;
+	case_insensitive_map_t<MetadataCacheValue> tables;
 };
 
 class IcebergCatalog : public Catalog {
@@ -109,14 +180,6 @@ public:
 	string GetDBPath() override;
 	static string GetOnlyMergeOnReadSupportedErrorMessage(const string &table_name, const string &property,
 	                                                      const string &property_value);
-	void StoreLoadTableResult(const string &table_key,
-	                          unique_ptr<const rest_api_objects::LoadTableResult> load_table_result);
-	//! Returns a reference to the metadata cache mutex. The caller is responsible for holding the lock
-	//! for the duration of any access to data returned by TryGetValidCachedLoadTableResult.
-	std::mutex &GetMetadataCacheLock();
-	optional_ptr<MetadataCacheValue>
-	TryGetValidCachedLoadTableResult(const string &table_key, lock_guard<std::mutex> &lock, bool validate_cache = true);
-	void RemoveLoadTableResult(const string &table_key);
 
 public:
 	AccessMode access_mode;
@@ -142,10 +205,7 @@ private:
 public:
 	unordered_set<string> supported_urls;
 	IcebergSchemaSet schemas;
-
-private:
-	std::mutex metadata_cache_mutex;
-	case_insensitive_map_t<unique_ptr<MetadataCacheValue>> metadata_cache;
+	LoadTableResultCache table_request_cache;
 };
 
 } // namespace duckdb

--- a/src/include/core/metadata/iceberg_table_metadata.hpp
+++ b/src/include/core/metadata/iceberg_table_metadata.hpp
@@ -28,7 +28,6 @@ public:
 public:
 	static rest_api_objects::TableMetadata Parse(const string &path, FileSystem &fs,
 	                                             const string &metadata_compression_codec);
-	static IcebergTableMetadata FromLoadTableResult(const rest_api_objects::LoadTableResult &load_table_result);
 	static IcebergTableMetadata FromTableMetadata(const rest_api_objects::TableMetadata &table_metadata);
 	static string GetMetaDataPath(ClientContext &context, const string &path, FileSystem &fs,
 	                              const IcebergOptions &options);
@@ -59,8 +58,6 @@ public:
 	optional_ptr<const IcebergSortOrder> FindSortOrderById(int32_t sort_id) const;
 	IcebergSnapshotScanInfo GetSnapshot(const IcebergSnapshotLookup &lookup) const;
 
-	//! Get the data and metadata paths, falling back to default if not set
-	const string &GetLatestMetadataJson() const;
 	const string &GetLocation() const;
 	const string GetDataPath(FileSystem &fs) const;
 	const string GetMetadataPath(FileSystem &fs) const;
@@ -95,8 +92,6 @@ private:
 
 public:
 	string table_uuid;
-	// when loading table metadata, store the path to the metadata.json for extension functions like iceberg_metadata()
-	string latest_metadata_json;
 	string location;
 
 	int32_t iceberg_version;


### PR DESCRIPTION
This PR fixes #929 

### Summary of changes

- Store the `config` and `storage_credentials` in the `IcebergTableInformation`, instead of looking it up from the cache entry. Since there is no guarantee it exists anymore when we reach the scan.
- Add `transaction_t` to the `MetadataCacheValue` to be able to check who owns it, for `Expire` purposes.
- Move the cache into its own struct - `LoadTableResultCache`