### PR TITLE
Omit stack-trace when creating a table in a schema that doesn't exist

### DIFF
--- a/src/catalog/rest/catalog_entry/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/iceberg_schema_entry.cpp
@@ -79,6 +79,10 @@ bool IcebergSchemaEntry::HandleCreateConflict(CatalogTransaction &transaction, C
 
 optional_ptr<CatalogEntry> IcebergSchemaEntry::CreateTable(CatalogTransaction &transaction, ClientContext &context,
                                                            BoundCreateTableInfo &info) {
+	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
+	if (!exists && iceberg_transaction.created_schemas.find(name) == iceberg_transaction.created_schemas.end()) {
+		throw InvalidInputException("Schema %s does not exist", name);
+	}
 	auto &base_info = info.Base();
 	auto &ir_catalog = catalog.Cast<IcebergCatalog>();
 	// check if we have an existing entry with this name

--- a/src/catalog/rest/catalog_entry/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/iceberg_schema_entry.cpp
@@ -81,7 +81,7 @@ optional_ptr<CatalogEntry> IcebergSchemaEntry::CreateTable(CatalogTransaction &t
                                                            BoundCreateTableInfo &info) {
 	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
 	if (!exists && iceberg_transaction.created_schemas.find(name) == iceberg_transaction.created_schemas.end()) {
-		throw InvalidInputException("Schema %s does not exist", name);
+		throw InvalidInputException("Schema with name \"%s\" does not exist", name);
 	}
 	auto &base_info = info.Base();
 	auto &ir_catalog = catalog.Cast<IcebergCatalog>();

--- a/test/sql/local/irc_any_catalog/create/test_create_table_non_existent_schema.test
+++ b/test/sql/local/irc_any_catalog/create/test_create_table_non_existent_schema.test
@@ -25,16 +25,16 @@ set logging_level='debug'
 
 # cleanup
 statement ok
-DROP TABLE IF EXISTS my_datalake.non_existent_schema.create_table_t1;
+DROP TABLE IF EXISTS my_datalake.now_this_schema_exists.mytable;
 
 statement ok
 DROP SCHEMA IF EXISTS my_datalake.now_this_schema_exists;
 
 # test
 statement error
-create table my_datalake.non_existent_schema.create_table_t1 (a int, b varchar);
+create table my_datalake.non_existent_schema.mytable (a int, b varchar);
 ----
-Catalog Error: Schema with name "non_existent_schema" not found
+Invalid Input Error: Schema with name "non_existent_schema" does not exist
 
 # transaction test
 statement ok
@@ -44,7 +44,7 @@ statement ok
 create schema if not exists my_datalake.now_this_schema_exists;
 
 statement ok
-create table my_datalake.now_this_schema_exists.create_table_t1 (a int, b varchar);
+create table my_datalake.now_this_schema_exists.mytable (a int, b varchar);
 
 statement ok
 COMMIT;

--- a/test/sql/local/irc_any_catalog/create/test_create_table_non_existent_schema.test
+++ b/test/sql/local/irc_any_catalog/create/test_create_table_non_existent_schema.test
@@ -1,0 +1,50 @@
+# name: test/sql/local/irc_any_catalog/create/test_create_table_non_existent_schema.test
+# description: test create table
+# group: [create]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require-env SECRETS_CREATED_AND_CATALOG_ATTACHED
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+set logging_level='debug'
+
+# cleanup
+statement ok
+DROP TABLE IF EXISTS my_datalake.non_existent_schema.create_table_t1;
+
+statement ok
+DROP SCHEMA IF EXISTS my_datalake.now_this_schema_exists;
+
+# test
+statement error
+create table my_datalake.non_existent_schema.create_table_t1 (a int, b varchar);
+----
+Catalog Error: Schema with name "non_existent_schema" not found
+
+# transaction test
+statement ok
+BEGIN;
+
+statement ok
+create schema if not exists my_datalake.now_this_schema_exists;
+
+statement ok
+create table my_datalake.now_this_schema_exists.create_table_t1 (a int, b varchar);
+
+statement ok
+COMMIT;

--- a/test/sql/local/irc_any_catalog/create/test_create_table_non_existent_schema.test
+++ b/test/sql/local/irc_any_catalog/create/test_create_table_non_existent_schema.test
@@ -14,37 +14,8 @@ require iceberg
 
 require httpfs
 
-# Do not ignore 'HTTP' error messages!
-set ignore_error_messages
-
-statement ok
-CALL enable_logging('HTTP');
-
-statement ok
-set logging_level='debug'
-
-# cleanup
-statement ok
-DROP TABLE IF EXISTS my_datalake.now_this_schema_exists.mytable;
-
-statement ok
-DROP SCHEMA IF EXISTS my_datalake.now_this_schema_exists;
-
 # test
 statement error
 create table my_datalake.non_existent_schema.mytable (a int, b varchar);
 ----
 Invalid Input Error: Schema with name "non_existent_schema" does not exist
-
-# transaction test
-statement ok
-BEGIN;
-
-statement ok
-create schema if not exists my_datalake.now_this_schema_exists;
-
-statement ok
-create table my_datalake.now_this_schema_exists.mytable (a int, b varchar);
-
-statement ok
-COMMIT;


### PR DESCRIPTION
https://github.com/duckdblabs/duckdb-internal/issues/9007

Omit stack-trace when creating a table in a schema that doesn't exist, also with transactions.
