### PR TITLE
bump avro pin to consume duckdb-avro#92 (fixes #979)

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@ if (NOT EMSCRIPTEN)
   duckdb_extension_load(avro
   LOAD_TESTS
   GIT_URL https://github.com/duckdb/duckdb-avro
-  GIT_TAG a73b60d629a92146cfd71c210936144a971783bd
+  GIT_TAG 0535350850786be8a8bc03b9ffc59e29dd32ecf7
 )
 endif()
 


### PR DESCRIPTION
Bumps avro pin from a73b60d to 0535350 (merge of duckdb/duckdb-avro#92) so iceberg's avro writes call handle->Close() in WriteAvroFinalize. Without that close, ADLS Gen2 (abfss://) leaves manifest list and manifest avro files at 0 bytes. Fixes #979. Same root cause as #834 and #966 (OneLake).