### PR TITLE
[Dev] Fix rollback infinite recursion

### DIFF
--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -569,6 +569,30 @@ void IcebergTransaction::DoSchemaDeletes(ClientContext &context) {
 	deleted_schemas.clear();
 }
 
+namespace {
+
+struct ScopedTransaction {
+public:
+	ScopedTransaction(DatabaseInstance &db) : connection(db) {
+		connection.BeginTransaction();
+	}
+	~ScopedTransaction() {
+		//! Prevent the connection from destructing with an active transaction
+		//! As that causes it to ROLLBACK and enter CleanupFiles - resulting in a stack overflow due to recursion
+		connection.Commit();
+	}
+
+public:
+	ClientContext &GetContext() {
+		return *connection.context;
+	}
+
+public:
+	Connection connection;
+};
+
+} // namespace
+
 void IcebergTransaction::CleanupFiles() {
 	// remove any files that were written
 	if (!catalog.attach_options.allows_deletes) {
@@ -577,10 +601,9 @@ void IcebergTransaction::CleanupFiles() {
 		// on the aws side will result in an error.
 		return;
 	}
-	Connection temp_con(db);
-	temp_con.BeginTransaction();
-	auto &temp_con_context = temp_con.context;
-	auto &fs = FileSystem::GetFileSystem(*temp_con_context);
+	ScopedTransaction temp_con(db);
+	auto &temp_context = temp_con.GetContext();
+	auto &fs = FileSystem::GetFileSystem(temp_context);
 
 	for (auto &transaction_update : transaction_updates) {
 		if (transaction_update->type != IcebergTransactionUpdateType::ALTER) {
@@ -605,8 +628,8 @@ void IcebergTransaction::CleanupFiles() {
 					continue;
 				}
 				// we need to recreate the keys in the current context.
-				auto &ic_table_entry = table.GetLatestSchema(*temp_con_context)->Cast<IcebergTableEntry>();
-				ic_table_entry.PrepareIcebergScanFromEntry(*temp_con_context);
+				auto &ic_table_entry = table.GetLatestSchema(temp_context)->Cast<IcebergTableEntry>();
+				ic_table_entry.PrepareIcebergScanFromEntry(temp_context);
 
 				auto &add_snapshot = update->Cast<IcebergAddSnapshot>();
 				const auto manifest_list_entries = add_snapshot.GetManifestFiles();
@@ -614,7 +637,7 @@ void IcebergTransaction::CleanupFiles() {
 					for (auto &manifest_entry : manifest.manifest_entries) {
 						auto &data_file = manifest_entry.data_file;
 						if (fs.TryRemoveFile(data_file.file_path)) {
-							DUCKDB_LOG(*temp_con_context, IcebergLogType,
+							DUCKDB_LOG(temp_context, IcebergLogType,
 							           "Iceberg Transaction Cleanup, deleted 'data_file': '%s'", data_file.file_path);
 						}
 					}

--- a/test/configs/fixture_duckdb_tests.json
+++ b/test/configs/fixture_duckdb_tests.json
@@ -10,37 +10,6 @@
   ],
   "skip_tests": [
     {
-      "reason": "SEGFAULT",
-      "paths": [
-        "test/sql/alter/rename_table/test_rename_table_many_transactions.test",
-        "test/sql/alter/rename_view/test_rename_view_many_transactions.test",
-        "test/sql/catalog/dependencies/test_prepare_dependencies_transactions.test",
-        "test/sql/catalog/test_schema.test",
-        "test/sql/delete/cleanup_delete_on_conflict.test",
-        "test/sql/insert/unaligned_interleaved_appends.test",
-        "test/sql/parallelism/interquery/concurrent_pk_transactional_appends.test_slow",
-        "test/sql/storage/multiple_clients_checkpoing_dependents.test_slow",
-        "test/sql/transactions/conflict_drop_then_delete.test",
-        "test/sql/transactions/conflict_rename_append.test",
-        "test/sql/transactions/rollback_drop.test",
-        "test/sql/transactions/test_null_version.test",
-        "test/sql/update/test_cascading_updates.test",
-        "test/sql/update/test_update_many_updaters.test",
-        "test/sql/update/test_update_many_updaters_nulls.test",
-        "test/sql/index/art/constraints/test_art_tx_conflict_revert.test",
-        "test/sql/index/art/constraints/test_art_tx_deletes_list.test",
-        "test/sql/index/art/constraints/test_art_tx_deletes_rollback.test",
-        "test/sql/index/art/constraints/test_art_tx_deletes_varchar.test",
-        "test/sql/index/art/constraints/test_art_tx_updates_list.test",
-        "test/sql/index/art/constraints/test_art_tx_updates_rollback.test",
-        "test/sql/index/art/constraints/test_art_tx_upserts_list.test",
-        "test/sql/index/art/constraints/test_art_tx_upserts_rollback.test",
-        "test/sql/index/art/create_drop/test_art_create_index_delete.test",
-        "test/sql/index/art/create_drop/test_art_create_if_exists.test",
-        "test/sql/index/art/create_drop/test_art_many_versions.test"
-      ]
-    },
-    {
       "reason": "Checks available databases/schemas",
       "paths": [
         "test/sql/attach/attach_did_you_mean.test",


### PR DESCRIPTION
In `CleanupFiles` we have to create a temporary `Connection` to hold credentials of the table, so we can clean up any files we created when the transaction aborted.

But this Connection holds an active transaction, and when the connection is destroyed, it triggers a Rollback - which enters `CleanupFiles`

^ That caused an infinite recursion.
The fix is to make sure that the transaction always commits before the connection is destroyed.