### PR TITLE
[Bug] Plan IcebergCreateTable operator In CTAS queries to avoid double table create requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(EXTENSION_SOURCES
 	src/execution/operator/iceberg_delete.cpp
 	src/execution/operator/iceberg_insert.cpp
 	src/execution/operator/iceberg_update.cpp
+	src/execution/operator/physical_iceberg_create_table.cpp
 	src/execution/operator/merge_into/iceberg_merge_into.cpp
 	src/execution/operator/merge_into/iceberg_merge_insert.cpp
 	src/execution/operator/merge_into/iceberg_merge_update.cpp

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -336,21 +336,12 @@ int64_t IcebergTableInformation::GetExistingSpecId(IcebergPartitionSpec &spec) {
 	}
 	return existing_spec_id;
 }
-void IcebergTableInformation::SetPartitionedBy(IcebergTransaction &transaction,
-                                               const vector<unique_ptr<ParsedExpression>> &partition_keys,
-                                               const IcebergTableSchema &schema, bool first_partition_spec) {
-	idx_t base_partition_field_id = 1000;
-	if (!first_partition_spec && table_metadata.HasLastPartitionId()) {
-		base_partition_field_id = table_metadata.GetLastPartitionFieldId() + 1;
-	}
 
-	idx_t new_spec_id = 0;
-	if (!first_partition_spec) {
-		new_spec_id = GetNextPartitionSpecId();
-	}
-	auto &transaction_data = GetOrCreateTransactionData(transaction);
-
-	IcebergPartitionSpec new_spec(new_spec_id);
+IcebergPartitionSpec
+IcebergTableInformation::BuildPartitionSpec(const vector<unique_ptr<ParsedExpression>> &partition_keys,
+                                            const IcebergTableSchema &schema, int32_t spec_id,
+                                            idx_t base_partition_field_id) {
+	IcebergPartitionSpec new_spec(spec_id);
 
 	for (auto &key : partition_keys) {
 		string column_name;
@@ -432,6 +423,26 @@ void IcebergTableInformation::SetPartitionedBy(IcebergTransaction &transaction,
 		field.SetPartitionSpecFieldName(column_name);
 		new_spec.fields.push_back(std::move(field));
 	}
+
+	return new_spec;
+}
+
+void IcebergTableInformation::SetPartitionedBy(IcebergTransaction &transaction,
+                                               const vector<unique_ptr<ParsedExpression>> &partition_keys,
+                                               const IcebergTableSchema &schema, bool first_partition_spec) {
+	idx_t base_partition_field_id = 1000;
+	if (!first_partition_spec && table_metadata.HasLastPartitionId()) {
+		base_partition_field_id = table_metadata.GetLastPartitionFieldId() + 1;
+	}
+
+	idx_t new_spec_id = 0;
+	if (!first_partition_spec) {
+		new_spec_id = GetNextPartitionSpecId();
+	}
+	auto &transaction_data = GetOrCreateTransactionData(transaction);
+
+	auto new_spec =
+	    BuildPartitionSpec(partition_keys, schema, static_cast<int32_t>(new_spec_id), base_partition_field_id);
 
 	// if spec definition already exists in a previous spec definition, set it to that spec id
 	// (some catalog may allow duplicate definitions, others not)

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -962,7 +962,6 @@ static unique_ptr<IcebergTableMetadata> BuildPlaceholderMetadata(BoundCreateTabl
 	auto metadata = make_uniq<IcebergTableMetadata>();
 	metadata->iceberg_version = 2;
 	metadata->default_spec_id = 0;
-	metadata->partition_specs.emplace(0, IcebergPartitionSpec(0));
 
 	auto schema = make_shared_ptr<IcebergTableSchema>();
 	schema->schema_id = 0;
@@ -979,6 +978,13 @@ static unique_ptr<IcebergTableMetadata> BuildPlaceholderMetadata(BoundCreateTabl
 	schema->last_column_id = static_cast<idx_t>(next_field_id - 1);
 	metadata->AddSchemaOrGetExisting(schema);
 	metadata->SetCurrentSchemaId(0);
+
+	// Build a placeholder partition spec from the parsed PARTITIONED BY clause so that
+	// PlanCopyForInsert appends the partition projection at plan time. The real spec is
+	// applied during PhysicalIcebergCreateTable::MakeCreateTableRequest, but the projection
+	// indices are derived from the same partition_keys/schema and so remain consistent.
+	auto placeholder_spec = IcebergTableInformation::BuildPartitionSpec(create_info.partition_keys, *schema, 0, 1000);
+	metadata->partition_specs.emplace(0, std::move(placeholder_spec));
 	return metadata;
 }
 

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -18,8 +18,12 @@
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
 #include "execution/operator/iceberg_delete.hpp"
+#include "execution/operator/physical_iceberg_create_table.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
 #include "core/metadata/schema/iceberg_column_definition.hpp"
+#include "core/metadata/schema/iceberg_table_schema.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
+#include "core/metadata/partition/iceberg_partition_spec.hpp"
 #include "planning/iceberg_multi_file_list.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
 #include "core/expression/iceberg_value.hpp"
@@ -360,11 +364,26 @@ void IcebergInsert::AddWrittenFiles(IcebergInsertGlobalState &global_state, Data
 	global_state.AddFiles(chunk, ic_table.name, table_metadata);
 }
 
+optional_ptr<TableCatalogEntry> IcebergInsert::GetEffectiveTable() const {
+	if (table) {
+		return table;
+	}
+	if (create_state) {
+		lock_guard<mutex> guard(create_state->lock);
+		return create_state->table_entry ? create_state->table_entry.get() : nullptr;
+	}
+	return nullptr;
+}
+
 SinkResultType IcebergInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
 	auto &global_state = input.global_state.Cast<IcebergInsertGlobalState>();
 
-	// TODO: pass through the partition id?
-	AddWrittenFiles(global_state, chunk, table);
+	// For CTAS, `table` is null at planning time and the catalog entry is
+	// produced by an upstream PhysicalIcebergCreateTable on the first chunk.
+	// By the time Sink runs that upstream operator has already populated
+	// `create_state->table_entry`, so resolve the effective table here.
+	auto effective_table = GetEffectiveTable();
+	AddWrittenFiles(global_state, chunk, effective_table);
 
 	return SinkResultType::NEED_MORE_INPUT;
 }
@@ -388,9 +407,15 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
                                          OperatorSinkFinalizeInput &input) const {
 	auto &global_state = input.global_state.Cast<IcebergInsertGlobalState>();
 
-	auto &irc_table = table->Cast<IcebergTableEntry>();
+	auto effective_table = GetEffectiveTable();
+	if (!effective_table) {
+		// No data was sunk and no CTAS table was created (e.g. the upstream
+		// pipeline produced zero chunks for an empty CTAS). Nothing to commit.
+		return SinkFinalizeType::READY;
+	}
+	auto &irc_table = effective_table->Cast<IcebergTableEntry>();
 	auto &table_info = irc_table.table_info;
-	auto &transaction = IcebergTransaction::Get(context, table->catalog);
+	auto &transaction = IcebergTransaction::Get(context, effective_table->catalog);
 	auto &iceberg_transaction = transaction.Cast<IcebergTransaction>();
 
 	vector<IcebergManifestEntry> written_files;
@@ -434,13 +459,21 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 // Helpers
 //===--------------------------------------------------------------------===//
 string IcebergInsert::GetName() const {
-	D_ASSERT(table);
 	return "ICEBERG_INSERT";
 }
 
 InsertionOrderPreservingMap<string> IcebergInsert::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
-	result["Table Name"] = table ? table->name : info->Base().table;
+	if (table) {
+		result["Table Name"] = table->name;
+	} else if (info) {
+		result["Table Name"] = info->Base().table;
+	} else if (create_state) {
+		lock_guard<mutex> guard(create_state->lock);
+		if (create_state->table_entry) {
+			result["Table Name"] = create_state->table_entry->name;
+		}
+	}
 	return result;
 }
 
@@ -925,34 +958,60 @@ PhysicalOperator &IcebergCatalog::PlanInsert(ClientContext &context, PhysicalPla
 	return insert;
 }
 
+static unique_ptr<IcebergTableMetadata> BuildPlaceholderMetadata(BoundCreateTableInfo &info) {
+	auto metadata = make_uniq<IcebergTableMetadata>();
+	metadata->iceberg_version = 2;
+	metadata->default_spec_id = 0;
+	metadata->partition_specs.emplace(0, IcebergPartitionSpec(0));
+
+	auto schema = make_shared_ptr<IcebergTableSchema>();
+	schema->schema_id = 0;
+	int32_t next_field_id = 1;
+	auto &create_info = info.Base().Cast<CreateTableInfo>();
+	for (auto &col : create_info.columns.Logical()) {
+		auto col_def = make_uniq<IcebergColumnDefinition>();
+		col_def->id = next_field_id++;
+		col_def->name = col.Name();
+		col_def->type = col.Type();
+		col_def->required = false;
+		schema->columns.push_back(std::move(col_def));
+	}
+	schema->last_column_id = static_cast<idx_t>(next_field_id - 1);
+	metadata->AddSchemaOrGetExisting(schema);
+	metadata->SetCurrentSchemaId(0);
+	return metadata;
+}
+
 PhysicalOperator &IcebergCatalog::PlanCreateTableAs(ClientContext &context, PhysicalPlanGenerator &planner,
                                                     LogicalCreateTable &op, PhysicalOperator &plan) {
-	// TODO: parse partition information here.
 	auto &schema = op.schema;
-
 	auto &ic_schema_entry = schema.Cast<IcebergSchemaEntry>();
-	auto &catalog = ic_schema_entry.catalog;
-	auto transaction = catalog.GetCatalogTransaction(context);
 
-	// create the table. Takes care of committing to rest catalog and getting the metadata location etc.
-	// setting the schema
-	auto table = ic_schema_entry.CreateTable(transaction, context, *op.info);
-	if (!table) {
-		throw InternalException("Table could not be created");
-	}
-	auto &ic_table = table->Cast<IcebergTableEntry>();
-	auto &table_metadata = ic_table.table_info.table_metadata;
-	// We need to load table credentials into our secrets for when we copy files
-	ic_table.PrepareIcebergScanFromEntry(context);
+	// create a fake local iceberg table with desired columns
+	auto placeholder_metadata = BuildPlaceholderMetadata(*op.info);
+	auto &placeholder_schema = placeholder_metadata->GetLatestSchema();
+	IcebergCopyInput copy_input(context, *placeholder_metadata, placeholder_schema);
+	auto &physical_copy_op = IcebergInsert::PlanCopyForInsert(context, planner, copy_input, &plan);
+	auto &physical_copy = physical_copy_op.Cast<PhysicalCopyToFile>();
 
-	auto &table_schema = table_metadata.GetLatestSchema();
+	D_ASSERT(physical_copy.children.size() == 1);
+	auto &upstream = physical_copy.children[0].get();
+	auto upstream_types = upstream.types;
+	auto upstream_card = upstream.estimated_cardinality;
 
-	// Create Copy Info
-	IcebergCopyInput info(context, table_metadata, table_schema);
-	auto &physical_copy = IcebergInsert::PlanCopyForInsert(context, planner, info, plan);
-	physical_index_vector_t<idx_t> column_index_map;
-	auto &insert = planner.Make<IcebergInsert>(op, ic_table, column_index_map);
+	// create shared state to be used between IcebergTableCreate and IcebergInsert
+	auto create_state = make_shared_ptr<IcebergCTASCreateState>();
+	// create a pass through IcebergCTASCrecateStatement operator to make the
+	// CreateTable API call when the operator is executed.
+	auto &create_op = planner.Make<PhysicalIcebergCreateTable>(ic_schema_entry, std::move(op.info), create_state,
+	                                                            physical_copy, std::move(upstream_types), upstream_card);
+	create_op.children.push_back(upstream);
+	physical_copy.children[0] = create_op;
 
+
+	auto &insert =
+	    planner.Make<IcebergInsert>(op, schema, unique_ptr<BoundCreateTableInfo>()).Cast<IcebergInsert>();
+	insert.create_state = std::move(create_state);
 	insert.children.push_back(physical_copy);
 	return insert;
 }

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -409,9 +409,8 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 
 	auto effective_table = GetEffectiveTable();
 	if (!effective_table) {
-		// No data was sunk and no CTAS table was created (e.g. the upstream
-		// pipeline produced zero chunks for an empty CTAS). Nothing to commit.
-		return SinkFinalizeType::READY;
+		// Table does not exist (INSERT INTO) or was not created in Physical Create Iceberg table (CTAS). Throw Error
+		throw InternalException("Table to insert into does not exist.");
 	}
 	auto &irc_table = effective_table->Cast<IcebergTableEntry>();
 	auto &table_info = irc_table.table_info;

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -1004,13 +1004,11 @@ PhysicalOperator &IcebergCatalog::PlanCreateTableAs(ClientContext &context, Phys
 	// create a pass through IcebergCTASCrecateStatement operator to make the
 	// CreateTable API call when the operator is executed.
 	auto &create_op = planner.Make<PhysicalIcebergCreateTable>(ic_schema_entry, std::move(op.info), create_state,
-	                                                            physical_copy, std::move(upstream_types), upstream_card);
+	                                                           physical_copy, std::move(upstream_types), upstream_card);
 	create_op.children.push_back(upstream);
 	physical_copy.children[0] = create_op;
 
-
-	auto &insert =
-	    planner.Make<IcebergInsert>(op, schema, unique_ptr<BoundCreateTableInfo>()).Cast<IcebergInsert>();
+	auto &insert = planner.Make<IcebergInsert>(op, schema, unique_ptr<BoundCreateTableInfo>()).Cast<IcebergInsert>();
 	insert.create_state = std::move(create_state);
 	insert.children.push_back(physical_copy);
 	return insert;

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -1006,7 +1006,7 @@ PhysicalOperator &IcebergCatalog::PlanCreateTableAs(ClientContext &context, Phys
 
 	// create shared state to be used between IcebergTableCreate and IcebergInsert
 	auto create_state = make_shared_ptr<IcebergCTASCreateState>();
-	// create a pass through IcebergCTASCrecateStatement operator to make the
+	// create a pass through IcebergCTASCreateStatement operator to make the
 	// CreateTable API call when the operator is executed.
 	auto &create_op = planner.Make<PhysicalIcebergCreateTable>(ic_schema_entry, std::move(op.info), create_state,
 	                                                           physical_copy, std::move(upstream_types), upstream_card);

--- a/src/execution/operator/physical_iceberg_create_table.cpp
+++ b/src/execution/operator/physical_iceberg_create_table.cpp
@@ -1,0 +1,93 @@
+#include "execution/operator/physical_iceberg_create_table.hpp"
+
+#include "duckdb/execution/operator/persistent/physical_copy_to_file.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
+
+#include "catalog/rest/catalog_entry/iceberg_schema_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/iceberg_catalog.hpp"
+#include "execution/operator/iceberg_insert.hpp"
+
+namespace duckdb {
+
+PhysicalIcebergCreateTable::PhysicalIcebergCreateTable(PhysicalPlan &physical_plan, IcebergSchemaEntry &schema_entry,
+                                                       unique_ptr<BoundCreateTableInfo> info,
+                                                       shared_ptr<IcebergCTASCreateState> create_state,
+                                                       PhysicalCopyToFile &copy_to_file_op, vector<LogicalType> types,
+                                                       idx_t estimated_cardinality)
+    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, std::move(types), estimated_cardinality),
+      schema_entry(schema_entry), info(std::move(info)), create_state(std::move(create_state)),
+      copy_to_file_op(copy_to_file_op) {
+}
+
+unique_ptr<GlobalOperatorState> PhysicalIcebergCreateTable::GetGlobalOperatorState(ClientContext &context) const {
+	return make_uniq<IcebergCreateTableGlobalState>();
+}
+
+OperatorResultType PhysicalIcebergCreateTable::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                       GlobalOperatorState &gstate_p, OperatorState &state) const {
+	auto &gstate = gstate_p.Cast<IcebergCreateTableGlobalState>();
+
+	// Create the table in the IRC, record the field ids (columns ids) and update the binding in the
+	std::call_once(gstate.init_flag, [&]() {
+		auto &client_context = context.client;
+		auto &catalog = schema_entry.catalog;
+		auto transaction = catalog.GetCatalogTransaction(client_context);
+
+		auto table = schema_entry.CreateTable(transaction, client_context, *info);
+		if (!table) {
+			throw InternalException("Iceberg CTAS: CreateTable request failed");
+		}
+		auto &ic_table = table->Cast<IcebergTableEntry>();
+		// Load any per-table credentials (e.g. SigV4 for the data location).
+		ic_table.PrepareIcebergScanFromEntry(client_context);
+
+		auto &table_metadata = ic_table.table_info.table_metadata;
+		auto &table_schema = table_metadata.GetLatestSchema();
+
+		IcebergCopyInput copy_input(client_context, table_metadata, table_schema);
+		auto copy_options = IcebergInsert::GetCopyOptions(client_context, copy_input);
+
+		auto &copy_op = copy_to_file_op.get();
+		copy_op.bind_data = std::move(copy_options.bind_data);
+		copy_op.file_path = std::move(copy_options.file_path);
+		copy_op.filename_pattern = std::move(copy_options.filename_pattern);
+		copy_op.file_extension = std::move(copy_options.file_extension);
+		copy_op.overwrite_mode = copy_options.overwrite_mode;
+		copy_op.per_thread_output = copy_options.per_thread_output;
+		copy_op.file_size_bytes = copy_options.file_size_bytes;
+		copy_op.rotate = copy_options.rotate;
+		copy_op.return_type = copy_options.return_type;
+		copy_op.partition_output = copy_options.partition_output;
+		copy_op.write_partition_columns = copy_options.write_partition_columns;
+		copy_op.write_empty_file = copy_options.write_empty_file;
+		copy_op.partition_columns = std::move(copy_options.partition_columns);
+		copy_op.names = std::move(copy_options.names);
+		copy_op.expected_types = std::move(copy_options.expected_types);
+
+		{
+			lock_guard<mutex> guard(create_state->lock);
+			create_state->table_entry = &ic_table;
+			create_state->created = true;
+		}
+	});
+
+	// Pass the chunk through unmodified.
+	chunk.Reference(input);
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+string PhysicalIcebergCreateTable::GetName() const {
+	return "ICEBERG_CREATE_TABLE";
+}
+
+InsertionOrderPreservingMap<string> PhysicalIcebergCreateTable::ParamsToString() const {
+	InsertionOrderPreservingMap<string> result;
+	if (info) {
+		result["Table Name"] = info->Base().table;
+	}
+	return result;
+}
+
+} // namespace duckdb

--- a/src/execution/operator/physical_iceberg_create_table.cpp
+++ b/src/execution/operator/physical_iceberg_create_table.cpp
@@ -22,13 +22,14 @@ PhysicalIcebergCreateTable::PhysicalIcebergCreateTable(PhysicalPlan &physical_pl
 }
 
 unique_ptr<GlobalOperatorState> PhysicalIcebergCreateTable::GetGlobalOperatorState(ClientContext &context) const {
-	return make_uniq<IcebergCreateTableGlobalState>();
+	auto global_state = make_uniq<IcebergCreateTableGlobalState>();
+	MakeCreateTableRequest(context, *global_state);
+	return global_state;
 }
 
-void PhysicalIcebergCreateTable::MakeCreateTableRequest(ExecutionContext &context,
+void PhysicalIcebergCreateTable::MakeCreateTableRequest(ClientContext &client_context,
                                                         IcebergCreateTableGlobalState &gstate) const {
 	std::call_once(gstate.init_flag, [&]() {
-		auto &client_context = context.client;
 		auto &catalog = schema_entry.catalog;
 		auto transaction = catalog.GetCatalogTransaction(client_context);
 
@@ -71,20 +72,8 @@ void PhysicalIcebergCreateTable::MakeCreateTableRequest(ExecutionContext &contex
 	});
 }
 
-OperatorFinalizeResultType PhysicalIcebergCreateTable::FinalExecute(ExecutionContext &context, DataChunk &chunk,
-                                                                    GlobalOperatorState &gstate,
-                                                                    OperatorState &state) const {
-	auto &global_state = gstate.Cast<IcebergCreateTableGlobalState>();
-	MakeCreateTableRequest(context, global_state);
-	return OperatorFinalizeResultType::FINISHED;
-}
-
 OperatorResultType PhysicalIcebergCreateTable::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
                                                        GlobalOperatorState &gstate_p, OperatorState &state) const {
-	auto &global_state = gstate_p.Cast<IcebergCreateTableGlobalState>();
-	// Create the table in the IRC, record the field ids (columns ids) and update the binding in the
-	MakeCreateTableRequest(context, global_state);
-	// Pass the chunk through unmodified.
 	chunk.Reference(input);
 	return OperatorResultType::NEED_MORE_INPUT;
 }

--- a/src/execution/operator/physical_iceberg_create_table.cpp
+++ b/src/execution/operator/physical_iceberg_create_table.cpp
@@ -25,11 +25,8 @@ unique_ptr<GlobalOperatorState> PhysicalIcebergCreateTable::GetGlobalOperatorSta
 	return make_uniq<IcebergCreateTableGlobalState>();
 }
 
-OperatorResultType PhysicalIcebergCreateTable::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
-                                                       GlobalOperatorState &gstate_p, OperatorState &state) const {
-	auto &gstate = gstate_p.Cast<IcebergCreateTableGlobalState>();
-
-	// Create the table in the IRC, record the field ids (columns ids) and update the binding in the
+void PhysicalIcebergCreateTable::MakeCreateTableRequest(ExecutionContext &context,
+                                                        IcebergCreateTableGlobalState &gstate) const {
 	std::call_once(gstate.init_flag, [&]() {
 		auto &client_context = context.client;
 		auto &catalog = schema_entry.catalog;
@@ -72,7 +69,21 @@ OperatorResultType PhysicalIcebergCreateTable::Execute(ExecutionContext &context
 			create_state->created = true;
 		}
 	});
+}
 
+OperatorFinalizeResultType PhysicalIcebergCreateTable::FinalExecute(ExecutionContext &context, DataChunk &chunk,
+                                                                    GlobalOperatorState &gstate,
+                                                                    OperatorState &state) const {
+	auto &global_state = gstate.Cast<IcebergCreateTableGlobalState>();
+	MakeCreateTableRequest(context, global_state);
+	return OperatorFinalizeResultType::FINISHED;
+}
+
+OperatorResultType PhysicalIcebergCreateTable::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                       GlobalOperatorState &gstate_p, OperatorState &state) const {
+	auto &global_state = gstate_p.Cast<IcebergCreateTableGlobalState>();
+	// Create the table in the IRC, record the field ids (columns ids) and update the binding in the
+	MakeCreateTableRequest(context, global_state);
 	// Pass the chunk through unmodified.
 	chunk.Reference(input);
 	return OperatorResultType::NEED_MORE_INPUT;

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -47,6 +47,10 @@ public:
 	int64_t GetExistingSpecId(IcebergPartitionSpec &spec);
 	void SetPartitionedBy(IcebergTransaction &transaction, const vector<unique_ptr<ParsedExpression>> &partition_keys,
 	                      const IcebergTableSchema &schema, bool first_partition_spec = false);
+	//! Build an IcebergPartitionSpec from parsed PARTITIONED BY expressions and a schema.
+	static IcebergPartitionSpec BuildPartitionSpec(const vector<unique_ptr<ParsedExpression>> &partition_keys,
+	                                               const IcebergTableSchema &schema, int32_t spec_id,
+	                                               idx_t base_partition_field_id);
 	IRCAPITableCredentials GetVendedCredentials(ClientContext &context);
 	const string &BaseFilePath() const;
 

--- a/src/include/execution/operator/iceberg_insert.hpp
+++ b/src/include/execution/operator/iceberg_insert.hpp
@@ -17,6 +17,7 @@
 #include "catalog/rest/catalog_entry/iceberg_schema_entry.hpp"
 #include "core/metadata/partition/iceberg_partition_spec.hpp"
 #include "core/metadata/schema/iceberg_table_schema.hpp"
+#include "execution/operator/physical_iceberg_create_table.hpp"
 
 namespace duckdb {
 
@@ -144,6 +145,10 @@ public:
 	//! When set, this insert is part of an UPDATE: points to the delete operator so Finalize
 	//! can call AddUpdateSnapshot instead of AddSnapshot.
 	optional_ptr<PhysicalOperator> update_delete_op;
+	//! When set, this insert is a CTAS whose table is created lazily by an
+	//! upstream PhysicalIcebergCreateTable. Sink/Finalize resolve the
+	//! TableCatalogEntry through this shared state instead of `table`.
+	shared_ptr<IcebergCTASCreateState> create_state;
 
 public:
 	// Source interface
@@ -169,6 +174,11 @@ public:
 	static vector<IcebergManifestEntry> GetInsertManifestEntries(IcebergInsertGlobalState &global_state);
 	static void AddWrittenFiles(IcebergInsertGlobalState &global_state, DataChunk &chunk,
 	                            optional_ptr<TableCatalogEntry> table);
+
+	//! Resolve the catalog entry this insert is targeting. For INSERT INTO this
+	//! is just `this->table`; for CTAS the table is created lazily by an
+	//! upstream PhysicalIcebergCreateTable, so we read it from `create_state`.
+	optional_ptr<TableCatalogEntry> GetEffectiveTable() const;
 
 	bool IsSink() const override {
 		return true;

--- a/src/include/execution/operator/physical_iceberg_create_table.hpp
+++ b/src/include/execution/operator/physical_iceberg_create_table.hpp
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// execution/operator/physical_iceberg_create_table.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/execution/physical_operator_states.hpp"
+#include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
+
+#include <mutex>
+
+namespace duckdb {
+
+class IcebergSchemaEntry;
+class IcebergTableEntry;
+class PhysicalCopyToFile;
+
+//! Shared mutable state populated at execution time by PhysicalIcebergCreateTable.
+//! Read by IcebergInsert during Sink/Finalize so it can resolve the catalog
+//! TableCatalogEntry that was created lazily.
+struct IcebergCTASCreateState {
+	mutex lock;
+	//! Set to true once the CreateTable REST call has completed successfully.
+	bool created = false;
+	//! Populated after CreateTable returns.
+	optional_ptr<IcebergTableEntry> table_entry;
+};
+
+class IcebergCreateTableGlobalState : public GlobalOperatorState {
+public:
+	IcebergCreateTableGlobalState() = default;
+	std::once_flag init_flag;
+};
+
+// Pass through operator between Insert source and CopyToFile/Insert that
+// is responsible for calling the IRC api to actually create the table.
+class PhysicalIcebergCreateTable : public PhysicalOperator {
+public:
+	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::EXTENSION;
+
+public:
+	PhysicalIcebergCreateTable(PhysicalPlan &physical_plan, IcebergSchemaEntry &schema_entry,
+	                            unique_ptr<BoundCreateTableInfo> info,
+	                            shared_ptr<IcebergCTASCreateState> create_state, PhysicalCopyToFile &copy_to_file_op,
+	                            vector<LogicalType> types, idx_t estimated_cardinality);
+
+public:
+	// Operator interface
+	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+	                           GlobalOperatorState &gstate, OperatorState &state) const override;
+	unique_ptr<GlobalOperatorState> GetGlobalOperatorState(ClientContext &context) const override;
+
+	bool ParallelOperator() const override {
+		return false;
+	}
+
+	string GetName() const override;
+	InsertionOrderPreservingMap<string> ParamsToString() const override;
+
+public:
+	IcebergSchemaEntry &schema_entry;
+	unique_ptr<BoundCreateTableInfo> info;
+	shared_ptr<IcebergCTASCreateState> create_state;
+	//! non-const reference to copy_to_file so we can rebind copy options and update field ids
+	reference<PhysicalCopyToFile> copy_to_file_op;
+};
+
+} // namespace duckdb

--- a/src/include/execution/operator/physical_iceberg_create_table.hpp
+++ b/src/include/execution/operator/physical_iceberg_create_table.hpp
@@ -53,22 +53,12 @@ public:
 	// Operator interface
 	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
 	                           GlobalOperatorState &gstate, OperatorState &state) const override;
-	// If no rows are returned in the CTAS, Execute never runs. We still want to create a
-	// table, so FinaleExecute will take care of that
-	OperatorFinalizeResultType FinalExecute(ExecutionContext &context, DataChunk &chunk, GlobalOperatorState &gstate,
-	                                        OperatorState &state) const override;
-	void MakeCreateTableRequest(ExecutionContext &context, IcebergCreateTableGlobalState &gstate) const;
+	void MakeCreateTableRequest(ClientContext &context, IcebergCreateTableGlobalState &gstate) const;
 	unique_ptr<GlobalOperatorState> GetGlobalOperatorState(ClientContext &context) const override;
 
 	bool ParallelOperator() const override {
-		return false;
-	}
-
-	bool RequiresFinalExecute() const override {
-		// in case a 0 row table is created, FinalExecute can
-		// make the Create Table API request
 		return true;
-	};
+	}
 
 	string GetName() const override;
 	InsertionOrderPreservingMap<string> ParamsToString() const override;

--- a/src/include/execution/operator/physical_iceberg_create_table.hpp
+++ b/src/include/execution/operator/physical_iceberg_create_table.hpp
@@ -53,11 +53,22 @@ public:
 	// Operator interface
 	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
 	                           GlobalOperatorState &gstate, OperatorState &state) const override;
