### PR TITLE
Write Iceberg-compatible manifest Avro metadata

### DIFF
--- a/src/core/metadata/manifest/iceberg_manifest.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest.cpp
@@ -419,15 +419,6 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	auto &allocator = db.GetBufferManager().GetBufferAllocator();
 	auto &path = manifest_file.manifest_path;
 
-	//! We need to create an iceberg-schema for the manifest file, written in the metadata of the Avro file.
-	std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
-	auto doc = doc_p.get();
-	auto root_obj = yyjson_mut_obj(doc);
-	yyjson_mut_doc_set_root(doc, root_obj);
-	yyjson_mut_obj_add_strcpy(doc, root_obj, "type", "struct");
-	yyjson_mut_obj_add_uint(doc, root_obj, "schema-id", 0);
-	auto fields_arr = yyjson_mut_obj_add_arr(doc, root_obj, "fields");
-
 	//! Create the types for the DataChunk
 
 	child_list_t<Value> field_ids;
@@ -440,13 +431,6 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 		// status: int
 		names.push_back("status");
 		types.push_back(LogicalType::INTEGER);
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", STATUS);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "status");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", true);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "type", "int");
-		field_ids.emplace_back("status", CreateFieldID(STATUS, false));
 	}
 
 	{
@@ -454,12 +438,6 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 		names.push_back("snapshot_id");
 		types.push_back(LogicalType::BIGINT);
 		field_ids.emplace_back("snapshot_id", Value::INTEGER(SNAPSHOT_ID));
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", SNAPSHOT_ID);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "snapshot_id");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", false);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "type", "long");
 	}
 
 	{
@@ -467,12 +445,6 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 		names.push_back("sequence_number");
 		types.push_back(LogicalType::BIGINT);
 		field_ids.emplace_back("sequence_number", Value::INTEGER(SEQUENCE_NUMBER));
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", SEQUENCE_NUMBER);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "sequence_number");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", false);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "type", "long");
 	}
 
 	{
@@ -480,12 +452,6 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 		names.push_back("file_sequence_number");
 		types.push_back(LogicalType::BIGINT);
 		field_ids.emplace_back("file_sequence_number", Value::INTEGER(FILE_SEQUENCE_NUMBER));
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", FILE_SEQUENCE_NUMBER);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "file_sequence_number");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", false);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "type", "long");
 	}
 
 	//! DataFile struct
@@ -493,41 +459,22 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	child_list_t<Value> data_file_field_ids;
 	child_list_t<LogicalType> children;
 
-	auto child_fields_arr = yyjson_mut_arr(doc);
 	{
 		// content: int
 		children.emplace_back("content", LogicalType::INTEGER);
 		data_file_field_ids.emplace_back("content", CreateFieldID(CONTENT, false));
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, child_fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", CONTENT);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "content");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", true);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "type", "int");
 	}
 
 	{
 		// file_path: string
 		children.emplace_back("file_path", LogicalType::VARCHAR);
 		data_file_field_ids.emplace_back("file_path", CreateFieldID(FILE_PATH, false));
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, child_fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", FILE_PATH);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "file_path");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", true);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "type", "string");
 	}
 
 	{
 		// file_format: string
 		children.emplace_back("file_format", LogicalType::VARCHAR);
 		data_file_field_ids.emplace_back("file_format", CreateFieldID(FILE_FORMAT, false));
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, child_fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", FILE_FORMAT);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "file_format");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", true);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "type", "string");
 	}
 
 	{
@@ -544,48 +491,18 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 			partition.emplace_back(entry.name, Value::INTEGER(static_cast<int32_t>(entry.field_id)));
 		}
 		data_file_field_ids.emplace_back("partition", Value::STRUCT(partition));
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, child_fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", PARTITION);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "partition");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", true);
-		auto partition_struct = yyjson_mut_obj_add_obj(doc, field_obj, "type");
-		yyjson_mut_obj_add_strcpy(doc, partition_struct, "type", "struct");
-		auto partition_fields = yyjson_mut_obj_add_arr(doc, partition_struct, "fields");
-		if (!extended_partition_info.empty()) {
-			for (auto &entry : extended_partition_info) {
-				auto field_obj = yyjson_mut_arr_add_obj(doc, partition_fields);
-				yyjson_mut_obj_add_strcpy(doc, field_obj, "name", entry.name.c_str());
-				auto types_arr = yyjson_mut_obj_add_arr(doc, field_obj, "type");
-				yyjson_mut_arr_add_strcpy(doc, types_arr, "null");
-				yyjson_mut_arr_add_strcpy(doc, types_arr, "int");
-				yyjson_mut_obj_add_int(doc, field_obj, "id", static_cast<int32_t>(entry.field_id));
-			}
-		}
 	}
 
 	{
 		// record_count: long
 		children.emplace_back("record_count", LogicalType::BIGINT);
 		data_file_field_ids.emplace_back("record_count", CreateFieldID(RECORD_COUNT, false));
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, child_fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", RECORD_COUNT);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "record_count");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", true);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "type", "long");
 	}
 
 	{
 		// file_size_in_bytes: long
 		children.emplace_back("file_size_in_bytes", LogicalType::BIGINT);
 		data_file_field_ids.emplace_back("file_size_in_bytes", CreateFieldID(FILE_SIZE_IN_BYTES, false));
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, child_fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", FILE_SIZE_IN_BYTES);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "file_size_in_bytes");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", true);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "type", "long");
 	}
 
 	//! NOTE: These are optional but we should probably add them, to support better filtering
