### PR TITLE
Cloud test main and v1.5

### DIFF
--- a/.github/workflows/CloudTestingManual.yaml
+++ b/.github/workflows/CloudTestingManual.yaml
@@ -8,10 +8,6 @@ on:
         description: 'DuckDB branch name or commit hash'
         required: false
         default: 'v1.5-variegata'
-      duckdb_iceberg_ref:
-        description: 'duckdb-iceberg branch name or commit hash'
-        required: false
-        default: 'main'
       httpfs_fork:
         description: 'URL of a duckdb-httpfs fork. Leave empty to use default duckdb/duckdb-httpfs.'
         required: false
@@ -26,7 +22,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cloud-tests:
+  cloud-tests-main:
+    name: Run Cloud tests on main
     uses: ./.github/workflows/CloudTestingReusable.yml
     with:
       duckdb_ref: ${{ github.event.inputs.duckdb_ref || '' }}
@@ -34,3 +31,15 @@ jobs:
       httpfs_fork: ${{ github.event.inputs.httpfs_fork || 'https://github.com/duckdb/duckdb-httpfs' }}
       httpfs_ref: ${{ github.event.inputs.httpfs_ref || '' }}
     secrets: inherit
+
+  cloud-tests-v1.5:
+    name: Run Cloud tests on v1.5-variegata
+    uses: ./.github/workflows/CloudTestingReusable.yml
+    with:
+      duckdb_ref: ${{ github.event.inputs.duckdb_ref || '' }}
+      duckdb_iceberg_ref: ${{ github.event.inputs.duckdb_iceberg_ref || 'main' }}
+      httpfs_fork: ${{ github.event.inputs.httpfs_fork || 'https://github.com/duckdb/duckdb-httpfs' }}
+      httpfs_ref: ${{ github.event.inputs.httpfs_ref || '' }}
+    secrets: inherit
+
+

--- a/.github/workflows/CloudTestingManual.yaml
+++ b/.github/workflows/CloudTestingManual.yaml
@@ -1,13 +1,15 @@
-name: Cloud functional tests
+name: Cloud functional tests (manual)
 on:
-  schedule:
-    - cron:  '0 3 * * 1,3,5' # runs at 3am monday wednesday and friday
   workflow_dispatch:
     inputs:
       duckdb_ref:
         description: 'DuckDB branch name or commit hash'
         required: false
         default: 'v1.5-variegata'
+      duckdb_iceberg_ref:
+        description: 'duckdb-iceberg branch name or commit hash'
+        required: false
+        default: 'main'
       httpfs_fork:
         description: 'URL of a duckdb-httpfs fork. Leave empty to use default duckdb/duckdb-httpfs.'
         required: false
@@ -22,8 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cloud-tests-main:
-    name: Run Cloud tests on main
+  cloud-tests:
     uses: ./.github/workflows/CloudTestingReusable.yml
     with:
       duckdb_ref: ${{ github.event.inputs.duckdb_ref || '' }}
@@ -31,15 +32,3 @@ jobs:
       httpfs_fork: ${{ github.event.inputs.httpfs_fork || 'https://github.com/duckdb/duckdb-httpfs' }}
       httpfs_ref: ${{ github.event.inputs.httpfs_ref || '' }}
     secrets: inherit
-
-  cloud-tests-v1.5:
-    name: Run Cloud tests on v1.5-variegata
-    uses: ./.github/workflows/CloudTestingReusable.yml
-    with:
-      duckdb_ref: ${{ github.event.inputs.duckdb_ref || '' }}
-      duckdb_iceberg_ref: ${{ github.event.inputs.duckdb_iceberg_ref || 'main' }}
-      httpfs_fork: ${{ github.event.inputs.httpfs_fork || 'https://github.com/duckdb/duckdb-httpfs' }}
-      httpfs_ref: ${{ github.event.inputs.httpfs_ref || '' }}
-    secrets: inherit
-
-

--- a/.github/workflows/CloudTestingReusable.yml
+++ b/.github/workflows/CloudTestingReusable.yml
@@ -7,10 +7,6 @@ on:
         required: false
         default: ''
         type: string
-      duckdb_iceberg_ref:
-        description: 'duckdb-iceberg branch name or commit hash'
-        required: true
-        type: string
       httpfs_fork:
         description: 'URL of a duckdb-httpfs fork (e.g. https://github.com/myfork/duckdb-httpfs). Leave empty to use the default duckdb/duckdb-httpfs.'
         required: false

--- a/.github/workflows/CloudTestingScheduled.yml
+++ b/.github/workflows/CloudTestingScheduled.yml
@@ -1,0 +1,30 @@
+name: Cloud functional tests (scheduled)
+on:
+  schedule:
+    - cron:  '0 3 * * 1,3,5' # runs at 3am monday wednesday and friday
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  cloud-tests-main:
+    name: Run Cloud tests on main
+    uses: ./.github/workflows/CloudTestingReusable.yml
+    with:
+      duckdb_ref: ''
+      duckdb_iceberg_ref: 'main'
+      httpfs_fork: 'https://github.com/duckdb/duckdb-httpfs'
+      httpfs_ref: ''
+    secrets: inherit
+
+  cloud-tests-v1.5-variegata:
+    name: Run Cloud tests on v1.5-variegata
+    uses: ./.github/workflows/CloudTestingReusable.yml
+    with:
+      duckdb_ref: ''
+      duckdb_iceberg_ref: 'v1.5-variegata'
+      httpfs_fork: 'https://github.com/duckdb/duckdb-httpfs'
+      httpfs_ref: ''
+    secrets: inherit
+


### PR DESCRIPTION
Want to test main and v1.5-variegata for cloud tests. 
Looks like main has an issue if you query iceberg via a proxy. 

```
1. test/sql/cloud/s3tables/http_proxy.test:45
================================================================================
Query unexpectedly failed! (test/sql/cloud/s3tables/http_proxy.test:45)!
================================================================================
attach or replace 'arn:aws:s3tables:<region>:<account_id>:bucket/iceberg-testing' as s3_catalog (
    TYPE ICEBERG,
    secret s1,
    ENDPOINT_TYPE 'S3_TABLES'
);
================================================================================
IO Error: Problem with the SSL CA cert (path? access rights?) error for HTTP GET to 'https://s3tables.us-east-2.amazonaws.com/iceberg/v1/config?warehouse=arn%3Aaws%3As3tables%3A<region>%3A<account_id>%3Abucket%2Ficeberg-testing'
```