### PR TITLE
Option that allows writing unsorted data to a sorted table

### DIFF
--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -973,8 +973,8 @@ PhysicalOperator &IcebergCatalog::PlanInsert(ClientContext &context, PhysicalPla
 			if (!context.TryGetCurrentSetting("unsafe_iceberg_ignore_sort_order", unsafe_ignore_sort_order) ||
 			    !unsafe_ignore_sort_order.GetValue<bool>()) {
 				throw NotImplementedException(
-				    "INSERT into a sorted iceberg table is not supported yet.\nTo ignore this error and write "
-				    "unsorted data (the declared sort order will NOT be preserved) "
+				    "INSERT into a sorted iceberg table is not supported yet.\nTo bypass this guard and "
+				    "write without applying the table's declared sort order, "
 				    "run \"SET unsafe_iceberg_ignore_sort_order=true\"");
 			}
 		}

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -969,7 +969,14 @@ PhysicalOperator &IcebergCatalog::PlanInsert(ClientContext &context, PhysicalPla
 	if (table_metadata.HasSortOrder()) {
 		auto &sort_spec = table_metadata.GetLatestSortOrder();
 		if (sort_spec.IsSorted()) {
-			throw NotImplementedException("INSERT into a sorted iceberg table is not supported yet");
+			Value unsafe_ignore_sort_order;
+			if (!context.TryGetCurrentSetting("unsafe_iceberg_ignore_sort_order", unsafe_ignore_sort_order) ||
+			    !unsafe_ignore_sort_order.GetValue<bool>()) {
+				throw NotImplementedException(
+				    "INSERT into a sorted iceberg table is not supported yet.\nTo ignore this error and write "
+				    "unsorted data (the declared sort order will NOT be preserved) "
+				    "run \"SET unsafe_iceberg_ignore_sort_order=true\"");
+			}
 		}
 	}
 

--- a/src/execution/operator/iceberg_update.cpp
+++ b/src/execution/operator/iceberg_update.cpp
@@ -53,8 +53,8 @@ IcebergUpdate &IcebergUpdate::PlanUpdateOperator(ClientContext &context, Physica
 			if (!context.TryGetCurrentSetting("unsafe_iceberg_ignore_sort_order", unsafe_ignore_sort_order) ||
 			    !unsafe_ignore_sort_order.GetValue<bool>()) {
 				throw NotImplementedException(
-				    "Update on a sorted iceberg table is not supported yet.\nTo ignore this error and write "
-				    "unsorted data (the declared sort order will NOT be preserved) "
+				    "Update on a sorted iceberg table is not supported yet.\nTo bypass this guard and "
+				    "write without applying the table's declared sort order, "
 				    "run \"SET unsafe_iceberg_ignore_sort_order=true\"");
 			}
 		}

--- a/src/execution/operator/iceberg_update.cpp
+++ b/src/execution/operator/iceberg_update.cpp
@@ -49,7 +49,14 @@ IcebergUpdate &IcebergUpdate::PlanUpdateOperator(ClientContext &context, Physica
 	if (table_metadata.HasSortOrder()) {
 		auto &sort_spec = table_metadata.GetLatestSortOrder();
 		if (sort_spec.IsSorted()) {
-			throw NotImplementedException("Update on a sorted iceberg table is not supported yet");
+			Value unsafe_ignore_sort_order;
+			if (!context.TryGetCurrentSetting("unsafe_iceberg_ignore_sort_order", unsafe_ignore_sort_order) ||
+			    !unsafe_ignore_sort_order.GetValue<bool>()) {
+				throw NotImplementedException(
+				    "Update on a sorted iceberg table is not supported yet.\nTo ignore this error and write "
+				    "unsorted data (the declared sort order will NOT be preserved) "
+				    "run \"SET unsafe_iceberg_ignore_sort_order=true\"");
+			}
 		}
 	}
 	if (table_metadata.iceberg_version < 2) {

--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -77,9 +77,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    LogicalType::BOOLEAN, Value::BOOLEAN(false));
 	config.AddExtensionOption(
 	    "unsafe_iceberg_ignore_sort_order",
-	    "Allow INSERT/UPDATE on iceberg tables that declare a sort order, without preserving that sort order. "
-	    "Unsafe: writes will not be sorted, so downstream readers relying on the declared sort order may "
-	    "produce incorrect results until the table is rewritten/compacted.",
+	    "Allow INSERT/UPDATE on iceberg tables that declare a sort order, without applying that sort order to "
+	    "the written data. The Iceberg spec permits this (writers are not required to honour a declared sort "
+	    "order, and readers do not assume files are sorted), but skipping the sort may reduce later file-pruning "
+	    "effectiveness and compression.",
 	    LogicalType::BOOLEAN, Value::BOOLEAN(false));
 
 	// Iceberg Table Functions

--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -75,6 +75,12 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    "ignore_row_group_size_for_partitioned_tables",
 	    "Ignore unsupported write.parquet.row-group-size-bytes table property for partitioned tables",
 	    LogicalType::BOOLEAN, Value::BOOLEAN(false));
+	config.AddExtensionOption(
+	    "unsafe_iceberg_ignore_sort_order",
+	    "Allow INSERT/UPDATE on iceberg tables that declare a sort order, without preserving that sort order. "
+	    "Unsafe: writes will not be sorted, so downstream readers relying on the declared sort order may "
+	    "produce incorrect results until the table is rewritten/compacted.",
+	    LogicalType::BOOLEAN, Value::BOOLEAN(false));
 
 	// Iceberg Table Functions
 	for (auto &fun : IcebergFunctions::GetTableFunctions(loader)) {

--- a/test/configs/polaris.json
+++ b/test/configs/polaris.json
@@ -23,6 +23,7 @@
       "reason" : "For some reason the tables cannot be generated in polaris yet",
       "paths" : [
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_into_sorted_table_fails.test",
+        "test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_into_sorted_table_fails.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/test_requests_to_partitioned_table.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/irc_catalog_read_deletes.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_read_upper_and_lower_bounds.test",

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_into_sorted_table_fails.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_into_sorted_table_fails.test
@@ -31,7 +31,10 @@ insert into my_datalake.default.table_sort_order select * from lineitem limit 5;
 ----
 <REGEX>:.*Not implemented Error.*INSERT into a sorted iceberg table is not supported yet.*
 
-# With the unsafe override enabled, the INSERT succeeds (writes are NOT sorted).
+# With the unsafe override enabled, the INSERT succeeds. The written data is
+# not sorted by the table's declared sort order, which the Iceberg spec permits
+# (writers are not required to honour the declared order, and readers do not
+# assume files are sorted).
 # Wrap in a transaction so the row-count assertions below stay stable.
 statement ok
 BEGIN;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_into_sorted_table_fails.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_into_sorted_table_fails.test
@@ -31,6 +31,29 @@ insert into my_datalake.default.table_sort_order select * from lineitem limit 5;
 ----
 <REGEX>:.*Not implemented Error.*INSERT into a sorted iceberg table is not supported yet.*
 
+# With the unsafe override enabled, the INSERT succeeds (writes are NOT sorted).
+# Wrap in a transaction so the row-count assertions below stay stable.
+statement ok
+BEGIN;
+
+statement ok
+SET unsafe_iceberg_ignore_sort_order=true;
+
+statement ok
+insert into my_datalake.default.table_sort_order select * from lineitem limit 5;
+
+statement ok
+ABORT;
+
+statement ok
+SET unsafe_iceberg_ignore_sort_order=false;
+
+# Without the override the guard still applies
+statement error
+insert into my_datalake.default.table_sort_order select * from lineitem limit 5;
+----
+<REGEX>:.*Not implemented Error.*INSERT into a sorted iceberg table is not supported yet.*
+
 statement ok
 BEGIN;
 

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_into_sorted_table_fails.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_into_sorted_table_fails.test
@@ -45,8 +45,20 @@ SET unsafe_iceberg_ignore_sort_order=true;
 statement ok
 insert into my_datalake.default.table_sort_order select * from lineitem limit 5;
 
+# Read back the staged rows inside the same transaction
+query I
+select count(*) from my_datalake.default.table_sort_order;
+----
+60180
+
 statement ok
 ABORT;
+
+# After ABORT the staged rows are gone
+query I
+select count(*) from my_datalake.default.table_sort_order;
+----
+60175
 
 statement ok
 SET unsafe_iceberg_ignore_sort_order=false;
@@ -75,4 +87,56 @@ select count(*) from my_datalake.default.table_sort_order;
 
 statement ok
 ABORT;
+
+# Commit an unsorted INSERT and read it back from a fresh transaction to prove
+# the rows survive the round-trip through the catalog. The inserted rows carry
+# a sentinel in l_comment so a follow-up commit can delete exactly those rows
+# and leave the table at its original row count for subsequent runs.
+statement ok
+SET unsafe_iceberg_ignore_sort_order=true;
+
+statement ok
+BEGIN;
+
+statement ok
+insert into my_datalake.default.table_sort_order
+select
+    l_orderkey, l_partkey, l_suppkey, l_linenumber,
+    l_quantity, l_extendedprice, l_discount, l_tax,
+    l_returnflag, l_linestatus,
+    l_shipdate, l_commitdate, l_receiptdate,
+    l_shipinstruct, l_shipmode,
+    'unsafe_sort_order_test_marker' as l_comment
+from lineitem limit 5;
+
+statement ok
+COMMIT;
+
+query I
+select count(*) from my_datalake.default.table_sort_order;
+----
+60180
+
+query I
+select count(*) from my_datalake.default.table_sort_order where l_comment = 'unsafe_sort_order_test_marker';
+----
+5
+
+# Clean up the marker rows so the table is back at its pristine row count
+statement ok
+BEGIN;
+
+statement ok
+delete from my_datalake.default.table_sort_order where l_comment = 'unsafe_sort_order_test_marker';
+
+statement ok
+COMMIT;
+
+statement ok
+SET unsafe_iceberg_ignore_sort_order=false;
+
+query I
+select count(*) from my_datalake.default.table_sort_order;
+----
+60175
 

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_into_sorted_table_fails.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_into_sorted_table_fails.test
@@ -28,7 +28,10 @@ update my_datalake.default.table_sort_order set l_partkey = l_partkey + 1 where 
 ----
 <REGEX>:.*Not implemented Error.*Update on a sorted iceberg table is not supported yet.*
 
-# With the unsafe override enabled, the UPDATE succeeds (writes are NOT sorted).
+# With the unsafe override enabled, the UPDATE succeeds. The written data is
+# not sorted by the table's declared sort order, which the Iceberg spec permits
+# (writers are not required to honour the declared order, and readers do not
+# assume files are sorted).
 # Wrap in a transaction so we don't leak state into other tests.
 statement ok
 BEGIN;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_into_sorted_table_fails.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_into_sorted_table_fails.test
@@ -1,0 +1,52 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_into_sorted_table_fails.test
+# group: [update]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require tpch
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+# Without the override, UPDATE on a sorted iceberg table is rejected
+statement error
+update my_datalake.default.table_sort_order set l_partkey = l_partkey + 1 where l_orderkey = 1;
+----
+<REGEX>:.*Not implemented Error.*Update on a sorted iceberg table is not supported yet.*
+
+# With the unsafe override enabled, the UPDATE succeeds (writes are NOT sorted).
+# Wrap in a transaction so we don't leak state into other tests.
+statement ok
+BEGIN;
+
+statement ok
+SET unsafe_iceberg_ignore_sort_order=true;
+
+statement ok
+update my_datalake.default.table_sort_order set l_partkey = l_partkey + 1 where l_orderkey = 1;
+
+statement ok
+ABORT;
+
+statement ok
+SET unsafe_iceberg_ignore_sort_order=false;
+
+# Without the override the guard still applies
+statement error
+update my_datalake.default.table_sort_order set l_partkey = l_partkey + 1 where l_orderkey = 1;
+----
+<REGEX>:.*Not implemented Error.*Update on a sorted iceberg table is not supported yet.*


### PR DESCRIPTION
See #851 for more information.

This PR adds a new option `unsafe_iceberg_ignore_sort_order` which allows duckdb to write _unsorted_ data to a _sorted_ table. This data will then need to be sorted at a later time by a compactor of some kind which happens automatically (with some configuration) in systems like S3 Tables.

This allows us to write many small unsorted files into an Iceberg table but have the resulting queries later read from a sorted and compacted large file that we never have to load into memory at any point.

I've added some simple tests and run the entire suite and everything looks okay on my end, unsure if there's CI too.