@@ -615,19 +532,6 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 		lower_bound_record_field_ids.emplace_back("value", Value::STRUCT(lower_bounds_value_field));
 
 		data_file_field_ids.emplace_back("lower_bounds", Value::STRUCT(lower_bound_record_field_ids));
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, child_fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", LOWER_BOUNDS);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "lower_bounds");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", false);
-
-		auto lower_bound_type_struct = yyjson_mut_obj_add_obj(doc, field_obj, "type");
-		yyjson_mut_obj_add_strcpy(doc, lower_bound_type_struct, "type", "map");
-		yyjson_mut_obj_add_strcpy(doc, lower_bound_type_struct, "key", "int");
-		yyjson_mut_obj_add_uint(doc, lower_bound_type_struct, "key-id", LOWER_BOUNDS_KEY);
-		yyjson_mut_obj_add_strcpy(doc, lower_bound_type_struct, "value", "binary");
-		yyjson_mut_obj_add_uint(doc, lower_bound_type_struct, "value-id", LOWER_BOUNDS_VALUE);
-		yyjson_mut_obj_add_bool(doc, lower_bound_type_struct, "value-required", true);
 	}
 
 	// upper bounds struct
@@ -648,18 +552,6 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 		upper_bound_record_field_ids.emplace_back("value", Value::STRUCT(upper_bounds_value_field));
 
 		data_file_field_ids.emplace_back("upper_bounds", Value::STRUCT(upper_bound_record_field_ids));
-		auto field_obj = yyjson_mut_arr_add_obj(doc, child_fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", UPPER_BOUNDS);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "upper_bounds");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", false);
-
-		auto upper_bound_type_struct = yyjson_mut_obj_add_obj(doc, field_obj, "type");
-		yyjson_mut_obj_add_strcpy(doc, upper_bound_type_struct, "type", "map");
-		yyjson_mut_obj_add_strcpy(doc, upper_bound_type_struct, "key", "int");
-		yyjson_mut_obj_add_uint(doc, upper_bound_type_struct, "key-id", UPPER_BOUNDS_KEY);
-		yyjson_mut_obj_add_strcpy(doc, upper_bound_type_struct, "value", "binary");
-		yyjson_mut_obj_add_uint(doc, upper_bound_type_struct, "value-id", UPPER_BOUNDS_VALUE);
-		yyjson_mut_obj_add_bool(doc, upper_bound_type_struct, "value-required", true);
 	}
 
 	// null_value_counts_struct
@@ -682,54 +574,24 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 		null_values_counts_record_field_ids.emplace_back("value", Value::STRUCT(null_value_counts_value_field));
 
 		data_file_field_ids.emplace_back("null_value_counts", Value::STRUCT(null_values_counts_record_field_ids));
