### PR TITLE
[ALTER] Support adjusting to an existing schema id

### DIFF
--- a/src/catalog/rest/catalog_entry/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/iceberg_schema_entry.cpp
@@ -329,12 +329,16 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		new_schema->schema_id++;
 		new_schema->columns.push_back(std::move(new_iceberg_column));
 		auto new_schema_id = new_schema->schema_id;
-		// Update the Table Metadata to have our new schema
-		updated_table.CreateSchemaVersion(*new_schema);
-		transaction_data.TableAddSchema(new_schema_id);
 
-		updated_table.table_metadata.AddSchema(std::move(new_schema));
-		updated_table.table_metadata.SetCurrentSchemaId(new_schema_id);
+		auto &result_schema = updated_table.table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
+		if (result_schema.schema_id == new_schema_id) {
+			// Update the Table Metadata to have our new schema
+			updated_table.CreateSchemaVersion(result_schema);
+			transaction_data.TableAddSchema(new_schema_id);
+		} else {
+			transaction_data.TableSetCurrentSchema();
+		}
+		updated_table.table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 		return;
 	}
 	case AlterTableType::REMOVE_COLUMN: {
@@ -372,11 +376,16 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		}
 
 		auto new_schema_id = new_schema->schema_id;
-		// Update the Table Metadata to have our new schema
-		updated_table.CreateSchemaVersion(*new_schema);
-		transaction_data.TableAddSchema(new_schema_id);
-		updated_table.table_metadata.AddSchema(std::move(new_schema));
-		updated_table.table_metadata.SetCurrentSchemaId(new_schema_id);
+
+		auto &result_schema = updated_table.table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
+		if (result_schema.schema_id == new_schema_id) {
+			// Update the Table Metadata to have our new schema
+			updated_table.CreateSchemaVersion(result_schema);
+			transaction_data.TableAddSchema(new_schema_id);
+		} else {
+			transaction_data.TableSetCurrentSchema();
+		}
+		updated_table.table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 		return;
 	}
 	case AlterTableType::ALTER_COLUMN_TYPE: {
@@ -399,12 +408,16 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		column.type = change_type_info.target_type;
 
 		auto new_schema_id = new_schema->schema_id;
-		// Update the Table Metadata to have our new schema
-		updated_table.CreateSchemaVersion(*new_schema);
-		transaction_data.TableAddSchema(new_schema_id);
 
-		updated_table.table_metadata.AddSchema(std::move(new_schema));
-		updated_table.table_metadata.SetCurrentSchemaId(new_schema_id);
+		auto &result_schema = updated_table.table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
+		if (result_schema.schema_id == new_schema_id) {
+			// Update the Table Metadata to have our new schema
+			updated_table.CreateSchemaVersion(result_schema);
+			transaction_data.TableAddSchema(new_schema_id);
+		} else {
+			transaction_data.TableSetCurrentSchema();
+		}
+		updated_table.table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 		return;
 	}
 	case AlterTableType::RENAME_TABLE: {
@@ -451,12 +464,16 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		column.name = new_name;
 
 		auto new_schema_id = new_schema->schema_id;
-		// Update the Table Metadata to have our new schema
-		updated_table.CreateSchemaVersion(*new_schema);
-		transaction_data.TableAddSchema(new_schema_id);
 
-		updated_table.table_metadata.AddSchema(std::move(new_schema));
-		updated_table.table_metadata.SetCurrentSchemaId(new_schema_id);
+		auto &result_schema = updated_table.table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
+		if (result_schema.schema_id == new_schema_id) {
+			// Update the Table Metadata to have our new schema
+			updated_table.CreateSchemaVersion(result_schema);
+			transaction_data.TableAddSchema(new_schema_id);
+		} else {
+			transaction_data.TableSetCurrentSchema();
+		}
+		updated_table.table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 		return;
 	}
 	case AlterTableType::SET_DEFAULT: {
@@ -482,12 +499,16 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		column.write_default = make_uniq<Value>(default_constant_value);
 
 		auto new_schema_id = new_schema->schema_id;
-		// Update the Table Metadata to have our new schema
-		updated_table.CreateSchemaVersion(*new_schema);
-		transaction_data.TableAddSchema(new_schema_id);
 
-		updated_table.table_metadata.AddSchema(std::move(new_schema));
-		updated_table.table_metadata.SetCurrentSchemaId(new_schema_id);
+		auto &result_schema = updated_table.table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
+		if (result_schema.schema_id == new_schema_id) {
+			// Update the Table Metadata to have our new schema
+			updated_table.CreateSchemaVersion(result_schema);
+			transaction_data.TableAddSchema(new_schema_id);
+		} else {
+			transaction_data.TableSetCurrentSchema();
+		}
+		updated_table.table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 		return;
 	}
 	default: {

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -223,7 +223,11 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 	auto new_schema = IcebergCreateTableRequest::CreateIcebergSchema(context, table_metadata, table_ptr->GetColumns(),
 	                                                                 table_ptr->GetConstraints(), last_column_id);
 	new_schema->schema_id = 0;
-	table_metadata.AddSchema(std::move(new_schema));
+	auto &result_schema = table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
+	if (result_schema.schema_id != 0) {
+		throw InternalException("Adding initial schema didn't result in schema id 0? (actual: %d)",
+		                        result_schema.schema_id);
+	}
 	table_metadata.SetCurrentSchemaId(0);
 	table_metadata.last_column_id = last_column_id;
 

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -365,7 +365,7 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 			commit_state.table_change.requirements.push_back(CreateAssertNoSnapshotRequirement());
 		}
 
