### PR TITLE
[Dev] Use `metadata-log` when available

### DIFF
--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -462,8 +462,7 @@ optional_ptr<CatalogEntry> IcebergTableInformation::GetSchemaVersion(const Icebe
 	auto transaction_start = meta_transaction.GetCurrentTransactionStartTimestamp();
 	auto transaction_start_millis = Timestamp::GetEpochMs(transaction_start);
 	int32_t schema_id;
-	if ((table_metadata.last_updated_ms.value >= transaction_start_millis && snapshot_info.snapshot) ||
-	    is_time_travel) {
+	if ((table_metadata.last_updated_ms.value > transaction_start_millis && snapshot_info.snapshot) || is_time_travel) {
 		// use snapshot
 		schema_id = snapshot_info.schema_id;
 	} else {
@@ -494,7 +493,8 @@ string IcebergTableInformation::GetTableKey() const {
 }
 
 IcebergSnapshotLookup IcebergTableInformation::GetSnapshotLookup(IcebergTransaction &iceberg_transaction) const {
-	auto &context = *iceberg_transaction.context.lock();
+	auto locked_context = iceberg_transaction.context.lock();
+	auto &context = *locked_context;
 	return GetSnapshotLookup(context);
 }
 
@@ -543,21 +543,54 @@ IcebergTableInformation IcebergTableInformation::Copy() const {
 
 IcebergTableInformation IcebergTableInformation::Copy(IcebergTransaction &iceberg_transaction) const {
 	auto ret = Copy();
-	auto snapshot_lookup = GetSnapshotLookup(iceberg_transaction);
-	if (ret.TableIsEmpty(snapshot_lookup)) {
+
+	auto locked_context = iceberg_transaction.context.lock();
+	auto &context = *locked_context;
+	auto &meta_transaction = MetaTransaction::Get(context);
+	auto transaction_start = meta_transaction.GetCurrentTransactionStartTimestamp();
+	auto transaction_start_millis = Timestamp::GetEpochMs(transaction_start);
+
+	if (table_metadata.last_updated_ms.value > transaction_start_millis) {
+		if (table_metadata.metadata_log.empty()) {
+			auto snapshot_lookup = GetSnapshotLookup(iceberg_transaction);
+			if (ret.TableIsEmpty(snapshot_lookup)) {
+				return ret;
+			}
+			IcebergSnapshotScanInfo snapshot_info;
+			snapshot_info = ret.table_metadata.GetSnapshot(snapshot_lookup);
+			if (!snapshot_info.snapshot) {
+				throw TransactionException("Table %s is already outdated. Please restart your transaction",
+				                           GetTableKey());
+			}
+
+			auto &snapshot = snapshot_info.snapshot;
+			D_ASSERT(snapshot);
+			ret.table_metadata.SetCurrentSchemaId(table_metadata.GetCurrentSchemaId());
+			ret.table_metadata.last_sequence_number = snapshot->sequence_number;
+			ret.table_metadata.current_snapshot_id = snapshot->snapshot_id;
+			return ret;
+		}
+		auto &log = table_metadata.metadata_log;
+
+		optional_idx log_item_index;
+		for (idx_t i = log.size(); i-- > 0;) {
+			if (log[i].timestamp_ms <= transaction_start_millis) {
+				log_item_index = i;
+				break;
+			}
+		}
+		if (!log_item_index.IsValid()) {
+			throw InternalException(
+			    "Metadata-log exists but none of the entries were valid for the current transaction start time (%s)",
+			    Timestamp::ToString(transaction_start));
+		}
+		auto &fs = FileSystem::GetFileSystem(context);
+		auto &path = log[log_item_index.GetIndex()].metadata_file;
+		auto parsed_metadata = IcebergTableMetadata::Parse(path, fs, "");
+		ret.table_metadata = IcebergTableMetadata::FromTableMetadata(parsed_metadata);
+		ret.latest_metadata_json = path;
 		return ret;
 	}
-	IcebergSnapshotScanInfo snapshot_info;
-	snapshot_info = ret.table_metadata.GetSnapshot(snapshot_lookup);
-	if (!snapshot_info.snapshot) {
-		throw TransactionException("Table %s is already outdated. Please restart your transaction", GetTableKey());
-	}
-
-	auto &snapshot = snapshot_info.snapshot;
-	D_ASSERT(snapshot);
-	ret.table_metadata.SetCurrentSchemaId(table_metadata.GetCurrentSchemaId());
-	ret.table_metadata.last_sequence_number = snapshot->sequence_number;
-	ret.table_metadata.current_snapshot_id = snapshot->snapshot_id;
 	return ret;
 }
 

--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -414,6 +414,9 @@ IcebergTableMetadata IcebergTableMetadata::FromTableMetadata(const rest_api_obje
 		res.last_partition_field_id = table_metadata.last_partition_id;
 	}
 
+	for (auto &item : table_metadata.metadata_log.value) {
+		res.metadata_log.emplace_back(item.metadata_file, item.timestamp_ms);
+	}
 	return res;
 }
 

--- a/src/include/core/metadata/iceberg_table_metadata.hpp
+++ b/src/include/core/metadata/iceberg_table_metadata.hpp
@@ -18,6 +18,16 @@ namespace duckdb {
 const string WRITE_UPDATE_MODE = "write.update.mode";
 const string WRITE_DELETE_MODE = "write.delete.mode";
 
+struct IcebergMetadataLogItem {
+public:
+	IcebergMetadataLogItem(const string &path, int64_t timestamp_ms) : metadata_file(path), timestamp_ms(timestamp_ms) {
+	}
+
+public:
+	string metadata_file;
+	int64_t timestamp_ms;
+};
+
 //! A structure to store "LoadTableResult" information that changes as a transaction goes on
 //! Everything is parsed from a load table result, but if a transaction changes a schema, those schema
 //! updates are reflected here and never within the catalog that lives beyond transactions
@@ -122,6 +132,8 @@ public:
 
 	//! table properties
 	case_insensitive_map_t<string> table_properties;
+
+	vector<IcebergMetadataLogItem> metadata_log;
 
 private:
 	int32_t current_schema_id;

--- a/test/sql/local/irc_any_catalog/alter/alter_add_column_warn_schema_mismatch.test
+++ b/test/sql/local/irc_any_catalog/alter/alter_add_column_warn_schema_mismatch.test
@@ -79,41 +79,44 @@ WARNING	Detected schema change during transaction (schema_id mismatch); ACID gua
 statement ok con2
 INSERT INTO my_datalake.default.alter_add_column_explicit_txn VALUES (42);
 
-# Now that we did the insert, the code at IcebergTableSet::GetEntry sees that the table has been updated within the transaction,
-# and does a snapshot lookup with LATEST instead of FROM_TIMESTAMP, therefore using current_schema_id instead. That's why we see the new column.
-query II con2
+query I con2
 FROM my_datalake.default.alter_add_column_explicit_txn ORDER BY a;
 ----
-0	NULL
-1	NULL
-2	NULL
-3	NULL
-4	NULL
-5	NULL
-6	NULL
-7	NULL
-8	NULL
-9	NULL
-42	NULL
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+42
+
+statement error con2
+INSERT INTO my_datalake.default.alter_add_column_explicit_txn VALUES (43, 43);
+----
+Binder Error: table alter_add_column_explicit_txn has 1 columns but 2 values were supplied
 
 statement ok con2
-INSERT INTO my_datalake.default.alter_add_column_explicit_txn VALUES (43, 43);
+INSERT INTO my_datalake.default.alter_add_column_explicit_txn VALUES (43);
 
-query II con2
+query I con2
 FROM my_datalake.default.alter_add_column_explicit_txn ORDER BY a;
 ----
-0	NULL
-1	NULL
-2	NULL
-3	NULL
-4	NULL
-5	NULL
-6	NULL
-7	NULL
-8	NULL
-9	NULL
-42	NULL
-43	43
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+42
+43
 
 statement ok con2
 commit;

--- a/test/sql/local/irc_any_catalog/alter/alter_rename_column.test
+++ b/test/sql/local/irc_any_catalog/alter/alter_rename_column.test
@@ -133,20 +133,18 @@ select alias(COLUMNS(*)) from my_datalake.default.tbl limit 1
 ----
 a	b
 
-# FIXME: con2 should not see the rename made by con1 yet, but we need to look at metadata-log to fix this
-statement error con2
+statement ok con2
 ALTER TABLE my_datalake.default.tbl RENAME b TO c;
-----
-Catalog Error: Column with name 'c' already exists on the table 'tbl', RENAME COLUMN failed
 
-# But when querying the table, we do fetch the snapshot for the transaction, which still uses the old schema
 query II con2
 select alias(COLUMNS(*)) from my_datalake.default.tbl limit 1
 ----
-a	b
+a	c
 
-statement ok con2
+statement error con2
 commit
+----
+<REGEX>:.*TransactionContext Error: Failed to commit.*
 
 # Rename to previously existing name
 


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/8774
Follow up to #932 

Should make us grab the right `schema-id` in more places