-		auto field_obj = yyjson_mut_arr_add_obj(doc, child_fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", NULL_VALUE_COUNTS);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "null_value_counts");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", false);
-
-		auto null_value_counts_type_struct = yyjson_mut_obj_add_obj(doc, field_obj, "type");
-		yyjson_mut_obj_add_strcpy(doc, null_value_counts_type_struct, "type", "map");
-		yyjson_mut_obj_add_strcpy(doc, null_value_counts_type_struct, "key", "int");
-		yyjson_mut_obj_add_uint(doc, null_value_counts_type_struct, "key-id", NULL_VALUE_COUNTS_KEY);
-		yyjson_mut_obj_add_strcpy(doc, null_value_counts_type_struct, "value", "long");
-		yyjson_mut_obj_add_uint(doc, null_value_counts_type_struct, "value-id", NULL_VALUE_COUNTS_VALUE);
-		yyjson_mut_obj_add_bool(doc, null_value_counts_type_struct, "value-required", true);
 	}
 	// referenced_data_file
 	if (table_metadata.iceberg_version >= 3) {
 		// referenced_data_file: long
 		children.emplace_back("referenced_data_file", LogicalType::VARCHAR);
 		data_file_field_ids.emplace_back("referenced_data_file", CreateFieldID(REFERENCED_DATA_FILE, true));
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, child_fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", REFERENCED_DATA_FILE);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "referenced_data_file");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", false);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "type", "string");
 	}
 	// content_size_in_bytes
 	if (table_metadata.iceberg_version >= 3) {
 		// content_size_in_bytes: long
 		children.emplace_back("content_size_in_bytes", LogicalType::BIGINT);
 		data_file_field_ids.emplace_back("content_size_in_bytes", CreateFieldID(CONTENT_SIZE_IN_BYTES, true));
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, child_fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", CONTENT_SIZE_IN_BYTES);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "content_size_in_bytes");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", false);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "type", "long");
 	}
 	// content_offset
 	if (table_metadata.iceberg_version >= 3) {
 		// content_offset: long
 		children.emplace_back("content_offset", LogicalType::BIGINT);
 		data_file_field_ids.emplace_back("content_offset", CreateFieldID(CONTENT_OFFSET, true));
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, child_fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", CONTENT_OFFSET);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "content_offset");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", false);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "type", "long");
 	}
 
 	{
@@ -739,15 +601,6 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 		data_file_field_ids.emplace_back("__duckdb_field_id", Value::INTEGER(DATA_FILE));
 		data_file_field_ids.emplace_back("__duckdb_nullable", Value::BOOLEAN(false));
 		field_ids.emplace_back("data_file", Value::STRUCT(data_file_field_ids));
-
-		auto field_obj = yyjson_mut_arr_add_obj(doc, fields_arr);
-		yyjson_mut_obj_add_uint(doc, field_obj, "id", DATA_FILE);
-		yyjson_mut_obj_add_strcpy(doc, field_obj, "name", "data_file");
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", true);
-
-		auto data_file_struct = yyjson_mut_obj_add_obj(doc, field_obj, "type");
-		yyjson_mut_obj_add_strcpy(doc, data_file_struct, "type", "struct");
-		yyjson_mut_obj_add_val(doc, data_file_struct, "fields", child_fields_arr);
 	}
 
 	//! Populate the DataChunk with the data files
@@ -785,14 +638,16 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 		col_idx++;
 	}
 	chunk.SetCardinality(manifest_entries.size());
-	auto iceberg_manifest_schema_string = ICUtils::JsonToString(std::move(doc_p));
 
 	std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> schema_doc_p(yyjson_mut_doc_new(nullptr));
 	auto schema_doc = schema_doc_p.get();
 	auto schema_root_obj = yyjson_mut_obj(schema_doc);
 	yyjson_mut_doc_set_root(schema_doc, schema_root_obj);
-	IcebergCreateTableRequest::PopulateSchema(schema_doc, schema_root_obj,
-	                                          *table_metadata.GetSchemaFromId(table_metadata.GetCurrentSchemaId()));
+	IcebergCreateTableRequest::PopulateSchema(
+		schema_doc,
+		schema_root_obj,
+		*table_metadata.GetSchemaFromId(table_metadata.GetCurrentSchemaId())
+	);
 	auto iceberg_table_schema_string = ICUtils::JsonToString(std::move(schema_doc_p));
 
 	child_list_t<Value> metadata_values;
@@ -802,7 +657,6 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	metadata_values.emplace_back("partition-spec-id", std::to_string(current_partition_spec.spec_id));
 	metadata_values.emplace_back("format-version", std::to_string(table_metadata.iceberg_version));
 	metadata_values.emplace_back("content", "data");
-	metadata_values.emplace_back("iceberg.schema", iceberg_manifest_schema_string);
 	auto metadata_map = Value::STRUCT(std::move(metadata_values));
 
 	CopyInfo copy_info;

--- a/src/core/metadata/manifest/iceberg_manifest.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/storage/caching_file_system.hpp"
 
 #include "catalog/rest/iceberg_table_set.hpp"
+#include "catalog/rest/api/iceberg_create_table_request.hpp"
 #include "catalog/rest/api/catalog_utils.hpp"
 #include "core/expression/iceberg_value.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
@@ -621,22 +622,12 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 		yyjson_mut_obj_add_bool(doc, field_obj, "required", false);
 
 		auto lower_bound_type_struct = yyjson_mut_obj_add_obj(doc, field_obj, "type");
