### PR TITLE
Ignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ test/python/__pycache__/
 test/sql/tmp.test
 data/iceberg/generated_*
 scripts/metastore_db/
+scripts/data/generated
 scripts/derby.log
 scripts/test-script-with-path.sql
 scripts/data_generators/__pycache__/


### PR DESCRIPTION
Ignore generated files created by `make fixture-data`

```
scripts/data/
└── generated
    └── files
        ├── file_0.parquet
        ├── file_1.parquet
        └── file_2.parquet
```