+	// If no rows are returned in the CTAS, Execute never runs. We still want to create a
+	// table, so FinaleExecute will take care of that
+	OperatorFinalizeResultType FinalExecute(ExecutionContext &context, DataChunk &chunk, GlobalOperatorState &gstate,
+	                                        OperatorState &state) const override;
+	void MakeCreateTableRequest(ExecutionContext &context, IcebergCreateTableGlobalState &gstate) const;
 	unique_ptr<GlobalOperatorState> GetGlobalOperatorState(ClientContext &context) const override;
 
 	bool ParallelOperator() const override {
 		return false;
 	}
+
+	bool RequiresFinalExecute() const override {
+		// in case a 0 row table is created, FinalExecute can
+		// make the Create Table API request
+		return true;
+	};
 
 	string GetName() const override;
 	InsertionOrderPreservingMap<string> ParamsToString() const override;

--- a/src/include/execution/operator/physical_iceberg_create_table.hpp
+++ b/src/include/execution/operator/physical_iceberg_create_table.hpp
@@ -45,9 +45,9 @@ public:
 
 public:
 	PhysicalIcebergCreateTable(PhysicalPlan &physical_plan, IcebergSchemaEntry &schema_entry,
-	                            unique_ptr<BoundCreateTableInfo> info,
-	                            shared_ptr<IcebergCTASCreateState> create_state, PhysicalCopyToFile &copy_to_file_op,
-	                            vector<LogicalType> types, idx_t estimated_cardinality);
+	                           unique_ptr<BoundCreateTableInfo> info, shared_ptr<IcebergCTASCreateState> create_state,
+	                           PhysicalCopyToFile &copy_to_file_op, vector<LogicalType> types,
+	                           idx_t estimated_cardinality);
 
 public:
 	// Operator interface