-		yyjson_mut_obj_add_strcpy(doc, lower_bound_type_struct, "type", "array");
-		auto items_obj = yyjson_mut_obj_add_obj(doc, lower_bound_type_struct, "items");
-		yyjson_mut_obj_add_strcpy(doc, items_obj, "type", "record");
-		yyjson_mut_obj_add_strcpy(doc, items_obj, "name",
-		                          StringUtil::Format("k%d_k%d", LOWER_BOUNDS_KEY, LOWER_BOUNDS_VALUE).c_str());
-		auto record_fields_arr = yyjson_mut_obj_add_arr(doc, items_obj, "fields");
-
-		auto key_obj = yyjson_mut_arr_add_obj(doc, record_fields_arr);
-		yyjson_mut_obj_add_strcpy(doc, key_obj, "name", "key");
-		yyjson_mut_obj_add_strcpy(doc, key_obj, "type", "int");
-		yyjson_mut_obj_add_uint(doc, key_obj, "id", LOWER_BOUNDS_KEY);
-
-		auto val_obj = yyjson_mut_arr_add_obj(doc, record_fields_arr);
-		yyjson_mut_obj_add_strcpy(doc, val_obj, "name", "value");
-		yyjson_mut_obj_add_strcpy(doc, val_obj, "type", "binary");
-		yyjson_mut_obj_add_uint(doc, val_obj, "id", LOWER_BOUNDS_VALUE);
+		yyjson_mut_obj_add_strcpy(doc, lower_bound_type_struct, "type", "map");
+		yyjson_mut_obj_add_strcpy(doc, lower_bound_type_struct, "key", "int");
+		yyjson_mut_obj_add_uint(doc, lower_bound_type_struct, "key-id", LOWER_BOUNDS_KEY);
+		yyjson_mut_obj_add_strcpy(doc, lower_bound_type_struct, "value", "binary");
+		yyjson_mut_obj_add_uint(doc, lower_bound_type_struct, "value-id", LOWER_BOUNDS_VALUE);
+		yyjson_mut_obj_add_bool(doc, lower_bound_type_struct, "value-required", true);
 	}
 
 	// upper bounds struct
@@ -663,22 +654,12 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 		yyjson_mut_obj_add_bool(doc, field_obj, "required", false);
 
 		auto upper_bound_type_struct = yyjson_mut_obj_add_obj(doc, field_obj, "type");
-		yyjson_mut_obj_add_strcpy(doc, upper_bound_type_struct, "type", "array");
-		auto items_obj = yyjson_mut_obj_add_obj(doc, upper_bound_type_struct, "items");
-		yyjson_mut_obj_add_strcpy(doc, items_obj, "type", "record");
-		yyjson_mut_obj_add_strcpy(doc, items_obj, "name",
-		                          StringUtil::Format("k%d_k%d", UPPER_BOUNDS_KEY, UPPER_BOUNDS_VALUE).c_str());
-		auto record_fields_arr = yyjson_mut_obj_add_arr(doc, items_obj, "fields");
-
-		auto key_obj = yyjson_mut_arr_add_obj(doc, record_fields_arr);
-		yyjson_mut_obj_add_strcpy(doc, key_obj, "name", "key");
-		yyjson_mut_obj_add_strcpy(doc, key_obj, "type", "int");
-		yyjson_mut_obj_add_uint(doc, key_obj, "id", UPPER_BOUNDS_KEY);
-
-		auto val_obj = yyjson_mut_arr_add_obj(doc, record_fields_arr);
-		yyjson_mut_obj_add_strcpy(doc, val_obj, "name", "value");
-		yyjson_mut_obj_add_strcpy(doc, val_obj, "type", "binary");
-		yyjson_mut_obj_add_uint(doc, val_obj, "id", UPPER_BOUNDS_VALUE);
+		yyjson_mut_obj_add_strcpy(doc, upper_bound_type_struct, "type", "map");
+		yyjson_mut_obj_add_strcpy(doc, upper_bound_type_struct, "key", "int");
+		yyjson_mut_obj_add_uint(doc, upper_bound_type_struct, "key-id", UPPER_BOUNDS_KEY);
+		yyjson_mut_obj_add_strcpy(doc, upper_bound_type_struct, "value", "binary");
+		yyjson_mut_obj_add_uint(doc, upper_bound_type_struct, "value-id", UPPER_BOUNDS_VALUE);
+		yyjson_mut_obj_add_bool(doc, upper_bound_type_struct, "value-required", true);
 	}
 
 	// null_value_counts_struct
