### PR TITLE
[Dev] Remove `requested_tables`, merge it with `current_table_data`

### DIFF
--- a/src/catalog/rest/catalog_entry/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/iceberg_schema_entry.cpp
@@ -52,7 +52,7 @@ bool IcebergSchemaEntry::HandleCreateConflict(CatalogTransaction &transaction, C
 		auto &iceberg_transaction = GetICTransaction(transaction);
 		auto table_key = IcebergTableInformation::GetTableKey(namespace_items, entry_name);
 		auto latest_state = iceberg_transaction.GetLatestTableState(table_key);
-		if (latest_state && latest_state->status != IcebergTableStatus::ALIVE) {
+		if (latest_state && latest_state->IsDroppedOrRenamed()) {
 			auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 			vector<string> qualified_name = {ic_catalog.GetName()};
 			qualified_name.insert(qualified_name.end(), namespace_items.begin(), namespace_items.end());
@@ -448,12 +448,11 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			auto &other_table_info = other_table_entry.table_info;
 			auto other_table_key = other_table_info.GetTableKey();
 			auto state = irc_transaction.GetLatestTableState(other_table_key);
-			if (!state || state->status == IcebergTableStatus::ALIVE) {
+			if (!state || state->IsAlive()) {
 				throw CatalogException("Table with name \"%s\" already exists!", new_name);
 			}
 			//! The table is dropped or renamed by this transaction, so it's not a conflict anymore
-			D_ASSERT(state &&
-			         (state->status == IcebergTableStatus::DROPPED || state->status == IcebergTableStatus::RENAMED));
+			D_ASSERT(state && state->IsDroppedOrRenamed());
 		}
 		irc_transaction.RenameTable(updated_table, new_name);
 		break;

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -278,6 +278,8 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 	transaction_data.TableSetDefaultSortOrder();
 	transaction_data.TableSetLocation();
 	transaction_data.TableSetProperties(table_metadata.table_properties);
+
+	iceberg_transaction.SetLatestTableState(table_info, IcebergTableStatus::ALIVE);
 	return table_info;
 }
 
@@ -323,7 +325,7 @@ optional_ptr<CatalogEntry> IcebergTableSet::GetEntry(ClientContext &context, con
 			entries.erase(table_name);
 		}
 		//! The table doesn't exist in the catalog
-		auto &state = iceberg_transaction.SetLatestTableState(table_key, IcebergTableStatus::MISSING);
+		iceberg_transaction.SetLatestTableState(table_key, IcebergTableStatus::MISSING);
 		return nullptr;
 	}
 

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -299,30 +299,14 @@ optional_ptr<CatalogEntry> IcebergTableSet::GetEntry(ClientContext &context, con
 	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
 	const auto &table_name = lookup.GetEntryName();
 	// first check transaction entries
-	auto table_key = IcebergTableInformation::GetTableKey(schema.namespace_items, table_name);
+	const auto table_key = IcebergTableInformation::GetTableKey(schema.namespace_items, table_name);
 	auto latest_state = iceberg_transaction.GetLatestTableState(table_key);
 	if (latest_state) {
-		if (latest_state->status != IcebergTableStatus::ALIVE) {
-			// If table has been deleted within the transaction, return null
+		if (!latest_state->IsAlive()) {
+			// If table has been deleted or is missing within the transaction, return null
 			return nullptr;
 		}
-		auto &table_info = latest_state->table.get();
-		auto snapshot_lookup = GetSnapshotLookup(table_info, context, lookup);
-		return table_info.GetSchemaVersion(snapshot_lookup, context);
-	}
-
-	auto previous_request_info = iceberg_transaction.GetTableRequestResult(table_key);
-	if (previous_request_info.exists) {
-		// transaction has already looked up this table, find it in entries
-		auto entry = entries.find(table_name);
-		if (entry == entries.end()) {
-			// table no longer exists (was most likely dropped in another transaction)
-			// TODO: we can recreate the table (but not insert it in the IcebergTableSet) by pulling it back
-			//  out of the MetadataCache. This doesn't make sense in the long run, as the transaction
-			//  will fail regardless
-			return nullptr;
-		}
-		auto &table_info = *entry->second;
+		auto &table_info = latest_state->GetInfo();
 		auto snapshot_lookup = GetSnapshotLookup(table_info, context, lookup);
 		return table_info.GetSchemaVersion(snapshot_lookup, context);
 	}
@@ -338,14 +322,15 @@ optional_ptr<CatalogEntry> IcebergTableSet::GetEntry(ClientContext &context, con
 		} else {
 			entries.erase(table_name);
 		}
-		iceberg_transaction.RecordTableRequest(table_key);
+		//! The table doesn't exist in the catalog
+		auto &state = iceberg_transaction.SetLatestTableState(table_key, IcebergTableStatus::MISSING);
 		return nullptr;
 	}
 
 	iceberg_transaction.tables[table_key] = new_version;
 	IcebergSnapshotLookup snapshot_lookup;
 
-	bool is_time_travel = lookup.GetAtClause();
+	const bool is_time_travel = lookup.GetAtClause();
 	if (!is_time_travel && !table_info.HasTransactionUpdates()) {
 		// if there is no user supplied AT () clause, and the table does not have transaction updates
 		// use transaction start time
@@ -360,15 +345,6 @@ optional_ptr<CatalogEntry> IcebergTableSet::GetEntry(ClientContext &context, con
 	// get the latest information and save it to the transaction cache
 	auto &ic_ret = ret->Cast<IcebergTableEntry>();
 	auto latest_snapshot = ic_ret.table_info.table_metadata.GetLatestSnapshot();
-	idx_t latest_sequence_number, latest_snapshot_id;
-	if (latest_snapshot) {
-		latest_snapshot_id = latest_snapshot->snapshot_id;
-		latest_sequence_number = latest_snapshot->sequence_number;
-	} else {
-		// table is not yet initialized.
-		latest_sequence_number = 0;
-		latest_snapshot_id = -1;
-	}
 
 	// Log warning on schema_id mismatch
 	auto &meta_transaction = MetaTransaction::Get(context);
@@ -383,7 +359,7 @@ optional_ptr<CatalogEntry> IcebergTableSet::GetEntry(ClientContext &context, con
 		    context, "Detected schema change during transaction (schema_id mismatch); ACID guarantees may not hold.");
 	}
 
-	iceberg_transaction.RecordTableRequest(table_key, latest_sequence_number, latest_snapshot_id);
+	iceberg_transaction.SetLatestTableState(table_info, IcebergTableStatus::ALIVE);
 	return ret;
 }
 

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -28,8 +28,8 @@
 
 namespace duckdb {
 
-IcebergTransactionTableState::IcebergTransactionTableState(IcebergTableInformation &table, IcebergTableSource source)
-    : table(table), source(source), status(IcebergTableStatus::ALIVE) {
+IcebergTransactionTableState::IcebergTransactionTableState(optional_ptr<IcebergTableInformation> table)
+    : table(table), status(table ? IcebergTableStatus::ALIVE : IcebergTableStatus::MISSING) {
 }
 
 IcebergTransaction::IcebergTransaction(IcebergCatalog &ic_catalog, TransactionManager &manager, ClientContext &context)
@@ -651,21 +651,6 @@ void IcebergTransaction::Rollback() {
 	CleanupFiles();
 }
 
-void IcebergTransaction::RecordTableRequest(const string &table_key, idx_t sequence_number, idx_t snapshot_id) {
-	requested_tables.emplace(table_key, TableInfoCache(sequence_number, snapshot_id));
-}
-
-void IcebergTransaction::RecordTableRequest(const string &table_key) {
-	requested_tables.emplace(table_key, TableInfoCache(false));
-}
-
-TableInfoCache IcebergTransaction::GetTableRequestResult(const string &table_key) {
-	if (requested_tables.find(table_key) == requested_tables.end()) {
-		return TableInfoCache(false);
-	}
-	return requested_tables.at(table_key);
-}
-
 IcebergTransaction &IcebergTransaction::Get(ClientContext &context, Catalog &catalog) {
 	D_ASSERT(catalog.GetCatalogType() == "iceberg");
 	return Transaction::Get(context, catalog).Cast<IcebergTransaction>();
@@ -687,17 +672,21 @@ optional_ptr<IcebergTransactionTableState> IcebergTransaction::GetLatestTableSta
 	return it->second;
 }
 
-IcebergTransactionTableState &IcebergTransaction::SetLatestTableState(IcebergTableInformation &table,
-                                                                      IcebergTableSource source) {
-	auto table_key = table.GetTableKey();
+IcebergTransactionTableState &IcebergTransaction::SetLatestTableState(const string &table_key,
+                                                                      IcebergTableStatus status) {
 	auto it = current_table_data.find(table_key);
 	if (it == current_table_data.end()) {
-		it = current_table_data.emplace(table_key, IcebergTransactionTableState(table, source)).first;
-		return it->second;
+		it = current_table_data.emplace(table_key, IcebergTransactionTableState(nullptr)).first;
 	}
-	auto &state = it->second;
-	state.table = table;
-	state.source = source;
+	it->second.SetStatus(status);
+	return it->second;
+}
+
+IcebergTransactionTableState &IcebergTransaction::SetLatestTableState(IcebergTableInformation &table,
+                                                                      IcebergTableStatus status) {
+	auto table_key = table.GetTableKey();
+	auto &state = SetLatestTableState(table_key, status);
+	state.SetTable(table);
 	return state;
 }
 
@@ -717,42 +706,37 @@ IcebergTableInformation &IcebergTransaction::DeleteTable(IcebergTableInformation
 
 	unique_ptr<IcebergTransactionDeleteUpdate> delete_update;
 	if (state) {
-		delete_update = make_uniq<IcebergTransactionDeleteUpdate>(*this, state->table);
+		auto &table_info = state->GetInfo();
+		delete_update = make_uniq<IcebergTransactionDeleteUpdate>(*this, table_info);
 	} else {
 		delete_update = make_uniq<IcebergTransactionDeleteUpdate>(*this, table);
-		auto &deleted_table = delete_update->deleted_table;
-		state = SetLatestTableState(deleted_table, IcebergTableSource::TRANSACTION);
 	}
+	auto &deleted_table = delete_update->deleted_table;
+	state = SetLatestTableState(deleted_table, IcebergTableStatus::DROPPED);
 	transaction_updates.push_back(std::move(delete_update));
-	state->status = IcebergTableStatus::DROPPED;
-	return state->table.get();
+	return state->GetInfo();
 }
 
 IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation &table, const string &new_name) {
 	auto table_key = table.GetTableKey();
 	auto state = GetLatestTableState(table_key);
 	if (state) {
-		auto &original_table = state->table.get();
+		auto &original_table = state->GetInfo();
 		if (original_table.HasTransactionUpdates()) {
 			throw CatalogException("This table (%s) was modified already, can't be renamed!", table.name);
 		}
 	}
 
-	if (!state) {
-		state = SetLatestTableState(table, IcebergTableSource::EXTERNAL);
-	}
-	//! Set the status of the old name to RENAMED
-	state->status = IcebergTableStatus::RENAMED;
+	state = SetLatestTableState(table, IcebergTableStatus::RENAMED);
 
 	//! Create the rename update, creating the new IcebergTableInformation in the process
-	auto rename = make_uniq<IcebergTransactionRenameUpdate>(*this, state->table, new_name);
+	auto rename = make_uniq<IcebergTransactionRenameUpdate>(*this, state->GetInfo(), new_name);
 	auto &rename_update = *rename;
 	transaction_updates.push_back(std::move(rename));
 
 	//! Update the state of the renamed table
 	auto &new_table = rename_update.new_table;
-	auto &new_table_state = SetLatestTableState(new_table, IcebergTableSource::TRANSACTION);
-	new_table_state.status = IcebergTableStatus::ALIVE;
+	SetLatestTableState(new_table, IcebergTableStatus::ALIVE);
 	new_table.InitSchemaVersions();
 
 	auto locked_context = context.lock();
@@ -766,7 +750,7 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 	table_request_cache.SetOrOverwriteInternal(cache_guard, client_context, new_table_key, cache->expires_at,
 	                                           std::move(cache->load_table_result));
 	table_request_cache.ExpireInternal(cache_guard, client_context, table_key);
-	return state->table;
+	return state->GetInfo();
 }
 
 void ApplyTableUpdate(IcebergTableInformation &table_info, IcebergTransaction &iceberg_transaction,

--- a/src/catalog/rest/transaction/iceberg_transaction_update.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_update.cpp
@@ -22,8 +22,7 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::GetOrInitializeTable(con
 		it = updated_tables.emplace(table_key, table.Copy(transaction)).first;
 		it->second.InitSchemaVersions();
 	}
-
-	transaction.SetLatestTableState(it->second, IcebergTableSource::TRANSACTION);
+	transaction.SetLatestTableState(it->second, IcebergTableStatus::ALIVE);
 	return it->second;
 }
 
@@ -34,8 +33,7 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::CreateTable(const string
 		throw InternalException("Table %s was already created somehow?", table_key);
 	}
 
-	transaction.current_table_data.emplace(
-	    table_key, IcebergTransactionTableState(emplace_res.first->second, IcebergTableSource::TRANSACTION));
+	transaction.current_table_data.emplace(table_key, IcebergTransactionTableState(emplace_res.first->second));
 	return emplace_res.first->second;
 }
 

--- a/src/function/metadata/iceberg_table_properties_functions.cpp
+++ b/src/function/metadata/iceberg_table_properties_functions.cpp
@@ -217,10 +217,10 @@ static void GetIcebergTablePropertiesFunction(ClientContext &context, TableFunct
 	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
 	auto table_key = iceberg_table->table_info.GetTableKey();
 	auto table_txn_state = iceberg_transaction.GetLatestTableState(table_key);
-	const IcebergTableInformation *txn_table_info =
-	    table_txn_state ? &table_txn_state->table.get() : &iceberg_table->table_info;
+	const IcebergTableInformation &txn_table_info =
+	    table_txn_state ? table_txn_state->GetInfo() : iceberg_table->table_info;
 
-	const auto &properties = txn_table_info->table_metadata.GetTableProperties();
+	const auto &properties = txn_table_info.table_metadata.GetTableProperties();
 	if (properties.empty()) {
 		output.SetCardinality(0);
 		return;

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -25,33 +25,40 @@ struct TableTransactionInfo {
 	bool has_assert_create = false;
 };
 
-struct TableInfoCache {
-	TableInfoCache(idx_t sequence_number, idx_t snapshot_id)
-	    : sequence_number(sequence_number), snapshot_id(snapshot_id), exists(true) {
-	}
-	TableInfoCache(bool exists_) : sequence_number(0), snapshot_id(0), exists(exists_) {
-	}
-	idx_t sequence_number;
-	idx_t snapshot_id;
-	bool exists;
-};
-
-enum class IcebergTableStatus : uint8_t { ALIVE, DROPPED, RENAMED };
-
-enum class IcebergTableSource : uint8_t {
-	//! Loaded from external source
-	EXTERNAL,
-	//! Version that exists within the transaction
-	TRANSACTION
-};
+enum class IcebergTableStatus : uint8_t { ALIVE, DROPPED, RENAMED, MISSING };
 
 struct IcebergTransactionTableState {
 public:
-	IcebergTransactionTableState(IcebergTableInformation &table, IcebergTableSource source);
+	IcebergTransactionTableState(optional_ptr<IcebergTableInformation> table);
 
 public:
-	reference<IcebergTableInformation> table;
-	IcebergTableSource source;
+	IcebergTableInformation &GetInfo() {
+		if (!table) {
+			throw InternalException("GetInfo called on IcebergTransactionTableState without a table, status: %d",
+			                        static_cast<uint8_t>(status));
+		}
+		return *table;
+	}
+
+public:
+	bool IsDroppedOrRenamed() const {
+		return status == IcebergTableStatus::DROPPED || status == IcebergTableStatus::RENAMED;
+	}
+	bool IsMissing() const {
+		return status == IcebergTableStatus::MISSING;
+	}
+	bool IsAlive() const {
+		return status == IcebergTableStatus::ALIVE;
+	}
+	void SetStatus(IcebergTableStatus value) {
+		status = value;
+	}
+	void SetTable(IcebergTableInformation &value) {
+		table = value;
+	}
+
+private:
+	optional_ptr<IcebergTableInformation> table;
 	IcebergTableStatus status;
 };
 
@@ -76,11 +83,9 @@ public:
 	IcebergCatalog &GetCatalog();
 	void DropSecrets(ClientContext &context);
 	TableTransactionInfo GetTransactionRequest(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
-	void RecordTableRequest(const string &table_key, idx_t sequence_number, idx_t snapshot_id);
-	void RecordTableRequest(const string &table_key);
-	TableInfoCache GetTableRequestResult(const string &table_key);
 	optional_ptr<IcebergTransactionTableState> GetLatestTableState(const string &table_key);
-	IcebergTransactionTableState &SetLatestTableState(IcebergTableInformation &table, IcebergTableSource source);
+	IcebergTransactionTableState &SetLatestTableState(IcebergTableInformation &table, IcebergTableStatus status);
+	IcebergTransactionTableState &SetLatestTableState(const string &table_key, IcebergTableStatus status);
 	bool StartedBefore(timestamp_t timestamp_ms) const;
 	IcebergTransactionAlterUpdate &GetOrCreateAlter();
 	IcebergTableInformation &DeleteTable(IcebergTableInformation &table);
@@ -93,12 +98,6 @@ private:
 	DatabaseInstance &db;
 	IcebergCatalog &catalog;
 	AccessMode access_mode;
-	//! Tables that have been requested in the current transaction
-	//! and do not need to be requested again. When we request, we also
-	//! store the latest snapshot id, so if the table is requested again
-	//! (with no updates), we can return table information at that snapshot
-	//! while other transactions can still request up to date tables
-	case_insensitive_map_t<TableInfoCache> requested_tables;
 
 public:
 	//! Tables referenced by this transaction that have to stay alive for the duration of the transaction.


### PR DESCRIPTION
The two were doing similar things, didn't make sense to keep both, so I've merged the two

### Summary of Changes
- Removed `IcebergTransaction::requested_tables`
- Removed `TableInfoCache` struct
- Made `IcebergTransactionTableState::table` an `optional_ptr` instead of a reference
- Added `IcebergTableStatus::MISSING`