--- a/test/python/test_python_ctas.py
+++ b/test/python/test_python_ctas.py
@@ -1,0 +1,168 @@
+import ctypes
+import glob
+import os
+import pathlib
+
+import pytest
+
+
+# SQL PREPARE does not accept CTAS, but ADBC prepares and executes CTAS through
+# DuckDB's C API. Exercise that path directly to cover issue #595 without dbt.
+pytestmark = pytest.mark.skipif(
+    os.getenv("ICEBERG_SERVER_AVAILABLE") is None,
+    reason="Iceberg test catalog is not available",
+)
+
+
+def _load_duckdb_library():
+    repo = pathlib.Path(__file__).resolve().parents[2]
+    candidates = []
+    for build_type in ["release"]:
+        candidates.extend(glob.glob(str(repo / "build" / build_type / "src" / "libduckdb.*")))
+    candidates = [path for path in candidates if pathlib.Path(path).suffix in (".so", ".dylib", ".dll")]
+    if not candidates:
+        pytest.skip("libduckdb was not built")
+    return ctypes.CDLL(candidates[0])
+
+
+class DuckDBResult(ctypes.Structure):
+    _fields_ = [
+        ("deprecated_column_count", ctypes.c_uint64),
+        ("deprecated_row_count", ctypes.c_uint64),
+        ("deprecated_rows_changed", ctypes.c_uint64),
+        ("deprecated_columns", ctypes.c_void_p),
+        ("deprecated_error_message", ctypes.c_char_p),
+        ("internal_data", ctypes.c_void_p),
+    ]
+
+
+def _init_api(lib):
+    lib.duckdb_open.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_void_p)]
+    lib.duckdb_open.restype = ctypes.c_int
+    lib.duckdb_connect.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+    lib.duckdb_connect.restype = ctypes.c_int
+    lib.duckdb_disconnect.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+    lib.duckdb_close.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+    lib.duckdb_query.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.POINTER(DuckDBResult)]
+    lib.duckdb_query.restype = ctypes.c_int
+    lib.duckdb_result_error.argtypes = [ctypes.POINTER(DuckDBResult)]
+    lib.duckdb_result_error.restype = ctypes.c_char_p
+    lib.duckdb_destroy_result.argtypes = [ctypes.POINTER(DuckDBResult)]
+    lib.duckdb_prepare.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.POINTER(ctypes.c_void_p)]
+    lib.duckdb_prepare.restype = ctypes.c_int
+    lib.duckdb_prepare_error.argtypes = [ctypes.c_void_p]
+    lib.duckdb_prepare_error.restype = ctypes.c_char_p
+    lib.duckdb_execute_prepared_streaming.argtypes = [ctypes.c_void_p, ctypes.POINTER(DuckDBResult)]
+    lib.duckdb_execute_prepared_streaming.restype = ctypes.c_int
+    lib.duckdb_destroy_prepare.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+    lib.duckdb_value_int32.argtypes = [ctypes.POINTER(DuckDBResult), ctypes.c_uint64, ctypes.c_uint64]
+    lib.duckdb_value_int32.restype = ctypes.c_int32
+    lib.duckdb_value_varchar.argtypes = [ctypes.POINTER(DuckDBResult), ctypes.c_uint64, ctypes.c_uint64]
+    lib.duckdb_value_varchar.restype = ctypes.c_void_p
+    lib.duckdb_free.argtypes = [ctypes.c_void_p]
+
+
+class DuckDB:
+    def __init__(self):
+        self.lib = _load_duckdb_library()
+        _init_api(self.lib)
+        self.db = ctypes.c_void_p()
+        self.con = ctypes.c_void_p()
+        assert self.lib.duckdb_open(None, ctypes.byref(self.db)) == 0
+        assert self.lib.duckdb_connect(self.db, ctypes.byref(self.con)) == 0
+
+    def close(self):
+        if self.con:
+            self.lib.duckdb_disconnect(ctypes.byref(self.con))
+        if self.db:
+            self.lib.duckdb_close(ctypes.byref(self.db))
+
+    def query(self, sql, expect_ok=True):
+        result = DuckDBResult()
+        state = self.lib.duckdb_query(self.con, sql.encode(), ctypes.byref(result))
+        error = self._result_error(result)
+        self.lib.duckdb_destroy_result(ctypes.byref(result))
+        if expect_ok:
+            assert state == 0, error
+        return state, error
+
+    def prepare(self, sql):
+        prepared = ctypes.c_void_p()
+        state = self.lib.duckdb_prepare(self.con, sql.encode(), ctypes.byref(prepared))
+        error = self.lib.duckdb_prepare_error(prepared)
+        assert state == 0, error.decode() if error else None
+        return prepared
+
+    def execute_prepared_streaming(self, prepared):
+        result = DuckDBResult()
+        state = self.lib.duckdb_execute_prepared_streaming(prepared, ctypes.byref(result))
+        error = self._result_error(result)
+        self.lib.duckdb_destroy_result(ctypes.byref(result))
+        assert state == 0, error
+
+    def destroy_prepare(self, prepared):
+        self.lib.duckdb_destroy_prepare(ctypes.byref(prepared))
+
+    def fetch_single_row(self, sql):
+        result = DuckDBResult()
+        state = self.lib.duckdb_query(self.con, sql.encode(), ctypes.byref(result))
+        error = self._result_error(result)
+        assert state == 0, error
+        text_ptr = self.lib.duckdb_value_varchar(ctypes.byref(result), 1, 0)
+        assert text_ptr
+        try:
+            row = (self.lib.duckdb_value_int32(ctypes.byref(result), 0, 0), ctypes.string_at(text_ptr).decode())
+        finally:
+            self.lib.duckdb_free(text_ptr)
+            self.lib.duckdb_destroy_result(ctypes.byref(result))
+        return row
+
+    def _result_error(self, result):
+        error = self.lib.duckdb_result_error(ctypes.byref(result))
+        return error.decode() if error else None
+
+
+@pytest.fixture()
+def duckdb_capi():
+    db = DuckDB()
+    try:
+        for extension in ("core_functions", "parquet", "avro", "httpfs", "iceberg"):
+            db.query(f"LOAD {extension}")
+        db.query(
+            "CREATE SECRET (TYPE S3,KEY_ID 'admin',SECRET 'password',ENDPOINT '127.0.0.1:9000',"
+            "URL_STYLE 'path',USE_SSL 0); "
+            "ATTACH '' AS my_datalake (TYPE ICEBERG,CLIENT_ID 'admin',CLIENT_SECRET 'password',"
+            "ENDPOINT 'http://127.0.0.1:8181'); "
+            "CREATE SCHEMA IF NOT EXISTS my_datalake.default;"
+        )
+        yield db
+    finally:
+        db.close()
+
+
+def test_iceberg_ctas_prepared_statement_rebinds_at_execute(duckdb_capi):
+    duckdb_capi.query("DROP TABLE IF EXISTS my_datalake.default.ctas_prepared_rebind_595")
+    prepared = duckdb_capi.prepare(
+        "CREATE TABLE my_datalake.default.ctas_prepared_rebind_595 AS SELECT 42 AS id, 'prepared' AS note"
+    )
+    try:
+        duckdb_capi.execute_prepared_streaming(prepared)
+    finally:
+        duckdb_capi.destroy_prepare(prepared)
+
+    assert duckdb_capi.fetch_single_row("SELECT id, note FROM my_datalake.default.ctas_prepared_rebind_595") == (
+        42,
+        "prepared",
+    )
+    duckdb_capi.query("DROP TABLE my_datalake.default.ctas_prepared_rebind_595")
+
+
+# def test_iceberg_duplicate_ctas_in_transaction_still_errors(duckdb_capi):
+#     duckdb_capi.query("DROP TABLE IF EXISTS my_datalake.default.ctas_duplicate_guard_595")
+#     duckdb_capi.query("BEGIN")
+#     duckdb_capi.query("CREATE TABLE my_datalake.default.ctas_duplicate_guard_595 AS SELECT 1 AS id")
+#     state, _ = duckdb_capi.query(
+#         "CREATE TABLE my_datalake.default.ctas_duplicate_guard_595 AS SELECT 2 AS id", expect_ok=False
+#     )
+#     assert state != 0
+#     duckdb_capi.query("ROLLBACK")

