### PR TITLE
Bump to duckdb latest (and update aws/avro extensions)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
       extension_name: iceberg
-      duckdb_version: v1.5.2
+      duckdb_version: 2a172f10f417db21cc1b630f45b4615e268b2c7f
       ci_tools_version: v1.5-variegata
       exclude_archs: 'windows_amd64_mingw'
       extra_toolchains: 'python3'
@@ -29,7 +29,7 @@ jobs:
     secrets: inherit
     with:
       extension_name: iceberg
-      duckdb_version: v1.5.2
+      duckdb_version: 2a172f10f417db21cc1b630f45b4615e268b2c7f
       ci_tools_version: v1.5-variegata
       exclude_archs: 'windows_amd64_mingw'
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@ if (NOT EMSCRIPTEN)
   duckdb_extension_load(avro
   LOAD_TESTS
   GIT_URL https://github.com/duckdb/duckdb-avro
-  GIT_TAG a73b60d629a92146cfd71c210936144a971783bd
+  GIT_TAG e1ab05026ee1221eb89977dbd6c8bdeaf17ff8b6
 )
 endif()
 
@@ -33,7 +33,7 @@ if (NOT EMSCRIPTEN)
     duckdb_extension_load(aws
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-aws
-            GIT_TAG 18803d5e55b9f9f6dda5047d0fdb4f4238b6801d
+            GIT_TAG ebce8e46e9a02576cfd0296fe29c23aeeddaa937
     )
   endif()
 endif()

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -761,12 +761,12 @@ IcebergCopyOptions IcebergInsert::GetCopyOptions(ClientContext &context, const I
 	if (copy_input.partition_spec) {
 		if (table_properties.find("write.target-file-size-bytes") != table_properties.end()) {
 			Value ignore_target_file_size_bytes_for_partitioned_tables;
-			if (!context.TryGetCurrentSetting("ignore_target_size_file_b_for_partitioned_tables",
+			if (!context.TryGetCurrentSetting("ignore_target_file_size_b_for_partitioned_tables",
 			                                  ignore_target_file_size_bytes_for_partitioned_tables) ||
 			    !ignore_target_file_size_bytes_for_partitioned_tables.GetValue<bool>()) {
 				throw InvalidInputException("Table property target-file-size-bytes is currently not supported for "
 				                            "partitioned tables.\nTo ignore this error "
-				                            "run \"SET ignore_target_size_file_b_for_partitioned_tables=true\"");
+				                            "run \"SET ignore_target_file_size_b_for_partitioned_tables=true\"");
 			}
 		}
 		if (table_properties.find("write.parquet.row-group-size-bytes") != table_properties.end()) {

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -761,22 +761,22 @@ IcebergCopyOptions IcebergInsert::GetCopyOptions(ClientContext &context, const I
 	if (copy_input.partition_spec) {
 		if (table_properties.find("write.target-file-size-bytes") != table_properties.end()) {
 			Value ignore_target_file_size_bytes_for_partitioned_tables;
-			if (!context.TryGetCurrentSetting("ignore_target_file_size_bytes_for_partitioned_tables",
+			if (!context.TryGetCurrentSetting("ignore_target_size_file_b_for_partitioned_tables",
 			                                  ignore_target_file_size_bytes_for_partitioned_tables) ||
 			    !ignore_target_file_size_bytes_for_partitioned_tables.GetValue<bool>()) {
 				throw InvalidInputException("Table property target-file-size-bytes is currently not supported for "
 				                            "partitioned tables.\nTo ignore this error "
-				                            "run \"SET ignore_target_file_size_bytes_for_partitioned_tables=true\"");
+				                            "run \"SET ignore_target_size_file_b_for_partitioned_tables=true\"");
 			}
 		}
 		if (table_properties.find("write.parquet.row-group-size-bytes") != table_properties.end()) {
 			Value ignore_row_group_size_bytes_for_partitioned_tables;
-			if (!context.TryGetCurrentSetting("ignore_row_group_size_bytes_for_partitioned_tables",
+			if (!context.TryGetCurrentSetting("ignore_row_group_size_b_for_partitioned_tables",
 			                                  ignore_row_group_size_bytes_for_partitioned_tables) ||
 			    !ignore_row_group_size_bytes_for_partitioned_tables.GetValue<bool>()) {
 				throw InvalidInputException("Table property row-group-size-bytes is currently not supported for "
 				                            "partitioned tables.\nTo ignore this error "
-				                            "run \"SET ignore_row_group_size_bytes_for_partitioned_tables=true\"");
+				                            "run \"SET ignore_row_group_size_b_for_partitioned_tables=true\"");
 			}
 		}
 		result.filename_pattern.SetFilenamePattern("{uuidv7}");

--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -68,11 +68,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    "Whether or not to make use of the (optional) 'metadata-log' of a table to ensure atomicity guarantees hold, "
 	    "at the cost of making another GET for json metadata in rare circumstances",
 	    LogicalType::BOOLEAN, Value::BOOLEAN(true));
-	config.AddExtensionOption("ignore_target_file_size_bytes_for_partitioned_tables",
+	config.AddExtensionOption("ignore_target_size_file_b_for_partitioned_tables",
 	                          "Ignore unsupported write.target-file-size-bytes table property for partitioned tables",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(false));
 	config.AddExtensionOption(
-	    "ignore_row_group_size_bytes_for_partitioned_tables",
+	    "ignore_row_group_size_b_for_partitioned_tables",
 	    "Ignore unsupported write.parquet.row-group-size-bytes table property for partitioned tables",
 	    LogicalType::BOOLEAN, Value::BOOLEAN(false));
 

--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -68,7 +68,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    "Whether or not to make use of the (optional) 'metadata-log' of a table to ensure atomicity guarantees hold, "
 	    "at the cost of making another GET for json metadata in rare circumstances",
 	    LogicalType::BOOLEAN, Value::BOOLEAN(true));
-	config.AddExtensionOption("ignore_target_size_file_b_for_partitioned_tables",
+	config.AddExtensionOption("ignore_target_file_size_b_for_partitioned_tables",
 	                          "Ignore unsupported write.target-file-size-bytes table property for partitioned tables",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(false));
 	config.AddExtensionOption(

--- a/test/configs/fixture_duckdb_tests.json
+++ b/test/configs/fixture_duckdb_tests.json
@@ -114,6 +114,16 @@
         "test/sql/table_function/sqlite_master_quotes.test",
         "test/sql/types/bignum/test_bignum_sum.test_slow"
       ]
+    },
+    {
+      "reason": "changing secret manager settings after the secret manager is used is not allowed",
+      "paths": [
+        "test/sql/secrets/create_secret_filesystem_logging.test",
+        "test/sql/settings/test_disabled_local_filesystem_metadata.test",
+        "test/sql/settings/test_disabled_local_filesystem_secrets.test",
+        "test/sql/settings/test_external_access_metadata.test",
+        "test/sql/settings/test_external_access_secrets.test"
+      ]
     }
   ]
 }

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/partitioning/partitioned_write_row-group-size-bytes.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/partitioning/partitioned_write_row-group-size-bytes.test
@@ -21,10 +21,10 @@ statement error
 INSERT INTO my_datalake.default.my_table SELECT * FROM range(1000);
 ----
 Invalid Input Error: Table property row-group-size-bytes is currently not supported for partitioned tables.
-To ignore this error run "SET ignore_row_group_size_bytes_for_partitioned_tables=true"
+To ignore this error run "SET ignore_row_group_size_b_for_partitioned_tables=true"
 
 statement ok
-SET ignore_row_group_size_bytes_for_partitioned_tables=true
+SET ignore_row_group_size_b_for_partitioned_tables=true
 
 statement error
 INSERT INTO my_datalake.default.my_table SELECT * FROM range(1000);

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/partitioning/partitioned_write_row-group-size-bytes_memory_specified.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/partitioning/partitioned_write_row-group-size-bytes_memory_specified.test
@@ -17,10 +17,10 @@ statement error
 INSERT INTO my_datalake.default.my_table SELECT * FROM range(1000);
 ----
 Invalid Input Error: Table property row-group-size-bytes is currently not supported for partitioned tables.
-To ignore this error run "SET ignore_row_group_size_bytes_for_partitioned_tables=true"
+To ignore this error run "SET ignore_row_group_size_b_for_partitioned_tables=true"
 
 statement ok
-SET ignore_row_group_size_bytes_for_partitioned_tables=true
+SET ignore_row_group_size_b_for_partitioned_tables=true
 
 statement error
 INSERT INTO my_datalake.default.my_table SELECT * FROM range(1000);

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/partitioning/partitioned_write_target-file-size-bytes.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/partitioning/partitioned_write_target-file-size-bytes.test
@@ -20,10 +20,10 @@ statement error
 INSERT INTO my_datalake.default.my_table SELECT * FROM range(100);
 ----
 Invalid Input Error: Table property target-file-size-bytes is currently not supported for partitioned tables.
-To ignore this error run "SET ignore_target_file_size_bytes_for_partitioned_tables=true"
+To ignore this error run "SET ignore_target_file_size_b_for_partitioned_tables=true"
 
 statement ok
-SET ignore_target_file_size_bytes_for_partitioned_tables=true
+SET ignore_target_file_size_b_for_partitioned_tables=true
 
 statement ok
 INSERT INTO my_datalake.default.my_table SELECT * FROM range(100);

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/partitioning/partitioned_write_target-file-size-bytes_memory_specified.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/partitioning/partitioned_write_target-file-size-bytes_memory_specified.test
@@ -17,10 +17,10 @@ statement error
 INSERT INTO my_datalake.default.my_table SELECT * FROM range(100);
 ----
 Invalid Input Error: Table property target-file-size-bytes is currently not supported for partitioned tables.
-To ignore this error run "SET ignore_target_file_size_bytes_for_partitioned_tables=true"
+To ignore this error run "SET ignore_target_file_size_b_for_partitioned_tables=true"
 
 statement ok
-SET ignore_target_file_size_bytes_for_partitioned_tables=true
+SET ignore_target_file_size_b_for_partitioned_tables=true
 
 statement ok
 INSERT INTO my_datalake.default.my_table SELECT * FROM range(100);


### PR DESCRIPTION
Bump duckdb to latest, but also shorten extension configs so they can be listed as extension entries.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9227