### PR TITLE
WIP: Map write.parquet.format-version to DuckDB Parquet V2 writes.

### DIFF
--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -730,7 +730,8 @@ static const IcebergParquetOptionMapping ICEBERG_TABLE_PROPERTY_MAPPING[] = {
     {"write.parquet.dict-size-bytes", "string_dictionary_page_size_limit"},
     {"write.parquet.row-group-size", "row_group_size"},
     {"write.parquet.page-size-bytes", "chunk_size"},
-    {"write.parquet.row-groups-per-file", "row_groups_per_file"}};
+    {"write.parquet.row-groups-per-file", "row_groups_per_file"},
+    {"write.parquet.format-version", "parquet_version"}};
 
 static const idx_t ICEBERG_TABLE_PROPERTY_MAPPING_SIZE =
     sizeof(ICEBERG_TABLE_PROPERTY_MAPPING) / sizeof(IcebergParquetOptionMapping);

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/test_parquet_copy_options.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/test_parquet_copy_options.test
@@ -97,3 +97,52 @@ query I
 select count(row_group_bytes) from parquet_metadata(getvariable('parquet_filepath'));
 ----
 49
+
+statement ok
+drop table if exists properties_table;
+
+# Parquet file format version defaults to v1
+statement ok
+create table properties_table (my_col bigint);
+
+statement ok
+insert into my_datalake.default.properties_table SELECT * FROM range(20000) my_col;
+
+statement ok
+set variable parquet_filepath = (select file_path from iceberg_metadata(my_datalake.default.properties_table) limit 1);
+
+query I
+select format_version from parquet_file_metadata(getvariable('parquet_filepath'));
+----
+1
+
+statement ok
+drop table if exists properties_table;
+
+# write.parquet.format-version maps to DuckDB's parquet_version copy option
+statement ok
+create table properties_table (my_col bigint)
+WITH (
+    'write.parquet.format-version'='v2'
+);
+
+query II
+select * from iceberg_table_properties(my_datalake.default.properties_table) where key = 'write.parquet.format-version';
+----
+write.parquet.format-version	v2
+
+statement ok
+insert into my_datalake.default.properties_table SELECT * FROM range(20000) my_col;
+
+statement ok
+set variable parquet_filepath = (select file_path from iceberg_metadata(my_datalake.default.properties_table) limit 1);
+
+query I
+select format_version from parquet_file_metadata(getvariable('parquet_filepath'));
+----
+2
+
+query I
+select encodings from parquet_metadata(getvariable('parquet_filepath'));
+----
+DELTA_BINARY_PACKED


### PR DESCRIPTION
Allow Iceberg tables to opt into Parquet file format version 2 via a table property instead of relying on the DuckDB default of V1.

No other behavior should change.