--- a/test/python/test_python_ctas.py
+++ b/test/python/test_python_ctas.py
@@ -9,7 +9,7 @@ import pytest
 # SQL PREPARE does not accept CTAS, but ADBC prepares and executes CTAS through
 # DuckDB's C API. Exercise that path directly to cover issue #595 without dbt.
 pytestmark = pytest.mark.skipif(
-    os.getenv("ICEBERG_SERVER_AVAILABLE") is None,
+    os.getenv("FIXTURE_SERVER_AVAILABLE") is None,
     reason="Iceberg test catalog is not available",
 )
 
@@ -157,12 +157,12 @@ def test_iceberg_ctas_prepared_statement_rebinds_at_execute(duckdb_capi):
     duckdb_capi.query("DROP TABLE my_datalake.default.ctas_prepared_rebind_595")
 
 
-# def test_iceberg_duplicate_ctas_in_transaction_still_errors(duckdb_capi):
-#     duckdb_capi.query("DROP TABLE IF EXISTS my_datalake.default.ctas_duplicate_guard_595")
-#     duckdb_capi.query("BEGIN")
-#     duckdb_capi.query("CREATE TABLE my_datalake.default.ctas_duplicate_guard_595 AS SELECT 1 AS id")
-#     state, _ = duckdb_capi.query(
-#         "CREATE TABLE my_datalake.default.ctas_duplicate_guard_595 AS SELECT 2 AS id", expect_ok=False
-#     )
-#     assert state != 0
-#     duckdb_capi.query("ROLLBACK")
+def test_iceberg_duplicate_ctas_in_transaction_still_errors(duckdb_capi):
+    duckdb_capi.query("DROP TABLE IF EXISTS my_datalake.default.ctas_duplicate_guard_595")
+    duckdb_capi.query("BEGIN")
+    duckdb_capi.query("CREATE TABLE my_datalake.default.ctas_duplicate_guard_595 AS SELECT 1 AS id")
+    state, _ = duckdb_capi.query(
+        "CREATE TABLE my_datalake.default.ctas_duplicate_guard_595 AS SELECT 2 AS id", expect_ok=False
+    )
+    assert state != 0
+    duckdb_capi.query("ROLLBACK")

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as.test
@@ -35,6 +35,16 @@ DROP TABLE if exists nested_types_2;
 statement ok
 DROP TABLE if exists fixed_array_table_as_list;
 
