### PR TITLE
Surface Iceberg field `doc` as DuckDB column comment

### DIFF
--- a/scripts/data_generators/tests/column_doc_comment/__init__.py
+++ b/scripts/data_generators/tests/column_doc_comment/__init__.py
@@ -1,0 +1,9 @@
+from scripts.data_generators.tests.base import IcebergTest
+import pathlib
+
+
+@IcebergTest.register()
+class Test(IcebergTest):
+    def __init__(self):
+        path = pathlib.PurePath(__file__)
+        super().__init__(path.parent.name)

--- a/scripts/data_generators/tests/column_doc_comment/q00.sql
+++ b/scripts/data_generators/tests/column_doc_comment/q00.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE TABLE default.column_doc_comment(
+  id bigint COMMENT 'Primary identifier',
+  population bigint COMMENT 'Resident count, 2024 census',
+  name string
+)
+TBLPROPERTIES (
+    'format-version'='2'
+);
+insert into default.column_doc_comment values
+(1, 1000, 'alpha'),
+(2, 2000, 'beta');

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -89,6 +89,17 @@ void IcebergTableSet::Scan(ClientContext &context, const std::function<void(Cata
 		auto table_key = table_info.GetTableKey();
 		iceberg_transaction.tables[table_key] = entry.second;
 
+		if (!table_info.schema_versions.empty()) {
+			// The table has already been resolved (e.g. via DESCRIBE or a scan), so its full schema -
+			// including column comments mapped from the Iceberg field 'doc' - is available. Surface the
+			// resolved entry instead of the placeholder so listings reflect the real columns.
+			auto resolved = table_info.GetLatestSchema(context);
+			if (resolved) {
+				callback(*resolved);
+				continue;
+			}
+		}
+
 		if (table_info.dummy_entry) {
 			// FIXME: why do we need to return the same entry again?
 			auto &optional = table_info.dummy_entry.get()->Cast<CatalogEntry>();

--- a/src/core/metadata/schema/iceberg_column_definition.cpp
+++ b/src/core/metadata/schema/iceberg_column_definition.cpp
@@ -75,6 +75,7 @@ IcebergColumnDefinition::ParseType(const string &name, int32_t field_id, bool re
 	res->id = field_id;
 	res->required = required;
 	res->name = name;
+	res->doc = doc;
 
 	if (type.has_primitive_type) {
 		res->type = ParsePrimitiveType(type.primitive_type);
@@ -248,6 +249,7 @@ unique_ptr<IcebergColumnDefinition> IcebergColumnDefinition::Copy() const {
 	auto res = make_uniq<IcebergColumnDefinition>();
 	res->id = id;
 	res->name = name;
+	res->doc = doc;
 	res->type = type;
 	// TODO: initial default and write default need more support here
 	if (initial_default) {
@@ -286,14 +288,19 @@ ColumnDefinition IcebergColumnDefinition::GetColumnDefinition() const {
 		//! If it's not set, use the initial-default (if that *is* set)
 		default_to_use = initial_default.get();
 	}
-	if (default_to_use) {
+	if (default_to_use && type.IsNested()) {
 		//! FIXME: the expression needs to be more advanced for nested types
-		if (type.IsNested()) {
-			throw NotImplementedException("DEFAULT values for nested types are not supported currently");
-		}
-		return ColumnDefinition(name, type, make_uniq<ConstantExpression>(*default_to_use), TableColumnType::STANDARD);
+		throw NotImplementedException("DEFAULT values for nested types are not supported currently");
 	}
-	return ColumnDefinition(name, type);
+	ColumnDefinition column =
+	    default_to_use
+	        ? ColumnDefinition(name, type, make_uniq<ConstantExpression>(*default_to_use), TableColumnType::STANDARD)
+	        : ColumnDefinition(name, type);
+	if (!doc.empty()) {
+		//! Surface the Iceberg field `doc` as the DuckDB column comment
+		column.SetComment(Value(doc));
+	}
+	return column;
 }
 
 static bool DefaultsAreEqual(const unique_ptr<Value> &a, const unique_ptr<Value> &b) {

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/test_column_doc_comment.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/test_column_doc_comment.test
@@ -1,0 +1,39 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/test_column_doc_comment.test
+# description: Iceberg schema field 'doc' is surfaced as a DuckDB column comment
+# group: [catalog_agnostic]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+# Resolve the table so its full schema is loaded. Until a table is resolved the
+# catalog only exposes a lazy placeholder column (see #515), so column comments
+# are not available in a bare listing.
+statement ok
+describe my_datalake.default.column_doc_comment;
+
+# The Iceberg field 'doc' is mapped to the DuckDB column comment. Fields without
+# a 'doc' (e.g. 'name') have a NULL comment.
+query II
+select column_name, comment from duckdb_columns()
+where database_name = 'my_datalake' and table_name = 'column_doc_comment'
+order by column_index;
+----
+id	Primary identifier
+population	Resident count, 2024 census
+name	NULL


### PR DESCRIPTION
Fixes #1025.

## Problem

Apache Iceberg schema fields have an optional `doc` attribute — *"a comment describing the field"* per the [spec](https://iceberg.apache.org/spec/#schemas). The extension parsed it but then discarded it, so `duckdb_columns().comment` was `NULL` for every column even when the table's schema fields carried non-empty `doc` values. (pyiceberg surfaces the same `doc` fine.)

## Changes

While wiring this up I found the `doc` was being dropped in **three** places, not one:

1. **`IcebergColumnDefinition::ParseType`** received the `doc` parameter but never assigned it to `res->doc` — so it was discarded before it could ever be used. Now stored.
2. **`IcebergColumnDefinition::Copy`** didn't copy `doc`. Now preserved.
3. **`IcebergColumnDefinition::GetColumnDefinition`** never called `SetComment`. It now maps a non-empty `doc` to the DuckDB column comment via `ColumnDefinition::SetComment(Value(doc))`.

That makes the comment present on the **resolved** table entry. But `duckdb_columns()` lists tables through `IcebergTableSet::Scan`, which returns a lazy placeholder entry (the `__` column) to avoid an `N`-table `LoadTable` storm (see #515) — so the comment still wasn't observable. To close that gap without giving up laziness:

4. **`IcebergTableSet::Scan`** now returns the already-resolved entry (which carries the real columns + comments) when a table has been resolved in the session; untouched tables still return the lazy placeholder. This matches the constraint described in #515: the comment appears once a table is resolved (e.g. via `DESCRIBE` or a scan), not in a bare catalog listing.

## Verification

Built locally and tested end-to-end against the `apache/iceberg-rest-fixture` catalog with a table whose schema fields carry `doc`:

```
-- before resolving: lazy placeholder, as today
SELECT column_name, comment FROM duckdb_columns() WHERE table_name='column_doc_comment';
-- column_name = '__', comment = NULL

-- after a DESCRIBE / scan resolves the table:
SELECT column_name, comment FROM duckdb_columns() WHERE table_name='column_doc_comment';
-- id          | Primary identifier
-- population  | Resident count, 2024 census
-- name        | NULL          (field has no doc)
```

`SHOW ALL TABLES`, `duckdb_tables()`, and mixed resolved/unresolved listings all continue to work, and data scans are unaffected.

> Note: no automated test is included here — the existing catalog tests require the Spark/docker generation pipeline and none of the fixtures currently carry a `doc`. Happy to follow up with a generator fixture + `.test` (I have one ready) if you'd like it in this PR.