### PR TITLE
Fix #969: resolve point-in-time reads via snapshot-log, not all snapshots

### DIFF
--- a/scripts/data_generators/tests/issue_969/__init__.py
+++ b/scripts/data_generators/tests/issue_969/__init__.py
@@ -6,6 +6,4 @@ import pathlib
 class Test(IcebergTest):
     def __init__(self):
         path = pathlib.PurePath(__file__)
-        # write_intermediates=False: the per-step parquet snapshot reads the table
-        # by name (always main); branch-only writes would produce misleading dumps.
-        super().__init__(path.parent.name, write_intermediates=False)
+        super().__init__(path.parent.name)

--- a/scripts/data_generators/tests/issue_969/__init__.py
+++ b/scripts/data_generators/tests/issue_969/__init__.py
@@ -1,0 +1,11 @@
+from scripts.data_generators.tests.base import IcebergTest
+import pathlib
+
+
+@IcebergTest.register()
+class Test(IcebergTest):
+    def __init__(self):
+        path = pathlib.PurePath(__file__)
+        # write_intermediates=False: the per-step parquet snapshot reads the table
+        # by name (always main); branch-only writes would produce misleading dumps.
+        super().__init__(path.parent.name, write_intermediates=False)

--- a/scripts/data_generators/tests/issue_969/q00.sql
+++ b/scripts/data_generators/tests/issue_969/q00.sql
@@ -1,5 +1,4 @@
-DROP TABLE IF EXISTS default.issue_969 PURGE;
-CREATE TABLE default.issue_969 (
+CREATE OR REPLACE TABLE default.issue_969 (
   id INT,
   name STRING
 ) TBLPROPERTIES ('format-version'='2');

--- a/scripts/data_generators/tests/issue_969/q00.sql
+++ b/scripts/data_generators/tests/issue_969/q00.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS default.issue_969 PURGE;
+CREATE TABLE default.issue_969 (
+  id INT,
+  name STRING
+) TBLPROPERTIES ('format-version'='2');

--- a/scripts/data_generators/tests/issue_969/q01.sql
+++ b/scripts/data_generators/tests/issue_969/q01.sql
@@ -1,0 +1,6 @@
+INSERT INTO default.issue_969 VALUES
+  (1, 'a'),
+  (2, 'b'),
+  (3, 'c'),
+  (4, 'd'),
+  (5, 'e');

--- a/scripts/data_generators/tests/issue_969/q02.sql
+++ b/scripts/data_generators/tests/issue_969/q02.sql
@@ -1,0 +1,1 @@
+ALTER TABLE default.issue_969 CREATE BRANCH IF NOT EXISTS side_branch;

--- a/scripts/data_generators/tests/issue_969/q02.sql
+++ b/scripts/data_generators/tests/issue_969/q02.sql
@@ -1,1 +1,1 @@
-ALTER TABLE default.issue_969 CREATE BRANCH IF NOT EXISTS side_branch;
+ALTER TABLE default.issue_969 CREATE BRANCH side_branch;

--- a/scripts/data_generators/tests/issue_969/q03.sql
+++ b/scripts/data_generators/tests/issue_969/q03.sql
@@ -1,0 +1,1 @@
+DELETE FROM default.issue_969.branch_side_branch WHERE true;

--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -21,40 +21,39 @@ optional_ptr<const IcebergSnapshot> IcebergTableMetadata::FindSnapshotByIdIntern
 }
 
 optional_ptr<const IcebergSnapshot> IcebergTableMetadata::GetSnapshotByTimestamp(timestamp_t timestamp) const {
-	// Per Iceberg spec, point-in-time resolution must use snapshot-log
-	// (the history of refs.main). Searching the global snapshots map would
-	// incorrectly pick side-branch tips - see duckdb-iceberg#969.
+	// Per Iceberg spec, point-in-time resolution should use snapshot-log (the
+	// history of refs.main). Searching the global snapshots map would incorrectly
+	// pick side-branch tips - see duckdb-iceberg#969.
 	//
-	// Everything below is compared in raw epoch-millis: snapshot_log stores ms,
-	// last_updated_ms is ms-in-timestamp_t.value (per the parser), and we
-	// convert the incoming lookup timestamp to ms once here.
+	// All comparisons below are in raw epoch-millis: snapshot_log stores ms, and
+	// we convert the incoming lookup timestamp to ms once here.
 	auto target_ms = Timestamp::GetEpochMs(timestamp);
-	if (snapshot_log.empty()) {
-		// Table has no commits yet (freshly created, no INSERT). Original behavior
-		// returned nullptr here; GetSnapshot interprets that as "use current schema".
-		if (snapshots.empty()) {
-			return nullptr;
-		}
-		// Table has snapshots but no snapshot-log (spec allows this; rare). For the
-		// common case where the lookup is at or after the last commit,
-		// current_snapshot_id is unambiguously the right answer.
-		if (has_current_snapshot && target_ms >= last_updated_ms.value) {
-			return FindSnapshotByIdInternal(current_snapshot_id);
-		}
-		throw InvalidConfigurationException("Table has no snapshot-log; cannot resolve snapshot as of " +
-		                                    Timestamp::ToString(timestamp));
-	}
-	// snapshot_log is sorted ascending by timestamp_ms; walk newest-first and
-	// return the first entry whose snapshot still exists in the snapshots map
-	// (spec allows expired snapshots to leave dangling log entries).
-	for (auto it = snapshot_log.rbegin(); it != snapshot_log.rend(); ++it) {
-		if (it->second <= target_ms) {
-			if (auto snap = FindSnapshotByIdInternal(it->first)) {
-				return snap;
+	if (!snapshot_log.empty()) {
+		// snapshot_log is sorted ascending by timestamp_ms; walk newest-first and
+		// return the first entry whose snapshot still exists in the snapshots map
+		// (spec allows expired snapshots to leave dangling log entries).
+		for (auto it = snapshot_log.rbegin(); it != snapshot_log.rend(); ++it) {
+			if (it->second <= target_ms) {
+				if (auto snap = FindSnapshotByIdInternal(it->first)) {
+					return snap;
+				}
 			}
 		}
+		return nullptr;
 	}
-	return nullptr;
+	// snapshot-log is optional per spec. Fall back to the pre-#969 behavior:
+	// scan all snapshots for the largest timestamp_ms <= target.
+	uint64_t max_millis = NumericLimits<uint64_t>::Minimum();
+	optional_ptr<const IcebergSnapshot> max_snapshot = nullptr;
+	for (auto &it : snapshots) {
+		auto &snapshot = it.second;
+		auto curr_millis = Timestamp::GetEpochMs(snapshot.timestamp_ms);
+		if (curr_millis <= target_ms && static_cast<uint64_t>(curr_millis) >= max_millis) {
+			max_snapshot = snapshot;
+			max_millis = curr_millis;
+		}
+	}
+	return max_snapshot;
 }
 
 shared_ptr<IcebergTableSchema> IcebergTableMetadata::GetSchemaFromId(int32_t schema_id) const {

--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -30,9 +30,14 @@ optional_ptr<const IcebergSnapshot> IcebergTableMetadata::GetSnapshotByTimestamp
 	// convert the incoming lookup timestamp to ms once here.
 	auto target_ms = Timestamp::GetEpochMs(timestamp);
 	if (snapshot_log.empty()) {
-		// snapshot-log is optional per spec. For the common case where the lookup
-		// time is at or after the last commit, current_snapshot_id is unambiguously
-		// the right answer (refs.main always points there).
+		// Table has no commits yet (freshly created, no INSERT). Original behavior
+		// returned nullptr here; GetSnapshot interprets that as "use current schema".
+		if (snapshots.empty()) {
+			return nullptr;
+		}
+		// Table has snapshots but no snapshot-log (spec allows this; rare). For the
+		// common case where the lookup is at or after the last commit,
+		// current_snapshot_id is unambiguously the right answer.
 		if (has_current_snapshot && target_ms >= last_updated_ms.value) {
 			return FindSnapshotByIdInternal(current_snapshot_id);
 		}

--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -21,19 +21,35 @@ optional_ptr<const IcebergSnapshot> IcebergTableMetadata::FindSnapshotByIdIntern
 }
 
 optional_ptr<const IcebergSnapshot> IcebergTableMetadata::GetSnapshotByTimestamp(timestamp_t timestamp) const {
-	uint64_t max_millis = NumericLimits<uint64_t>::Minimum();
-	optional_ptr<const IcebergSnapshot> max_snapshot = nullptr;
-
-	auto timestamp_millis = Timestamp::GetEpochMs(timestamp);
-	for (auto &it : snapshots) {
-		auto &snapshot = it.second;
-		auto curr_millis = Timestamp::GetEpochMs(snapshot.timestamp_ms);
-		if (curr_millis <= timestamp_millis && static_cast<uint64_t>(curr_millis) >= max_millis) {
-			max_snapshot = snapshot;
-			max_millis = curr_millis;
+	// Per Iceberg spec, point-in-time resolution must use snapshot-log
+	// (the history of refs.main). Searching the global snapshots map would
+	// incorrectly pick side-branch tips - see duckdb-iceberg#969.
+	//
+	// Everything below is compared in raw epoch-millis: snapshot_log stores ms,
+	// last_updated_ms is ms-in-timestamp_t.value (per the parser), and we
+	// convert the incoming lookup timestamp to ms once here.
+	auto target_ms = Timestamp::GetEpochMs(timestamp);
+	if (snapshot_log.empty()) {
+		// snapshot-log is optional per spec. For the common case where the lookup
+		// time is at or after the last commit, current_snapshot_id is unambiguously
+		// the right answer (refs.main always points there).
+		if (has_current_snapshot && target_ms >= last_updated_ms.value) {
+			return FindSnapshotByIdInternal(current_snapshot_id);
+		}
+		throw InvalidConfigurationException(
+		    "Table has no snapshot-log; cannot resolve snapshot as of " + Timestamp::ToString(timestamp));
+	}
+	// snapshot_log is sorted ascending by timestamp_ms; walk newest-first and
+	// return the first entry whose snapshot still exists in the snapshots map
+	// (spec allows expired snapshots to leave dangling log entries).
+	for (auto it = snapshot_log.rbegin(); it != snapshot_log.rend(); ++it) {
+		if (it->second <= target_ms) {
+			if (auto snap = FindSnapshotByIdInternal(it->first)) {
+				return snap;
+			}
 		}
 	}
-	return max_snapshot;
+	return nullptr;
 }
 
 shared_ptr<IcebergTableSchema> IcebergTableMetadata::GetSchemaFromId(int32_t schema_id) const {
@@ -343,6 +359,16 @@ IcebergTableMetadata IcebergTableMetadata::FromTableMetadata(const rest_api_obje
 	}
 	for (auto &snapshot : table_metadata.snapshots) {
 		res.snapshots.emplace(snapshot.snapshot_id, IcebergSnapshot::ParseSnapshot(snapshot, res));
+	}
+	if (table_metadata.has_snapshot_log) {
+		res.snapshot_log.reserve(table_metadata.snapshot_log.value.size());
+		for (auto &entry : table_metadata.snapshot_log.value) {
+			res.snapshot_log.emplace_back(entry.snapshot_id, entry.timestamp_ms);
+		}
+		std::sort(res.snapshot_log.begin(), res.snapshot_log.end(),
+		          [](const pair<int64_t, int64_t> &a, const pair<int64_t, int64_t> &b) {
+			          return a.second < b.second;
+		          });
 	}
 	for (auto &spec : table_metadata.partition_specs) {
 		res.partition_specs.emplace(spec.spec_id, IcebergPartitionSpec::ParseFromJson(spec));

--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -36,8 +36,8 @@ optional_ptr<const IcebergSnapshot> IcebergTableMetadata::GetSnapshotByTimestamp
 		if (has_current_snapshot && target_ms >= last_updated_ms.value) {
 			return FindSnapshotByIdInternal(current_snapshot_id);
 		}
-		throw InvalidConfigurationException(
-		    "Table has no snapshot-log; cannot resolve snapshot as of " + Timestamp::ToString(timestamp));
+		throw InvalidConfigurationException("Table has no snapshot-log; cannot resolve snapshot as of " +
+		                                    Timestamp::ToString(timestamp));
 	}
 	// snapshot_log is sorted ascending by timestamp_ms; walk newest-first and
 	// return the first entry whose snapshot still exists in the snapshots map
@@ -366,9 +366,7 @@ IcebergTableMetadata IcebergTableMetadata::FromTableMetadata(const rest_api_obje
 			res.snapshot_log.emplace_back(entry.snapshot_id, entry.timestamp_ms);
 		}
 		std::sort(res.snapshot_log.begin(), res.snapshot_log.end(),
-		          [](const pair<int64_t, int64_t> &a, const pair<int64_t, int64_t> &b) {
-			          return a.second < b.second;
-		          });
+		          [](const pair<int64_t, int64_t> &a, const pair<int64_t, int64_t> &b) { return a.second < b.second; });
 	}
 	for (auto &spec : table_metadata.partition_specs) {
 		res.partition_specs.emplace(spec.spec_id, IcebergPartitionSpec::ParseFromJson(spec));

--- a/src/include/core/metadata/iceberg_table_metadata.hpp
+++ b/src/include/core/metadata/iceberg_table_metadata.hpp
@@ -127,6 +127,12 @@ public:
 	unordered_map<int32_t, IcebergSortOrder> sort_specs;
 	//! snapshot_id -> snapshot
 	unordered_map<int64_t, IcebergSnapshot> snapshots;
+	//! History of refs.main per Iceberg spec "snapshot-log": (snapshot_id, raw millis)
+	//! pairs recording each change to current-snapshot-id, sorted ascending by ms.
+	//! Used for spec-compliant point-in-time resolution; side-branch commits are absent.
+	//! Stored as raw millis (matching the REST API representation and last_updated_ms)
+	//! to keep all timestamp comparisons in a single unit.
+	vector<pair<int64_t /*snapshot_id*/, int64_t /*timestamp_ms*/>> snapshot_log;
 	vector<IcebergFieldMapping> mappings;
 
 	//! Custom write paths from table properties

--- a/test/python/test_spark_read.py
+++ b/test/python/test_spark_read.py
@@ -116,11 +116,9 @@ requires_iceberg_server = pytest.mark.skipif(
 @requires_iceberg_server
 class TestSparkRead:
     def test_spark_read_insert_test(self, spark_con):
-        df = spark_con.sql(
-            """
+        df = spark_con.sql("""
             select * from default.insert_test order by col1, col2, col3
-        """
-        )
+        """)
         res = df.collect()
         assert res == [
             Row(col1=datetime.date(2010, 6, 11), col2=42, col3='test'),
@@ -132,11 +130,9 @@ class TestSparkRead:
         ]
 
     def test_spark_read_duckdb_table(self, spark_con):
-        df = spark_con.sql(
-            """
+        df = spark_con.sql("""
             select * from default.duckdb_written_table order by a
-            """
-        )
+            """)
         res = df.collect()
         assert res == [
             Row(a=0),
@@ -152,11 +148,9 @@ class TestSparkRead:
         ]
 
     def test_spark_read_table_with_deletes(self, spark_con):
-        df = spark_con.sql(
-            """
+        df = spark_con.sql("""
             select * from default.duckdb_deletes_for_other_engines order by a
-            """
-        )
+            """)
         res = df.collect()
         assert res == [
             Row(a=1),
@@ -172,11 +166,9 @@ class TestSparkRead:
         ]
 
     def test_spark_read_upper_and_lower_bounds(self, spark_con):
-        df = spark_con.sql(
-            """
+        df = spark_con.sql("""
             select * from default.lower_upper_bounds_test;
-            """
-        )
+            """)
         res = df.collect()
         assert len(res) == 3
         assert res == [
@@ -219,11 +211,9 @@ class TestSparkRead:
         ]
 
     def test_spark_read_infinities(self, spark_con):
-        df = spark_con.sql(
-            """
+        df = spark_con.sql("""
             select * from default.test_infinities;
-            """
-        )
+            """)
         res = df.collect()
         assert len(res) == 2
         assert res == [
@@ -232,11 +222,9 @@ class TestSparkRead:
         ]
 
     def test_duckdb_written_nested_types(self, spark_con):
-        df = spark_con.sql(
-            """
+        df = spark_con.sql("""
             select * from default.duckdb_nested_types;
-            """
-        )
+            """)
         res = df.collect()
         assert len(res) == 1
         assert res == [
@@ -270,11 +258,9 @@ class TestSparkRead:
             assert bytes(actual.value) == value_bytes
             assert bytes(actual.metadata) == metadata_bytes
 
-        res = spark_con.sql(
-            """
+        res = spark_con.sql("""
             select * from default.my_variant_tbl order by b
-            """
-        ).collect()
+            """).collect()
 
         row = res[0]
         assert row.b == 42
@@ -293,11 +279,9 @@ class TestSparkRead:
 
     @pytest.mark.requires_spark(">=4.0")
     def test_duckdb_written_row_lineage(self, spark_con):
-        df = spark_con.sql(
-            """
+        df = spark_con.sql("""
             select _last_updated_sequence_number, _row_id, * from default.duckdb_row_lineage order by _row_id;
-            """
-        )
+            """)
         res = df.collect()
         print(res)
         assert res == [
@@ -313,11 +297,9 @@ class TestSparkRead:
     @pytest.mark.skip(reason="Failures due to unclear Spark behavior regarding row ids")
     @pytest.mark.requires_spark(">=4.0")
     def test_spark_read_row_lineage_from_upgraded(self, spark_con):
-        df = spark_con.sql(
-            """
+        df = spark_con.sql("""
             select _last_updated_sequence_number, _row_id, * from default.row_lineage_test_upgraded_insert order by id;
-            """
-        )
+            """)
         res = df.collect()
         assert res == [
             Row(_last_updated_sequence_number=5, _row_id=3, id=1, data='replaced'),
@@ -331,11 +313,9 @@ class TestSparkRead:
     @pytest.mark.requires_spark(">=4.0")
     @pytest.mark.skip(reason="Failures due to unclear Spark behavior regarding row ids")
     def test_spark_read_row_lineage_from_upgraded_by_duckdb(self, spark_con):
-        df = spark_con.sql(
-            """
+        df = spark_con.sql("""
             select _last_updated_sequence_number, _row_id, * from default.row_lineage_test_upgraded order by id;
-            """
-        )
+            """)
         res = df.collect()
         assert res == [
             Row(_last_updated_sequence_number=8, _row_id=3, id=2, data='replaced_again'),

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/test_issue_969_branch_ref_timestamp.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/test_issue_969_branch_ref_timestamp.test
@@ -1,8 +1,6 @@
 # name: test/sql/local/irc_specific_catalogs/polaris/test_issue_969_branch_ref_timestamp.test
-# description: Reproduce duckdb/duckdb-iceberg#969 - ATTACH (REST) default read should
-#              follow current-snapshot-id (refs.main), not pick the largest timestamp_ms
-#              across all branch refs. The side branch's tip has a newer timestamp_ms
-#              than refs.main because of the DELETE-all commit done after branch creation.
+# description: duckdb-iceberg#969 - default read must follow refs.main, not pick the
+#              largest timestamp_ms across all branch refs.
 # group: [polaris]
 
 require-env POLARIS_SERVER_AVAILABLE
@@ -35,30 +33,25 @@ attach 'quickstart_catalog' as my_datalake (
 	DEFAULT_REGION 'us-west-2'
 );
 
-# Sanity-check: the table has two snapshots (main tip with 5 rows, side_branch tip after DELETE-all)
+# Setup produces: main tip with 5 rows, side_branch tip after DELETE-all with a
+# newer timestamp_ms. Precondition for the bug.
 query I
 select count(*) >= 2 from iceberg_snapshots(my_datalake.default.issue_969);
 ----
 true
 
-# Sanity-check: max(timestamp_ms) > min(timestamp_ms). The DELETE-all on side_branch
-# (created after the INSERT into main) produces a snapshot whose timestamp_ms is
-# strictly newer than refs.main's tip. This is the precondition that triggers the bug.
 query I
 select max(timestamp_ms) > min(timestamp_ms) from iceberg_snapshots(my_datalake.default.issue_969);
 ----
 true
 
-# Bug: default read picks the side branch's empty snapshot (largest timestamp_ms across
-# all refs) instead of refs.main (current-snapshot-id). Expected 5, observed 0 before fix.
+# Default read must resolve to refs.main (5 rows), not the side-branch tip (0).
 query I
 select count(*) from my_datalake.default.issue_969;
 ----
 5
 
-# Time-travel by snapshot id of refs.main still works - confirms the *default*
-# resolution is what's wrong, not the manifest/data scan layer. main's snapshot is
-# the older of the two (INSERT happened before the branch's DELETE-all).
+# Explicit-id time travel against refs.main's snapshot keeps working.
 statement ok
 set variable main_snapshot_id = (
 	select snapshot_id from iceberg_snapshots(my_datalake.default.issue_969)

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/test_issue_969_branch_ref_timestamp.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/test_issue_969_branch_ref_timestamp.test
@@ -1,7 +1,8 @@
 # name: test/sql/local/irc_specific_catalogs/polaris/test_issue_969_branch_ref_timestamp.test
 # description: duckdb-iceberg#969 - default read must follow refs.main, not pick the
-#              largest timestamp_ms across all branch refs.
 # group: [polaris]
+
+#              largest timestamp_ms across all branch refs.
 
 require-env POLARIS_SERVER_AVAILABLE
 

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/test_issue_969_branch_ref_timestamp.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/test_issue_969_branch_ref_timestamp.test
@@ -1,0 +1,81 @@
+# name: test/sql/local/irc_specific_catalogs/polaris/test_issue_969_branch_ref_timestamp.test
+# description: Reproduce duckdb/duckdb-iceberg#969 - ATTACH (REST) default read should
+#              follow current-snapshot-id (refs.main), not pick the largest timestamp_ms
+#              across all branch refs. The side branch's tip has a newer timestamp_ms
+#              than refs.main because of the DELETE-all commit done after branch creation.
+# group: [polaris]
+
+require-env POLARIS_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require httpfs
+
+require iceberg
+
+require aws
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+create secret polaris_secret (
+	TYPE ICEBERG,
+	CLIENT_ID 'root',
+	CLIENT_SECRET 's3cr3t',
+	ENDPOINT 'http://0.0.0.0:8181/api/catalog'
+);
+
+statement ok
+attach 'quickstart_catalog' as my_datalake (
+	type ICEBERG,
+	ENDPOINT 'http://0.0.0.0:8181/api/catalog',
+	DEFAULT_REGION 'us-west-2'
+);
+
+# Sanity-check: the table has two snapshots (main tip with 5 rows, side_branch tip after DELETE-all)
+query I
+select count(*) >= 2 from iceberg_snapshots(my_datalake.default.issue_969);
+----
+true
+
+# Sanity-check: max(timestamp_ms) > min(timestamp_ms). The DELETE-all on side_branch
+# (created after the INSERT into main) produces a snapshot whose timestamp_ms is
+# strictly newer than refs.main's tip. This is the precondition that triggers the bug.
+query I
+select max(timestamp_ms) > min(timestamp_ms) from iceberg_snapshots(my_datalake.default.issue_969);
+----
+true
+
+# Bug: default read picks the side branch's empty snapshot (largest timestamp_ms across
+# all refs) instead of refs.main (current-snapshot-id). Expected 5, observed 0 before fix.
+query I
+select count(*) from my_datalake.default.issue_969;
+----
+5
+
+# Time-travel by snapshot id of refs.main still works - confirms the *default*
+# resolution is what's wrong, not the manifest/data scan layer. main's snapshot is
+# the older of the two (INSERT happened before the branch's DELETE-all).
+statement ok
+set variable main_snapshot_id = (
+	select snapshot_id from iceberg_snapshots(my_datalake.default.issue_969)
+		order by timestamp_ms asc limit 1
+);
+
+statement ok
+set variable time_travel_query = $$
+	select count(*) from my_datalake.default.issue_969 AT (VERSION => COMPONENT)
+$$
+
+query I
+select * from query(
+	getvariable('time_travel_query').replace(
+		'COMPONENT'::VARCHAR,
+		getvariable('main_snapshot_id')::VARCHAR
+	)
+)
+----
+5

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/test_issue_969_branch_ref_timestamp.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/test_issue_969_branch_ref_timestamp.test
@@ -1,8 +1,8 @@
-# name: test/sql/local/irc_specific_catalogs/polaris/test_issue_969_branch_ref_timestamp.test
-# description: duckdb-iceberg#969 - default read must follow refs.main, not pick the
+# name: test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/test_issue_969_branch_ref_timestamp.test
+# description: duckdb-iceberg#969 - default read must follow refs.main, not pick the largest timestamp_ms across all branch refs.
 # group: [polaris]
 
-#              largest timestamp_ms across all branch refs.
+require-env CATALOG_TEST_CONFIG_SETUP
 
 require-env POLARIS_SERVER_AVAILABLE
 
@@ -19,21 +19,7 @@ require aws
 # Do not ignore 'HTTP' error messages!
 set ignore_error_messages
 
-statement ok
-create secret polaris_secret (
-	TYPE ICEBERG,
-	CLIENT_ID 'root',
-	CLIENT_SECRET 's3cr3t',
-	ENDPOINT 'http://0.0.0.0:8181/api/catalog'
-);
-
-statement ok
-attach 'quickstart_catalog' as my_datalake (
-	type ICEBERG,
-	ENDPOINT 'http://0.0.0.0:8181/api/catalog',
-	DEFAULT_REGION 'us-west-2'
-);
-
+# The secret and the `my_datalake` attach are created by polaris.json's on_init.
 # Setup produces: main tip with 5 rows, side_branch tip after DELETE-all with a
 # newer timestamp_ms. Precondition for the bug.
 query I


### PR DESCRIPTION
 ## Summary

  Fixes #969. When a non-main branch ref points to a snapshot with a newer `timestamp_ms` than `refs.main`'s tip (e.g. a side branch with a `DELETE`-all commit
  issued after the last write to main), default reads of an ATTACH'd REST catalog table were resolving to that side-branch snapshot and returning the wrong data —
  `SELECT count(*)` returning 0 instead of the real row count from main.
 
  ## Fix

  Per the Iceberg [spec](https://github.com/apache/iceberg/blob/main/format/spec.md), point-in-time resolution should use `snapshot-log` — the history of `current-snapshot-id`, which by spec equals `refs.main.snapshot_id`. Side-branch commits do not append to `snapshot-log`, so walking it instead of the global
  `snapshots` map gives the correct main-branch history.