+# explain create table as works
+statement ok
+EXPLAIN create table should_not_exist as select range a from range(10);
+
+# table does not exist
+statement error
+select * from should_not_exist;
+----
+<REGEX>:.*does not exist.*
+
 # create primitive type table from test all types
 statement ok
 create table all_types_table_primitives_2 as select

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as_requests.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as_requests.test
@@ -63,11 +63,11 @@ statement ok
 create table ctas_partitioned_with_options
 PARTITIONED BY (category, year(ts))
 WITH (
-    'write.parquet.row-group-size-bytes'='200KB'
+    'foo'='buzz'
 ) AS
 select range as id,
        case range % 2 when 0 then 'even' else 'odd' end as category,
-       make_timestamp(2020 + (range % 2), 6, 15, 12, 0, 0) as ts
+       make_timestamp(2020 + (range % 4), 6, 15, 12, 0, 0) as ts
 from range(40);
 
 query I
@@ -77,9 +77,9 @@ select count(*) from ctas_partitioned_with_options;
 
 query II
 select * from iceberg_table_properties(my_datalake.default.ctas_partitioned_with_options)
-where key = 'write.parquet.row-group-size-bytes';
+where key = 'foo';
 ----
-write.parquet.row-group-size-bytes	200KB
+foo	buzz
 
 query I
 select count(*) from iceberg_metadata(my_datalake.default.ctas_partitioned_with_options)

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as_requests.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as_requests.test
@@ -28,7 +28,7 @@ use my_datalake.default;
 
 # explain create table as works
 statement ok
