### PR TITLE
Pin versions in requirements.txt

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,6 +2,6 @@ pyspark==4.0.1
 duckdb==1.4.0
 pydantic==2.9.0
 pyiceberg==0.9.1
-pyarrow
-pytest
+pyarrow==24.0.0
+pytest==9.0.3
 mitmproxy==12.2.1


### PR DESCRIPTION
This pins the versions used for testing to

1. Not break the tests if a new major version is published
2. Not become victim of a supply chain attach if the newest version of one of these packages gets compromised 