### PR TITLE
[ALTER] Add support for adding fields to STRUCT columns

### DIFF
--- a/src/catalog/rest/api/iceberg_create_table_request.cpp
+++ b/src/catalog/rest/api/iceberg_create_table_request.cpp
@@ -206,6 +206,33 @@ static void AddUnnamedField(yyjson_mut_doc *doc, yyjson_mut_val *field_obj, cons
 	}
 }
 
+unique_ptr<IcebergColumnDefinition>
+IcebergCreateTableRequest::CreateIcebergColumn(const ColumnDefinition &column_def, IcebergDefaultBinder &default_binder,
+                                               bool required, const std::function<idx_t(void)> &next_field_id,
+                                               idx_t iceberg_version) {
+	const auto &name = column_def.Name();
+	const auto &logical_type = column_def.GetType();
+	idx_t first_id = next_field_id();
+	rest_api_objects::Type type;
+	if (logical_type.IsNested()) {
+		type = IcebergTypeHelper::CreateIcebergRestType(logical_type, next_field_id);
+	} else {
+		type.has_primitive_type = true;
+		type.primitive_type = rest_api_objects::PrimitiveType();
+		type.primitive_type.value = IcebergTypeHelper::LogicalTypeToIcebergType(logical_type);
+	}
+	auto iceberg_column_def = IcebergColumnDefinition::ParseType(name, first_id, required, type, "", nullptr);
+	if (column_def.HasDefaultValue()) {
+		auto &default_expr = column_def.DefaultValue();
+		auto val = default_binder.Evaluate(default_expr, logical_type);
+		if (iceberg_version < 3 && !val.IsNull()) {
+			throw InvalidInputException("non-null DEFAULT values are not supported for <V3 tables");
+		}
+		iceberg_column_def->initial_default = make_uniq<Value>(val);
+	}
+	return iceberg_column_def;
+}
+
 shared_ptr<IcebergTableSchema> IcebergCreateTableRequest::CreateIcebergSchema(
     ClientContext &context, const IcebergTableMetadata &table_metadata, const ColumnList &columns,
     optional_ptr<const vector<unique_ptr<Constraint>>> constraints_p, int32_t &last_column_id) {
@@ -240,29 +267,10 @@ shared_ptr<IcebergTableSchema> IcebergCreateTableRequest::CreateIcebergSchema(
 	IcebergDefaultBinder binder(context);
 	for (auto column = column_iterator.begin(); column != column_iterator.end(); ++column) {
 		auto &column_def = *column;
-		auto name = column_def.Name();
-		// check if there is a not null constraint
 		const bool required = required_columns.count(column.pos);
 
-		const auto &logical_type = column_def.GetType();
-		idx_t first_id = next_field_id();
-		rest_api_objects::Type type;
-		if (logical_type.IsNested()) {
-			type = IcebergTypeHelper::CreateIcebergRestType(logical_type, next_field_id);
-		} else {
-			type.has_primitive_type = true;
-			type.primitive_type = rest_api_objects::PrimitiveType();
-			type.primitive_type.value = IcebergTypeHelper::LogicalTypeToIcebergType(logical_type);
-		}
-		auto iceberg_column_def = IcebergColumnDefinition::ParseType(name, first_id, required, type, "", nullptr);
-		if (column_def.HasDefaultValue()) {
-			auto &default_expr = column_def.DefaultValue();
-			auto val = binder.Evaluate(default_expr, logical_type);
-			if (table_metadata.iceberg_version < 3 && !val.IsNull()) {
-				throw InvalidInputException("non-null DEFAULT values are not supported for <V3 tables");
-			}
-			iceberg_column_def->initial_default = make_uniq<Value>(val);
-		}
+		auto iceberg_column_def =
+		    CreateIcebergColumn(column_def, binder, required, next_field_id, table_metadata.iceberg_version);
 		schema->columns.push_back(std::move(iceberg_column_def));
 	}
 	last_column_id = field_id - 1;

--- a/src/catalog/rest/catalog_entry/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/iceberg_schema_entry.cpp
@@ -335,30 +335,19 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			}
 		}
 