-EXPLAIN create table should_not_exist as select range a from range(10);
+EXPLAIN create table should_not_exist as select range a from range(100);
 
 # table was not created during explain call
 query I
@@ -53,6 +53,15 @@ query I
 select count(*) from should_exist;
 ----
 0
+
+statement error
+create table should_exist as select range a from range(100) limit 0;
+----
+<REGEX>:.*already exists.*
+
+# explain create table should_exist still works
+statement ok
+EXPLAIN create table should_exist as select range a from range(100);
 
 statement ok
 drop table if exists ctas_partitioned_with_options;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as_requests.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as_requests.test
@@ -54,3 +54,36 @@ select count(*) from should_exist;
 ----
 0
 
+statement ok
+drop table if exists ctas_partitioned_with_options;
+
+# partitioned CTAS with a non-identity transform should create the table
+# at execution time, then rebind COPY options using the real table metadata.
+statement ok
+create table ctas_partitioned_with_options
+PARTITIONED BY (category, year(ts))
+WITH (
+    'write.parquet.row-group-size-bytes'='200KB'
+) AS
+select range as id,
+       case range % 2 when 0 then 'even' else 'odd' end as category,
+       make_timestamp(2020 + (range % 2), 6, 15, 12, 0, 0) as ts
+from range(40);
+
+query I
+select count(*) from ctas_partitioned_with_options;
+----
+40
+
+query II
+select * from iceberg_table_properties(my_datalake.default.ctas_partitioned_with_options)
+where key = 'write.parquet.row-group-size-bytes';
+----
+write.parquet.row-group-size-bytes	200KB
+
+query I
+select count(*) from iceberg_metadata(my_datalake.default.ctas_partitioned_with_options)
+where file_path like '%identity_category_2=%'
+  and file_path like '%year_ts_3=%';
+----
+4

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as_requests.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as_requests.test
@@ -1,0 +1,44 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as_requests.test
+# description: test create table as
+# group: [create]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require core_functions
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+set logging_level='debug'
+
+statement ok
+use my_datalake.default;
+
+# explain create table as works
+statement ok
+EXPLAIN create table should_not_exist as select range a from range(10);
+
+# table was not created during explain call
+query I
+select count(*) from duckdb_logs_parsed('HTTP') where request.type = 'POST';
+----
+0
+
+# table does not exist
+statement error
+select * from should_not_exist;
+----
+<REGEX>:.*does not exist.*
+

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as_requests.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as_requests.test
@@ -42,3 +42,15 @@ select * from should_not_exist;
 ----
 <REGEX>:.*does not exist.*
 
