### PR TITLE
fix: pass correct operation type to IcebergAddSnapshot

### DIFF
--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -15,8 +15,9 @@
 
 namespace duckdb {
 
-IcebergAddSnapshot::IcebergAddSnapshot(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SNAPSHOT, table_info) {
+IcebergAddSnapshot::IcebergAddSnapshot(const IcebergTableInformation &table_info,
+                                       IcebergSnapshotOperationType operation)
+    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SNAPSHOT, table_info), operation(operation) {
 	//! FIXME: Do we also need to capture the current partition spec and sort order?
 	//! This is a bit of a code smell, the `IcebergTableInformation` should instead be const
 	//! and all transactional changes should live in the IcebergTransactionData
@@ -188,7 +189,7 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 
 	//! Construct the snapshot
 	IcebergSnapshot new_snapshot;
-	new_snapshot.operation = IcebergSnapshotOperationType::OVERWRITE;
+	new_snapshot.operation = operation;
 	new_snapshot.snapshot_id = snapshot_id;
 	new_snapshot.sequence_number = sequence_number;
 	new_snapshot.SetSchemaId(schema_id);

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -101,7 +101,7 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 	    IcebergManifestListEntry::CreateFromEntries(fs, bogus_snapshot_id, temp_sequence_number, table_metadata,
 	                                                manifest_content_type, std::move(data_files), next_row_id);
 
-	auto add_snapshot = make_uniq<IcebergAddSnapshot>(table_info);
+	auto add_snapshot = make_uniq<IcebergAddSnapshot>(table_info, operation);
 	add_snapshot->AddManifestFile(std::move(manifest_file));
 	// make sure we are still inserting into the current schema
 	if (table_metadata.has_current_snapshot) {

--- a/src/core/metadata/snapshot/iceberg_snapshot.cpp
+++ b/src/core/metadata/snapshot/iceberg_snapshot.cpp
@@ -185,6 +185,19 @@ IcebergSnapshot IcebergSnapshot::ParseSnapshot(const rest_api_objects::Snapshot 
 	ret.manifest_list = snapshot.manifest_list;
 	ret.metrics = MetricsFromSummary(snapshot.summary.additional_properties);
 
+	auto &op = snapshot.summary.operation;
+	if (op == "append") {
+		ret.operation = IcebergSnapshotOperationType::APPEND;
+	} else if (op == "replace") {
+		ret.operation = IcebergSnapshotOperationType::REPLACE;
+	} else if (op == "overwrite") {
+		ret.operation = IcebergSnapshotOperationType::OVERWRITE;
+	} else if (op == "delete") {
+		ret.operation = IcebergSnapshotOperationType::DELETE;
+	} else {
+		throw InvalidConfigurationException("Unknown snapshot operation type: '%s'", op);
+	}
+
 	ret.has_first_row_id = snapshot.has_first_row_id;
 	ret.first_row_id = snapshot.first_row_id;
 

--- a/src/function/metadata/iceberg_snapshots.cpp
+++ b/src/function/metadata/iceberg_snapshots.cpp
@@ -6,10 +6,26 @@
 #include "iceberg_options.hpp"
 #include "common/iceberg_utils.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
+#include "core/metadata/snapshot/iceberg_snapshot.hpp"
 
 #include <string>
 
 namespace duckdb {
+
+static string SnapshotOperationToString(IcebergSnapshotOperationType type) {
+	switch (type) {
+	case IcebergSnapshotOperationType::APPEND:
+		return "append";
+	case IcebergSnapshotOperationType::REPLACE:
+		return "replace";
+	case IcebergSnapshotOperationType::OVERWRITE:
+		return "overwrite";
+	case IcebergSnapshotOperationType::DELETE:
+		return "delete";
+	default:
+		return "unknown";
+	}
+}
 
 struct IcebergSnaphotsBindData : public TableFunctionData {
 	IcebergSnaphotsBindData() {};
@@ -76,6 +92,9 @@ static unique_ptr<FunctionData> IcebergSnapshotsBind(ClientContext &context, Tab
 	names.emplace_back("manifest_list");
 	return_types.emplace_back(LogicalType::VARCHAR);
 
+	names.emplace_back("operation");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
 	return std::move(bind_data);
 }
 
@@ -96,6 +115,8 @@ static void IcebergSnapshotsFunction(ClientContext &context, TableFunctionInput 
 		FlatVector::GetData<timestamp_t>(output.data[2])[i] = snapshot.timestamp_ms;
 		string_t manifest_string_t = StringVector::AddString(output.data[3], string_t(snapshot.manifest_list));
 		FlatVector::GetData<string_t>(output.data[3])[i] = manifest_string_t;
+		auto operation_str = SnapshotOperationToString(snapshot.operation);
+		FlatVector::GetData<string_t>(output.data[4])[i] = StringVector::AddString(output.data[4], operation_str);
 		i++;
 	}
 	output.SetCardinality(i);

--- a/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
+++ b/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
@@ -20,7 +20,8 @@ struct IcebergAddSnapshot : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SNAPSHOT;
 
 public:
-	IcebergAddSnapshot(const IcebergTableInformation &table_info);
+	IcebergAddSnapshot(const IcebergTableInformation &table_info,
+	                   IcebergSnapshotOperationType operation = IcebergSnapshotOperationType::OVERWRITE);
 
 public:
 	void ConstructManifestList(IcebergManifestList &manifest_list, CopyFunction &avro_copy, DatabaseInstance &db,
@@ -35,6 +36,7 @@ public:
 private:
 	vector<IcebergManifestListEntry> manifest_files;
 	int32_t schema_id;
+	IcebergSnapshotOperationType operation;
 };
 
 } // namespace duckdb

--- a/test/configs/nessie.json
+++ b/test/configs/nessie.json
@@ -76,7 +76,9 @@
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_transactional_updates.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_transactional_updates_error_omits_stacktrace.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/add_column/alter_add_column_time_travel.test",
-        "test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_rename_column.test"
+        "test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_rename_column.test",
+        "test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_snapshot_operation_type.test",
+        "test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_snapshot_operation_in_transaction.test"
       ]
     },
     {

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_snapshot_operation_type.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_snapshot_operation_type.test
@@ -1,0 +1,187 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_snapshot_operation_type.test
+# description: Test that snapshot operation type is correctly set (APPEND for insert, DELETE for delete, OVERWRITE for update)
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+# Create a fresh table for testing operation types
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.test_snapshot_operation_type;
+
+statement ok
+CREATE TABLE my_datalake.default.test_snapshot_operation_type (id INTEGER, data VARCHAR);
+
+# After CREATE TABLE, there should be no snapshots (empty table)
+query I
+select count(*) from iceberg_snapshots(my_datalake.default.test_snapshot_operation_type);
+----
+0
+
+# INSERT should produce a snapshot with operation=append
+statement ok
+INSERT INTO my_datalake.default.test_snapshot_operation_type VALUES (1, 'hello'), (2, 'world'), (3, 'foo');
+
+# Verify operation type is 'append'
+query II
+select sequence_number, operation from iceberg_snapshots(my_datalake.default.test_snapshot_operation_type) order by sequence_number;
+----
+1	append
+
+# Verify the data is correct
+query II
+select * from my_datalake.default.test_snapshot_operation_type order by id;
+----
+1	hello
+2	world
+3	foo
+
+# INSERT more data - should produce another snapshot with operation=append
+statement ok
+INSERT INTO my_datalake.default.test_snapshot_operation_type VALUES (4, 'bar'), (5, 'baz');
+
+# Both snapshots should have operation=append
+query II
+select sequence_number, operation from iceberg_snapshots(my_datalake.default.test_snapshot_operation_type) order by sequence_number;
+----
+1	append
+2	append
+
+# DELETE should produce a snapshot with operation=delete
+statement ok
+DELETE FROM my_datalake.default.test_snapshot_operation_type WHERE id IN (2, 4);
+
+# Verify: two appends and one delete
+query II
+select sequence_number, operation from iceberg_snapshots(my_datalake.default.test_snapshot_operation_type) order by sequence_number;
+----
+1	append
+2	append
+3	delete
+
+# Verify the remaining data
+query II
+select * from my_datalake.default.test_snapshot_operation_type order by id;
+----
+1	hello
+3	foo
+5	baz
+
+# INSERT after DELETE should still produce operation=append
+statement ok
+INSERT INTO my_datalake.default.test_snapshot_operation_type VALUES (6, 'new_entry');
+
+query II
+select sequence_number, operation from iceberg_snapshots(my_datalake.default.test_snapshot_operation_type) order by sequence_number;
+----
+1	append
+2	append
+3	delete
+4	append
+
+query II
+select * from my_datalake.default.test_snapshot_operation_type order by id;
+----
+1	hello
+3	foo
+5	baz
+6	new_entry
+
+# UPDATE should produce a snapshot with operation=overwrite
+# (UPDATE both removes the old row and adds a new data file, which Iceberg classifies as 'overwrite')
+statement ok
+UPDATE my_datalake.default.test_snapshot_operation_type SET data = 'updated_hello' WHERE id = 1;
+
+query II
+select sequence_number, operation from iceberg_snapshots(my_datalake.default.test_snapshot_operation_type) order by sequence_number;
+----
+1	append
+2	append
+3	delete
+4	append
+5	overwrite
+
+# Verify the data after UPDATE
+query II
+select * from my_datalake.default.test_snapshot_operation_type order by id;
+----
+1	updated_hello
+3	foo
+5	baz
+6	new_entry
+
+# UPDATE that touches multiple rows should also produce a single snapshot with operation=overwrite
+statement ok
+UPDATE my_datalake.default.test_snapshot_operation_type SET data = data || '_v2' WHERE id IN (3, 5);
+
+query II
+select sequence_number, operation from iceberg_snapshots(my_datalake.default.test_snapshot_operation_type) order by sequence_number;
+----
+1	append
+2	append
+3	delete
+4	append
+5	overwrite
+6	overwrite
+
+query II
+select * from my_datalake.default.test_snapshot_operation_type order by id;
+----
+1	updated_hello
+3	foo_v2
+5	baz_v2
+6	new_entry
+
+# UPDATE that matches no rows should NOT create a new snapshot
+statement ok
+UPDATE my_datalake.default.test_snapshot_operation_type SET data = 'nope' WHERE id = 9999;
+
+query II
+select sequence_number, operation from iceberg_snapshots(my_datalake.default.test_snapshot_operation_type) order by sequence_number;
+----
+1	append
+2	append
+3	delete
+4	append
+5	overwrite
+6	overwrite
+
+# A subsequent INSERT should still produce operation=append (i.e. the previous UPDATE didn't mutate global state)
+statement ok
+INSERT INTO my_datalake.default.test_snapshot_operation_type VALUES (7, 'after_update');
+
+query II
+select sequence_number, operation from iceberg_snapshots(my_datalake.default.test_snapshot_operation_type) order by sequence_number;
+----
+1	append
+2	append
+3	delete
+4	append
+5	overwrite
+6	overwrite
+7	append
+
+query II
+select * from my_datalake.default.test_snapshot_operation_type order by id;
+----
+1	updated_hello
+3	foo_v2
+5	baz_v2
+6	new_entry
+7	after_update

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_snapshot_operation_in_transaction.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_snapshot_operation_in_transaction.test
@@ -1,0 +1,142 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_snapshot_operation_in_transaction.test
+# description: Test that snapshot operation type is correctly passed through transactions
+# group: [transactions]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+# Create a fresh table
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.test_txn_operation_type;
+
+statement ok
+CREATE TABLE my_datalake.default.test_txn_operation_type (id INTEGER, value VARCHAR);
+
+# Test INSERT in explicit transaction produces correct operation type (append)
+statement ok
+begin transaction;
+
+statement ok
+INSERT INTO my_datalake.default.test_txn_operation_type VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+statement ok
+commit;
+
+query II
+select sequence_number, operation from iceberg_snapshots(my_datalake.default.test_txn_operation_type) order by sequence_number;
+----
+1	append
+
+# Test DELETE in explicit transaction produces correct operation type (delete)
+statement ok
+begin transaction;
+
+statement ok
+DELETE FROM my_datalake.default.test_txn_operation_type WHERE id = 2;
+
+statement ok
+commit;
+
+# Verify: one append and one delete
+query II
+select sequence_number, operation from iceberg_snapshots(my_datalake.default.test_txn_operation_type) order by sequence_number;
+----
+1	append
+2	delete
+
+# Verify final state
+query II
+select * from my_datalake.default.test_txn_operation_type order by id;
+----
+1	a
+3	c
+
+# Test UPDATE in explicit transaction produces correct operation type (overwrite)
+statement ok
+begin transaction;
+
+statement ok
+UPDATE my_datalake.default.test_txn_operation_type SET value = 'a_updated' WHERE id = 1;
+
+statement ok
+commit;
+
+# Verify: append, delete, overwrite
+query II
+select sequence_number, operation from iceberg_snapshots(my_datalake.default.test_txn_operation_type) order by sequence_number;
+----
+1	append
+2	delete
+3	overwrite
+
+query II
+select * from my_datalake.default.test_txn_operation_type order by id;
+----
+1	a_updated
+3	c
+
+# Test UPDATE rolled back in a transaction does NOT create a snapshot
+statement ok
+begin transaction;
+
+statement ok
+UPDATE my_datalake.default.test_txn_operation_type SET value = 'should_not_persist' WHERE id = 3;
+
+statement ok
+rollback;
+
+query II
+select sequence_number, operation from iceberg_snapshots(my_datalake.default.test_txn_operation_type) order by sequence_number;
+----
+1	append
+2	delete
+3	overwrite
+
+query II
+select * from my_datalake.default.test_txn_operation_type order by id;
+----
+1	a_updated
+3	c
+
+# Test multiple operations in a single transaction each produce their own snapshot with correct operation type
+statement ok
+begin transaction;
+
+statement ok
+INSERT INTO my_datalake.default.test_txn_operation_type VALUES (4, 'd'), (5, 'e');
+
+statement ok
+UPDATE my_datalake.default.test_txn_operation_type SET value = 'd_v2' WHERE id = 4;
+
+statement ok
+DELETE FROM my_datalake.default.test_txn_operation_type WHERE id = 5;
+
+statement ok
+commit;
+
+# Three new snapshots should have been added: append, overwrite, delete
+query II
+select sequence_number, operation from iceberg_snapshots(my_datalake.default.test_txn_operation_type) order by sequence_number;
+----
+1	append
+2	delete
+3	overwrite
+4	append
+5	overwrite
+6	delete


### PR DESCRIPTION
Previously, IcebergAddSnapshot always hardcoded the snapshot operation as OVERWRITE, regardless of the actual operation (INSERT → APPEND, DELETE → DELETE). This fix passes the operation type through from IcebergTransactionData::AddSnapshot to the snapshot, ensuring the REST API receives the correct operation in the snapshot summary.

Also exposes the operation field in the iceberg_snapshots() table function and parses it from snapshot metadata, so users can query snapshot operation types directly.