### PR TITLE
[Dev] introduce mutex to protect mutable state of `IcebergDeletionVector`

### DIFF
--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -216,8 +216,7 @@ IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(ClientConte
 
 		//! Only use credentials whose prefix matches the storage type (e.g. "s3"),
 		//! matching Iceberg Java S3FileIO behavior: filter(c -> c.prefix().startsWith(ROOT_PREFIX))
-		if (!ignore_credential_prefix &&
-		    !CredentialMatchesStorageType(credential.prefix, storage_type)) {
+		if (!ignore_credential_prefix && !CredentialMatchesStorageType(credential.prefix, storage_type)) {
 			continue;
 		}
 

--- a/src/core/deletes/iceberg_deletion_vector.cpp
+++ b/src/core/deletes/iceberg_deletion_vector.cpp
@@ -188,6 +188,7 @@ idx_t IcebergDeletionVector::Filter(row_t start_row_index, idx_t count, Selectio
 		//! FIXME: How do we test this? These offsets are **huge**
 		const idx_t next_offset = MinValue<idx_t>(start_row_index + count, next_high_boundary) - start_row_index;
 
+		lock_guard<mutex> guard(lock);
 		//! Update the state
 		if (!has_current_high || current_high != high) {
 			auto it = bitmaps.find(high);
@@ -214,6 +215,7 @@ idx_t IcebergDeletionVector::Filter(row_t start_row_index, idx_t count, Selectio
 				selection_idx += !is_deleted;
 			}
 		}
+
 		offset = next_offset;
 	}
 	return selection_idx;

--- a/src/include/core/deletes/iceberg_deletion_vector.hpp
+++ b/src/include/core/deletes/iceberg_deletion_vector.hpp
@@ -38,6 +38,10 @@ public:
 public:
 	//! Immutable state of the deletion vector
 	shared_ptr<const IcebergDeletionVectorData> data;
+
+	//! Lock to protect the mutable cache state,
+	//! since this instance can be shared by multiple threads
+	mutex lock;
 	//! State shared between Filter calls
 	roaring::BulkContext bulk_context;
 	optional_ptr<const roaring::Roaring> current_bitmap = nullptr;


### PR DESCRIPTION
This PR fixes #1005 

This should fix it, the mutable state is only a cache for the lookups into the bitmaps.