+statement ok
+drop table if exists should_exist;
+
+# table with no rows should still create
+statement ok
+create table should_exist as select range a from range(100) limit 0;
+
+query I
+select count(*) from should_exist;
+----
+0
+

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_into_tpch.test_slow
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_into_tpch.test_slow
@@ -30,7 +30,7 @@ statement ok
 DROP TABLE IF EXISTS my_datalake.default.random_lineitem;
 
 statement ok
-CREATE TABLE my_datalake.default.random_lineitem AS FROM lineitem LIMIT 0
+CREATE TABLE my_datalake.default.random_lineitem AS FROM lineitem LIMIT 0;
 
 # create lineitem but with a random subset of the rows
 statement ok


### PR DESCRIPTION
This supersedes https://github.com/duckdb/duckdb-iceberg/pull/962

Resolves: https://github.com/duckdb/duckdb-iceberg/issues/595
related: https://github.com/dbt-labs/dbt-core/issues/14547
related: https://github.com/duckdb/dbt-duckdb/pull/725

962 involves registering a client context on attach, but this will break down if many clients are involved since only one client will run the attach. 

The solution in this PR is to introduce an intermediate `Create Iceberg Table` operator between the `Copy to File` and `Select` that is only responsible for creating the table on first chunk. This way the table is not created During Binding/Planning. 

This also fixes an issue where `EXPLAIN Create table as ..` queries would actually create the table (assuming `supports_stage_create = false`.


