### PR TITLE
Fix Iceberg LIST field name mapping

### DIFF
--- a/src/planning/iceberg_multi_file_reader.cpp
+++ b/src/planning/iceberg_multi_file_reader.cpp
@@ -100,21 +100,24 @@ IcebergMultiFileReader::InitializeGlobalState(ClientContext &context, const Mult
 static void ApplyFieldMapping(MultiFileColumnDefinition &col, const vector<IcebergFieldMapping> &mappings,
                               const case_insensitive_map_t<idx_t> &fields, ClientContext &context,
                               optional_ptr<MultiFileColumnDefinition> parent = nullptr) {
+	auto name = col.name;
+	if (parent && parent->type.id() == LogicalTypeId::LIST) {
+		if (fields.find(name) == fields.end() && fields.find("element") != fields.end()) {
+			name = "element";
+		}
+		col.name = "list";
+	}
+
 	if (!col.identifier.IsNull()) {
 		return;
 	}
 
-	auto name = col.name;
 	if (parent && parent->type.id() == LogicalTypeId::MAP && StringUtil::CIEquals(name, "key_value")) {
 		//! Deal with MAP, it has a 'key_value' child, which holds the 'key' + 'value' columns
 		for (auto &child : col.children) {
 			ApplyFieldMapping(child, mappings, fields, context, parent);
 		}
 		return;
-	}
-	if (parent && parent->type.id() == LogicalTypeId::LIST && StringUtil::CIEquals(name, "list")) {
-		//! Deal with LIST, it has a 'element' child, which has the column for the underlying list data
-		name = "element";
 	}
 
 	auto it = fields.find(name);

--- a/test/sql/local/column_mapping.test
+++ b/test/sql/local/column_mapping.test
@@ -26,3 +26,8 @@ SELECT * FROM iceberg_scan('__WORKING_DIRECTORY__/data/persistent/column_mapping
 1	Alice	25	{height=5.5, weight=130}	[85, 90]	{'email': alice@example.com, 'verified': true}
 2	Bob	30	{height=6.0, weight=180}	[78, 82, 88]	{'email': bob@example.com, 'verified': false}
 3	Charlie	35	{height=5.8, weight=160}	[92]	{'email': charlie@example.com, 'verified': true}
+
+query II
+SELECT id, scores FROM iceberg_scan('__WORKING_DIRECTORY__/data/persistent/column_mapping/warehouse/default.db/my_table') WHERE id = 1;
+----
+1	[85, 90]


### PR DESCRIPTION
Fixes part of #903.

Iceberg name mapping identifies list items as `element`, but DuckDB's nested column remap expects the synthetic LIST child to remain named `list`. When the Parquet/Iceberg local field is resolved through name mapping, this now looks up `element` while preserving the local child name as `list` for nested remapping.

Adds a regression query for the existing column-mapping fixture that projects the mapped LIST column directly.