### PR TITLE
fix: handle explicit null doc field in StructField JSON parsing

### DIFF
--- a/src/rest_catalog/objects/struct_field.cpp
+++ b/src/rest_catalog/objects/struct_field.cpp
@@ -70,7 +70,7 @@ string StructField::TryFromJSON(yyjson_val *obj) {
 		}
 	}
 	auto doc_val = yyjson_obj_get(obj, "doc");
-	if (doc_val) {
+	if (doc_val && !yyjson_is_null(doc_val)) {
 		has_doc = true;
 		if (yyjson_is_str(doc_val)) {
 			doc = yyjson_get_str(doc_val);


### PR DESCRIPTION
## Problem

When an Iceberg table writes `"doc": null` explicitly in schema fields instead of omitting the key entirely, DuckDB's StructField parser fails because it treats any non-absent `doc` value as requiring a string type, causing queries to fail with:

`    StructField property 'doc' is not of type 'string', found 'null' instead`

## Fix

Added a `!yyjson_is_null` guard so an explicit JSON null is treated identically to an absent field — consistent with the Iceberg spec, which defines `doc` as an optional string where null is a valid representation of "not set".

## Iceberg Spec Reference

> `doc`: **optional string** — a comment describing the field

Null is a valid JSON representation of an absent optional field.

## Affected Input

```json
{ "id": 0, "name": "id", "required": true, "type": "int", "doc": null }