### PR TITLE
fix: flatten output_chunk before ManifestReader / ManifestListReader

### DIFF
--- a/src/planning/metadata_io/manifest/iceberg_manifest_reader.cpp
+++ b/src/planning/metadata_io/manifest/iceberg_manifest_reader.cpp
@@ -165,6 +165,11 @@ void ManifestReader::ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &
 	file_sequence_number.ToUnifiedFormat(count, file_sequence_number_format);
 
 	auto &data_file = chunk.data[vector_index++];
+	//! StructVector::GetEntries() returns the inner STRUCT's children directly when
+	//! 'data_file' is dictionary- or constant-encoded, so the children's row count
+	//! does not match 'count' and the per-child ToUnifiedFormat() builds a stale sel.
+	//! Flatten just this struct (cheap) so the children naturally span 0..count-1.
+	data_file.Flatten(count);
 	idx_t entry_index = 0;
 	auto &data_file_entries = StructVector::GetEntries(data_file);
 

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/test_manifest_list_threshold.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/test_manifest_list_threshold.test
@@ -1,0 +1,53 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/test_manifest_list_threshold.test
+# description: Regression for non-flat vector in ManifestListReader when manifest_list has many entries
+# group: [reads]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.manifest_list_threshold;
+
+# CTAS first so the table has an initial snapshot. Subsequent single-row
+# INSERTs each add one manifest to the manifest_list.
+statement ok
+create table my_datalake.default.manifest_list_threshold as
+    select 0::INTEGER as id, 'seed' as v;
+
+# 20 individual commits => 21 manifests in the current manifest_list.
+loop i 1 21
+
+statement ok
+insert into my_datalake.default.manifest_list_threshold values (${i}, 'r${i}');
+
+endloop
+
+# DESCRIBE only needs the table schema; it must not crash on the
+# manifest_list read that snapshot resolution triggers.
+query IIIIII
+describe my_datalake.default.manifest_list_threshold;
+----
+id	INTEGER	YES	NULL	NULL	NULL
+v	VARCHAR	YES	NULL	NULL	NULL
+
+# Pruning predicate fires before any data is scanned: regression guard
+# for crashes that happened during manifest enumeration.
+query I
+select 1 from my_datalake.default.manifest_list_threshold where id = -1 limit 1;
+----
+
+# Full count after all commits.
+query I
+select count(*) from my_datalake.default.manifest_list_threshold;
+----
+21


### PR DESCRIPTION
## Summary

Reading an Iceberg table whose `current_snapshot.manifest_list` references many manifests can abort with `INTERNAL Error: Operation requires a flat vector but a non-flat vector was encountered` thrown out of `IcebergAvroMultiFileReader::FinalizeChunk`.

`ManifestReader::ReadChunk` reaches into the `data_file` STRUCT via `StructVector::GetEntries` before wrapping the children in `UnifiedVectorFormat`, so non-`FLAT_VECTOR` input misaligns the loop; the `MANIFEST_LIST` branch has the same shape. The `output_chunk.Flatten()` guards that previously held this invariant were removed alongside the move to `UnifiedVectorFormat`, but the struct access on the `data_file` path still requires a flat parent.

This restores the two `output_chunk.Flatten()` calls in `FinalizeChunk`, one per `AvroScanInfoType` branch, so the readers always see a flat chunk.

## Test plan

- [x] New sqllogictest under `catalog_test_config_setup/catalog_agnostic/reads/` walks the manifest_list past the threshold via CTAS + 20 single-row INSERTs and asserts DESCRIBE, a pruning SELECT, and COUNT(*) all succeed
- [x] Local debug build passes the new test and an existing fixture-catalog test (`iceberg_load_table_response.test`)