-		if (!transaction_data.schema_updates.empty()) {
+		if (transaction_data.set_schema_id) {
 			SetCurrentSchema update(table_info);
 			update.CreateUpdate(db, context, commit_state);
 		}
@@ -434,8 +434,9 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 
 		// if there are no new tables, we can post to the transactions/commit endpoint
 		// otherwise we fall back to posting a commit for each table.
-		if (!transaction_info.has_assert_create &&
-		    catalog.supported_urls.find("POST /v1/{prefix}/transactions/commit") != catalog.supported_urls.end()) {
+		const bool can_use_multi_table_commit = !transaction_info.has_assert_create &&
+		                                        catalog.supported_urls.count("POST /v1/{prefix}/transactions/commit");
+		if (can_use_multi_table_commit) {
 			// commit all transactions at once
 			std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
 			auto doc = doc_p.get();
@@ -449,8 +450,7 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 				alter_update.committed_tables.insert(it.first);
 			}
 		} else {
-			D_ASSERT(catalog.supported_urls.find("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}") !=
-			         catalog.supported_urls.end());
+			D_ASSERT(catalog.supported_urls.count("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}"));
 			// each table change will make a separate request
 			for (auto &it : transaction_info.table_requests) {
 				auto &table_change = transaction.table_changes[it.second];

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -149,9 +149,13 @@ void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&de
 
 void IcebergTransactionData::TableAddSchema(int32_t schema_id) {
 	auto add_schema_update = make_uniq<AddSchemaUpdate>(table_info, schema_id);
-	schema_updates.push_back(*add_schema_update);
 	updates.push_back(std::move(add_schema_update));
 	assert_schema_id = true;
+	set_schema_id = true;
+}
+
+void IcebergTransactionData::TableSetCurrentSchema() {
+	set_schema_id = true;
 }
 
 void IcebergTransactionData::TableAssignUUID() {

--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -282,19 +282,18 @@ int32_t IcebergTableMetadata::GetCurrentSchemaId() const {
 	return current_schema_id;
 }
 
-void IcebergTableMetadata::AddSchema(shared_ptr<IcebergTableSchema> schema) {
-	optional_idx existing_schema_id;
+IcebergTableSchema &IcebergTableMetadata::AddSchemaOrGetExisting(shared_ptr<IcebergTableSchema> schema) {
+	optional_ptr<IcebergTableSchema> existing_schema;
 	for (auto &it : schemas) {
-		auto &id = it.first;
-		auto &existing_schema = *it.second;
+		auto &item = *it.second;
 
-		if (schema->Equals(existing_schema)) {
-			existing_schema_id = id;
+		if (schema->Equals(item)) {
+			existing_schema = item;
 			break;
 		}
 	}
-	if (existing_schema_id.IsValid()) {
-		throw NotImplementedException("Attempted to add a schema that already exists in the table");
+	if (existing_schema) {
+		return *existing_schema;
 	}
 	auto new_schema_id = schema->schema_id;
 	auto res = schemas.emplace(new_schema_id, std::move(schema));
@@ -302,6 +301,7 @@ void IcebergTableMetadata::AddSchema(shared_ptr<IcebergTableSchema> schema) {
 		throw InvalidConfigurationException("Attempted to add schema with id %d, but this already exists in the table!",
 		                                    new_schema_id);
 	}
+	return *res.first->second;
 }
 
 const unordered_map<int32_t, shared_ptr<IcebergTableSchema>> &IcebergTableMetadata::GetSchemas() const {

--- a/src/function/copy/iceberg_copy_function.cpp
+++ b/src/function/copy/iceberg_copy_function.cpp
@@ -59,7 +59,10 @@ CopyIcebergBindData::CopyIcebergBindData(const CopyInfo &info, vector<string> &&
 	table_schema =
 	    IcebergCreateTableRequest::CreateIcebergSchema(context, *table_metadata, columns, nullptr, last_column_id);
 	table_schema->schema_id = 0;
-	table_metadata->AddSchema(table_schema);
+	auto &result_schema = table_metadata->AddSchemaOrGetExisting(table_schema);
+	if (result_schema.schema_id != 0) {
+		throw InternalException("Iceberg COPY created non-0 schema id (%d)", result_schema.schema_id);
+	}
 	table_metadata->SetCurrentSchemaId(0);
 	//! FIXME: adapt when we have partitioning support
 	table_metadata->partition_specs.emplace(0, IcebergPartitionSpec(0));

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -30,6 +30,7 @@ public:
 	                       IcebergManifestDeletes &&altered_manifests);
 	// add a schema update for a table
 	void TableAddSchema(int32_t schema_id);
+	void TableSetCurrentSchema();
 	void TableAddAssertCreate();
 	void TableAddAssertCurrentSchemaId();
 	void TableAddAssertLastAssignedFieldId();
@@ -61,7 +62,6 @@ public:
 
 	//! Every insert/update/delete creates an alter of the table data
 	vector<reference<IcebergAddSnapshot>> alters;
-	vector<reference<AddSchemaUpdate>> schema_updates;
 	//! The 'referenced_data_file' -> 'data_file.file_path' of the currently active transaction-local deletes
 	case_insensitive_map_t<string> transactional_delete_files;
 	//! Track the current row id for this transaction
@@ -69,6 +69,8 @@ public:
 
 	//! If we perform an update that relies on the current schema id staying unchanged
 	bool assert_schema_id = false;
+	//! Whether the current schema of the table should be updated
+	bool set_schema_id = false;
 	mutex lock;
 };
 

--- a/src/include/core/metadata/iceberg_table_metadata.hpp
+++ b/src/include/core/metadata/iceberg_table_metadata.hpp
@@ -89,7 +89,7 @@ public:
 	void SetCurrentSchemaId(int32_t schema_id);
 	int32_t GetCurrentSchemaId() const;
 
-	void AddSchema(shared_ptr<IcebergTableSchema> schema);
+	IcebergTableSchema &AddSchemaOrGetExisting(shared_ptr<IcebergTableSchema> schema);
 	const unordered_map<int32_t, shared_ptr<IcebergTableSchema>> &GetSchemas() const;
 
 private:

--- a/test/sql/local/irc_any_catalog/alter/alter_default.test
+++ b/test/sql/local/irc_any_catalog/alter/alter_default.test
@@ -88,26 +88,12 @@ select * from my_datalake.default.drop_default order by all
 hello world	false
 test	true
 
-# FIXME: https://github.com/duckdb/duckdb-iceberg/pull/911
-
-# DROP DEFAULT will set the 'write-default' to NULL, which is a state that already existed on the table
-statement error
-ALTER TABLE my_datalake.default.drop_default ALTER COLUMN b DROP DEFAULT;
-----
-Not implemented Error: Attempted to add a schema that already exists in the table
-
-statement ok
-ALTER TABLE my_datalake.default.drop_default ADD COLUMN c INTEGER;
-
-# Now it's fine, because the old state didn't have the 'c' column
 statement ok
 ALTER TABLE my_datalake.default.drop_default ALTER COLUMN b DROP DEFAULT;
 
 statement ok
 insert into my_datalake.default.drop_default(a) VALUES ('not null')
 
-# By dropping the default, the 'initial-default' value gets used instead
-# note that because of this, if 'initial-default' is not NULL, it's not possible to make the DEFAULT for new rows be NULL
 query II
 select a, b from my_datalake.default.drop_default order by all
 ----

--- a/test/sql/local/irc_any_catalog/alter/test_add_existing_schema.test
+++ b/test/sql/local/irc_any_catalog/alter/test_add_existing_schema.test
@@ -35,9 +35,25 @@ CREATE TABLE my_datalake.default.existing_schema_add(
 )
 
 statement ok
+insert into my_datalake.default.existing_schema_add VALUES ('test', true)
+
+query II
+select * from my_datalake.default.existing_schema_add order by all
+----
+test	true
+
+statement ok
 ALTER TABLE my_datalake.default.existing_schema_add ADD COLUMN c INTEGER;
 
-statement error
-ALTER TABLE my_datalake.default.existing_schema_add DROP COLUMN c;
+query III
+select * from my_datalake.default.existing_schema_add order by all
 ----
-Not implemented Error: Attempted to add a schema that already exists in the table
+test	true	NULL
+
+statement ok
+ALTER TABLE my_datalake.default.existing_schema_add DROP COLUMN c;
+
+query II
+select * from my_datalake.default.existing_schema_add order by all
+----
+test	true


### PR DESCRIPTION
This PR fixes #935 

Replaced:
`void IcebergTableMetadata::AddSchema`
with:
`IcebergTableSchema &IcebergTableMetadata::AddSchemaOrGetExisting`

Adjusted callers of `AddSchema` to check the return and conditionally perform a `TableAddSchema` or `TableSetCurrentSchema` call.