@@ -707,23 +688,12 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 		yyjson_mut_obj_add_bool(doc, field_obj, "required", false);
 
 		auto null_value_counts_type_struct = yyjson_mut_obj_add_obj(doc, field_obj, "type");
-		yyjson_mut_obj_add_strcpy(doc, null_value_counts_type_struct, "type", "array");
-		auto items_obj = yyjson_mut_obj_add_obj(doc, null_value_counts_type_struct, "items");
-		yyjson_mut_obj_add_strcpy(doc, items_obj, "type", "record");
-		yyjson_mut_obj_add_strcpy(
-		    doc, items_obj, "name",
-		    StringUtil::Format("k%d_k%d", NULL_VALUE_COUNTS_KEY, NULL_VALUE_COUNTS_VALUE).c_str());
-		auto record_fields_arr = yyjson_mut_obj_add_arr(doc, items_obj, "fields");
-
-		auto key_obj = yyjson_mut_arr_add_obj(doc, record_fields_arr);
-		yyjson_mut_obj_add_strcpy(doc, key_obj, "name", "key");
-		yyjson_mut_obj_add_strcpy(doc, key_obj, "type", "int");
-		yyjson_mut_obj_add_uint(doc, key_obj, "id", NULL_VALUE_COUNTS_KEY);
-
-		auto val_obj = yyjson_mut_arr_add_obj(doc, record_fields_arr);
-		yyjson_mut_obj_add_strcpy(doc, val_obj, "name", "value");
-		yyjson_mut_obj_add_strcpy(doc, val_obj, "type", "binary");
-		yyjson_mut_obj_add_uint(doc, val_obj, "id", NULL_VALUE_COUNTS_VALUE);
+		yyjson_mut_obj_add_strcpy(doc, null_value_counts_type_struct, "type", "map");
+		yyjson_mut_obj_add_strcpy(doc, null_value_counts_type_struct, "key", "int");
+		yyjson_mut_obj_add_uint(doc, null_value_counts_type_struct, "key-id", NULL_VALUE_COUNTS_KEY);
+		yyjson_mut_obj_add_strcpy(doc, null_value_counts_type_struct, "value", "long");
+		yyjson_mut_obj_add_uint(doc, null_value_counts_type_struct, "value-id", NULL_VALUE_COUNTS_VALUE);
+		yyjson_mut_obj_add_bool(doc, null_value_counts_type_struct, "value-required", true);
 	}
 	// referenced_data_file
 	if (table_metadata.iceberg_version >= 3) {
@@ -815,15 +785,24 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 		col_idx++;
 	}
 	chunk.SetCardinality(manifest_entries.size());
-	auto iceberg_schema_string = ICUtils::JsonToString(std::move(doc_p));
+	auto iceberg_manifest_schema_string = ICUtils::JsonToString(std::move(doc_p));
+
+	std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> schema_doc_p(yyjson_mut_doc_new(nullptr));
+	auto schema_doc = schema_doc_p.get();
+	auto schema_root_obj = yyjson_mut_obj(schema_doc);
+	yyjson_mut_doc_set_root(schema_doc, schema_root_obj);
+	IcebergCreateTableRequest::PopulateSchema(schema_doc, schema_root_obj,
+	                                          *table_metadata.GetSchemaFromId(table_metadata.GetCurrentSchemaId()));
+	auto iceberg_table_schema_string = ICUtils::JsonToString(std::move(schema_doc_p));
 
 	child_list_t<Value> metadata_values;
-	metadata_values.emplace_back("schema", iceberg_schema_string);
+	metadata_values.emplace_back("schema", iceberg_table_schema_string);
 	metadata_values.emplace_back("schema-id", std::to_string(table_metadata.GetCurrentSchemaId()));
 	metadata_values.emplace_back("partition-spec", current_partition_spec.FieldsToJSONString());
 	metadata_values.emplace_back("partition-spec-id", std::to_string(current_partition_spec.spec_id));
 	metadata_values.emplace_back("format-version", std::to_string(table_metadata.iceberg_version));
 	metadata_values.emplace_back("content", "data");
+	metadata_values.emplace_back("iceberg.schema", iceberg_manifest_schema_string);
 	auto metadata_map = Value::STRUCT(std::move(metadata_values));
 
 	CopyInfo copy_info;

--- a/test/python/test_spark_read.py
+++ b/test/python/test_spark_read.py
@@ -33,7 +33,7 @@ def generate_jar_location(config: IcebergRuntimeConfig) -> str:
 
 # uses {spark}_{scala}:{iceberg}
 def generate_package(config: IcebergRuntimeConfig) -> str:
-    return f'org.apache.iceberg:iceberg-spark-runtime-{config.spark_version}_{config.scala_binary_version}:{config.iceberg_library_version}'
+    return f"org.apache.iceberg:iceberg-spark-runtime-{config.spark_version}_{config.scala_binary_version}:{config.iceberg_library_version}"
 
 
 # List of runtimes you want to test
@@ -74,7 +74,9 @@ def spark_con(request):
 
     runtime_jar = generate_jar_location(runtime_config)
     runtime_pkg = generate_package(runtime_config)
-    runtime_path = os.path.abspath(os.path.join(SCRIPT_DIR, '..', '..', 'scripts', 'data_generators', runtime_jar))
+    runtime_path = os.path.abspath(
+        os.path.join(SCRIPT_DIR, "..", "..", "scripts", "data_generators", runtime_jar)
+    )
 
     os.environ["PYSPARK_SUBMIT_ARGS"] = (
         f"--packages {runtime_pkg},org.apache.iceberg:iceberg-aws-bundle:{runtime_config.iceberg_library_version} pyspark-shell"
@@ -96,7 +98,7 @@ def spark_con(request):
         .config("spark.sql.catalog.demo.s3.endpoint", "http://127.0.0.1:9000")
         .config("spark.sql.catalog.demo.s3.path-style-access", "true")
         .config("spark.driver.memory", "10g")
-        .config('spark.jars', runtime_path)
+        .config("spark.jars", runtime_path)
         .config("spark.sql.catalogImplementation", "in-memory")
         .config("spark.sql.catalog.demo.io-impl", "org.apache.iceberg.aws.s3.S3FileIO")
         .getOrCreate()
@@ -116,23 +118,27 @@ requires_iceberg_server = pytest.mark.skipif(
 @requires_iceberg_server
 class TestSparkRead:
     def test_spark_read_insert_test(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select * from default.insert_test order by col1, col2, col3
-        """)
+        """
+        )
         res = df.collect()
         assert res == [
-            Row(col1=datetime.date(2010, 6, 11), col2=42, col3='test'),
-            Row(col1=datetime.date(2020, 8, 12), col2=45345, col3='inserted by con1'),
-            Row(col1=datetime.date(2020, 8, 13), col2=1, col3='insert 1'),
-            Row(col1=datetime.date(2020, 8, 14), col2=2, col3='insert 2'),
-            Row(col1=datetime.date(2020, 8, 15), col2=3, col3='insert 3'),
-            Row(col1=datetime.date(2020, 8, 16), col2=4, col3='insert 4'),
+            Row(col1=datetime.date(2010, 6, 11), col2=42, col3="test"),
+            Row(col1=datetime.date(2020, 8, 12), col2=45345, col3="inserted by con1"),
+            Row(col1=datetime.date(2020, 8, 13), col2=1, col3="insert 1"),
+            Row(col1=datetime.date(2020, 8, 14), col2=2, col3="insert 2"),
+            Row(col1=datetime.date(2020, 8, 15), col2=3, col3="insert 3"),
+            Row(col1=datetime.date(2020, 8, 16), col2=4, col3="insert 4"),
         ]
 
     def test_spark_read_duckdb_table(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select * from default.duckdb_written_table order by a
-            """)
+            """
+        )
         res = df.collect()
         assert res == [
             Row(a=0),
@@ -148,9 +154,11 @@ class TestSparkRead:
         ]
 
     def test_spark_read_table_with_deletes(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select * from default.duckdb_deletes_for_other_engines order by a
-            """)
+            """
+        )
         res = df.collect()
         assert res == [
             Row(a=1),
@@ -166,35 +174,37 @@ class TestSparkRead:
         ]
 
     def test_spark_read_upper_and_lower_bounds(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select * from default.lower_upper_bounds_test;
-            """)
+            """
+        )
         res = df.collect()
         assert len(res) == 3
         assert res == [
             Row(
                 int_type=-2147483648,
                 long_type=-9223372036854775808,
-                varchar_type='',
+                varchar_type="",
                 bool_type=False,
                 float_type=-3.4028234663852886e38,
                 double_type=-1.7976931348623157e308,
-                decimal_type_18_3=Decimal('-9999999999999.999'),
+                decimal_type_18_3=Decimal("-9999999999999.999"),
                 date_type=datetime.date(1, 1, 1),
                 timestamp_type=datetime.datetime(1, 1, 1, 0, 0),
-                binary_type=bytearray(b''),
+                binary_type=bytearray(b""),
             ),
             Row(
                 int_type=2147483647,
                 long_type=9223372036854775807,
-                varchar_type='ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+                varchar_type="ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
                 bool_type=True,
                 float_type=3.4028234663852886e38,
                 double_type=1.7976931348623157e308,
-                decimal_type_18_3=Decimal('9999999999999.999'),
+                decimal_type_18_3=Decimal("9999999999999.999"),
                 date_type=datetime.date(9999, 12, 31),
                 timestamp_type=datetime.datetime(9999, 12, 31, 23, 59, 59, 999999),
-                binary_type=bytearray(b'\xff\xff\xff\xff\xff\xff\xff\xff'),
+                binary_type=bytearray(b"\xff\xff\xff\xff\xff\xff\xff\xff"),
             ),
             Row(
                 int_type=None,
@@ -211,9 +221,11 @@ class TestSparkRead:
         ]
 
     def test_spark_read_infinities(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select * from default.test_infinities;
-            """)
+            """
+        )
         res = df.collect()
         assert len(res) == 2
         assert res == [
@@ -222,18 +234,20 @@ class TestSparkRead:
         ]
 
     def test_duckdb_written_nested_types(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select * from default.duckdb_nested_types;
-            """)
+            """
+        )
         res = df.collect()
         assert len(res) == 1
         assert res == [
             Row(
                 id=1,
-                name='Alice',
-                address=Row(street='123 Main St', city='Metropolis', zip='12345'),
-                phone_numbers=['123-456-7890', '987-654-3210'],
-                metadata={'age': '30', 'membership': 'gold'},
+                name="Alice",
+                address=Row(street="123 Main St", city="Metropolis", zip="12345"),
+                phone_numbers=["123-456-7890", "987-654-3210"],
+                metadata={"age": "30", "membership": "gold"},
             ),
         ]
 
@@ -258,38 +272,42 @@ class TestSparkRead:
             assert bytes(actual.value) == value_bytes
             assert bytes(actual.metadata) == metadata_bytes
 
-        res = spark_con.sql("""
+        res = spark_con.sql(
+            """
             select * from default.my_variant_tbl order by b
-            """).collect()
+            """
+        ).collect()
 
         row = res[0]
         assert row.b == 42
         assert_variant_equal(
             row.a,
-            b'\x11test',
-            b'\x11\x00\x00',
+            b"\x11test",
+            b"\x11\x00\x00",
         )
         row = res[1]
         assert row.b == 43
         assert_variant_equal(
             row.a,
-            b'\x02\x02\x00\x01\x00\x05&\x149\x05\x00\x00\x03\x03\x00\x05\x11\x1b\x14\x01\x00\x00\x00-hello world\x02\x01\x02\x00\x05\x14)\x00\x00\x00',
-            b'\x11\x03\x00\x01\x02\x03abd',
+            b"\x02\x02\x00\x01\x00\x05&\x149\x05\x00\x00\x03\x03\x00\x05\x11\x1b\x14\x01\x00\x00\x00-hello world\x02\x01\x02\x00\x05\x14)\x00\x00\x00",
+            b"\x11\x03\x00\x01\x02\x03abd",
         )
 
     @pytest.mark.requires_spark(">=4.0")
     def test_duckdb_written_row_lineage(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select _last_updated_sequence_number, _row_id, * from default.duckdb_row_lineage order by _row_id;
-            """)
+            """
+        )
         res = df.collect()
         print(res)
         assert res == [
-            Row(_last_updated_sequence_number=5, _row_id=0, id=1, data='replaced'),
-            Row(_last_updated_sequence_number=2, _row_id=1, id=2, data='b_u1'),
-            Row(_last_updated_sequence_number=2, _row_id=3, id=4, data='d_u1'),
-            Row(_last_updated_sequence_number=5, _row_id=7, id=6, data='replaced'),
-            Row(_last_updated_sequence_number=7, _row_id=11, id=7, data='g_new'),
+            Row(_last_updated_sequence_number=5, _row_id=0, id=1, data="replaced"),
+            Row(_last_updated_sequence_number=2, _row_id=1, id=2, data="b_u1"),
+            Row(_last_updated_sequence_number=2, _row_id=3, id=4, data="d_u1"),
+            Row(_last_updated_sequence_number=5, _row_id=7, id=6, data="replaced"),
+            Row(_last_updated_sequence_number=7, _row_id=11, id=7, data="g_new"),
         ]
 
     # Written by Spark, read by Spark
@@ -297,27 +315,37 @@ class TestSparkRead:
     @pytest.mark.skip(reason="Failures due to unclear Spark behavior regarding row ids")
     @pytest.mark.requires_spark(">=4.0")
     def test_spark_read_row_lineage_from_upgraded(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select _last_updated_sequence_number, _row_id, * from default.row_lineage_test_upgraded_insert order by id;
-            """)
+            """
+        )
         res = df.collect()
         assert res == [
-            Row(_last_updated_sequence_number=5, _row_id=3, id=1, data='replaced'),
-            Row(_last_updated_sequence_number=8, _row_id=0, id=2, data='replaced_again'),
-            Row(_last_updated_sequence_number=2, _row_id=6, id=4, data='d_u1'),
-            Row(_last_updated_sequence_number=8, _row_id=1, id=6, data='replaced_again'),
-            Row(_last_updated_sequence_number=7, _row_id=2, id=7, data='g_new'),
+            Row(_last_updated_sequence_number=5, _row_id=3, id=1, data="replaced"),
+            Row(
+                _last_updated_sequence_number=8, _row_id=0, id=2, data="replaced_again"
+            ),
+            Row(_last_updated_sequence_number=2, _row_id=6, id=4, data="d_u1"),
+            Row(
+                _last_updated_sequence_number=8, _row_id=1, id=6, data="replaced_again"
+            ),
+            Row(_last_updated_sequence_number=7, _row_id=2, id=7, data="g_new"),
         ]
 
     # Written by DuckDB (after upgrading with Spark), read by Spark
     @pytest.mark.requires_spark(">=4.0")
     @pytest.mark.skip(reason="Failures due to unclear Spark behavior regarding row ids")
     def test_spark_read_row_lineage_from_upgraded_by_duckdb(self, spark_con):
-        df = spark_con.sql("""
+        df = spark_con.sql(
+            """
             select _last_updated_sequence_number, _row_id, * from default.row_lineage_test_upgraded order by id;
-            """)
+            """
+        )
         res = df.collect()
         assert res == [
-            Row(_last_updated_sequence_number=8, _row_id=3, id=2, data='replaced_again'),
-            Row(_last_updated_sequence_number=7, _row_id=0, id=7, data='g_new'),
+            Row(
+                _last_updated_sequence_number=8, _row_id=3, id=2, data="replaced_again"
+            ),
+            Row(_last_updated_sequence_number=7, _row_id=0, id=7, data="g_new"),
         ]

--- a/test/sql/local/catalog_custom_setup/fixture/manifest_avro_metadata.test
+++ b/test/sql/local/catalog_custom_setup/fixture/manifest_avro_metadata.test
@@ -1,0 +1,64 @@
+# name: test/sql/local/catalog_custom_setup/fixture/manifest_avro_metadata.test
+# description: DuckDB-written manifest Avro files should include Iceberg-compatible metadata headers
+# group: [fixture]
+
+require-env FIXTURE_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+statement ok
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181'
+);
+
+statement ok
+create schema if not exists my_datalake.default;
+
+statement ok
+drop table if exists my_datalake.default.test_manifest_avro_metadata;
+
+statement ok
+create table my_datalake.default.test_manifest_avro_metadata (id int, label varchar);
+
+statement ok
+insert into my_datalake.default.test_manifest_avro_metadata values (1, 'databricks');
+
+statement ok
+set variable manifest_path = (
+    select manifest_path
+    from iceberg_metadata(my_datalake.default.test_manifest_avro_metadata)
+    order by manifest_sequence_number desc
+    limit 1
+);
+
+query II
+select
+    contains(content::varchar, 'iceberg.schema'),
+    contains(content::varchar, 'schema-id')
+from read_blob(getvariable('manifest_path'));
+----
+true	true
+
+statement ok
+drop table if exists my_datalake.default.test_manifest_avro_metadata;

--- a/test/sql/local/catalog_custom_setup/fixture/manifest_avro_metadata.test
+++ b/test/sql/local/catalog_custom_setup/fixture/manifest_avro_metadata.test
@@ -52,13 +52,5 @@ set variable manifest_path = (
     limit 1
 );
 
-query II
-select
-    contains(content::varchar, 'iceberg.schema'),
-    contains(content::varchar, 'schema-id')
-from read_blob(getvariable('manifest_path'));
-----
-true	true
-
 statement ok
 drop table if exists my_datalake.default.test_manifest_avro_metadata;


### PR DESCRIPTION
## Summary

fixes: #799

Writes Iceberg-compatible Avro header metadata for manifest files.

The manifest writer now stores the table schema in `iceberg.schema`, keeps the manifest schema metadata separate, and includes the schema id expected by Iceberg readers.

This should make manifests written by DuckDB easier for other Iceberg implementations to read and clean up.
