### PR TITLE
Don't prune files on filter expressions whose column side is not a direct reference (fixes #1052)

### DIFF
--- a/src/planning/pruning/iceberg_predicate.cpp
+++ b/src/planning/pruning/iceberg_predicate.cpp
@@ -18,28 +18,6 @@
 
 namespace duckdb {
 
-namespace {
-
-struct BoundExpressionReplacer : public LogicalOperatorVisitor {
-public:
-	BoundExpressionReplacer(const Value &val) : val(val) {
-	}
-
-public:
-	unique_ptr<Expression> VisitReplace(BoundReferenceExpression &expr, unique_ptr<Expression> *expr_ptr) override {
-		if (expr.index != 0) {
-			return nullptr;
-		}
-		auto &return_type = expr.GetReturnType();
-		return make_uniq<BoundConstantExpression>(val.DefaultCastAs(return_type, true));
-	}
-
-public:
-	const Value &val;
-};
-
-} // namespace
-
 template <class TRANSFORM>
 bool MatchBoundsTemplated(ClientContext &context, const ExpressionFilter &filter, const IcebergPredicateStats &stats,
                           const IcebergTransform &transform);
@@ -90,37 +68,6 @@ static bool MatchBoundsIsNullFilter(const IcebergPredicateStats &stats, const Ic
 template <class TRANSFORM>
 static bool MatchBoundsIsNotNullFilter(const IcebergPredicateStats &stats, const IcebergTransform &transform) {
 	return stats.has_not_null == true;
-}
-
-template <class TRANSFORM>
-bool MatchTransformedBounds(ClientContext &context, ExpressionType comparison_type, const Expression &left,
-                            const Expression &right, const IcebergPredicateStats &stats,
-                            const IcebergTransform &transform) {
-	BoundExpressionReplacer lower_replacer(stats.lower_bound);
-	BoundExpressionReplacer upper_replacer(stats.upper_bound);
-	auto lower_copy = left.Copy();
-	auto upper_copy = left.Copy();
-	lower_replacer.VisitExpression(&lower_copy);
-	upper_replacer.VisitExpression(&upper_copy);
-
-	Value right_constant;
-	if (!ExpressionExecutor::TryEvaluateScalar(context, right, right_constant)) {
-		return true;
-	}
-
-	Value transformed_lower_bound;
-	Value transformed_upper_bound;
-	if (!ExpressionExecutor::TryEvaluateScalar(context, *lower_copy, transformed_lower_bound)) {
-		return true;
-	}
-	if (!ExpressionExecutor::TryEvaluateScalar(context, *upper_copy, transformed_upper_bound)) {
-		return true;
-	}
-	IcebergPredicateStats transformed_stats(stats);
-	transformed_stats.lower_bound = transformed_lower_bound;
-	transformed_stats.upper_bound = transformed_upper_bound;
-
-	return MatchBoundsConstant<TRANSFORM>(right_constant, comparison_type, transformed_stats, transform);
 }
 
 // template <class TRANSFORM>
@@ -261,23 +208,13 @@ static bool MatchBoundsExpression(ClientContext &context, const Expression &expr
 			return MatchBoundsConstant<TRANSFORM>(left.Cast<BoundConstantExpression>().GetValue(),
 			                                      FlipComparisonExpression(comparison_type), stats, transform);
 		}
-		if (comparison_type == ExpressionType::COMPARE_EQUAL && stats.lower_bound.type() == LogicalType::VARCHAR) {
-			//! Filters on strings (e.g len(my_string_col)) do not maintain lexicographic ordering properties
-			return true;
-		}
-		if (transform.Type() == IcebergTransformType::IDENTITY) {
-			//! No further processing has been done on the stats (lower/upper bounds)
-			bool left_foldable = left.IsFoldable();
-			bool right_foldable = right.IsFoldable();
-			if (!left_foldable && !right_foldable) {
-				//! Both are not foldable, can't evaluate at all
-				return true;
-			}
-			if (left_foldable) {
-				return MatchTransformedBounds<TRANSFORM>(context, comparison_type, right, left, stats, transform);
-			}
-			return MatchTransformedBounds<TRANSFORM>(context, comparison_type, left, right, stats, transform);
-		}
+		//! The column side is not a direct column reference (e.g. `pk % 8 = 4`, `day(ts) = 5`).
+		//! Evaluating such an expression at the lower/upper bound and comparing against the
+		//! result range is only sound when the expression is MONOTONE over the bound interval,
+		//! which we cannot establish in general: e.g. for `pk % 8` over a file with bounds
+		//! [0, 49] that approach yields [0 % 8, 49 % 8] = [0, 1] and would incorrectly prune
+		//! files containing pk % 8 ∈ {2..7} — silently dropping correct rows from the result
+		//! (duckdb/duckdb-iceberg#1052). Be conservative: don't prune.
 		return true;
 	}
 

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filter_pushdown_non_monotone.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filter_pushdown_non_monotone.test
@@ -1,0 +1,52 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filter_pushdown_non_monotone.test
+# description: Filters whose column side is not a direct column reference (e.g. pk % 8 = 2) must not be used for stats-based file pruning (duckdb/duckdb-iceberg#1052)
+# group: [reads]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.non_monotone_pruning;
+
+statement ok
+CREATE TABLE my_datalake.default.non_monotone_pruning AS
+SELECT r.range::INT AS pk FROM range(50) r;
+
+# The single data file has pk bounds [0, 49]. Evaluating the column-side
+# expression at the bounds gives [0 % 8, 49 % 8] = [0, 1] — using that as the
+# expression's range over the file is only valid for monotone expressions, so
+# it must not prune: residues 2..7 each have 6 matching rows in the file.
+query I
+SELECT count(*) FROM my_datalake.default.non_monotone_pruning WHERE pk % 8 = 2;
+----
+6
+
+query I
+SELECT count(*) FROM my_datalake.default.non_monotone_pruning WHERE pk % 8 = 7;
+----
+6
+
+# Residues that happen to "pass" the bounds-folded check must of course also work.
+query I
+SELECT count(*) FROM my_datalake.default.non_monotone_pruning WHERE pk % 8 = 0;
+----
+7
+
+# Direct-reference comparisons keep pruning soundly.
+query I
+SELECT count(*) FROM my_datalake.default.non_monotone_pruning WHERE pk = 4;
+----
+1
+
+statement ok
+DROP TABLE my_datalake.default.non_monotone_pruning;


### PR DESCRIPTION
## What

Fixes #1052 — stats-based file pruning silently returns wrong results for pushed-down filters whose column side is not a direct column reference.

`MatchBoundsExpression` evaluated the column-side expression at the file's lower/upper bound and treated `[f(min), f(max)]` as the range of `f` over the file. That is only sound when `f` is monotone over the bound interval — which cannot be established in general. For `pk % 8 = 4` over a file with bounds `[0, 49]` it computes `[0 % 8, 49 % 8] = [0, 1]` and prunes the file, silently dropping all matching rows from the result (residues 0 and 1 "work" by coincidence, 2–7 lose data). Same class applies to `day(ts)`, `abs(x)`, etc.

## Fix

Conservative: only direct column-reference comparisons participate in bounds pruning (the existing `MatchBoundsConstant` paths); any other comparison shape returns "cannot prune". Removes the now-unused `MatchTransformedBounds` / `BoundExpressionReplacer`. A follow-up could reclaim pruning for provably monotone shapes (e.g. widening casts) behind an explicit allowlist — happy to take guidance on whether that's wanted.

## Validation

- New catalog-agnostic test (`reads/filter_pushdown_non_monotone.test`): `pk % 8 ∈ {2, 7, 0}` counts plus a direct-reference control.
- Against a live Polaris REST catalog + S3, on this branch: the previously failing queries return correct counts, and an 8-tick repeated-MERGE SCD2 soak that was derailed by this pruning (its source subquery used `pk % 8 = residue` and read zero files at tick 3) now passes 8/8 with the SCD2 invariant intact — both with modulo and with range predicates.
- Confirmed the bug reproduces on the v1.5.2 release and `main` (`c5221e1e`) before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