-		// Add the new column
-		auto new_iceberg_column = make_uniq<IcebergColumnDefinition>();
 		auto &last_column_id = updated_table.table_metadata.last_column_id;
 		if (!last_column_id.IsValid()) {
 			throw InternalException("No last_column_id when trying to ADD COLUMN %s", add_column_info.name);
 		}
-		new_iceberg_column->id = last_column_id.GetIndex() + 1;
-		last_column_id = optional_idx(new_iceberg_column->id);
+		auto field_id = last_column_id.GetIndex() + 1;
+		auto next_field_id = [&field_id]() -> idx_t {
+			return field_id++;
+		};
 
-		new_iceberg_column->name = column_definition.GetName();
-		new_iceberg_column->type = column_definition.GetType();
-
-		if (column_definition.HasDefaultValue()) {
-			auto &default_value = column_definition.DefaultValue();
-
-			IcebergDefaultBinder binder(context);
-			auto default_constant_value = binder.Evaluate(default_value, new_iceberg_column->type);
-			new_iceberg_column->initial_default = make_uniq<Value>(default_constant_value);
-			if (updated_table.table_metadata.iceberg_version >= 3) {
-				new_iceberg_column->write_default = make_uniq<Value>(default_constant_value);
-			}
-		}
-
-		new_iceberg_column->required = false;
+		IcebergDefaultBinder binder(context);
+		auto new_iceberg_column = IcebergCreateTableRequest::CreateIcebergColumn(
+		    column_definition, binder, false, next_field_id, updated_table.table_metadata.iceberg_version);
+		last_column_id = field_id - 1;
 
 		auto new_schema = current_schema.Copy();
 		new_schema->schema_id++;
@@ -594,6 +583,43 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			transaction_data.TableSetCurrentSchema();
 		}
 		updated_table.table_metadata.SetCurrentSchemaId(result_schema.schema_id);
