### PR TITLE
Resolve virtual columns in GetScanFunction like Ducklake

### DIFF
--- a/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
@@ -241,6 +241,7 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 	auto result = iceberg_scan_function.bind(context, bind_input, return_types, names);
 	bind_data = std::move(result);
 	auto &file_bind_data = bind_data->Cast<MultiFileBindData>();
+	file_bind_data.virtual_columns = GetVirtualColumns();
 	D_ASSERT(file_bind_data.file_list);
 	auto &ic_file_list = file_bind_data.file_list->Cast<IcebergMultiFileList>();
 	ic_file_list.table = this;


### PR DESCRIPTION
`IcebergTableEntry::GetScanFunction(context, bind_data, lookup)` calls `iceberg_scan_function.bind()` to create `MultiFileBindData`, but never populates `MultiFileBindData::virtual_columns`. The `get_virtual_columns` callback (`IcebergVirtualColumns`) normally handles this during plan creation, but callers that invoke `GetScanFunction` directly and skip the planner never trigger that callback.

DuckLake equivalent for reference 
https://github.com/duckdb/ducklake/blob/d897bc5a35f887c9087403bc20efd92d99272e69/src/storage/ducklake_table_entry.cpp#L324