### PR TITLE
[Dev] Use correct metadata for the current transaction during CRUD operations.

### DIFF
--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -535,7 +535,23 @@ bool IcebergTableInformation::TableIsEmpty(const IcebergSnapshotLookup &snapshot
 }
 
 bool IcebergTableInformation::HasTransactionUpdates() const {
-	return transaction_data && (!transaction_data->updates.empty() || !transaction_data->requirements.empty());
+	if (!transaction_data) {
+		return false;
+	}
+	auto &data = *transaction_data;
+	if (!data.updates.empty()) {
+		return true;
+	}
+	if (!data.requirements.empty()) {
+		return true;
+	}
+	if (data.set_schema_id) {
+		return true;
+	}
+	if (data.assert_schema_id) {
+		return true;
+	}
+	return false;
 }
 
 IcebergTableInformation IcebergTableInformation::Copy() const {

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -428,42 +428,42 @@ void IcebergTransaction::Commit() {
 }
 
 void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context) {
-	if (!alter_update.updated_tables.empty()) {
-		auto transaction_info = GetTransactionRequest(alter_update, context);
-		auto &transaction = transaction_info.request;
-
-		// if there are no new tables, we can post to the transactions/commit endpoint
-		// otherwise we fall back to posting a commit for each table.
-		const bool can_use_multi_table_commit = !transaction_info.has_assert_create &&
-		                                        catalog.supported_urls.count("POST /v1/{prefix}/transactions/commit");
-		if (can_use_multi_table_commit) {
-			// commit all transactions at once
-			std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
-			auto doc = doc_p.get();
-			auto root_object = yyjson_mut_obj(doc);
-			yyjson_mut_doc_set_root(doc, root_object);
-
-			CommitTransactionToJSON(doc, root_object, transaction);
-			auto transaction_json = JsonDocToString(std::move(doc_p));
-			IRCAPI::CommitMultiTableUpdate(context, catalog, transaction_json);
-			for (auto &it : alter_update.updated_tables) {
-				alter_update.committed_tables.insert(it.first);
-			}
-		} else {
-			D_ASSERT(catalog.supported_urls.count("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}"));
-			// each table change will make a separate request
-			for (auto &it : transaction_info.table_requests) {
-				auto &table_change = transaction.table_changes[it.second];
-				D_ASSERT(table_change.has_identifier);
-				auto transaction_json = ConstructTableUpdateJSON(table_change);
-				IRCAPI::CommitTableUpdate(context, catalog, table_change.identifier._namespace.value,
-				                          table_change.identifier.name, transaction_json);
-				alter_update.committed_tables.insert(it.first);
-			}
-		}
-		// updated_tables.clear();
-		DropSecrets(context);
+	if (!alter_update.HasUpdates()) {
+		return;
 	}
+	auto transaction_info = GetTransactionRequest(alter_update, context);
+	auto &transaction = transaction_info.request;
+
+	// if there are no new tables, we can post to the transactions/commit endpoint
+	// otherwise we fall back to posting a commit for each table.
+	const bool can_use_multi_table_commit =
+	    !transaction_info.has_assert_create && catalog.supported_urls.count("POST /v1/{prefix}/transactions/commit");
+	if (can_use_multi_table_commit) {
+		// commit all transactions at once
+		std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
+		auto doc = doc_p.get();
+		auto root_object = yyjson_mut_obj(doc);
+		yyjson_mut_doc_set_root(doc, root_object);
+
+		CommitTransactionToJSON(doc, root_object, transaction);
+		auto transaction_json = JsonDocToString(std::move(doc_p));
+		IRCAPI::CommitMultiTableUpdate(context, catalog, transaction_json);
+		for (auto &it : alter_update.updated_tables) {
+			alter_update.committed_tables.insert(it.first);
+		}
+	} else {
+		D_ASSERT(catalog.supported_urls.count("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}"));
+		// each table change will make a separate request
+		for (auto &it : transaction_info.table_requests) {
+			auto &table_change = transaction.table_changes[it.second];
+			D_ASSERT(table_change.has_identifier);
+			auto transaction_json = ConstructTableUpdateJSON(table_change);
+			IRCAPI::CommitTableUpdate(context, catalog, table_change.identifier._namespace.value,
+			                          table_change.identifier.name, transaction_json);
+			alter_update.committed_tables.insert(it.first);
+		}
+	}
+	DropSecrets(context);
 }
 
 static yyjson_mut_val *CreateRenameComponentJSON(yyjson_mut_doc *doc, const IcebergSchemaEntry &schema,

--- a/src/catalog/rest/transaction/iceberg_transaction_update.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_update.cpp
@@ -26,6 +26,16 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::GetOrInitializeTable(con
 	return it->second;
 }
 
+bool IcebergTransactionAlterUpdate::HasUpdates() const {
+	for (auto &it : updated_tables) {
+		auto &table = it.second;
+		if (table.HasTransactionUpdates()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 IcebergTableInformation &IcebergTransactionAlterUpdate::CreateTable(const string &table_key,
                                                                     IcebergTableInformation &&table) {
 	auto emplace_res = updated_tables.emplace(table_key, std::move(table));

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -428,6 +428,7 @@ PhysicalOperator &IcebergCatalog::PlanDelete(ClientContext &context, PhysicalPla
 		throw BinderException("RETURNING clause not yet supported for deletion from Iceberg table");
 	}
 	auto &table_entry = op.table.Cast<IcebergTableEntry>();
+	table_entry.PrepareIcebergScanFromEntry(context);
 
 	auto &irc_transaction = IcebergTransaction::Get(context, *this);
 	auto &alter = irc_transaction.GetOrCreateAlter();

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -20,6 +20,7 @@
 #include "core/metadata/manifest/iceberg_manifest.hpp"
 
 #include "core/deletes/iceberg_deletion_vector.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_update.hpp"
 
 namespace duckdb {
 class IcebergDeleteLocalState;
@@ -337,6 +338,7 @@ SinkFinalizeType IcebergDelete::Finalize(Pipeline &pipeline, Event &event, Clien
 
 	// write out the new manifest file
 	auto &irc_table = table.Cast<IcebergTableEntry>();
+
 	auto &table_info = irc_table.table_info;
 	auto iceberg_delete_files = GenerateDeleteManifestEntries(global_state);
 
@@ -425,11 +427,19 @@ PhysicalOperator &IcebergCatalog::PlanDelete(ClientContext &context, PhysicalPla
 	if (op.return_chunk) {
 		throw BinderException("RETURNING clause not yet supported for deletion from Iceberg table");
 	}
-	auto &ic_table_entry = op.table.Cast<IcebergTableEntry>();
-	auto iceberg_version = ic_table_entry.table_info.table_metadata.iceberg_version;
+	auto &table_entry = op.table.Cast<IcebergTableEntry>();
+
+	auto &irc_transaction = IcebergTransaction::Get(context, *this);
+	auto &alter = irc_transaction.GetOrCreateAlter();
+	auto &updated_table = alter.GetOrInitializeTable(table_entry.table_info);
+	auto &table_metadata = updated_table.table_metadata;
+	auto &schema = table_metadata.GetLatestSchema();
+	auto &updated_table_entry = *updated_table.schema_versions[schema.schema_id];
+
+	auto iceberg_version = updated_table_entry.table_info.table_metadata.iceberg_version;
 	if (iceberg_version < 2) {
 		throw NotImplementedException("Delete from Iceberg V%d tables",
-		                              ic_table_entry.table_info.table_metadata.iceberg_version);
+		                              updated_table_entry.table_info.table_metadata.iceberg_version);
 	}
 
 	vector<idx_t> row_id_indexes;
@@ -444,16 +454,16 @@ PhysicalOperator &IcebergCatalog::PlanDelete(ClientContext &context, PhysicalPla
 		row_id_indexes.push_back(bound_ref.index);
 	}
 
-	auto allows_positional_deletes =
-	    ic_table_entry.table_info.table_metadata.PropertiesAllowPositionalDeletes(IcebergSnapshotOperationType::DELETE);
+	auto allows_positional_deletes = updated_table_entry.table_info.table_metadata.PropertiesAllowPositionalDeletes(
+	    IcebergSnapshotOperationType::DELETE);
 	if (!allows_positional_deletes) {
-		auto delete_table_property = ic_table_entry.table_info.table_metadata.GetTableProperty(WRITE_DELETE_MODE);
+		auto delete_table_property = updated_table_entry.table_info.table_metadata.GetTableProperty(WRITE_DELETE_MODE);
 		auto error_message = IcebergCatalog::GetOnlyMergeOnReadSupportedErrorMessage(
-		    ic_table_entry.name, WRITE_DELETE_MODE, delete_table_property);
+		    updated_table_entry.name, WRITE_DELETE_MODE, delete_table_property);
 		throw NotImplementedException(error_message);
 	}
 
-	auto &iceberg_delete = IcebergDelete::PlanDelete(context, planner, ic_table_entry, plan, row_id_indexes);
+	auto &iceberg_delete = IcebergDelete::PlanDelete(context, planner, updated_table_entry, plan, row_id_indexes);
 	return iceberg_delete;
 }
 

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -26,6 +26,7 @@
 #include "core/expression/iceberg_transform.hpp"
 #include "catalog/rest/api/iceberg_type.hpp"
 #include "common/iceberg_utils.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_update.hpp"
 
 namespace duckdb {
 
@@ -897,13 +898,16 @@ PhysicalOperator &IcebergCatalog::PlanInsert(ClientContext &context, PhysicalPla
 	if (!op.column_index_map.empty()) {
 		plan = planner.ResolveDefaultsProjection(op, *plan);
 	}
-
 	auto &table_entry = op.table.Cast<IcebergTableEntry>();
-	table_entry.PrepareIcebergScanFromEntry(context);
-	auto &table_metadata = table_entry.table_info.table_metadata;
 
-	auto &schema = table_entry.schema_id.IsValid() ? *table_metadata.GetSchemaFromId(table_entry.schema_id.GetIndex())
-	                                               : table_metadata.GetLatestSchema();
+	auto &irc_transaction = IcebergTransaction::Get(context, *this);
+	auto &alter = irc_transaction.GetOrCreateAlter();
+	auto &updated_table = alter.GetOrInitializeTable(table_entry.table_info);
+	auto &table_metadata = updated_table.table_metadata;
+	auto &schema = table_metadata.GetLatestSchema();
+	auto &updated_table_entry = *updated_table.schema_versions[schema.schema_id];
+
+	table_entry.PrepareIcebergScanFromEntry(context);
 
 	if (table_metadata.HasSortOrder()) {
 		auto &sort_spec = table_metadata.GetLatestSortOrder();
@@ -914,7 +918,7 @@ PhysicalOperator &IcebergCatalog::PlanInsert(ClientContext &context, PhysicalPla
 
 	// Create Copy Info
 	IcebergCopyInput info(context, table_metadata, schema);
-	auto &insert = planner.Make<IcebergInsert>(op, op.table, op.column_index_map);
+	auto &insert = planner.Make<IcebergInsert>(op, updated_table_entry, op.column_index_map);
 	auto &physical_copy = IcebergInsert::PlanCopyForInsert(context, planner, info, plan);
 	insert.children.push_back(physical_copy);
 

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -899,6 +899,7 @@ PhysicalOperator &IcebergCatalog::PlanInsert(ClientContext &context, PhysicalPla
 		plan = planner.ResolveDefaultsProjection(op, *plan);
 	}
 	auto &table_entry = op.table.Cast<IcebergTableEntry>();
+	table_entry.PrepareIcebergScanFromEntry(context);
 
 	auto &irc_transaction = IcebergTransaction::Get(context, *this);
 	auto &alter = irc_transaction.GetOrCreateAlter();
@@ -906,8 +907,6 @@ PhysicalOperator &IcebergCatalog::PlanInsert(ClientContext &context, PhysicalPla
 	auto &table_metadata = updated_table.table_metadata;
 	auto &schema = table_metadata.GetLatestSchema();
 	auto &updated_table_entry = *updated_table.schema_versions[schema.schema_id];
-
-	table_entry.PrepareIcebergScanFromEntry(context);
 
 	if (table_metadata.HasSortOrder()) {
 		auto &sort_spec = table_metadata.GetLatestSortOrder();

--- a/src/execution/operator/iceberg_update.cpp
+++ b/src/execution/operator/iceberg_update.cpp
@@ -12,6 +12,7 @@
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_update.hpp"
 
 namespace duckdb {
 
@@ -181,9 +182,14 @@ PhysicalOperator &IcebergCatalog::PlanUpdate(ClientContext &context, PhysicalPla
 		throw BinderException("RETURNING clause not yet supported for updates of a Iceberg table");
 	}
 
-	auto &table = op.table.Cast<IcebergTableEntry>();
-	auto &table_metadata = table.table_info.table_metadata;
-	auto &table_schema = table_metadata.GetLatestSchema();
+	auto &table_entry = op.table.Cast<IcebergTableEntry>();
+
+	auto &irc_transaction = IcebergTransaction::Get(context, *this);
+	auto &alter = irc_transaction.GetOrCreateAlter();
+	auto &updated_table = alter.GetOrInitializeTable(table_entry.table_info);
+	auto &table_metadata = updated_table.table_metadata;
+	auto &schema = table_metadata.GetLatestSchema();
+	auto &updated_table_entry = *updated_table.schema_versions[schema.schema_id];
 
 	if (table_metadata.HasSortOrder()) {
 		auto &sort_spec = table_metadata.GetLatestSortOrder();
@@ -197,16 +203,17 @@ PhysicalOperator &IcebergCatalog::PlanUpdate(ClientContext &context, PhysicalPla
 
 	// Plan the delete operator (used as a side-sink from IcebergUpdate::Execute)
 	vector<idx_t> row_id_indexes = {0, 1};
-	auto &delete_op = IcebergDelete::PlanDelete(context, planner, table, child_plan, std::move(row_id_indexes));
+	auto &delete_op =
+	    IcebergDelete::PlanDelete(context, planner, updated_table_entry, child_plan, std::move(row_id_indexes));
 
 	// Create the IcebergUpdate intermediate operator
 	auto &update_op = planner
-	                      .Make<IcebergUpdate>(table, op.columns, child_plan, delete_op, std::move(op.expressions),
-	                                           std::move(op.bound_defaults))
+	                      .Make<IcebergUpdate>(updated_table_entry, op.columns, child_plan, delete_op,
+	                                           std::move(op.expressions), std::move(op.bound_defaults))
 	                      .Cast<IcebergUpdate>();
 
 	// Set output types: physical columns + optional _row_id for v3
-	vector<LogicalType> update_output_types = table.GetTypes();
+	vector<LogicalType> update_output_types = updated_table_entry.GetTypes();
 	if (table_metadata.iceberg_version >= 3) {
 		update_output_types.push_back(LogicalType::BIGINT); // _row_id
 	}
@@ -214,7 +221,7 @@ PhysicalOperator &IcebergCatalog::PlanUpdate(ClientContext &context, PhysicalPla
 
 	// Plan the copy operator with update_op as child.
 	// PlanCopyForInsert will add a partition projection on top if needed.
-	IcebergCopyInput copy_input(context, table_metadata, table_schema);
+	IcebergCopyInput copy_input(context, table_metadata, schema);
 	if (table_metadata.iceberg_version >= 3) {
 		copy_input.virtual_columns = IcebergInsertVirtualColumns::WRITE_ROW_ID;
 	}
@@ -222,7 +229,7 @@ PhysicalOperator &IcebergCatalog::PlanUpdate(ClientContext &context, PhysicalPla
 	auto &copy_op = IcebergInsert::PlanCopyForInsert(context, planner, copy_input, plan);
 
 	// Plan the insert sink and wire it up
-	auto &insert_op = IcebergInsert::PlanInsert(context, planner, table).Cast<IcebergInsert>();
+	auto &insert_op = IcebergInsert::PlanInsert(context, planner, updated_table_entry).Cast<IcebergInsert>();
 	insert_op.update_delete_op = delete_op;
 	insert_op.children.push_back(copy_op);
 	return insert_op;

--- a/src/execution/operator/iceberg_update.cpp
+++ b/src/execution/operator/iceberg_update.cpp
@@ -183,6 +183,7 @@ PhysicalOperator &IcebergCatalog::PlanUpdate(ClientContext &context, PhysicalPla
 	}
 
 	auto &table_entry = op.table.Cast<IcebergTableEntry>();
+	table_entry.PrepareIcebergScanFromEntry(context);
 
 	auto &irc_transaction = IcebergTransaction::Get(context, *this);
 	auto &alter = irc_transaction.GetOrCreateAlter();

--- a/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
@@ -52,8 +52,7 @@ public:
 public:
 	IcebergTableInformation &CreateTable(const string &table_key, IcebergTableInformation &&table);
 	IcebergTableInformation &GetOrInitializeTable(const IcebergTableInformation &table);
-
-public:
+	bool HasUpdates() const;
 	//! All the tables touched in this atomic block
 	case_insensitive_map_t<IcebergTableInformation> updated_tables;
 	//! The tables successively committed (used if multi-table commit isn't available)

--- a/test/sql/local/irc_any_catalog/alter/not_null/alter_drop_not_null_warn_schema_mismatch.test
+++ b/test/sql/local/irc_any_catalog/alter/not_null/alter_drop_not_null_warn_schema_mismatch.test
@@ -45,10 +45,10 @@ query II
 SELECT log_level, message FROM duckdb_logs
 ----
 
-# Ideally this statement would fail because at the time of `BEGIN;`, NOT NULL was set.
-# But it succeeds and we log a warning instead. This could be improved by using the metadata_log if present.
-statement ok con2
+statement error con2
 INSERT INTO my_datalake.default.my_table VALUES (NULL);
+----
+Constraint Error: NOT NULL constraint failed: my_table.a
 
 query II
 SELECT log_level, message FROM duckdb_logs


### PR DESCRIPTION
This PR supersedes #944 

Because we don't currently use the `metadata-log` during a regular lookup of a table (`IcebergTableSet::GetEntry`), we were given an `IcebergTableInformation` + `IcebergTableEntry` that might have a `schema_id` that shouldn't be reachable by the transaction.

To fix this, during `PlanUpdate|Insert|Delete` we get-or-create the `IcebergTransactionAlterUpdate` and `GetOrInitializeTable` the table into it.
This performs `IcebergTableInformation::Copy(IcebergTransaction &transaction)` that *does* make use of the `metadata-log` to acquire the correct metadata for the current transaction.

This step was already performed by the Insert/Update/Delete operators, but only *after* it performed various verifications using the info it received during planning - such as NULL verification for a `required` column.