### PR TITLE
Round up the partition field summary string upper bound

### DIFF
--- a/src/core/metadata/manifest/iceberg_manifest_list.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest_list.cpp
@@ -216,7 +216,7 @@ void ManifestPartitions::Create(const IcebergTableMetadata &metadata, const Iceb
 			lower_result = IcebergValue::SerializeValue(min_values[i].DefaultCastAs(LogicalType::VARCHAR),
 			                                            min_values[i].type(), SerializeBound::LOWER_BOUND);
 			upper_result = IcebergValue::SerializeValue(max_values[i].DefaultCastAs(LogicalType::VARCHAR),
-			                                            max_values[i].type(), SerializeBound::LOWER_BOUND);
+			                                            max_values[i].type(), SerializeBound::UPPER_BOUND);
 		}
 
 		if (lower_result.HasValue()) {

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/test_partition_summary_string_upper_bound.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/test_partition_summary_string_upper_bound.test
@@ -1,0 +1,45 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/test_partition_summary_string_upper_bound.test
+# description: The manifest-list partition field summary upper_bound for a string partition must be rounded up (>= the partition value), not a plain 16-byte truncation. A truncated-down upper bound wrongly prunes the partition from its own manifest (see duckdb-iceberg#1047).
+# group: [partitions]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.partition_summary_upper_bound;
+
+statement ok
+create table my_datalake.default.partition_summary_upper_bound (id integer, p varchar);
+
+# truncate(20) produces a 20-byte partition value, longer than the 16-byte bound truncation.
+statement ok
+alter table my_datalake.default.partition_summary_upper_bound set partitioned by (truncate(20, p));
+
+statement ok
+insert into my_datalake.default.partition_summary_upper_bound values (1, '0123456789abcdef0123456789abcdef');
+
+# The partition value is truncate(20, key) = '0123456789abcdef0123'. The field-summary
+# upper_bound must be >= that value. Previously it was the plain 16-byte truncation
+# '0123456789abcdef', which is < the value and excludes the partition from its own manifest.
+query I
+select upper_bound >= '0123456789abcdef0123'
+from iceberg_partition_stats('my_datalake.default.partition_summary_upper_bound');
+----
+true
+
+# The lower bound is a valid lower bound (plain truncation is fine here).
+query I
+select lower_bound <= '0123456789abcdef0123'
+from iceberg_partition_stats('my_datalake.default.partition_summary_upper_bound');
+----
+true


### PR DESCRIPTION
The manifest-list partition field summary `upper_bound` for a string partition is serialized with `SerializeBound::LOWER_BOUND`, so it is a plain 16-byte truncation instead of being rounded up. For any partition value longer than 16 bytes the truncated `upper_bound` sorts *less than* the value, so the summary claims the manifest cannot contain its own partition.

Engines that prune by manifest-list partition summaries (Trino/Athena, Spark) then skip the manifest: partition-equality filters silently drop rows, and `OPTIMIZE` / `rewrite_data_files` aborts with `Missing required files to delete` for files that exist.

The column-metrics writer already passes `SerializeBound::UPPER_BOUND` (which routes through `TruncateAndIncrementString`, the path fixed in #1022); only the partition-summary path was wrong. This passes `UPPER_BOUND` there too.

Before/after with `truncate(20, p)` on a 32-byte key (partition value `0123456789abcdef0123`):

| | upper_bound | `>= value` |
| --- | --- | --- |
| before | `0123456789abcdef` | false |
| after | `0123456789abcdeg` | true |

Added a regression test under `insert/partitions/` using `iceberg_partition_stats` (red before, green after).

Fixes #1047.