### PR TITLE
Use metadata log in scan

### DIFF
--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -474,9 +474,16 @@ optional_ptr<CatalogEntry> IcebergTableInformation::GetSchemaVersion(ClientConte
 		}
 		schema_id = snapshot.GetSchemaId();
 	} else {
+		bool use_metadata_log = true;
+		Value val;
+		if (context.TryGetCurrentSetting("iceberg_use_metadata_log", val)) {
+			if (!val.IsNull() && val.type().id() == LogicalTypeId::BOOLEAN) {
+				use_metadata_log = val.GetValue<bool>();
+			}
+		}
+
 		const bool latest_metadata_is_too_fresh = table_metadata.last_updated_ms.value > transaction_start_millis;
-		const bool can_use_metadata_log =
-		    catalog.attach_options.use_metadata_log && !table_metadata.metadata_log.empty();
+		const bool can_use_metadata_log = use_metadata_log && !table_metadata.metadata_log.empty();
 		if (latest_metadata_is_too_fresh && can_use_metadata_log) {
 			string metadata_path;
 			auto relevant_metadata = CreateMetadataFromLog(context, transaction_start_millis, metadata_path);
@@ -584,7 +591,6 @@ IcebergTableMetadata IcebergTableInformation::CreateMetadataFromLog(ClientContex
                                                                     int64_t transaction_start_millis,
                                                                     string &metadata_path) const {
 	auto &log = table_metadata.metadata_log;
-	D_ASSERT(catalog.attach_options.use_metadata_log);
 
 	optional_idx log_item_index;
 	for (idx_t i = log.size(); i-- > 0;) {
@@ -617,8 +623,15 @@ IcebergTableInformation IcebergTableInformation::Copy(IcebergTransaction &iceber
 	auto transaction_start_millis = Timestamp::GetEpochMs(transaction_start);
 
 	if (table_metadata.last_updated_ms.value > transaction_start_millis) {
-		const bool can_use_metadata_log =
-		    catalog.attach_options.use_metadata_log && !table_metadata.metadata_log.empty();
+		bool use_metadata_log = true;
+		Value val;
+		if (context.TryGetCurrentSetting("iceberg_use_metadata_log", val)) {
+			if (!val.IsNull() && val.type().id() == LogicalTypeId::BOOLEAN) {
+				use_metadata_log = val.GetValue<bool>();
+			}
+		}
+
+		const bool can_use_metadata_log = use_metadata_log && !table_metadata.metadata_log.empty();
 		if (!can_use_metadata_log) {
 			auto snapshot_lookup = GetSnapshotLookup(iceberg_transaction);
 			if (ret.TableIsEmpty(snapshot_lookup)) {

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -598,9 +598,10 @@ IcebergTableMetadata IcebergTableInformation::CreateMetadataFromLog(ClientContex
 		    "Metadata-log exists but none of the entries were valid for the current transaction start time (%s)",
 		    Timestamp::ToString(timestamp_ms_t(transaction_start_millis)));
 	}
-	auto &fs = FileSystem::GetFileSystem(context);
+
+	auto fs = make_shared_ptr<CachingFileSystemWrapper>(FileSystem::GetFileSystem(context), *context.db);
 	auto &path = log[log_item_index.GetIndex()].metadata_file;
-	auto parsed_metadata = IcebergTableMetadata::Parse(path, fs, "");
+	auto parsed_metadata = IcebergTableMetadata::Parse(path, *fs, "");
 
 	metadata_path = path;
 	return IcebergTableMetadata::FromTableMetadata(parsed_metadata);

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -461,7 +461,7 @@ optional_ptr<CatalogEntry> IcebergTableInformation::GetSchemaVersion(ClientConte
 	auto transaction_start = meta_transaction.GetCurrentTransactionStartTimestamp();
 	auto transaction_start_millis = Timestamp::GetEpochMs(transaction_start);
 
-	auto snapshot_lookup = GetSnapshotLookup(context, at);
+	auto snapshot_lookup = IcebergSnapshotLookup::FromAtClause(at);
 	auto snapshot_info = table_metadata.GetSnapshot(snapshot_lookup);
 
 	int32_t schema_id;
@@ -469,23 +469,19 @@ optional_ptr<CatalogEntry> IcebergTableInformation::GetSchemaVersion(ClientConte
 		//! Time travel query, verify this is reachable
 		auto &snapshot = *snapshot_info.snapshot;
 		if (snapshot.timestamp_ms.value > transaction_start.value) {
-			//! Not reachable, return null instead
-			snapshot_info.snapshot = nullptr;
+			//! Not reachable by the current transaction
+			return nullptr;
 		}
+		schema_id = snapshot.GetSchemaId();
 	} else {
 		const bool latest_metadata_is_too_fresh = table_metadata.last_updated_ms.value > transaction_start_millis;
 		if (latest_metadata_is_too_fresh && !table_metadata.metadata_log.empty()) {
 			string metadata_path;
-			auto relevant_metadata = CreateMetadataFromLog(transaction_start_millis, metadata_path);
-			snapshot_info.schema_id = relevant_metadata.GetCurrentSchemaId();
+			auto relevant_metadata = CreateMetadataFromLog(context, transaction_start_millis, metadata_path);
+			schema_id = relevant_metadata.GetCurrentSchemaId();
+		} else {
+			schema_id = table_metadata.GetCurrentSchemaId();
 		}
-	}
-
-	if ((latest_metadata_is_too_fresh && snapshot_info.snapshot) || at) {
-		// use snapshot
-		schema_id = snapshot_info.schema_id;
-	} else {
-		schema_id = table_metadata.GetCurrentSchemaId();
 	}
 	return schema_versions[schema_id].get();
 }
@@ -566,8 +562,11 @@ IcebergTableInformation IcebergTableInformation::Copy() const {
 	return ret;
 }
 
-IcebergTableMetadata IcebergTableInformation::CreateMetadataFromLog(int64_t transaction_start_millis,
-                                                                    string &metadata_path) {
+IcebergTableMetadata IcebergTableInformation::CreateMetadataFromLog(ClientContext &context,
+                                                                    int64_t transaction_start_millis,
+                                                                    string &metadata_path) const {
+	auto &log = table_metadata.metadata_log;
+
 	optional_idx log_item_index;
 	for (idx_t i = log.size(); i-- > 0;) {
 		if (log[i].timestamp_ms <= transaction_start_millis) {
@@ -578,7 +577,7 @@ IcebergTableMetadata IcebergTableInformation::CreateMetadataFromLog(int64_t tran
 	if (!log_item_index.IsValid()) {
 		throw InternalException(
 		    "Metadata-log exists but none of the entries were valid for the current transaction start time (%s)",
-		    Timestamp::ToString(transaction_start));
+		    Timestamp::ToString(timestamp_ms_t(transaction_start_millis)));
 	}
 	auto &fs = FileSystem::GetFileSystem(context);
 	auto &path = log[log_item_index.GetIndex()].metadata_file;
@@ -617,7 +616,7 @@ IcebergTableInformation IcebergTableInformation::Copy(IcebergTransaction &iceber
 			ret.table_metadata.current_snapshot_id = snapshot->snapshot_id;
 			return ret;
 		}
-		ret.CreateMetadataFromLog(transaction_start_millis, ret.latest_metadata_json);
+		ret.table_metadata = ret.CreateMetadataFromLog(context, transaction_start_millis, ret.latest_metadata_json);
 		return ret;
 	}
 	return ret;

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -475,7 +475,9 @@ optional_ptr<CatalogEntry> IcebergTableInformation::GetSchemaVersion(ClientConte
 		schema_id = snapshot.GetSchemaId();
 	} else {
 		const bool latest_metadata_is_too_fresh = table_metadata.last_updated_ms.value > transaction_start_millis;
-		if (latest_metadata_is_too_fresh && !table_metadata.metadata_log.empty()) {
+		const bool can_use_metadata_log =
+		    catalog.attach_options.use_metadata_log && !table_metadata.metadata_log.empty();
+		if (latest_metadata_is_too_fresh && can_use_metadata_log) {
 			string metadata_path;
 			auto relevant_metadata = CreateMetadataFromLog(context, transaction_start_millis, metadata_path);
 			schema_id = relevant_metadata.GetCurrentSchemaId();
@@ -582,6 +584,7 @@ IcebergTableMetadata IcebergTableInformation::CreateMetadataFromLog(ClientContex
                                                                     int64_t transaction_start_millis,
                                                                     string &metadata_path) const {
 	auto &log = table_metadata.metadata_log;
+	D_ASSERT(catalog.attach_options.use_metadata_log);
 
 	optional_idx log_item_index;
 	for (idx_t i = log.size(); i-- > 0;) {
@@ -613,7 +616,9 @@ IcebergTableInformation IcebergTableInformation::Copy(IcebergTransaction &iceber
 	auto transaction_start_millis = Timestamp::GetEpochMs(transaction_start);
 
 	if (table_metadata.last_updated_ms.value > transaction_start_millis) {
-		if (table_metadata.metadata_log.empty()) {
+		const bool can_use_metadata_log =
+		    catalog.attach_options.use_metadata_log && !table_metadata.metadata_log.empty();
+		if (!can_use_metadata_log) {
 			auto snapshot_lookup = GetSnapshotLookup(iceberg_transaction);
 			if (ret.TableIsEmpty(snapshot_lookup)) {
 				return ret;

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -565,12 +565,12 @@ bool IcebergTableInformation::HasTransactionUpdates() const {
 	return false;
 }
 
-IcebergTableInformation IcebergTableInformation::Copy() const {
+IcebergTableInformation IcebergTableInformation::Copy(ClientContext &context) const {
 	auto ret = IcebergTableInformation(catalog, schema, name);
 	auto table_key = ret.GetTableKey();
 	{
 		lock_guard<std::mutex> cache_lock(catalog.table_request_cache.Lock());
-		auto cached_result = catalog.table_request_cache.Get(table_key, cache_lock, false);
+		auto cached_result = catalog.table_request_cache.Get(context, table_key, cache_lock, false);
 		D_ASSERT(cached_result);
 		auto &cached_table_result = *cached_result->load_table_result;
 		ret.InitializeFromLoadTableResult(cached_table_result, false);
@@ -604,10 +604,10 @@ IcebergTableMetadata IcebergTableInformation::CreateMetadataFromLog(ClientContex
 }
 
 IcebergTableInformation IcebergTableInformation::Copy(IcebergTransaction &iceberg_transaction) const {
-	auto ret = Copy();
-
 	auto locked_context = iceberg_transaction.context.lock();
 	auto &context = *locked_context;
+
+	auto ret = Copy(context);
 	auto &meta_transaction = MetaTransaction::Get(context);
 	auto transaction_start = meta_transaction.GetCurrentTransactionStartTimestamp();
 	auto transaction_start_millis = Timestamp::GetEpochMs(transaction_start);

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -464,8 +464,23 @@ optional_ptr<CatalogEntry> IcebergTableInformation::GetSchemaVersion(ClientConte
 	auto snapshot_lookup = GetSnapshotLookup(context, at);
 	auto snapshot_info = table_metadata.GetSnapshot(snapshot_lookup);
 
-	const bool latest_metadata_is_too_fresh = table_metadata.last_updated_ms.value > transaction_start_millis;
 	int32_t schema_id;
+	if (!snapshot_lookup.IsLatest() && snapshot_info.snapshot) {
+		//! Time travel query, verify this is reachable
+		auto &snapshot = *snapshot_info.snapshot;
+		if (snapshot.timestamp_ms.value > transaction_start.value) {
+			//! Not reachable, return null instead
+			snapshot_info.snapshot = nullptr;
+		}
+	} else {
+		const bool latest_metadata_is_too_fresh = table_metadata.last_updated_ms.value > transaction_start_millis;
+		if (latest_metadata_is_too_fresh && !table_metadata.metadata_log.empty()) {
+			string metadata_path;
+			auto relevant_metadata = CreateMetadataFromLog(transaction_start_millis, metadata_path);
+			snapshot_info.schema_id = relevant_metadata.GetCurrentSchemaId();
+		}
+	}
+
 	if ((latest_metadata_is_too_fresh && snapshot_info.snapshot) || at) {
 		// use snapshot
 		schema_id = snapshot_info.schema_id;
@@ -551,6 +566,28 @@ IcebergTableInformation IcebergTableInformation::Copy() const {
 	return ret;
 }
 
+IcebergTableMetadata IcebergTableInformation::CreateMetadataFromLog(int64_t transaction_start_millis,
+                                                                    string &metadata_path) {
+	optional_idx log_item_index;
+	for (idx_t i = log.size(); i-- > 0;) {
+		if (log[i].timestamp_ms <= transaction_start_millis) {
+			log_item_index = i;
+			break;
+		}
+	}
+	if (!log_item_index.IsValid()) {
+		throw InternalException(
+		    "Metadata-log exists but none of the entries were valid for the current transaction start time (%s)",
+		    Timestamp::ToString(transaction_start));
+	}
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto &path = log[log_item_index.GetIndex()].metadata_file;
+	auto parsed_metadata = IcebergTableMetadata::Parse(path, fs, "");
+
+	metadata_path = path;
+	return IcebergTableMetadata::FromTableMetadata(parsed_metadata);
+}
+
 IcebergTableInformation IcebergTableInformation::Copy(IcebergTransaction &iceberg_transaction) const {
 	auto ret = Copy();
 
@@ -580,25 +617,7 @@ IcebergTableInformation IcebergTableInformation::Copy(IcebergTransaction &iceber
 			ret.table_metadata.current_snapshot_id = snapshot->snapshot_id;
 			return ret;
 		}
-		auto &log = table_metadata.metadata_log;
-
-		optional_idx log_item_index;
-		for (idx_t i = log.size(); i-- > 0;) {
-			if (log[i].timestamp_ms <= transaction_start_millis) {
-				log_item_index = i;
-				break;
-			}
-		}
-		if (!log_item_index.IsValid()) {
-			throw InternalException(
-			    "Metadata-log exists but none of the entries were valid for the current transaction start time (%s)",
-			    Timestamp::ToString(transaction_start));
-		}
-		auto &fs = FileSystem::GetFileSystem(context);
-		auto &path = log[log_item_index.GetIndex()].metadata_file;
-		auto parsed_metadata = IcebergTableMetadata::Parse(path, fs, "");
-		ret.table_metadata = IcebergTableMetadata::FromTableMetadata(parsed_metadata);
-		ret.latest_metadata_json = path;
+		ret.CreateMetadataFromLog(transaction_start_millis, ret.latest_metadata_json);
 		return ret;
 	}
 	return ret;

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -560,8 +560,6 @@ unique_ptr<Catalog> IcebergCatalog::Attach(optional_ptr<StorageExtensionInfo> st
 			default_schema = entry.second.ToString();
 		} else if (lower_name == "encode_entire_prefix") {
 			attach_options.encode_entire_prefix = true;
-		} else if (lower_name == "use_metadata_log") {
-			attach_options.use_metadata_log = entry.second.DefaultCastAs(LogicalType::BOOLEAN).GetValue<bool>();
 		} else if (lower_name == "max_table_staleness") {
 			auto interval_option = entry.second.DefaultCastAs(LogicalType::INTERVAL);
 			auto interval_value = interval_option.GetValue<interval_t>();

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -519,19 +519,15 @@ void IcebergCatalog::SetAWSCatalogOptions(IcebergAttachOptions &attach_options,
 unique_ptr<Catalog> IcebergCatalog::Attach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
                                            AttachedDatabase &db, const string &name, AttachInfo &info,
                                            AttachOptions &options) {
-	IRCEndpointBuilder endpoint_builder;
-
-	string endpoint_type_string;
-	string authorization_type_string;
-	string access_mode_string;
-
 	IcebergAttachOptions attach_options;
 	attach_options.warehouse = info.path;
 	attach_options.name = name;
 
 	// check if we have a secret provided
-	string secret_name;
 	string default_schema;
+	string endpoint_type_string;
+	string authorization_type_string;
+	string access_mode_string;
 	case_insensitive_set_t set_by_attach_options;
 	//! First handle generic attach options
 	for (auto &entry : info.options) {
@@ -564,6 +560,8 @@ unique_ptr<Catalog> IcebergCatalog::Attach(optional_ptr<StorageExtensionInfo> st
 			default_schema = entry.second.ToString();
 		} else if (lower_name == "encode_entire_prefix") {
 			attach_options.encode_entire_prefix = true;
+		} else if (lower_name == "use_metadata_log") {
+			attach_options.use_metadata_log = entry.second.DefaultCastAs(LogicalType::BOOLEAN).GetValue<bool>();
 		} else if (lower_name == "max_table_staleness") {
 			auto interval_option = entry.second.DefaultCastAs(LogicalType::INTERVAL);
 			auto interval_value = interval_option.GetValue<interval_t>();

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -320,6 +320,9 @@ optional_ptr<CatalogEntry> IcebergTableSet::GetEntry(ClientContext &context, con
 
 	iceberg_transaction.tables[table_key] = new_version;
 	auto ret = table_info.GetSchemaVersion(context, at);
+	if (!ret) {
+		return nullptr;
+	}
 
 	// get the latest information and save it to the transaction cache
 	auto &ic_ret = ret->Cast<IcebergTableEntry>();

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -39,7 +39,7 @@ bool IcebergTableSet::FillEntry(ClientContext &context, IcebergTableInformation 
 	// Only check cache if MAX_TABLE_STALENESS option is set
 	if (ic_catalog.attach_options.max_table_staleness_micros.IsValid()) {
 		lock_guard<mutex> cache_lock(ic_catalog.table_request_cache.Lock());
-		auto cached_result = ic_catalog.table_request_cache.Get(table_key, cache_lock);
+		auto cached_result = ic_catalog.table_request_cache.Get(context, table_key, cache_lock);
 		if (cached_result) {
 			// Use the cached result instead of making a new request
 			table.InitializeFromLoadTableResult(*cached_result->load_table_result);
@@ -69,7 +69,7 @@ bool IcebergTableSet::FillEntry(ClientContext &context, IcebergTableInformation 
 	ic_catalog.table_request_cache.SetOrOverwrite(context, table_key, std::move(get_table_result.result_));
 	{
 		lock_guard<std::mutex> cache_lock(ic_catalog.table_request_cache.Lock());
-		auto cached_table_result = ic_catalog.table_request_cache.Get(table_key, cache_lock, false);
+		auto cached_table_result = ic_catalog.table_request_cache.Get(context, table_key, cache_lock, false);
 		D_ASSERT(cached_table_result);
 		auto &load_table_result = *cached_table_result->load_table_result;
 		table.InitializeFromLoadTableResult(load_table_result);
@@ -257,7 +257,7 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 	catalog.table_request_cache.SetOrOverwrite(context, key, std::move(load_table_result));
 	{
 		lock_guard<mutex> cache_lock(catalog.table_request_cache.Lock());
-		auto cached_table_result = catalog.table_request_cache.Get(key, cache_lock, false);
+		auto cached_table_result = catalog.table_request_cache.Get(context, key, cache_lock, false);
 		D_ASSERT(cached_table_result);
 		auto &load_table_result = cached_table_result->load_table_result;
 		table_info.InitializeFromLoadTableResult(*load_table_result, false);

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -746,8 +746,8 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 	auto new_table_key = new_table.GetTableKey();
 	auto &table_request_cache = catalog.table_request_cache;
 	lock_guard<mutex> cache_guard(table_request_cache.Lock());
-	auto cache = table_request_cache.Get(table_key, cache_guard, false);
-	table_request_cache.SetOrOverwriteInternal(cache_guard, client_context, new_table_key, cache->expires_at,
+	auto cache = table_request_cache.Get(client_context, table_key, cache_guard, false);
+	table_request_cache.SetOrOverwriteInternal(cache_guard, client_context, new_table_key, cache->expire_timestamp,
 	                                           std::move(cache->load_table_result));
 	table_request_cache.ExpireInternal(cache_guard, client_context, table_key);
 	return state->GetInfo();

--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -20,8 +20,7 @@ optional_ptr<const IcebergSnapshot> IcebergTableMetadata::FindSnapshotByIdIntern
 	return it->second;
 }
 
-optional_ptr<const IcebergSnapshot>
-IcebergTableMetadata::FindSnapshotByIdTimestampInternal(timestamp_t timestamp) const {
+optional_ptr<const IcebergSnapshot> IcebergTableMetadata::GetSnapshotByTimestamp(timestamp_t timestamp) const {
 	uint64_t max_millis = NumericLimits<uint64_t>::Minimum();
 	optional_ptr<const IcebergSnapshot> max_snapshot = nullptr;
 
@@ -105,10 +104,6 @@ optional_ptr<const IcebergSnapshot> IcebergTableMetadata::GetSnapshotById(int64_
 		throw InvalidConfigurationException("Could not find snapshot with id " + to_string(snapshot_id));
 	}
 	return snapshot;
-}
-
-optional_ptr<const IcebergSnapshot> IcebergTableMetadata::GetSnapshotByTimestamp(timestamp_t timestamp) const {
-	return FindSnapshotByIdTimestampInternal(timestamp);
 }
 
 IcebergSnapshotScanInfo IcebergTableMetadata::GetSnapshot(const IcebergSnapshotLookup &lookup) const {

--- a/src/function/metadata/iceberg_column_stats.cpp
+++ b/src/function/metadata/iceberg_column_stats.cpp
@@ -60,7 +60,8 @@ static unique_ptr<FunctionData> IcebergColumnStatsBind(ClientContext &context, T
 	// return a TableRef that contains the scans for the
 	auto ret = make_uniq<IcebergColumnStatsBindData>();
 
-	FileSystem &fs = FileSystem::GetFileSystem(context);
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto caching_fs = make_shared_ptr<CachingFileSystemWrapper>(FileSystem::GetFileSystem(context), *context.db);
 	auto input_string = input.inputs[0].ToString();
 	auto filename = IcebergUtils::GetStorageLocation(context, input_string);
 
@@ -103,7 +104,8 @@ static unique_ptr<FunctionData> IcebergColumnStatsBind(ClientContext &context, T
 	}
 
 	auto iceberg_meta_path = IcebergTableMetadata::GetMetaDataPath(context, filename, fs, options);
-	auto table_metadata = IcebergTableMetadata::Parse(iceberg_meta_path, fs, options.metadata_compression_codec);
+	auto table_metadata =
+	    IcebergTableMetadata::Parse(iceberg_meta_path, *caching_fs, options.metadata_compression_codec);
 	ret->metadata = IcebergTableMetadata::FromTableMetadata(table_metadata);
 
 	ret->snapshot_to_scan = ret->metadata.GetSnapshot(options.snapshot_lookup);

--- a/src/function/metadata/iceberg_metadata.cpp
+++ b/src/function/metadata/iceberg_metadata.cpp
@@ -88,7 +88,8 @@ static unique_ptr<FunctionData> IcebergMetaDataBind(ClientContext &context, Tabl
 	// return a TableRef that contains the scans for the
 	auto ret = make_uniq<IcebergMetaDataBindData>();
 
-	FileSystem &fs = FileSystem::GetFileSystem(context);
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto caching_fs = make_shared_ptr<CachingFileSystemWrapper>(fs, *context.db);
 	auto input_string = input.inputs[0].ToString();
 	auto filename = IcebergUtils::GetStorageLocation(context, input_string);
 
@@ -131,7 +132,8 @@ static unique_ptr<FunctionData> IcebergMetaDataBind(ClientContext &context, Tabl
 	}
 
 	auto iceberg_meta_path = IcebergTableMetadata::GetMetaDataPath(context, filename, fs, options);
-	auto table_metadata = IcebergTableMetadata::Parse(iceberg_meta_path, fs, options.metadata_compression_codec);
+	auto table_metadata =
+	    IcebergTableMetadata::Parse(iceberg_meta_path, *caching_fs, options.metadata_compression_codec);
 	auto metadata = IcebergTableMetadata::FromTableMetadata(table_metadata);
 
 	auto snapshot_to_scan = metadata.GetSnapshot(options.snapshot_lookup);

--- a/src/function/metadata/iceberg_partition_stats.cpp
+++ b/src/function/metadata/iceberg_partition_stats.cpp
@@ -58,7 +58,8 @@ static unique_ptr<FunctionData> IcebergPartitionStatsBind(ClientContext &context
 	// return a TableRef that contains the scans for the
 	auto ret = make_uniq<IcebergPartitionStatsBindData>();
 
-	FileSystem &fs = FileSystem::GetFileSystem(context);
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto caching_fs = make_shared_ptr<CachingFileSystemWrapper>(fs, *context.db);
 	auto input_string = input.inputs[0].ToString();
 	auto filename = IcebergUtils::GetStorageLocation(context, input_string);
 
@@ -101,7 +102,8 @@ static unique_ptr<FunctionData> IcebergPartitionStatsBind(ClientContext &context
 	}
 
 	auto iceberg_meta_path = IcebergTableMetadata::GetMetaDataPath(context, filename, fs, options);
-	auto table_metadata = IcebergTableMetadata::Parse(iceberg_meta_path, fs, options.metadata_compression_codec);
+	auto table_metadata =
+	    IcebergTableMetadata::Parse(iceberg_meta_path, *caching_fs, options.metadata_compression_codec);
 	ret->metadata = IcebergTableMetadata::FromTableMetadata(table_metadata);
 
 	ret->snapshot_to_scan = ret->metadata.GetSnapshot(options.snapshot_lookup);

--- a/src/function/metadata/iceberg_snapshots.cpp
+++ b/src/function/metadata/iceberg_snapshots.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/storage/caching_file_system_wrapper.hpp"
 
 #include "function/iceberg_functions.hpp"
 #include "iceberg_options.hpp"
@@ -22,12 +23,13 @@ public:
 		auto bind_data = input.bind_data->Cast<IcebergSnaphotsBindData>();
 		auto global_state = make_uniq<IcebergSnapshotGlobalTableFunctionState>();
 
-		FileSystem &fs = FileSystem::GetFileSystem(context);
+		auto &fs = FileSystem::GetFileSystem(context);
+		auto caching_fs = make_shared_ptr<CachingFileSystemWrapper>(fs, *context.db);
 
 		auto iceberg_meta_path =
 		    IcebergTableMetadata::GetMetaDataPath(context, bind_data.filename, fs, bind_data.options);
 		auto table_metadata =
-		    IcebergTableMetadata::Parse(iceberg_meta_path, fs, bind_data.options.metadata_compression_codec);
+		    IcebergTableMetadata::Parse(iceberg_meta_path, *caching_fs, bind_data.options.metadata_compression_codec);
 		global_state->metadata = IcebergTableMetadata::FromTableMetadata(table_metadata);
 
 		auto &info = global_state->metadata;

--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -63,6 +63,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("iceberg_test_force_token_expiry",
 	                          "DEBUG SETTING: force OAuth2 token expiry for testing automatic refresh",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(false));
+	config.AddExtensionOption(
+	    "iceberg_use_metadata_log",
+	    "Whether or not to make use of the (optional) 'metadata-log' of a table to ensure atomicity guarantees hold, "
+	    "at the cost of making another GET for json metadata in rare circumstances",
+	    LogicalType::BOOLEAN, Value::BOOLEAN(true));
 
 	// Iceberg Table Functions
 	for (auto &fun : IcebergFunctions::GetTableFunctions(loader)) {

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -53,7 +53,8 @@ public:
 
 	static string GetTableKey(const vector<string> &namespace_items, const string &table_name);
 	string GetTableKey() const;
-	IcebergTableMetadata CreateMetadataFromLog(int64_t transaction_start_millis) const;
+	IcebergTableMetadata CreateMetadataFromLog(ClientContext &context, int64_t transaction_start_millis,
+	                                           string &metadata_path) const;
 	// we pass the transaction, because we are only allowed to copy table information state provded by the catalog
 	// from before our transaction start time.
 	IcebergTableInformation Copy(IcebergTransaction &iceberg_transaction) const;

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -53,6 +53,7 @@ public:
 
 	static string GetTableKey(const vector<string> &namespace_items, const string &table_name);
 	string GetTableKey() const;
+	IcebergTableMetadata CreateMetadataFromLog(int64_t transaction_start_millis) const;
 	// we pass the transaction, because we are only allowed to copy table information state provded by the catalog
 	// from before our transaction start time.
 	IcebergTableInformation Copy(IcebergTransaction &iceberg_transaction) const;

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb/catalog/catalog_entry.hpp"
+#include "duckdb/storage/caching_file_system_wrapper.hpp"
 
 #include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
 #include "core/metadata/manifest/iceberg_manifest.hpp"

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -59,7 +59,7 @@ public:
 	// from before our transaction start time.
 	IcebergTableInformation Copy(IcebergTransaction &iceberg_transaction) const;
 	// This copy is used for deletes, where we don't care about valid table state
-	IcebergTableInformation Copy() const;
+	IcebergTableInformation Copy(ClientContext &context) const;
 	void InitSchemaVersions();
 
 	IcebergSnapshotLookup GetSnapshotLookup(IcebergTransaction &iceberg_transaction) const;

--- a/src/include/catalog/rest/iceberg_catalog.hpp
+++ b/src/include/catalog/rest/iceberg_catalog.hpp
@@ -20,16 +20,16 @@ class IcebergSchemaEntry;
 
 class MetadataCacheValue {
 public:
-	MetadataCacheValue(transaction_t creator, const system_clock::time_point expires_at,
+	MetadataCacheValue(transaction_t creator, timestamp_t expire_timestamp,
 	                   unique_ptr<const rest_api_objects::LoadTableResult> load_table_result)
-	    : creator(creator), expires_at(expires_at), load_table_result(std::move(load_table_result)) {
+	    : creator(creator), expire_timestamp(expire_timestamp), load_table_result(std::move(load_table_result)) {
 	}
 
 public:
 	//! Store the id of the transaction that added the entry
 	transaction_t creator;
 	//! The timestamp until when this entry is valid
-	const system_clock::time_point expires_at;
+	timestamp_t expire_timestamp;
 	//! The payload of the cache entry
 	unique_ptr<const rest_api_objects::LoadTableResult> load_table_result;
 };
@@ -45,26 +45,32 @@ public:
 	}
 
 	//! NOTE: lock needs to be held by the caller until the result goes out of scope
-	optional_ptr<MetadataCacheValue> Get(const string &table_key, lock_guard<mutex> &lock, bool validate_cache = true) {
+	optional_ptr<MetadataCacheValue> Get(ClientContext &context, const string &table_key, lock_guard<mutex> &lock,
+	                                     bool validate_cache = true) {
 		(void)lock;
 		auto it = tables.find(table_key);
 		if (it == tables.end()) {
 			return nullptr;
 		}
+
+		auto &meta_transaction = MetaTransaction::Get(context);
+		auto transaction_start = meta_transaction.GetCurrentTransactionStartTimestamp();
+
 		auto &entry = it->second;
-		if (validate_cache && system_clock::now() > entry.expires_at) {
+		if (validate_cache && transaction_start > entry.expire_timestamp) {
 			// cached value has expired
 			return nullptr;
 		}
 		return entry;
 	}
 	void SetOrOverwriteInternal(lock_guard<mutex> &guard, ClientContext &context, const string &table_key,
-	                            system_clock::time_point expires_at,
+	                            timestamp_t expire_timestamp,
 	                            unique_ptr<const rest_api_objects::LoadTableResult> load_table_result) {
 		// erase load table result if it exists.
 		tables.erase(table_key);
 		auto &meta_transaction = MetaTransaction::Get(context);
-		tables.emplace(table_key, MetadataCacheValue(meta_transaction.global_transaction_id, expires_at,
+
+		tables.emplace(table_key, MetadataCacheValue(meta_transaction.global_transaction_id, expire_timestamp,
 		                                             std::move(load_table_result)));
 	}
 	void SetOrOverwrite(ClientContext &context, const string &table_key,
@@ -78,7 +84,9 @@ public:
 		} else {
 			expires_at = system_clock::time_point::min();
 		}
-		SetOrOverwriteInternal(guard, context, table_key, expires_at, std::move(load_table_result));
+		auto epoch_micros = duration_cast<microseconds>(expires_at.time_since_epoch()).count();
+		auto expire_timestamp = Timestamp::FromEpochMicroSeconds(epoch_micros);
+		SetOrOverwriteInternal(guard, context, table_key, expire_timestamp, std::move(load_table_result));
 	}
 	void ExpireInternal(lock_guard<mutex> &guard, ClientContext &context, const string &table_key) {
 		auto &meta_transaction = MetaTransaction::Get(context);

--- a/src/include/catalog/rest/storage/iceberg_authorization.hpp
+++ b/src/include/catalog/rest/storage/iceberg_authorization.hpp
@@ -33,9 +33,6 @@ struct IcebergAttachOptions {
 	unordered_map<string, Value> options;
 	// max staleness for cached table metadata in minutes (optional - if not set, always request fresh metadata)
 	optional_idx max_table_staleness_micros;
-	// whether or not to use metadata-log to fetch relevant metadata
-	// in the event the fetched metadata was created after the transaction started
-	bool use_metadata_log = true;
 };
 
 //! Hold the pre-initialized HTTPClient for a given connection

--- a/src/include/catalog/rest/storage/iceberg_authorization.hpp
+++ b/src/include/catalog/rest/storage/iceberg_authorization.hpp
@@ -33,6 +33,9 @@ struct IcebergAttachOptions {
 	unordered_map<string, Value> options;
 	// max staleness for cached table metadata in minutes (optional - if not set, always request fresh metadata)
 	optional_idx max_table_staleness_micros;
+	// whether or not to use metadata-log to fetch relevant metadata
+	// in the event the fetched metadata was created after the transaction started
+	bool use_metadata_log = true;
 };
 
 //! Hold the pre-initialized HTTPClient for a given connection

--- a/src/include/common/iceberg_utils.hpp
+++ b/src/include/common/iceberg_utils.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "yyjson.hpp"
+#include "duckdb/storage/caching_file_system.hpp"
 
 #include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
 

--- a/src/include/core/metadata/iceberg_table_metadata.hpp
+++ b/src/include/core/metadata/iceberg_table_metadata.hpp
@@ -65,7 +65,6 @@ public:
 
 	//! Internal JSON parsing functions
 	optional_ptr<const IcebergSnapshot> FindSnapshotByIdInternal(int64_t target_id) const;
-	optional_ptr<const IcebergSnapshot> FindSnapshotByIdTimestampInternal(timestamp_t timestamp) const;
 	shared_ptr<IcebergTableSchema> GetSchemaFromId(int32_t schema_id) const;
 	optional_ptr<const IcebergPartitionSpec> FindPartitionSpecById(int32_t spec_id) const;
 	optional_ptr<const IcebergSortOrder> FindSortOrderById(int32_t sort_id) const;

--- a/src/include/core/metadata/iceberg_table_metadata.hpp
+++ b/src/include/core/metadata/iceberg_table_metadata.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/storage/caching_file_system_wrapper.hpp"
 
 #include "core/metadata/schema/iceberg_column_definition.hpp"
 #include "core/metadata/schema/iceberg_table_schema.hpp"

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -194,13 +194,15 @@ void IcebergMultiFileList::Bind(vector<LogicalType> &return_types, vector<string
 		return_types = this->types;
 		return;
 	}
-
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto caching_fs = make_shared_ptr<CachingFileSystemWrapper>(FileSystem::GetFileSystem(context), *context.db);
 	if (!scan_info) {
 		D_ASSERT(!path.empty());
 		auto input_string = path;
 		auto iceberg_path = IcebergUtils::GetStorageLocation(context, input_string);
 		auto iceberg_meta_path = IcebergTableMetadata::GetMetaDataPath(context, iceberg_path, fs, options);
-		auto table_metadata = IcebergTableMetadata::Parse(iceberg_meta_path, fs, options.metadata_compression_codec);
+		auto table_metadata =
+		    IcebergTableMetadata::Parse(iceberg_meta_path, *caching_fs, options.metadata_compression_codec);
 
 		auto temp_data = make_uniq<IcebergScanTemporaryData>();
 		temp_data->metadata = IcebergTableMetadata::FromTableMetadata(table_metadata);


### PR DESCRIPTION
This PR fixes https://github.com/duckdblabs/duckdb-internal/issues/8825

Similar to #946 we now also use `metadata-log` when grabbing the `IcebergTableEntry` from the Catalog.

I've added a new `iceberg_use_metadata_log` setting, which defaults to `true`.
This can be set to false to prevent making further GET requests for the relevant `metadata.json` file.
This could result in breaking atomicity guarantees that shield transactions from seeing outside changes.

This PR also changes the `table_request_cache` expiration and validation to be based on the transaction timestamp, rather than the exact time the request was made.