+		return;
+	}
+	case AlterTableType::ADD_FIELD: {
+		auto &add_field_info = alter_table_info.Cast<AddFieldInfo>();
+		auto &column_path = add_field_info.column_path;
+		auto &new_field = add_field_info.new_field;
+		auto &if_field_not_exists = add_field_info.if_field_not_exists;
+
+		auto new_schema = current_schema.Copy();
+		new_schema->schema_id++;
+
+		auto parent_path = column_path;
+		column_path.push_back(new_field.GetName());
+
+		auto parent_p = new_schema->GetMutableFromPath(parent_path, nullptr);
+		if (!parent_p) {
+			throw CatalogException(
+			    "The parent column ('%s') does not exist on the table '%s', ADD COLUMN failed to add a new field",
+			    StringUtil::Join(parent_path, "."), table_entry.name);
+		}
+		auto &parent = *parent_p;
+
+		auto column_p = new_schema->GetMutableFromPath(column_path, nullptr);
+		if (column_p && !if_field_not_exists) {
+			throw CatalogException(
+			    "The column ('%s') already exists on the table '%s', ADD COLUMN failed to add a new field",
+			    StringUtil::Join(column_path, "."), table_entry.name);
+		}
+
+		if (parent.type.id() != LogicalTypeId::STRUCT) {
+			throw CatalogException("Can't add field '%s' to column '%s', because the parent is not a struct (type: %s)",
+			                       new_field.GetName(), StringUtil::Join(parent_path, "."), parent.type.ToString());
+		}
+
+		// parent.children.push_back(new_struct_field);
+
+		IntroduceNewSchema(updated_table, transaction_data, new_schema);
 		return;
 	}
 	default: {

--- a/src/catalog/rest/catalog_entry/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/iceberg_schema_entry.cpp
@@ -606,7 +606,10 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		auto &parent = *parent_p;
 
 		auto column_p = new_schema->GetMutableFromPath(column_path, nullptr);
-		if (column_p && !if_field_not_exists) {
+		if (column_p) {
+			if (if_field_not_exists) {
+				return;
+			}
 			throw CatalogException(
 			    "The column ('%s') already exists on the table '%s', ADD COLUMN failed to add a new field",
 			    StringUtil::Join(column_path, "."), table_entry.name);
@@ -617,7 +620,22 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			                       new_field.GetName(), StringUtil::Join(parent_path, "."), parent.type.ToString());
 		}
 
-		// parent.children.push_back(new_struct_field);
+		auto &last_column_id = updated_table.table_metadata.last_column_id;
+		if (!last_column_id.IsValid()) {
+			throw InternalException("No last_column_id when trying to ADD COLUMN %s",
+			                        StringUtil::Join(column_path, "."));
+		}
+		auto field_id = last_column_id.GetIndex() + 1;
+		auto next_field_id = [&field_id]() -> idx_t {
+			return field_id++;
+		};
+
+		IcebergDefaultBinder binder(context);
+		auto new_iceberg_column = IcebergCreateTableRequest::CreateIcebergColumn(
+		    new_field, binder, false, next_field_id, updated_table.table_metadata.iceberg_version);
+		last_column_id = field_id - 1;
+
+		parent.children.push_back(std::move(new_iceberg_column));
 
 		IntroduceNewSchema(updated_table, transaction_data, new_schema);
 		return;

--- a/src/core/metadata/schema/iceberg_column_definition.cpp
+++ b/src/core/metadata/schema/iceberg_column_definition.cpp
@@ -299,6 +299,16 @@ bool IcebergColumnDefinition::Equals(const IcebergColumnDefinition &other) const
 	if (doc != other.doc) {
 		return false;
 	}
+	if (children.size() != other.children.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < children.size(); i++) {
+		auto &a_child = children[i];
+		auto &b_child = other.children[i];
+		if (!a_child->Equals(*b_child)) {
+			return false;
+		}
+	}
 
 	if (!DefaultsAreEqual(initial_default, other.initial_default)) {
 		return false;

--- a/src/include/catalog/rest/api/iceberg_create_table_request.hpp
+++ b/src/include/catalog/rest/api/iceberg_create_table_request.hpp
@@ -11,6 +11,7 @@
 #include "core/metadata/schema/iceberg_table_schema.hpp"
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
 #include "core/metadata/snapshot/iceberg_snapshot.hpp"
+#include "common/iceberg_default.hpp"
 
 using namespace duckdb_yyjson;
 namespace duckdb {
@@ -23,6 +24,10 @@ struct IcebergCreateTableRequest {
 	explicit IcebergCreateTableRequest(const IcebergTableInformation &table_info);
 
 public:
+	static unique_ptr<IcebergColumnDefinition>
+	CreateIcebergColumn(const ColumnDefinition &coldef, IcebergDefaultBinder &default_binder, bool is_required,
+	                    const std::function<idx_t(void)> &next_field_id, idx_t iceberg_version);
+
 	static shared_ptr<IcebergTableSchema>
 	CreateIcebergSchema(ClientContext &context, const IcebergTableMetadata &table_metadata, const ColumnList &columns,
 	                    optional_ptr<const vector<unique_ptr<Constraint>>> constraints, int32_t &last_column_id);

--- a/test/sql/local/catalog_custom_setup/fixture/enable_logging_http/iceberg_catalog_read.test
+++ b/test/sql/local/catalog_custom_setup/fixture/enable_logging_http/iceberg_catalog_read.test
@@ -99,4 +99,4 @@ select count(*) from my_datalake.default.pyspark_iceberg_table_v2;
 statement error
 Alter table my_datalake.default.table_more_deletes add column new_column INTEGER default 10;
 ----
-Request returned HTTP 500 for HTTP POST
+Invalid Input Error: non-null DEFAULT values are not supported for <V3 tables

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/add_field.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/add_field.test
@@ -1,0 +1,163 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/add_field.test
+# group: [alter]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require ducklake
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+statement ok
+drop table if exists my_datalake.default.add_struct_field;
+
+statement ok
+create table my_datalake.default.add_struct_field(
+	col STRUCT(
+		a VARCHAR,
+		b BOOLEAN,
+		nested STRUCT(d DATE)
+	),
+	not_a_struct BOOLEAN
+);
+
+statement ok
+insert into my_datalake.default.add_struct_field VALUES (
+	{'a': 'test', 'b': false, 'nested': {'d': '2012/8/19'::DATE}}, false
+);
+
+# Field 'not_a_struct' is not a struct
+statement error
+ALTER TABLE my_datalake.default.add_struct_field ADD COLUMN not_a_struct.b DATE;
+----
+Catalog Error: Can't add field 'b' to column 'not_a_struct', because the parent is not a struct (type: BOOLEAN)
+
+# Path doesn't exist
+statement error
+ALTER TABLE my_datalake.default.add_struct_field ADD COLUMN col.not_existant.path DATE;
+----
+Catalog Error: The parent column ('col.not_existant') does not exist on the table 'add_struct_field', ADD COLUMN failed to add a new field
+
+# Field 'b' already exists
+statement error
+ALTER TABLE my_datalake.default.add_struct_field ADD COLUMN col.b DATE;
+----
+Catalog Error: The column ('col.b') already exists on the table 'add_struct_field', ADD COLUMN failed to add a new field
+
+# Alter doesn't fail because we add IF NOT EXISTS (even though the type is different...)
+statement ok
+ALTER TABLE my_datalake.default.add_struct_field ADD COLUMN IF NOT EXISTS col.b DATE;
+
+# No difference
+query I
+select typeof(col) from my_datalake.default.add_struct_field limit 1;
+----
+STRUCT(a VARCHAR, b BOOLEAN, nested STRUCT(d DATE))
+
+# ---------- Add primitive type to STRUCT ----------
+
+statement ok
+ALTER TABLE my_datalake.default.add_struct_field ADD COLUMN IF NOT EXISTS col.c DATE;
+
+# Added the new field 'c' to 'col'
+query I
+select typeof(col) from my_datalake.default.add_struct_field limit 1;
+----
+STRUCT(a VARCHAR, b BOOLEAN, nested STRUCT(d DATE), c DATE)
+
+statement ok
+insert into my_datalake.default.add_struct_field VALUES (
+	{'a': 'hello world', 'b': NULL, 'c': '1934/5/21'::DATE, 'nested': {'d': '1982/2/12'::DATE}}, true
+)
+
+query II
+select * from my_datalake.default.add_struct_field order by all;
+----
+{'a': hello world, 'b': NULL, 'nested': {'d': 1982-02-12}, 'c': 1934-05-21}	true
+{'a': test, 'b': false, 'nested': {'d': 2012-08-19}, 'c': NULL}	false
+
+# ---------- Add primitive type to nested STRUCT ----------
+
+statement ok
+ALTER TABLE my_datalake.default.add_struct_field ADD COLUMN IF NOT EXISTS col.nested.prim VARCHAR;
+
+query I
+select typeof(col) from my_datalake.default.add_struct_field limit 1;
+----
+STRUCT(a VARCHAR, b BOOLEAN, nested STRUCT(d DATE, prim VARCHAR), c DATE)
+
+statement ok
+insert into my_datalake.default.add_struct_field VALUES (
+	{
+		'a': 'hello world',
+		'b': NULL,
+		'c': '1934/5/21'::DATE,
+		'nested': {
+			'd': '1982/2/12'::DATE,
+			'prim': 'this is a long string'
+		}
+	},
+	true
+);
+
+query II
+select * from my_datalake.default.add_struct_field order by all;
+----
+{'a': hello world, 'b': NULL, 'nested': {'d': 1982-02-12, 'prim': this is a long string}, 'c': 1934-05-21}	true
+{'a': hello world, 'b': NULL, 'nested': {'d': 1982-02-12, 'prim': NULL}, 'c': 1934-05-21}	true
+{'a': test, 'b': false, 'nested': {'d': 2012-08-19, 'prim': NULL}, 'c': NULL}	false
+
+# ---------- Add STRUCT type to STRUCT ----------
+
+statement ok
+ALTER TABLE my_datalake.default.add_struct_field ADD COLUMN IF NOT EXISTS col.another_struct STRUCT(
+	col STRUCT(
+		inception BOOLEAN
+	)
+);
+
+query I
+select typeof(col) from my_datalake.default.add_struct_field limit 1;
+----
+STRUCT(a VARCHAR, b BOOLEAN, nested STRUCT(d DATE, prim VARCHAR), c DATE, another_struct STRUCT(col STRUCT(inception BOOLEAN)))
+
+statement ok
+insert into my_datalake.default.add_struct_field VALUES (
+	{
+		'a': 'hello world',
+		'b': NULL,
+		'another_struct': {
+			'col': {
+				'inception': true
+			}
+		},
+		'c': '1934/5/21'::DATE,
+		'nested': {
+			'd': '1982/2/12'::DATE,
+			'prim': 'test test test'
+		}
+	},
+	true
+);
+
+query II
+select * from my_datalake.default.add_struct_field order by all;
+----
+{'a': hello world, 'b': NULL, 'nested': {'d': 1982-02-12, 'prim': test test test}, 'c': 1934-05-21, 'another_struct': {'col': {'inception': true}}}	true
+{'a': hello world, 'b': NULL, 'nested': {'d': 1982-02-12, 'prim': this is a long string}, 'c': 1934-05-21, 'another_struct': NULL}	true
+{'a': hello world, 'b': NULL, 'nested': {'d': 1982-02-12, 'prim': NULL}, 'c': 1934-05-21, 'another_struct': NULL}	true
+{'a': test, 'b': false, 'nested': {'d': 2012-08-19, 'prim': NULL}, 'c': NULL, 'another_struct': NULL}	false

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_infinity_timestamp.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_infinity_timestamp.test
@@ -36,43 +36,59 @@ statement ok
 drop table if exists my_datalake.default.test_time_types_upper_lower_bounds;
 
 statement error
-create table my_datalake.default.test_date_inf as select DATE 'infinity' date_type;
+create table my_datalake.default.test_date_inf WITH (
+	'format-version'='2'
+) as select DATE 'infinity' date_type ;
 ----
 <REGEX>:.*Conversion Error.*
 
 statement error
-create table my_datalake.default.test_date_ninf as select DATE '-infinity' date_type;
+create table my_datalake.default.test_date_ninf WITH (
+	'format-version'='2'
+) as select DATE '-infinity' date_type;
 ----
 <REGEX>:.*Conversion Error.*
 
 statement error
-create table my_datalake.default.test_timestamp_inf as select TIMESTAMP 'infinity'  timestamp_type;
+create table my_datalake.default.test_timestamp_inf WITH (
+	'format-version'='2'
+) as select TIMESTAMP 'infinity' timestamp_type;
 ----
 <REGEX>:.*Conversion Error.*
 
 statement error
-create table my_datalake.default.test_dtimestampninf as select TIMESTAMP '-infinity' timestamp_type;
+create table my_datalake.default.test_dtimestampninf WITH (
+	'format-version'='2'
+) as select TIMESTAMP '-infinity' timestamp_type;
 ----
 <REGEX>:.*Conversion Error.*
 
 statement error
-create table my_datalake.default.test_timestamp_tz_inf as select TIMESTAMPTZ 'infinity' timestamptz_type;
+create table my_datalake.default.test_timestamp_tz_inf WITH (
+	'format-version'='2'
+) as select TIMESTAMPTZ 'infinity' timestamptz_type;
 ----
 <REGEX>:.*Conversion Error.*
 
 statement error
-create table my_datalake.default.test_timestamp_tz_ninf as select TIMESTAMPTZ '-infinity' timestamptz_type;
+create table my_datalake.default.test_timestamp_tz_ninf WITH (
+	'format-version'='2'
+) as select TIMESTAMPTZ '-infinity' timestamptz_type;
 ----
 <REGEX>:.*Conversion Error.*
 
 # v2 REST catalog rejects timestamp_ns (v3-only) before infinity is evaluated.
 statement error
-create table my_datalake.default.test_timestamp_ns_inf as select TIMESTAMP_NS 'infinity' timestamp_ns_type;
+create table my_datalake.default.test_timestamp_ns_inf WITH (
+	'format-version'='2'
+) as select TIMESTAMP_NS 'infinity' timestamp_ns_type;
 ----
 <REGEX>:.*Invalid Configuration Error.*
 
 statement error
-create table my_datalake.default.test_timestamp_ns_ninf as select TIMESTAMP_NS '-infinity' timestamp_ns_type;
+create table my_datalake.default.test_timestamp_ns_ninf WITH (
+	'format-version'='2'
+) as select TIMESTAMP_NS '-infinity' timestamp_ns_type;
 ----
 <REGEX>:.*Invalid Configuration Error.*
 
@@ -80,4 +96,9 @@ statement ok
 drop table if exists my_datalake.default.test_infinities;
 
 statement ok
-create table my_datalake.default.test_infinities as from values (FLOAT 'infinity', DOUBLE 'infinity'), (FLOAT '-infinity', DOUBLE '-infinity') t(float_type, double_type);
+create table my_datalake.default.test_infinities WITH (
+	'format-version'='2'
+) as from values
+	(FLOAT 'infinity', DOUBLE 'infinity'),
+	(FLOAT '-infinity', DOUBLE '-infinity')
+t(float_type, double_type);

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/fixture/alter/alter_add_column_v2.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/fixture/alter/alter_add_column_v2.test
@@ -45,7 +45,7 @@ FROM my_datalake.default.alter_add_column_table;
 statement error
 ALTER TABLE my_datalake.default.alter_add_column_table ADD COLUMN c int DEFAULT 42;
 ----
-Request returned HTTP 500 for HTTP POST to
+Invalid Input Error: non-null DEFAULT values are not supported for <V3 tables
 
 query II
 FROM my_datalake.default.alter_add_column_table;

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/lakekeeper/alter/alter_add_column_v2.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/lakekeeper/alter/alter_add_column_v2.test
@@ -48,7 +48,7 @@ ALTER TABLE my_datalake.default.alter_add_column_table ADD COLUMN c int DEFAULT 
 ----
 Invalid Input Error: non-null DEFAULT values are not supported for <V3 tables
 
-query III
+query II
 FROM my_datalake.default.alter_add_column_table;
 ----
 0	NULL

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/lakekeeper/alter/alter_add_column_v2.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/lakekeeper/alter/alter_add_column_v2.test
@@ -43,7 +43,7 @@ FROM my_datalake.default.alter_add_column_table;
 9	NULL
 
 # Lakekeeper somehow supports non-null default values with Iceberg v2 tables. This differs from fixture's behavior.
-statement ok
+statement error
 ALTER TABLE my_datalake.default.alter_add_column_table ADD COLUMN c int DEFAULT 42;
 ----
 Invalid Input Error: non-null DEFAULT values are not supported for <V3 tables

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/lakekeeper/alter/alter_add_column_v2.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/lakekeeper/alter/alter_add_column_v2.test
@@ -23,7 +23,7 @@ statement ok
 drop table if exists my_datalake.default.alter_add_column_table;
 
 statement ok
-CREATE TABLE my_datalake.default.alter_add_column_table WITH ('format-version' = 3) AS (select range a FROM range(10));
+CREATE TABLE my_datalake.default.alter_add_column_table WITH ('format-version' = 2) AS (select range a FROM range(10));
 
 statement ok
 ALTER TABLE my_datalake.default.alter_add_column_table ADD COLUMN b int;

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/lakekeeper/alter/alter_add_column_v2.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/lakekeeper/alter/alter_add_column_v2.test
@@ -45,17 +45,19 @@ FROM my_datalake.default.alter_add_column_table;
 # Lakekeeper somehow supports non-null default values with Iceberg v2 tables. This differs from fixture's behavior.
 statement ok
 ALTER TABLE my_datalake.default.alter_add_column_table ADD COLUMN c int DEFAULT 42;
+----
+Invalid Input Error: non-null DEFAULT values are not supported for <V3 tables
 
 query III
 FROM my_datalake.default.alter_add_column_table;
 ----
-0	NULL	42
-1	NULL	42
-2	NULL	42
-3	NULL	42
-4	NULL	42
-5	NULL	42
-6	NULL	42
-7	NULL	42
-8	NULL	42
-9	NULL	42
+0	NULL
+1	NULL
+2	NULL
+3	NULL
+4	NULL
+5	NULL
+6	NULL
+7	NULL
+8	NULL
+9	NULL

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/nessie/alter/faulty_alter_add_column_v2.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/nessie/alter/faulty_alter_add_column_v2.test
@@ -47,7 +47,7 @@ ALTER TABLE my_datalake.default.alter_add_column_table ADD COLUMN c int DEFAULT 
 ----
 Invalid Input Error: non-null DEFAULT values are not supported for <V3 tables
 
-query III
+query II
 FROM my_datalake.default.alter_add_column_table;
 ----
 0	NULL

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/nessie/alter/faulty_alter_add_column_v2.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/nessie/alter/faulty_alter_add_column_v2.test
@@ -42,22 +42,21 @@ FROM my_datalake.default.alter_add_column_table;
 8	NULL
 9	NULL
 
-# Nessie mistakingly accepts this query and poulates the column with NULLs, even though the query specifies `DEFAULT 42`.
-# This test is a mere documentation of this result, and not an assertion of correct behavior.
-# This test should be corrected when nessie fixes this.
-statement ok
+statement error
 ALTER TABLE my_datalake.default.alter_add_column_table ADD COLUMN c int DEFAULT 42;
+----
+Invalid Input Error: non-null DEFAULT values are not supported for <V3 tables
 
 query III
 FROM my_datalake.default.alter_add_column_table;
 ----
-0	NULL	NULL
-1	NULL	NULL
-2	NULL	NULL
-3	NULL	NULL
-4	NULL	NULL
-5	NULL	NULL
-6	NULL	NULL
-7	NULL	NULL
-8	NULL	NULL
-9	NULL	NULL
+0	NULL
+1	NULL
+2	NULL
+3	NULL
+4	NULL
+5	NULL
+6	NULL
+7	NULL
+8	NULL
+9	NULL

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/nessie/alter/faulty_alter_add_column_v3.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/nessie/alter/faulty_alter_add_column_v3.test
@@ -25,22 +25,21 @@ drop table if exists my_datalake.default.alter_add_column_table;
 statement ok
 CREATE TABLE my_datalake.default.alter_add_column_table WITH ('format-version' = 3) AS (select range a FROM range(10));
 
-# Nessie mistakingly accepts this query and poulates the column with NULLs, even though the query specifies `DEFAULT 42`.
-# This test is a mere documentation of this result, and not an assertion of correct behavior.
-# This test should be corrected when nessie fixes this.
-statement ok
+statement error
 ALTER TABLE my_datalake.default.alter_add_column_table ADD COLUMN b int DEFAULT 42;
+----
+Invalid Input Error: non-null DEFAULT values are not supported for <V3 tables
 
-query II
+query I
 FROM my_datalake.default.alter_add_column_table;
 ----
-0	NULL
-1	NULL
-2	NULL
-3	NULL
-4	NULL
-5	NULL
-6	NULL
-7	NULL
-8	NULL
-9	NULL
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/alter/alter_add_column_v2.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/alter/alter_add_column_v2.test
@@ -45,7 +45,7 @@ FROM my_datalake.default.alter_add_column_table;
 statement error
 ALTER TABLE my_datalake.default.alter_add_column_table ADD COLUMN c int DEFAULT 42;
 ----
-Request returned HTTP 500 for HTTP POST to
+Invalid Input Error: non-null DEFAULT values are not supported for <V3 tables
 
 query II
 FROM my_datalake.default.alter_add_column_table;


### PR DESCRIPTION
This PR continues on #853 

By adding `ADD_FIELD` support, we can now add fields to struct columns.

On top of that, this PR also fixes a likely problem of adding STRUCT columns with `ADD COLUMN`, as we weren't correctly setting the right `last_field_id` in the case multiple columns were added.

Another thing fixed by this PR is the `IcebergColumnDefinition::Equals`, it now correctly recursively checks the children, previously it ignored the children completely. Which is required for correct create-or-get schema logic.