### PR TITLE
Parse geometry coordinate reference system

### DIFF
--- a/src/catalog/rest/api/iceberg_type.cpp
+++ b/src/catalog/rest/api/iceberg_type.cpp
@@ -58,8 +58,13 @@ string IcebergTypeHelper::LogicalTypeToIcebergType(const LogicalType &type) {
 		return "map";
 	case LogicalTypeId::VARIANT:
 		return "variant";
-	case LogicalTypeId::GEOMETRY:
-		return "geometry";
+	case LogicalTypeId::GEOMETRY: {
+		if (GeoType::HasCRS(type)) {
+			return StringUtil::Format("geometry(%s)", GeoType::GetCRS(type).GetIdentifier());
+		}
+		// use default coordinate system
+		return "geometry(" + StringUtil::Lower("OGC:CRS84") + ")";
+	}
 	default:
 		throw InvalidInputException("Column type %s is not a valid Iceberg Type.", LogicalTypeIdToString(type.id()));
 	}

--- a/src/core/metadata/schema/iceberg_column_definition.cpp
+++ b/src/core/metadata/schema/iceberg_column_definition.cpp
@@ -178,9 +178,20 @@ LogicalType IcebergColumnDefinition::ParsePrimitiveTypeString(const string &type
 	if (type_str == "variant") {
 		return LogicalType::VARIANT();
 	}
-	if (type_str == "geometry") {
-		// Geometry is an Iceberg v3 type stored as WKB binary in parquet
-		return LogicalType::GEOMETRY();
+	if (StringUtil::StartsWith(type_str, "geometry")) {
+		// Geometry is an Iceberg v3 type stored as WKB binary in parquet.
+		// The type string may include a CRS parameter: geometry(<crs>)
+		if (type_str == "geometry") {
+			return LogicalType::GEOMETRY();
+		}
+		if (type_str.size() > 9 && type_str[8] == '(' && type_str.back() == ')') {
+			auto crs_str = type_str.substr(9, type_str.size() - 10);
+			return LogicalType::GEOMETRY(crs_str);
+		}
+		throw InvalidConfigurationException("Invalid geometry type format: %s", type_str);
+	}
+	if (StringUtil::StartsWith(type_str, "geography")) {
+		throw NotImplementedException("Geography support");
 	}
 	throw InvalidConfigurationException("Unrecognized primitive type: %s", type_str);
 }

--- a/test/sql/local/irc_any_catalog/insert/iceberg_types/test_geometry_type.test
+++ b/test/sql/local/irc_any_catalog/insert/iceberg_types/test_geometry_type.test
@@ -1,0 +1,42 @@
+# name: test/sql/local/irc_any_catalog/insert/iceberg_types/test_geometry_type.test
+# group: [insert]
+
+require-env ICEBERG_SERVER_AVAILABLE
+
+require-env SECRETS_CREATED_AND_CATALOG_ATTACHED
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+statement ok
+drop table if exists my_datalake.default.geometry_type_crs;
+
+# no geometry types allowed in v2 tables.
+statement error
+create table my_datalake.default.geometry_type_crs (goe_type GEOMETRY('OGC:CRS83')) with ('format-version'='2');
+----
+
+statement ok
+create table my_datalake.default.geometry_type_crs (goe_type GEOMETRY('OGC:CRS83')) with ('format-version'='3');
+
+statement ok
+insert into my_datalake.default.geometry_type_crs VALUES ('POINT(1 2)'::GEOMETRY), ('LINESTRING Z (5 5 5, 10 10 10)'::GEOMETRY);
+
+# cannot combine CRS systems
+statement error
+insert into my_datalake.default.geometry_type_crs VALUES ('POINT(1 2)'::GEOMETRY('OGC:CRS84')), ('LINESTRING Z (5 5 5, 10 10 10)'::GEOMETRY);
+----

--- a/test/sql/local/irc_any_catalog/insert/iceberg_types/test_geometry_type.test
+++ b/test/sql/local/irc_any_catalog/insert/iceberg_types/test_geometry_type.test
@@ -1,5 +1,5 @@
 # name: test/sql/local/irc_any_catalog/insert/iceberg_types/test_geometry_type.test
-# group: [insert]
+# group: [iceberg_types]
 
 require-env ICEBERG_SERVER_AVAILABLE
 

--- a/test/sql/local/irc_any_catalog/insert/iceberg_types/test_geometry_type_nested.test
+++ b/test/sql/local/irc_any_catalog/insert/iceberg_types/test_geometry_type_nested.test
@@ -1,4 +1,4 @@
-# name: test/sql/local/irc_any_catalog/insert/test_create_geometry_type.test
+# name: test/sql/local/irc_any_catalog/insert/iceberg_types/test_create_geometry_type_nested.test
 # group: [insert]
 
 require-env ICEBERG_SERVER_AVAILABLE

--- a/test/sql/local/irc_any_catalog/insert/iceberg_types/test_geometry_type_nested.test
+++ b/test/sql/local/irc_any_catalog/insert/iceberg_types/test_geometry_type_nested.test
@@ -1,5 +1,5 @@
-# name: test/sql/local/irc_any_catalog/insert/iceberg_types/test_create_geometry_type_nested.test
-# group: [insert]
+# name: test/sql/local/irc_any_catalog/insert/iceberg_types/test_geometry_type_nested.test
+# group: [iceberg_types]
 
 require-env ICEBERG_SERVER_AVAILABLE
 


### PR DESCRIPTION
The Geoemtry type should also use the coordinate system. Geometry types will also be created using the default coordinate system `OGC:CRS84`.

Users will need to load spatial to use other coordinate systems.