### PR TITLE
Compute string upper bounds on code point boundaries

### DIFF
--- a/src/core/expression/iceberg_value.cpp
+++ b/src/core/expression/iceberg_value.cpp
@@ -252,44 +252,51 @@ string IcebergValue::TruncateString(const string &input) {
 	return std::string(bytes.begin(), bytes.end());
 }
 
-string IcebergValue::TruncateAndIncrementString(const string &input) {
-	idx_t original_input_size = input.size();
-	std::vector<unsigned char> bytes(input.begin(), input.end());
-	idx_t truncated_length = std::min<idx_t>(IcebergValue::MAX_STRING_UPPERBOUND_LENGTH, bytes.size());
-	while (truncated_length > 0) {
-		// Truncate to first 16 bytes
-		bytes.resize(truncated_length);
-		// if the original string is less than our length upperbound, return the string as is.
-		if (original_input_size <= IcebergValue::MAX_STRING_UPPERBOUND_LENGTH) {
-			break;
-		}
-		// if original string size > max_upper_bound increment the last non-continuation byte
-		// so that the upper bound will be higher than the string
-		idx_t i = truncated_length - 1;
-		while (((bytes[i] & 0xC0) == 0x80) && i > 0) {
-			// skip continuation bytes
-			--i;
-		}
-		bytes[i]++;
-		// make sure the buffer is still valid UTF-8
-		if (Utf8Proc::IsValid(reinterpret_cast<const char *>(bytes.data()), bytes.size())) {
-			// it is! we can return bytes as the current string
-			break;
-		}
-		// revert last byte
-		bytes[i]--;
-		// decrease truncated length until we can truncate and increase the
-		// last byte and keep valid utf8 characteristics
-		truncated_length--;
+bool IcebergValue::TruncateAndIncrementString(const string &input, string &result) {
+	// If the whole value fits within the bound length it is itself a valid
+	// (exact) upper bound; nothing to truncate or increment.
+	if (input.size() <= IcebergValue::MAX_STRING_UPPERBOUND_LENGTH) {
+		result = input;
+		return true;
 	}
-	if (truncated_length == 0 && original_input_size > 0) {
-		throw ConversionException("Could not write upper bounds for string column");
+
+	// Truncate to at most MAX_STRING_UPPERBOUND_LENGTH bytes, backing off so we
+	// never split a multi-byte UTF-8 character.
+	idx_t len = IcebergValue::MAX_STRING_UPPERBOUND_LENGTH;
+	while (len > 0 && (static_cast<unsigned char>(input[len]) & 0xC0) == 0x80) {
+		len--;
 	}
-	if (truncated_length == 0) {
-		bytes.resize(0);
+
+	// Round the truncated prefix up to a valid upper bound by incrementing the
+	// last code point to the next scalar value (skipping the UTF-16 surrogate
+	// range). This works on whole code points rather than raw bytes, so it is
+	// correct for multi-byte UTF-8 (e.g. full-width or Turkish titles). If the
+	// last code point is already the maximum, drop it and carry the increment to
+	// the previous one. If every code point is the maximum, no representable
+	// upper bound exists and the caller should omit it (it is optional).
+	while (len > 0) {
+		// find the start of the last code point in input[0, len)
+		idx_t last_start = len - 1;
+		while (last_start > 0 && (static_cast<unsigned char>(input[last_start]) & 0xC0) == 0x80) {
+			last_start--;
+		}
+		int cp_size;
+		int32_t codepoint = Utf8Proc::UTF8ToCodepoint(input.c_str() + last_start, cp_size) + 1;
+		if (codepoint >= 0xD800 && codepoint <= 0xDFFF) {
+			// skip the surrogate range to the next valid scalar value
+			codepoint = 0xE000;
+		}
+		char encoded[4];
+		int encoded_size;
+		if (Utf8Proc::CodepointToUtf8(codepoint, encoded_size, encoded)) {
+			result = input.substr(0, last_start) + string(encoded, static_cast<size_t>(encoded_size));
+			return true;
+		}
+		// the last code point was U+10FFFF and cannot be incremented; drop it and
+		// carry the increment to the preceding code point.
+		len = last_start;
 	}
-	// Convert back to string
-	return std::string(bytes.begin(), bytes.end());
+	return false;
 }
 
 std::vector<uint8_t> HexStringToBytes(const std::string &hex) {
@@ -327,7 +334,10 @@ SerializeResult IcebergValue::SerializeValue(Value input_value, const LogicalTyp
 		string val;
 		if (bound_type == SerializeBound::UPPER_BOUND) {
 			// if we are serializing upper bound, we must truncate and increment
-			val = IcebergValue::TruncateAndIncrementString(input_value.GetValue<string>());
+			if (!IcebergValue::TruncateAndIncrementString(input_value.GetValue<string>(), val)) {
+				// No representable upper bound could be produced; omit it (optional per spec).
+				return SerializeResult();
+			}
 		} else {
 			// for lower bound truncating is enough
 			val = IcebergValue::TruncateString(input_value.GetValue<string>());

--- a/src/include/core/expression/iceberg_value.hpp
+++ b/src/include/core/expression/iceberg_value.hpp
@@ -82,7 +82,10 @@ public:
 	static DeserializeResult DeserializeValue(const string_t &blob, const LogicalType &target);
 	static SerializeResult SerializeValue(Value input_value, const LogicalType &column_type, SerializeBound bound_type);
 	static string TruncateString(const string &input);
-	static string TruncateAndIncrementString(const string &input);
+	// Computes a truncated, incremented upper bound for a string. Returns false
+	// (and leaves `result` untouched) when no valid bound can be produced, so the
+	// caller can omit the optional upper bound instead of failing.
+	static bool TruncateAndIncrementString(const string &input, string &result);
 };
 
 } // namespace duckdb

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_non_ascii_string_upper_bound.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_non_ascii_string_upper_bound.test
@@ -16,9 +16,6 @@ require httpfs
 set ignore_error_messages
 
 statement ok
-SET TimeZone = 'UTC';
-
-statement ok
 drop table if exists my_datalake.default.non_ascii_upper_bound_test;
 
 statement ok

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_non_ascii_string_upper_bound.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_non_ascii_string_upper_bound.test
@@ -1,0 +1,78 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_non_ascii_string_upper_bound.test
+# description: A long non-ASCII string (multi-byte UTF-8) must not fail the write with "Could not write upper bounds for string column"; the upper bound is computed on whole code points so a valid bound (>= the column max) is still produced.
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+SET TimeZone = 'UTC';
+
+statement ok
+drop table if exists my_datalake.default.non_ascii_upper_bound_test;
+
+statement ok
+create table my_datalake.default.non_ascii_upper_bound_test (
+    id int,
+    title varchar
+);
+
+# These strings are longer than 16 bytes and contain multi-byte UTF-8 within
+# the first 16 bytes. Previously the upper-bound truncate+increment could not
+# produce valid UTF-8 and the whole insert failed.
+statement ok
+insert into my_datalake.default.non_ascii_upper_bound_test values
+    (1, 'ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲ'),
+    (2, 'Ünïcödé strïng wïth ëxtra bytës'),
+    (3, 'short ascii');
+
+# Data round-trips intact.
+query IT
+select id, title from my_datalake.default.non_ascii_upper_bound_test order by id;
+----
+1	ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲ
+2	Ünïcödé strïng wïth ëxtra bytës
+3	short ascii
+
+statement ok
+set variable mp = (select manifest_path from iceberg_metadata(my_datalake.default.non_ascii_upper_bound_test) order by manifest_sequence_number desc limit 1);
+
+# The varchar column (field id 2) gets an upper bound even though its max value
+# is a long non-ASCII string: the bound is produced by incrementing the last
+# code point of the truncated prefix.
+query I
+select count(*) from (
+    select unnest(map_keys(upper_bounds)) k
+    from (select unnest(data_file) from read_avro(getvariable('mp')))
+) where k = 2;
+----
+1
+
+# And it is a valid upper bound: decoded, it is >= the column's max value.
+query I
+select decode(ub) >= (select max(title) from my_datalake.default.non_ascii_upper_bound_test)
+from (
+    select unnest(map_keys(upper_bounds)) k, unnest(map_values(upper_bounds)) ub
+    from (select unnest(data_file) from read_avro(getvariable('mp')))
+) where k = 2;
+----
+true
+
+# The lower bound for the varchar column is written too (truncation only).
+query I
+select count(*) from (
+    select unnest(map_keys(lower_bounds)) k
+    from (select unnest(data_file) from read_avro(getvariable('mp')))
+) where k = 2;
+----
+1


### PR DESCRIPTION
Writing a string longer than 16 bytes whose leading bytes are multi-byte UTF-8 currently fails the whole insert with `Could not write upper bounds for string column`. It shows up with any longer non-ASCII text, e.g. full-width or accented characters.

The bound is built in `TruncateAndIncrementString` by truncating to 16 bytes and incrementing the last non-continuation byte. That works on raw bytes, so it splits multi-byte characters and increments a byte rather than a code point, which usually lands on invalid UTF-8. It then shrinks and retries until it gives up and throws.

The fix does it on whole code points, the same way duckdb already does for prefix filters in [`FilterCombiner::FindNextLegalUTF8`](https://github.com/duckdb/duckdb/blob/main/src/optimizer/filter_combiner.cpp): truncate on a code point boundary, then increment the last code point to the next scalar value (skipping the surrogate range). If that code point is already the maximum, drop it and carry the increment to the previous one. Only if every code point is the maximum is there no representable bound, in which case it omits it, which is allowed since bounds are optional in the spec ([Manifests / Data File Fields](https://iceberg.apache.org/spec/#manifests), field 128 `upper_bounds` is `optional`). This matches the Java side ([`UnicodeUtil.truncateStringMax`](https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java)).

So these strings now get a real bound, e.g. `ＡＢＣＤＥ…` truncates and increments to `ＡＢＣＤＦ`. Lower bounds are untouched (plain truncation, no increment). Added a regression test with full-width and accented strings that checks the insert succeeds, the data round-trips, and the produced upper bound decodes to a value `>=` the column max.
