### PR TITLE
Support optimistic-concurrency commit retries (#786)

### DIFF
--- a/.github/workflows/BuildIceberg.yml
+++ b/.github/workflows/BuildIceberg.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           make release
 
-      - name: Run C++ logic unit tests (manifest compression)
+      - name: Run C++ logic unit tests (manifest compression + merge)
         run: |
           make test_logic
 

--- a/.github/workflows/BuildIceberg.yml
+++ b/.github/workflows/BuildIceberg.yml
@@ -50,6 +50,10 @@ jobs:
         run: |
           make release
 
+      - name: Run C++ logic unit tests (manifest compression)
+        run: |
+          make test_logic
+
       - name: Upload DuckDB-Iceberg no link folder
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/BuildIceberg.yml
+++ b/.github/workflows/BuildIceberg.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           make release
 
-      - name: Run C++ logic unit tests (manifest compression + merge)
+      - name: Run C++ logic unit tests (manifest compression + merge + commit retry)
         run: |
           make test_logic
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ __pycache__/
 
 tmp/
 .catalogs/
+.cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(EXTENSION_SOURCES
 	src/catalog/rest/api/iceberg_add_snapshot.cpp
 	src/catalog/rest/api/iceberg_create_table_request.cpp
 	src/catalog/rest/api/iceberg_manifest_merge.cpp
+	src/catalog/rest/api/iceberg_retry.cpp
 	src/catalog/rest/api/iceberg_table_update.cpp
 	src/catalog/rest/api/iceberg_type.cpp
 	src/catalog/rest/api/table_update.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(EXTENSION_SOURCES
 	src/catalog/rest/api/catalog_utils.cpp
 	src/catalog/rest/api/iceberg_add_snapshot.cpp
 	src/catalog/rest/api/iceberg_create_table_request.cpp
+	src/catalog/rest/api/iceberg_manifest_merge.cpp
 	src/catalog/rest/api/iceberg_table_update.cpp
 	src/catalog/rest/api/iceberg_type.cpp
 	src/catalog/rest/api/table_update.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(EXTENSION_SOURCES
 	src/core/metadata/iceberg_table_metadata.cpp
 	src/core/metadata/manifest/iceberg_manifest_list.cpp
 	src/core/metadata/manifest/iceberg_manifest.cpp
+	src/core/metadata/manifest/iceberg_avro_codec.cpp
 	src/core/metadata/partition/iceberg_partition_spec.cpp
 	src/core/metadata/schema/iceberg_column_definition.cpp
 	src/core/metadata/schema/iceberg_field_mapping.cpp

--- a/make/util.mk
+++ b/make/util.mk
@@ -15,3 +15,14 @@ define set_active_catalog
 	@mkdir -p $(dir $(ACTIVE_CATALOG_FILE))
 	@echo "$(1)" > $(ACTIVE_CATALOG_FILE)
 endef
+
+# Standalone C++ logic tests for manifest Avro compression. Dependency-free (only zlib, for the Avro
+# OCF deflate round-trip), so they build and run without a catalog or the DuckDB unittest harness.
+# They cover codec resolution and the OCF recompress/varint round-trip the SQL integration tests
+# cannot reach. Run with `make test_logic`.
+CXX ?= c++
+.PHONY: test_logic
+test_logic:
+	@mkdir -p build
+	$(CXX) -std=c++17 test/cpp/test_compression_logic.cpp -lz -o build/test_compression_logic
+	./build/test_compression_logic

--- a/make/util.mk
+++ b/make/util.mk
@@ -16,13 +16,15 @@ define set_active_catalog
 	@echo "$(1)" > $(ACTIVE_CATALOG_FILE)
 endef
 
-# Standalone C++ logic tests for manifest Avro compression. Dependency-free (only zlib, for the Avro
-# OCF deflate round-trip), so they build and run without a catalog or the DuckDB unittest harness.
-# They cover codec resolution and the OCF recompress/varint round-trip the SQL integration tests
-# cannot reach. Run with `make test_logic`.
+# Standalone C++ logic tests. Dependency-free (the compression suite uses zlib for the Avro OCF
+# deflate round-trip), so they build and run without a catalog or the DuckDB unittest harness. They
+# cover codec resolution / OCF recompress and the manifest bin-packing / merge-decision logic the SQL
+# integration tests cannot reach. Run with `make test_logic`.
 CXX ?= c++
 .PHONY: test_logic
 test_logic:
 	@mkdir -p build
 	$(CXX) -std=c++17 test/cpp/test_compression_logic.cpp -lz -o build/test_compression_logic
 	./build/test_compression_logic
+	$(CXX) -std=c++17 test/cpp/test_merge_logic.cpp -o build/test_merge_logic
+	./build/test_merge_logic

--- a/make/util.mk
+++ b/make/util.mk
@@ -18,7 +18,8 @@ endef
 
 # Standalone C++ logic tests. Dependency-free (the compression suite uses zlib for the Avro OCF
 # deflate round-trip), so they build and run without a catalog or the DuckDB unittest harness. They
-# cover codec resolution / OCF recompress and the manifest bin-packing / merge-decision logic the SQL
+# cover codec resolution / OCF recompress, the manifest bin-packing / merge-decision logic, and the
+# commit-retry backoff / status-classification / ancestry / delete-attribution logic the SQL
 # integration tests cannot reach. Run with `make test_logic`.
 CXX ?= c++
 .PHONY: test_logic
@@ -28,3 +29,5 @@ test_logic:
 	./build/test_compression_logic
 	$(CXX) -std=c++17 test/cpp/test_merge_logic.cpp -o build/test_merge_logic
 	./build/test_merge_logic
+	$(CXX) -std=c++17 test/cpp/test_retry_logic.cpp -o build/test_retry_logic
+	./build/test_retry_logic

--- a/scripts/fault_injection_addon.py
+++ b/scripts/fault_injection_addon.py
@@ -1,0 +1,115 @@
+"""mitmproxy addon: deterministic fault injection for the Iceberg commit-retry tests.
+
+It sits between DuckDB and the REST catalog and rewrites the *response* of a commit request so we can
+exercise the optimistic-concurrency path that is otherwise impossible to trigger deterministically
+from SQL:
+
+  UNKNOWN-then-committed: the upstream catalog actually applies the commit, but we replace its
+  successful response with a 502. DuckDB must NOT treat this as a hard failure, must NOT blindly
+  retry, and must NOT clean up data files; its status-check has to re-load the table, find the
+  committed snapshot, and resolve the commit as a success.
+
+Because the rewrite happens in the `response` hook (after the upstream has answered), for a 2xx
+commit the change is already durably applied on the catalog when we turn the response into a 502 --
+that is exactly the "committed but the client could not tell" case.
+
+The injection is keyed off the *table name* in the request path, so it only affects tables created by
+the fault-injection test and leaves every other table/test untouched. Each rule fires a bounded
+number of times (so the eventual real attempt/state-check succeeds).
+
+Enable in CI with:  mitmdump --mode regular@<port> -s scripts/fault_injection_addon.py
+
+Markers (substring of the table name in the commit path):
+  inject_unknown_once  -> the first commit response for this table becomes 502 (upstream still
+                          applied it); subsequent commits pass through unchanged. Exercises
+                          UNKNOWN -> CheckCommitStatus -> ALL_COMMITTED (commit landed, response lost).
+  inject_fail_before_apply_once -> the first commit POST for this table is answered with a 502 in the
+                          REQUEST hook *without forwarding to the catalog*, so the commit provably did
+                          NOT apply; subsequent commits pass through. Exercises
+                          UNKNOWN -> CheckCommitStatus -> NONE_COMMITTED -> retry-to-success (a
+                          transient 5xx that never reached/applied at the catalog).
+"""
+
+from mitmproxy import http
+
+import logging
+
+# marker -> max number of times to inject (per distinct request path)
+_LIMITS = {
+    "inject_unknown_once": 1,
+    "inject_fail_before_apply_once": 1,
+}
+
+# How many times each (marker, path) has fired. Shared across the request and response hooks so each
+# marker's budget is counted once regardless of which hook performs the injection.
+_fired = {}
+
+# 502 is classified UNKNOWN by the extension (ClassifyCommitStatus), which is the ambiguous-outcome
+# path we want to exercise.
+_INJECT_STATUS = 502
+
+
+def _is_commit_request(flow: http.HTTPFlow) -> bool:
+    # Iceberg REST commit endpoints: single-table update (POST .../tables/<name>) and the multi-table
+    # transaction commit (POST .../transactions/commit).
+    if flow.request.method != "POST":
+        return False
+    path = flow.request.path
+    return ("/tables/" in path) or path.endswith("/transactions/commit")
+
+
+def _marker_for(flow: http.HTTPFlow):
+    # The table name appears in the request path for single-table commits, and in the body for the
+    # multi-table transaction endpoint; check both.
+    body = ""
+    try:
+        body = flow.request.get_text() or ""
+    except Exception:
+        body = ""
+    haystack = flow.request.path + " " + body
+    for marker in _LIMITS:
+        if marker in haystack:
+            return marker
+    return None
+
+
+def _inject_502(marker: str, path: str, hook: str) -> http.Response:
+    _fired[(marker, path)] = _fired.get((marker, path), 0) + 1
+    # Distinctive log line so the test can assert the fault was actually injected (otherwise a
+    # mis-wired proxy / unmatched marker would let a normal response through and the test would pass
+    # without ever exercising the targeted path).
+    logging.warning("ICEBERG_FAULT_INJECTED marker=%s status=%d hook=%s path=%s", marker, _INJECT_STATUS, hook, path)
+    return http.Response.make(
+        _INJECT_STATUS,
+        b'{"error": {"message": "injected ambiguous commit outcome", "type": "ServerError", "code": 502}}',
+        {"Content-Type": "application/json"},
+    )
+
+
+def request(flow: http.HTTPFlow) -> None:
+    # NONE_COMMITTED path: short-circuit the commit POST *before* it reaches the catalog, so the
+    # commit provably never applies. Setting flow.response in the request hook prevents forwarding
+    # upstream entirely. Only the inject_fail_before_apply_once marker uses this hook.
+    if not _is_commit_request(flow):
+        return
+    marker = _marker_for(flow)
+    if marker != "inject_fail_before_apply_once":
+        return
+    key = (marker, flow.request.path)
+    if _fired.get(key, 0) >= _LIMITS[marker]:
+        return  # budget exhausted: let the request reach the catalog and succeed
+    flow.response = _inject_502(marker, flow.request.path, "request")
+
+
+def response(flow: http.HTTPFlow) -> None:
+    if not _is_commit_request(flow):
+        return
+    if flow.response is None or flow.response.status_code not in (200, 204):
+        return  # only convert a *successful* commit into an ambiguous one
+    marker = _marker_for(flow)
+    if marker != "inject_unknown_once":
+        return  # the before-apply marker is handled in the request hook
+    key = (marker, flow.request.path)
+    if _fired.get(key, 0) >= _LIMITS[marker]:
+        return  # budget exhausted: let the real (successful) response through
+    flow.response = _inject_502(marker, flow.request.path, "response")

--- a/src/catalog/rest/api/catalog_api.cpp
+++ b/src/catalog/rest/api/catalog_api.cpp
@@ -1,4 +1,5 @@
 #include "catalog/rest/api/catalog_api.hpp"
+#include "catalog/rest/api/iceberg_commit_exceptions.hpp"
 
 #include "duckdb/main/secret/secret.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
@@ -10,6 +11,7 @@
 #include "catalog/rest/api/catalog_utils.hpp"
 #include "iceberg_logging.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
 #include "common/iceberg_utils.hpp"
@@ -76,6 +78,39 @@ static void LogPostBody(ClientContext &context, const IRCEndpointBuilder &url_bu
 		body_to_log = body;
 	}
 	DUCKDB_LOG(context, IcebergLogType, "POST %s body=%s", url_builder.GetURLEncoded(), body_to_log);
+}
+
+//! Send a commit POST, converting a transport-level throw (connection reset / timeout / DNS, which
+//! makes the HTTP layer throw rather than return a status) into an UNKNOWN-outcome commit exception.
+//! A commit POST that failed in transit is ambiguous: it may have reached the catalog and been
+//! applied, so the retry driver must run a status-check and never clean up data files. Shared by the
+//! single- and multi-table commit paths so this safety-critical conversion is defined once.
+static unique_ptr<HTTPResponse> SendCommitPost(ClientContext &context, IcebergCatalog &catalog,
+                                               IRCEndpointBuilder &url_builder, HTTPHeaders &headers,
+                                               const string &body) {
+	try {
+		return catalog.auth_handler->Request(RequestType::POST_REQUEST, context, url_builder, headers, body);
+	} catch (std::exception &ex) {
+		ErrorData error(ex);
+		throw IcebergCommitException(IcebergCommitOutcome::UNKNOWN,
+		                             StringUtil::Format("Commit request to '%s' failed at the transport level (outcome "
+		                                                "unknown, not retried blindly): %s",
+		                                                url_builder.GetURLEncoded(), error.RawMessage()));
+	}
+}
+
+//! Throw the right exception for a non-2xx commit response: FATAL keeps the original exception type
+//! so non-retry callers are unaffected; CONFLICT/UNKNOWN throw the retry-classified exception,
+//! honoring any server-supplied Retry-After (e.g. a rate-limited 429/503). Shared by both commit
+//! paths so the classification + Retry-After handling cannot drift between them.
+static void ThrowCommitResponseError(const HTTPResponse &response, const string &message) {
+	auto outcome = ClassifyCommitStatus(response.status);
+	if (outcome == IcebergCommitOutcome::FATAL) {
+		throw InvalidConfigurationException(message);
+	}
+	auto retry_after_ms =
+	    response.HasHeader("Retry-After") ? ParseRetryAfterMs(response.GetHeaderValue("Retry-After")) : -1;
+	throw IcebergCommitException(outcome, message, retry_after_ms);
 }
 
 static IRCEntryLookupStatus CheckVerificationResponse(ClientContext &context, HTTPStatusCode &status) {
@@ -378,26 +413,25 @@ void IRCAPI::CommitMultiTableUpdate(ClientContext &context, IcebergCatalog &cata
 	HTTPHeaders headers(*context.db);
 	headers.Insert("Content-Type", "application/json");
 	LogPostBody(context, url_builder, body);
-	auto response = catalog.auth_handler->Request(RequestType::POST_REQUEST, context, url_builder, headers, body);
+	auto response = SendCommitPost(context, catalog, url_builder, headers, body);
 	if (response->status != HTTPStatusCode::OK_200 && response->status != HTTPStatusCode::NoContent_204) {
 		std::unique_ptr<yyjson_doc, YyjsonDocDeleter> out_doc;
 		yyjson_val *error_obj = ICUtils::GetErrorMessage(response->body, out_doc);
-		if (error_obj == nullptr) {
-			throw InvalidConfigurationException(response->body);
-		}
-		auto error = rest_api_objects::IcebergErrorResponse::FromJSON(error_obj);
-		string stack_trace;
-		for (const auto &str : error._error.stack) {
-			stack_trace.append(str + "\n");
-		}
-		DUCKDB_LOG(context, IcebergLogType, stack_trace);
 
-		// Omit stack from error output
-		error._error.stack = vector<string>();
-		throw InvalidConfigurationException(
-		    "Request to '%s' returned a non-200 status code (%s). \n message: %s\n type: %s\n reason: %s\n",
-		    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), error._error.message, error._error.type,
-		    response->reason);
+		string message = response->body;
+		if (error_obj != nullptr) {
+			auto error = rest_api_objects::IcebergErrorResponse::FromJSON(error_obj);
+			string stack_trace;
+			for (const auto &str : error._error.stack) {
+				stack_trace.append(str + "\n");
+			}
+			DUCKDB_LOG(context, IcebergLogType, stack_trace);
+			message = StringUtil::Format(
+			    "Request to '%s' returned a non-200 status code (%s). \n message: %s\n type: %s\n reason: %s\n",
+			    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), error._error.message,
+			    error._error.type, response->reason);
+		}
+		ThrowCommitResponseError(*response, message);
 	}
 }
 
@@ -412,11 +446,35 @@ void IRCAPI::CommitTableUpdate(ClientContext &context, IcebergCatalog &catalog, 
 	HTTPHeaders headers(*context.db);
 	headers.Insert("Content-Type", "application/json");
 	LogPostBody(context, url_builder, body);
-	auto response = catalog.auth_handler->Request(RequestType::POST_REQUEST, context, url_builder, headers, body);
+	auto response = SendCommitPost(context, catalog, url_builder, headers, body);
 	if (response->status != HTTPStatusCode::OK_200 && response->status != HTTPStatusCode::NoContent_204) {
-		throw InvalidConfigurationException(
-		    "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
-		    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), response->reason, response->body);
+		auto message =
+		    StringUtil::Format("Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
+		                       url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), response->reason,
+		                       response->body);
+		ThrowCommitResponseError(*response, message);
+	}
+
+	//! Success: the Iceberg REST UpdateTable response carries the new LoadTableResult (full committed
+	//! metadata). Refill the per-table cache with it so the next operation reuses it instead of
+	//! issuing a fresh GET -- this is exactly what Java's RESTTableOperations.commit() does via
+	//! updateCurrentMetadata(response). Best-effort: a catalog returning an empty/partial body (or
+	//! 204) must not fail the (already successful) commit, so swallow any parse error and leave the
+	//! cache to be refreshed by the normal GET path. The refill is only consulted when
+	//! max_table_staleness is enabled (otherwise SetOrOverwrite stores it already-expired).
+	try {
+		if (!response->body.empty()) {
+			auto doc = ICUtils::APIResultToDoc(response->body);
+			auto *root = yyjson_doc_get_root(doc.get());
+			if (root) {
+				auto load_result = make_uniq<const rest_api_objects::LoadTableResult>(
+				    rest_api_objects::LoadTableResult::FromJSON(root));
+				auto table_key = IcebergTableInformation::GetTableKey(schema, table);
+				catalog.table_request_cache.SetOrOverwrite(context, table_key, std::move(load_result));
+			}
+		}
+	} catch (std::exception &refill_ex) {
+		// Ignore: commit already succeeded; the cache will be (re)loaded by the normal GET path.
 	}
 }
 

--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/storage/caching_file_system.hpp"
 #include "duckdb/common/types/uuid.hpp"
+#include "duckdb/common/unordered_set.hpp"
 
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
 #include "core/metadata/manifest/iceberg_avro_codec.hpp"
@@ -97,7 +98,14 @@ static void RewriteManifestFile(IcebergManifestListEntry &list_entry, CopyFuncti
 	auto &manifest_entries = list_entry.manifest_entries;
 	auto &table_metadata = commit_state.table_info.table_metadata;
 
-	//! Finally overwrite the input 'manifest_file' with our edited copy
+	//! A rewritten manifest is a NEW file of this snapshot, so write it under a fresh path rather
+	//! than overwriting the carried-over manifest's existing location. Reusing the path would both
+	//! mutate a file still referenced by the parent snapshot and fail with HTTP 412 on retry (the
+	//! object already exists; stores create with If-None-Match). A new UUID per write avoids both.
+	auto &fs = FileSystem::GetFileSystem(commit_state.context);
+	auto manifest_uuid = UUID::ToString(UUID::GenerateRandomUUID());
+	manifest_file.manifest_path = fs.JoinPath(table_metadata.GetMetadataPath(fs), manifest_uuid + "-m0.avro");
+
 	auto manifest_length = manifest_file::WriteToFile(table_metadata, manifest_file, manifest_entries, avro_copy, db,
 	                                                  commit_state.context, commit_state.manifest_avro_codec);
 	manifest_file.manifest_length = manifest_length;
@@ -131,10 +139,21 @@ static IcebergManifestListEntry WriteManifestListEntry(const IcebergTableInforma
                                                        const IcebergManifestListEntry &list_entry,
                                                        CopyFunction &avro_copy, DatabaseInstance &db,
                                                        ClientContext &context, const string &avro_codec) {
-	auto manifest_length = manifest_file::WriteToFile(table_info.table_metadata, list_entry.file,
-	                                                  list_entry.manifest_entries, avro_copy, db, context, avro_codec);
 	IcebergManifestListEntry new_entry(list_entry.file);
 	new_entry.manifest_entries = list_entry.manifest_entries;
+	//! Generate a fresh manifest file path for THIS write. The staged entry's path was minted once
+	//! when the snapshot was assembled; reusing it across commit-retry attempts would re-write the
+	//! same object, which fails with HTTP 412 (Precondition Failed) on stores that create with
+	//! If-None-Match (e.g. S3 Tables / FILE_FLAGS_FILE_CREATE_NEW). A new UUID per attempt makes each
+	//! attempt write a distinct, never-before-seen object. Losing-attempt files are tracked for
+	//! cleanup separately, so this does not leak (and S3-Tables-style catalogs GC them anyway).
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto manifest_uuid = UUID::ToString(UUID::GenerateRandomUUID());
+	new_entry.file.manifest_path =
+	    fs.JoinPath(table_info.table_metadata.GetMetadataPath(fs), manifest_uuid + "-m0.avro");
+
+	auto manifest_length = manifest_file::WriteToFile(table_info.table_metadata, new_entry.file,
+	                                                  new_entry.manifest_entries, avro_copy, db, context, avro_codec);
 	new_entry.file.manifest_length = manifest_length;
 	return new_entry;
 }
@@ -220,6 +239,11 @@ void IcebergAddSnapshot::MergeManifestList(IcebergManifestList &new_manifest_lis
 
 void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &context,
                                       IcebergCommitState &commit_state) const {
+	ApplyTableChanges(db, context, commit_state);
+}
+
+void IcebergAddSnapshot::ApplyTableChanges(DatabaseInstance &db, ClientContext &context,
+                                           IcebergCommitState &commit_state) const {
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);
 	auto &schema = system_catalog.GetSchema(data, DEFAULT_SCHEMA);
@@ -239,7 +263,11 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 	    table_metadata.GetTableProperty("write.manifest.compression-codec"),
 	    commit_state.table_info.catalog.attach_options.allows_deletes);
 
-	const auto snapshot_id = IcebergSnapshot::NewSnapshotId();
+	//! Assign the snapshot id once and keep it stable across retry attempts (see GetSnapshotId). This
+	//! lets a post-ambiguous-failure status-check look for exactly this id in the refreshed table.
+	if (snapshot_id < 0) {
+		snapshot_id = IcebergSnapshot::NewSnapshotId();
+	}
 	const auto sequence_number = commit_state.next_sequence_number++;
 
 	auto &fs = FileSystem::GetFileSystem(context);
@@ -253,6 +281,11 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 
 	//! Construct the snapshot
 	IcebergSnapshot new_snapshot;
+	//! Use the operation the caller declared when staging this change: INSERT =>
+	//! APPEND, DELETE => DELETE, UPDATE/mixed => OVERWRITE. The old code hard-coded OVERWRITE, which
+	//! mislabels a plain append to external incremental readers (Spark/Trino/PyIceberg append scans,
+	//! CDC). The label is informational here -- it never feeds this extension's own read path or the
+	//! retry validation (ValidateRetrySafe keys on the actual delete content, not on this enum).
 	new_snapshot.operation = operation;
 	new_snapshot.snapshot_id = snapshot_id;
 	new_snapshot.sequence_number = sequence_number;
@@ -280,6 +313,13 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 
 		auto new_manifest_list_entry =
 		    WriteManifestListEntry(table_info, manifest_list_entry, avro_copy, db, context, commit_state.manifest_avro_codec);
+		//! Track the file we just physically wrote for cleanup-on-failure. We record it here, before
+		//! the merge below may repack it into a different file: a merged-away manifest is an orphan on
+		//! disk that the post-merge entry list no longer references, so tracking only the final entries
+		//! would leak it on a failed/aborted commit. Over-tracking is safe: cleanup
+		//! only runs for uncommitted tables and only when the catalog allows deletes, and these are all
+		//! freshly-written this-attempt files (never carried-over history).
+		commit_state.written_metadata_paths.push_back(new_manifest_list_entry.file.manifest_path);
 		new_manifest_list.AddNewManifestFile(std::move(new_manifest_list_entry));
 
 		if (table_metadata.iceberg_version >= 3) {
@@ -291,13 +331,27 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 		}
 	}
 
-	//! Physically reorganize the manifest list to bound manifest growth. This is a pure repacking of
-	//! the manifests we just assembled -- it does not change the snapshot's logical added/deleted
-	//! stats (already accumulated above), only how entries are grouped into files.
+	//! Physically reorganize the manifest list to bound manifest growth. This is a
+	//! pure repacking of the manifests we just assembled -- it does not change the snapshot's logical
+	//! added/deleted stats (already accumulated above), only how entries are grouped into files.
 	MergeManifestList(new_manifest_list, snapshot_id, avro_copy, db, commit_state);
 
 	manifest_list::WriteToFile(table_metadata, new_manifest_list, avro_copy, db, context, commit_state.manifest_avro_codec);
 	commit_state.manifests = new_manifest_list.GetManifestListEntries();
+
+	//! Track the remaining metadata files we wrote for cleanup-on-failure. The pre-merge manifests
+	//! were already recorded as they were written (above); here we add the manifest list itself and
+	//! any merge-product manifests (also created by this snapshot, but written during MergeManifestList
+	//! after the loop above). Carried-over manifests belong to history and must never be deleted.
+	//! Dedup against what we already tracked so a surviving-unmerged manifest is not listed twice.
+	commit_state.written_metadata_paths.push_back(manifest_list_path);
+	unordered_set<string> already_tracked(commit_state.written_metadata_paths.begin(),
+	                                       commit_state.written_metadata_paths.end());
+	for (auto &entry : commit_state.manifests) {
+		if (entry.file.added_snapshot_id == snapshot_id && !already_tracked.count(entry.file.manifest_path)) {
+			commit_state.written_metadata_paths.push_back(entry.file.manifest_path);
+		}
+	}
 
 	commit_state.created_snapshots.push_back(new_snapshot);
 	commit_state.latest_snapshot = commit_state.created_snapshots.back();
@@ -308,6 +362,27 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 
 void IcebergAddSnapshot::AddManifestFile(IcebergManifestListEntry &&manifest_file) {
 	manifest_files.push_back(std::move(manifest_file));
+}
+
+int64_t IcebergAddSnapshot::GetSnapshotId() const {
+	return snapshot_id;
+}
+
+void IcebergAddSnapshot::ReassignFirstRowIds(int64_t &next_row_id) {
+	//! Only V3 manifests carry a first_row_id; V2 manifests have none. DELETE manifests never carry
+	//! a first_row_id. Reassign DATA manifests in their staged order so the assignment stays
+	//! contiguous and matches what manifest_list::WriteToFile / the snapshot's first_row_id expect.
+	for (auto &manifest_list_entry : manifest_files) {
+		auto &manifest_file = manifest_list_entry.file;
+		if (manifest_file.content != IcebergManifestContentType::DATA) {
+			continue;
+		}
+		if (!manifest_file.has_first_row_id) {
+			continue;
+		}
+		manifest_file.first_row_id = next_row_id;
+		next_row_id += manifest_file.added_rows_count + manifest_file.existing_rows_count;
+	}
 }
 
 const vector<IcebergManifestListEntry> &IcebergAddSnapshot::GetManifestFiles() const {

--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -10,6 +10,7 @@
 
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
 #include "core/metadata/manifest/iceberg_avro_codec.hpp"
+#include "catalog/rest/api/iceberg_manifest_merge.hpp"
 #include "catalog/rest/iceberg_table_set.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
@@ -38,30 +39,6 @@ static rest_api_objects::TableUpdate CreateAddSnapshotUpdate(const IcebergTableI
 	update.action = "add-snapshot";
 	update.snapshot = snapshot.ToRESTObject(table_info.table_metadata);
 	return table_update;
-}
-
-static IcebergManifestListEntry ScanExistingManifestFile(const IcebergManifestFile &manifest_file,
-                                                         IcebergCommitState &commit_state, int32_t schema_id) {
-	vector<IcebergManifestListEntry> manifest_files;
-	manifest_files.push_back(manifest_file);
-
-	IcebergOptions options;
-	auto &fs = FileSystem::GetFileSystem(commit_state.context);
-	auto &table_metadata = commit_state.table_info.table_metadata;
-
-	IcebergSnapshotScanInfo snapshot_info;
-	snapshot_info.snapshot = commit_state.latest_snapshot;
-	snapshot_info.schema_id = schema_id;
-
-	auto manifest_scan =
-	    AvroScan::ScanManifest(snapshot_info, manifest_files, options, fs, "", table_metadata, commit_state.context);
-	auto manifest_file_reader = make_uniq<manifest_file::ManifestReader>(*manifest_scan);
-
-	while (!manifest_file_reader->Finished()) {
-		manifest_file_reader->Read();
-	}
-
-	return std::move(manifest_files[0]);
 }
 
 static bool ManifestFileNeedsToBeRewritten(IcebergCommitState &commit_state, IcebergManifestListEntry &list_entry,
@@ -137,9 +114,7 @@ void IcebergAddSnapshot::ConstructManifestList(IcebergManifestList &new_manifest
 	}
 
 	for (auto &manifest_list_entry : commit_state.manifests) {
-		auto &existing_manifest_file = manifest_list_entry.file;
-
-		auto scanned_manifest_file = ScanExistingManifestFile(existing_manifest_file, commit_state, schema_id);
+		auto scanned_manifest_file = ScanManifestEntries(manifest_list_entry, commit_state, schema_id);
 		bool needs_rewrite = ManifestFileNeedsToBeRewritten(commit_state, scanned_manifest_file, altered_manifests);
 		if (!needs_rewrite) {
 			new_manifest_list.AddExistingManifestFile(std::move(manifest_list_entry));
@@ -162,6 +137,85 @@ static IcebergManifestListEntry WriteManifestListEntry(const IcebergTableInforma
 	new_entry.manifest_entries = list_entry.manifest_entries;
 	new_entry.file.manifest_length = manifest_length;
 	return new_entry;
+}
+
+//! Physically repack the assembled manifest list to reduce the number of manifest files. DATA and
+//! DELETE manifests are merged independently and never mixed. A manifest is "new in this
+//! transaction" iff it was added by the snapshot we are building (`added_snapshot_id ==
+//! snapshot_id`); the min-count guard only applies to bins containing such a manifest.
+void IcebergAddSnapshot::MergeManifestList(IcebergManifestList &new_manifest_list, int64_t snapshot_id,
+                                           CopyFunction &avro_copy, DatabaseInstance &db,
+                                           IcebergCommitState &commit_state) const {
+	auto config = ManifestMergeConfig::FromTableMetadata(commit_state.table_info.table_metadata);
+	if (!config.enabled) {
+		return;
+	}
+
+	auto &entries = new_manifest_list.GetManifestFilesMutable();
+	if (entries.size() <= 1) {
+		return;
+	}
+
+	//! V3 row lineage: a row's first_row_id is a stable per-row identifier and, per spec, MUST be
+	//! preserved when a manifest is rewritten/merged -- it may never be reassigned. Already-committed
+	//! ("carried-over") manifests have their first_row_id settled, so merging them is safe (each
+	//! merged manifest keeps the minimum first_row_id of the manifests it absorbs). This transaction's
+	//! brand-new data manifests, however, do not yet have per-entry first_row_id materialized -- those
+	//! rows still rely on manifest-level inheritance assigned later in manifest_list::WriteToFile.
+	//! Folding such not-yet-assigned rows into a merged manifest alongside already-assigned rows would
+	//! break the per-manifest inheritance basis. Correctly merging them requires materializing every
+	//! entry's first_row_id before merging, which needs end-to-end V3 row-lineage tests to validate;
+	//! a silent error here corrupts row identity (not just a crash). We therefore leave new V3 data
+	//! manifests unmerged. This costs almost nothing: next commit they are carried-over and become
+	//! eligible, so V3 manifest growth still converges -- it is merely delayed by one commit.
+	//! V2 has no row lineage, so everything is eligible there.
+	const bool is_v3 = commit_state.table_info.table_metadata.iceberg_version >= 3;
+
+	//! Split by content type, tagging each manifest's origin. Manifests excluded from merging are
+	//! kept aside and re-appended unchanged.
+	vector<MergeInputManifest> data_input;
+	vector<MergeInputManifest> delete_input;
+	vector<IcebergManifestListEntry> kept;
+	for (auto &entry : entries) {
+		auto source =
+		    entry.file.added_snapshot_id == snapshot_id ? ManifestSource::NEW_THIS_TRANSACTION : ManifestSource::CARRIED_OVER;
+		//! V3 row lineage only constrains DATA manifests (first_row_id). New DELETE manifests carry no
+		//! first_row_id, so they remain eligible for merging even on V3.
+		if (is_v3 && source == ManifestSource::NEW_THIS_TRANSACTION &&
+		    entry.file.content == IcebergManifestContentType::DATA) {
+			kept.push_back(std::move(entry));
+			continue;
+		}
+		auto &target = entry.file.content == IcebergManifestContentType::DELETE ? delete_input : data_input;
+		target.push_back(MergeInputManifest {std::move(entry), source});
+	}
+
+	auto merged_data = MergeManifests(std::move(data_input), IcebergManifestContentType::DATA, config, avro_copy, db,
+	                                  commit_state, schema_id, snapshot_id);
+	auto merged_delete = MergeManifests(std::move(delete_input), IcebergManifestContentType::DELETE, config, avro_copy,
+	                                    db, commit_state, schema_id, snapshot_id);
+
+	//! Reassemble. A manifest produced by the merge is a brand-new file created by this snapshot, so
+	//! stamp it with the snapshot's sequence number / id while preserving its computed
+	//! min_sequence_number (which reflects the historical entries it absorbed). The merge writes its
+	//! products with a placeholder snapshot id of -1 (see CreateFromEntries call in the merge), which
+	//! distinguishes them from both new and carried-over manifests that pass through unmerged.
+	entries.clear();
+	auto reassemble = [&](vector<IcebergManifestListEntry> &merged) {
+		for (auto &entry : merged) {
+			if (entry.file.added_snapshot_id < 0) {
+				entry.file.added_snapshot_id = snapshot_id;
+				entry.file.sequence_number = new_manifest_list.GetSequenceNumber();
+			}
+			entries.push_back(std::move(entry));
+		}
+	};
+	reassemble(merged_data);
+	reassemble(merged_delete);
+	//! Re-append manifests that were excluded from merging (e.g. V3 new-data manifests) unchanged.
+	for (auto &entry : kept) {
+		entries.push_back(std::move(entry));
+	}
 }
 
 void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -236,6 +290,11 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 			}
 		}
 	}
+
+	//! Physically reorganize the manifest list to bound manifest growth. This is a pure repacking of
+	//! the manifests we just assembled -- it does not change the snapshot's logical added/deleted
+	//! stats (already accumulated above), only how entries are grouped into files.
+	MergeManifestList(new_manifest_list, snapshot_id, avro_copy, db, commit_state);
 
 	manifest_list::WriteToFile(table_metadata, new_manifest_list, avro_copy, db, context, commit_state.manifest_avro_codec);
 	commit_state.manifests = new_manifest_list.GetManifestListEntries();

--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -9,7 +9,10 @@
 #include "duckdb/common/types/uuid.hpp"
 
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
+#include "core/metadata/manifest/iceberg_avro_codec.hpp"
 #include "catalog/rest/iceberg_table_set.hpp"
+#include "catalog/rest/iceberg_catalog.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
 #include "planning/metadata_io/avro/avro_scan.hpp"
 #include "planning/metadata_io/manifest/iceberg_manifest_reader.hpp"
 
@@ -119,7 +122,7 @@ static void RewriteManifestFile(IcebergManifestListEntry &list_entry, CopyFuncti
 
 	//! Finally overwrite the input 'manifest_file' with our edited copy
 	auto manifest_length = manifest_file::WriteToFile(table_metadata, manifest_file, manifest_entries, avro_copy, db,
-	                                                  commit_state.context);
+	                                                  commit_state.context, commit_state.manifest_avro_codec);
 	manifest_file.manifest_length = manifest_length;
 }
 
@@ -152,9 +155,9 @@ void IcebergAddSnapshot::ConstructManifestList(IcebergManifestList &new_manifest
 static IcebergManifestListEntry WriteManifestListEntry(const IcebergTableInformation &table_info,
                                                        const IcebergManifestListEntry &list_entry,
                                                        CopyFunction &avro_copy, DatabaseInstance &db,
-                                                       ClientContext &context) {
+                                                       ClientContext &context, const string &avro_codec) {
 	auto manifest_length = manifest_file::WriteToFile(table_info.table_metadata, list_entry.file,
-	                                                  list_entry.manifest_entries, avro_copy, db, context);
+	                                                  list_entry.manifest_entries, avro_copy, db, context, avro_codec);
 	IcebergManifestListEntry new_entry(list_entry.file);
 	new_entry.manifest_entries = list_entry.manifest_entries;
 	new_entry.file.manifest_length = manifest_length;
@@ -174,6 +177,13 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 	D_ASSERT(!uncommitted_manifest_files.empty());
 
 	auto &table_metadata = commit_state.table_info.table_metadata;
+
+	//! Resolve the manifest Avro codec once for this apply: from write.manifest.compression-codec,
+	//! but forced to uncompressed when the catalog forbids client deletes (compression needs a
+	//! deletable temp file). Every manifest/manifest-list write below uses commit_state.manifest_avro_codec.
+	commit_state.manifest_avro_codec = iceberg_avro_codec::ResolveAvroCodec(
+	    table_metadata.GetTableProperty("write.manifest.compression-codec"),
+	    commit_state.table_info.catalog.attach_options.allows_deletes);
 
 	const auto snapshot_id = IcebergSnapshot::NewSnapshotId();
 	const auto sequence_number = commit_state.next_sequence_number++;
@@ -214,7 +224,8 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 		auto &manifest_file = manifest_list_entry.file;
 		new_snapshot.metrics.AddManifestFile(manifest_file);
 
-		auto new_manifest_list_entry = WriteManifestListEntry(table_info, manifest_list_entry, avro_copy, db, context);
+		auto new_manifest_list_entry =
+		    WriteManifestListEntry(table_info, manifest_list_entry, avro_copy, db, context, commit_state.manifest_avro_codec);
 		new_manifest_list.AddNewManifestFile(std::move(new_manifest_list_entry));
 
 		if (table_metadata.iceberg_version >= 3) {
@@ -226,7 +237,7 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 		}
 	}
 
-	manifest_list::WriteToFile(table_metadata, new_manifest_list, avro_copy, db, context);
+	manifest_list::WriteToFile(table_metadata, new_manifest_list, avro_copy, db, context, commit_state.manifest_avro_codec);
 	commit_state.manifests = new_manifest_list.GetManifestListEntries();
 
 	commit_state.created_snapshots.push_back(new_snapshot);

--- a/src/catalog/rest/api/iceberg_manifest_merge.cpp
+++ b/src/catalog/rest/api/iceberg_manifest_merge.cpp
@@ -1,0 +1,352 @@
+#include "catalog/rest/api/iceberg_manifest_merge.hpp"
+
+#include "duckdb/common/types/uuid.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/map.hpp"
+
+#include "catalog/rest/api/iceberg_table_update.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
+#include "planning/metadata_io/avro/avro_scan.hpp"
+#include "planning/metadata_io/manifest/iceberg_manifest_reader.hpp"
+
+#include <algorithm>
+#include <string>
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Config
+//===--------------------------------------------------------------------===//
+namespace {
+
+constexpr const char *MERGE_ENABLED = "commit.manifest-merge.enabled";
+constexpr const char *MIN_COUNT_TO_MERGE = "commit.manifest.min-count-to-merge";
+constexpr const char *TARGET_SIZE_BYTES = "commit.manifest.target-size-bytes";
+
+//! Aligned with Apache Iceberg Java defaults (the authoritative reference).
+constexpr bool MERGE_ENABLED_DEFAULT = true;
+constexpr idx_t MIN_COUNT_TO_MERGE_DEFAULT = 100;
+constexpr int64_t TARGET_SIZE_BYTES_DEFAULT = 8 * 1024 * 1024;
+
+bool ParseBoolProperty(const string &value, bool fallback) {
+	if (value.empty()) {
+		return fallback;
+	}
+	auto lowered = StringUtil::Lower(value);
+	if (lowered == "true") {
+		return true;
+	}
+	if (lowered == "false") {
+		return false;
+	}
+	return fallback;
+}
+
+template <class T>
+T ParseIntProperty(const string &value, T fallback) {
+	if (value.empty()) {
+		return fallback;
+	}
+	try {
+		auto parsed = std::stoll(value);
+		//! A non-positive threshold is meaningless; fall back rather than disable merging silently.
+		return parsed > 0 ? static_cast<T>(parsed) : fallback;
+	} catch (...) {
+		return fallback;
+	}
+}
+
+} // namespace
+
+ManifestMergeConfig ManifestMergeConfig::FromTableMetadata(const IcebergTableMetadata &metadata) {
+	ManifestMergeConfig config;
+	config.enabled = ParseBoolProperty(metadata.GetTableProperty(MERGE_ENABLED), MERGE_ENABLED_DEFAULT);
+	config.min_count_to_merge =
+	    ParseIntProperty<idx_t>(metadata.GetTableProperty(MIN_COUNT_TO_MERGE), MIN_COUNT_TO_MERGE_DEFAULT);
+	config.target_size_bytes =
+	    ParseIntProperty<int64_t>(metadata.GetTableProperty(TARGET_SIZE_BYTES), TARGET_SIZE_BYTES_DEFAULT);
+	return config;
+}
+
+//===--------------------------------------------------------------------===//
+// Bin-packing (pure logic)
+//===--------------------------------------------------------------------===//
+vector<vector<idx_t>> BinPackManifests(const vector<int64_t> &weights, int64_t target_weight) {
+	//! Mirror Java `ManifestMergeManager`/PyIceberg `ListPacker.pack_end` exactly: first-fit
+	//! bin-packing with lookback=1 over the reversed input, then reverse the result. lookback=1 keeps
+	//! at most one open bin, so manifests are not reordered across distant positions -- this is what
+	//! makes the under-filled bin land on the newest manifests (merged next time) and avoids random
+	//! deletes when data files are later aged off (see Java mergeGroup comment).
+	//!
+	//! PackingIterator semantics: maintain a list of open bins; place an item into the first open bin
+	//! that fits, else open a new bin; whenever the number of open bins exceeds `lookback`, close
+	//! (emit) the oldest open bin (FIFO). At the end, emit the remaining open bins in order.
+	constexpr idx_t LOOKBACK = 1;
+
+	struct OpenBin {
+		vector<idx_t> items;
+		int64_t weight = 0;
+	};
+
+	//! Pack over the reversed input (pack_end).
+	vector<vector<idx_t>> packed; // closed bins, in close order
+	vector<OpenBin> open_bins;
+	for (idx_t rev = weights.size(); rev-- > 0;) {
+		auto weight = weights[rev];
+		OpenBin *target = nullptr;
+		for (auto &b : open_bins) {
+			if (b.weight + weight <= target_weight) {
+				target = &b;
+				break;
+			}
+		}
+		if (target) {
+			target->items.push_back(rev);
+			target->weight += weight;
+		} else {
+			OpenBin b;
+			b.items.push_back(rev);
+			b.weight = weight;
+			open_bins.push_back(std::move(b));
+			if (open_bins.size() > LOOKBACK) {
+				//! Close the oldest open bin (FIFO).
+				packed.push_back(std::move(open_bins.front().items));
+				open_bins.erase(open_bins.begin());
+			}
+		}
+	}
+	for (auto &b : open_bins) {
+		packed.push_back(std::move(b.items));
+	}
+
+	//! pack_end: reverse each bin's items and the list of bins to restore original ascending order.
+	vector<vector<idx_t>> result;
+	result.reserve(packed.size());
+	for (idx_t i = packed.size(); i-- > 0;) {
+		auto &bin = packed[i];
+		std::reverse(bin.begin(), bin.end());
+		result.push_back(std::move(bin));
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Merge decision
+//===--------------------------------------------------------------------===//
+bool ShouldMergeBin(const vector<MergeInputManifest> &input, const vector<idx_t> &bin, idx_t min_count_to_merge) {
+	if (bin.size() <= 1) {
+		return false;
+	}
+	bool has_new = false;
+	for (auto idx : bin) {
+		if (input[idx].source == ManifestSource::NEW_THIS_TRANSACTION) {
+			has_new = true;
+			break;
+		}
+	}
+	//! A bin containing a freshly-created manifest is only merged once it reaches the threshold,
+	//! so small new manifests are not repeatedly rewritten together with large old ones.
+	if (has_new && bin.size() < min_count_to_merge) {
+		return false;
+	}
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Merge execution
+//===--------------------------------------------------------------------===//
+
+//! Read the manifest_entries of a manifest from its Avro file, reusing the vectorized manifest
+//! reader. Returns the list entry with `manifest_entries` populated. Shared by the delete-rewrite
+//! path and the merge path so both load entries identically.
+IcebergManifestListEntry ScanManifestEntries(const IcebergManifestListEntry &list_entry,
+                                             IcebergCommitState &commit_state, int32_t schema_id) {
+	vector<IcebergManifestListEntry> manifest_files;
+	manifest_files.push_back(list_entry);
+
+	IcebergOptions options;
+	auto &fs = FileSystem::GetFileSystem(commit_state.context);
+	auto &table_metadata = commit_state.table_info.table_metadata;
+
+	IcebergSnapshotScanInfo snapshot_info;
+	snapshot_info.snapshot = commit_state.latest_snapshot;
+	snapshot_info.schema_id = schema_id;
+
+	auto manifest_scan =
+	    AvroScan::ScanManifest(snapshot_info, manifest_files, options, fs, "", table_metadata, commit_state.context);
+	auto reader = make_uniq<manifest_file::ManifestReader>(*manifest_scan);
+	while (!reader->Finished()) {
+		reader->Read();
+	}
+	return std::move(manifest_files[0]);
+}
+
+namespace {
+
+//! Merge one spec-homogeneous bin into a single new manifest. Returns the new list entry.
+IcebergManifestListEntry MergeBin(const vector<MergeInputManifest> &input, const vector<idx_t> &bin,
+                                  IcebergManifestContentType content, CopyFunction &avro_copy, DatabaseInstance &db,
+                                  IcebergCommitState &commit_state, int32_t schema_id, int32_t partition_spec_id,
+                                  int64_t snapshot_id) {
+	auto &table_metadata = commit_state.table_info.table_metadata;
+	const bool is_v3 = table_metadata.iceberg_version >= 3;
+
+	//! Gather every entry from the bin's manifests, preserving status and historical sequence
+	//! numbers. New (ADDED) entries keep inherited sequence numbers; everything else keeps its
+	//! materialized historical value.
+	vector<IcebergManifestEntry> merged_entries;
+	//! Merging is a pure physical repack: it creates no new rows, so V3 row lineage must be
+	//! preserved, not reassigned. The first_row_id is a manifest-file-level value, so the merged
+	//! manifest's first_row_id is the smallest first_row_id among the manifests it absorbs.
+	//! This uses file-level metadata only -- no entry read required.
+	bool has_first_row_id = false;
+	int64_t min_first_row_id = 0;
+	//! The merged manifest's min_sequence_number must be the smallest data_sequence_number among its
+	//! entries. CreateFromEntries cannot compute this (it derives it from the manifest-file sequence
+	//! number, which is a placeholder here), so we track the true minimum and set it ourselves before
+	//! the manifest is written / handed to AddNewManifestFile. If left as the placeholder, scan
+	//! planning's `seq > X` pruning would mis-judge which historical data the manifest can contain.
+	bool has_min_seq = false;
+	int64_t min_seq = 0;
+	for (auto idx : bin) {
+		auto &member = input[idx].entry;
+		const bool carried_over = input[idx].source == ManifestSource::CARRIED_OVER;
+		if (is_v3 && member.file.has_first_row_id) {
+			if (!has_first_row_id || member.file.first_row_id < min_first_row_id) {
+				min_first_row_id = member.file.first_row_id;
+				has_first_row_id = true;
+			}
+		}
+		auto loaded = member.manifest_entries.empty() ? ScanManifestEntries(member, commit_state, schema_id) : member;
+		for (auto &entry : loaded.manifest_entries) {
+			//! DELETED entries: only deletes made by THIS snapshot are carried into the new manifest;
+			//! deletes from earlier snapshots are dropped (they already took effect and would only bloat
+			//! the merged manifest forever). Mirrors Java ManifestMergeManager.createManifest.
+			if (entry.status == IcebergManifestEntryStatusType::DELETED) {
+				if (entry.HasSnapshotId() && entry.GetSnapshotId() == snapshot_id) {
+					merged_entries.push_back(std::move(entry));
+				}
+				continue;
+			}
+			//! Entries absorbed from an already-committed manifest are EXISTING in the new snapshot:
+			//! demote their ADDED status (the file was added by an earlier snapshot, not this one) so
+			//! the merged manifest's added/existing counts and the snapshot summary stay correct.
+			//! Their historical sequence numbers are preserved by GetSequenceNumber.
+			//! Entries from this transaction's own new manifest keep ADDED (genuinely new this commit).
+			if (carried_over && entry.status == IcebergManifestEntryStatusType::ADDED) {
+				auto seq = entry.GetSequenceNumber(member.file);
+				auto file_seq = entry.GetFileSequenceNumber(member.file);
+				entry.SetSequenceNumber(seq);
+				entry.SetFileSequenceNumber(file_seq);
+				entry.status = IcebergManifestEntryStatusType::EXISTING;
+			}
+			//! Live entries determine the manifest's minimum data sequence number.
+			auto entry_seq = entry.GetSequenceNumber(member.file);
+			if (!has_min_seq || entry_seq < min_seq) {
+				min_seq = entry_seq;
+				has_min_seq = true;
+			}
+			merged_entries.push_back(std::move(entry));
+		}
+	}
+
+	//! A bin can collapse to nothing (e.g. every entry was a DELETED-by-an-earlier-snapshot entry and
+	//! was filtered out above). An empty manifest must never be written -- WriteToFile asserts on it
+	//! (and an empty Avro manifest is meaningless). Return an entry with no manifest_entries so the
+	//! caller drops it; do this BEFORE CreateFromEntries/WriteToFile.
+	if (merged_entries.empty()) {
+		IcebergManifestListEntry empty {IcebergManifestFile {""}};
+		return empty;
+	}
+
+	//! CreateFromEntries computes all counts, min_sequence_number and the partition field summary
+	//! from the entries; pass the bin's own spec id so the summary is computed against the correct
+	//! (possibly historical) spec, not the table default. We pass a throwaway row-id
+	//! counter so the global one is not advanced, then restore the lineage-preserving value below.
+	int64_t scratch_row_id = 0;
+	auto result = IcebergManifestListEntry::CreateFromEntries(FileSystem::GetFileSystem(commit_state.context),
+	                                                          /*snapshot_id*/ -1, /*sequence_number*/ 0, table_metadata,
+	                                                          content, std::move(merged_entries), scratch_row_id,
+	                                                          partition_spec_id);
+	//! first_row_id applies to DATA manifests only; a DELETE manifest's first_row_id is always null.
+	if (is_v3 && content == IcebergManifestContentType::DATA) {
+		result.file.has_first_row_id = has_first_row_id;
+		result.file.first_row_id = has_first_row_id ? min_first_row_id : 0;
+	} else {
+		result.file.has_first_row_id = false;
+	}
+	//! Set the true minimum data sequence number from the absorbed entries (see above). Done before
+	//! WriteToFile / AddNewManifestFile so scan-planning pruning sees the correct lower bound.
+	if (has_min_seq) {
+		result.file.has_min_sequence_number = true;
+		result.file.min_sequence_number = min_seq;
+	}
+
+	auto manifest_length = manifest_file::WriteToFile(table_metadata, result.file, result.manifest_entries, avro_copy,
+	                                                  db, commit_state.context, commit_state.manifest_avro_codec);
+	result.file.manifest_length = manifest_length;
+	return result;
+}
+
+} // namespace
+
+vector<IcebergManifestListEntry> MergeManifests(vector<MergeInputManifest> &&input, IcebergManifestContentType content,
+                                                const ManifestMergeConfig &config, CopyFunction &avro_copy,
+                                                DatabaseInstance &db, IcebergCommitState &commit_state,
+                                                int32_t schema_id, int64_t snapshot_id) {
+	vector<IcebergManifestListEntry> result;
+	if (!config.enabled || input.size() <= 1) {
+		for (auto &member : input) {
+			result.push_back(std::move(member.entry));
+		}
+		return result;
+	}
+
+	//! Group by partition spec id: only manifests with the same spec may be merged together.
+	map<int32_t, vector<idx_t>> by_spec;
+	for (idx_t i = 0; i < input.size(); i++) {
+		by_spec[input[i].entry.file.partition_spec_id].push_back(i);
+	}
+
+	for (auto &spec_group : by_spec) {
+		auto spec_id = spec_group.first;
+		auto &group_indices = spec_group.second;
+
+		//! Bin-pack using manifest-file-level lengths only (no entries read yet -- decide first, read
+		//! later). Indices in `bins` are into `group_indices`.
+		vector<int64_t> weights;
+		weights.reserve(group_indices.size());
+		for (auto idx : group_indices) {
+			weights.push_back(input[idx].entry.file.manifest_length);
+		}
+		auto bins = BinPackManifests(weights, config.target_size_bytes);
+
+		for (auto &local_bin : bins) {
+			//! Translate local (group) indices back to global input indices.
+			vector<idx_t> bin;
+			bin.reserve(local_bin.size());
+			for (auto local : local_bin) {
+				bin.push_back(group_indices[local]);
+			}
+
+			if (!ShouldMergeBin(input, bin, config.min_count_to_merge)) {
+				for (auto idx : bin) {
+					result.push_back(std::move(input[idx].entry));
+				}
+				continue;
+			}
+
+			auto merged = MergeBin(input, bin, content, avro_copy, db, commit_state, schema_id, spec_id, snapshot_id);
+			//! A bin can collapse to nothing (e.g. all entries were deleted and filtered out); never
+			//! write or reference an empty manifest.
+			if (merged.manifest_entries.empty()) {
+				continue;
+			}
+			result.push_back(std::move(merged));
+		}
+	}
+	return result;
+}
+
+} // namespace duckdb

--- a/src/catalog/rest/api/iceberg_retry.cpp
+++ b/src/catalog/rest/api/iceberg_retry.cpp
@@ -1,0 +1,129 @@
+#include "catalog/rest/api/iceberg_retry.hpp"
+
+#include "core/metadata/iceberg_table_metadata.hpp"
+
+#include <string>
+
+namespace duckdb {
+
+namespace {
+
+constexpr const char *NUM_RETRIES = "commit.retry.num-retries";
+constexpr const char *MIN_WAIT_MS = "commit.retry.min-wait-ms";
+constexpr const char *MAX_WAIT_MS = "commit.retry.max-wait-ms";
+constexpr const char *TOTAL_WAIT_MS = "commit.retry.total-timeout-ms";
+
+constexpr idx_t NUM_RETRIES_DEFAULT = 4;
+constexpr int64_t MIN_WAIT_MS_DEFAULT = 100;
+constexpr int64_t MAX_WAIT_MS_DEFAULT = 60 * 1000;
+constexpr int64_t TOTAL_WAIT_MS_DEFAULT = 30 * 60 * 1000;
+
+template <class T>
+T ParseInt(const string &value, T fallback, bool allow_zero) {
+	if (value.empty()) {
+		return fallback;
+	}
+	try {
+		auto parsed = std::stoll(value);
+		if (parsed < 0 || (parsed == 0 && !allow_zero)) {
+			return fallback;
+		}
+		return static_cast<T>(parsed);
+	} catch (...) {
+		return fallback;
+	}
+}
+
+} // namespace
+
+IcebergRetryConfig IcebergRetryConfig::FromTableMetadata(const IcebergTableMetadata &metadata) {
+	IcebergRetryConfig config;
+	//! num-retries may legitimately be 0 (no retries, single attempt).
+	config.num_retries = ParseInt<idx_t>(metadata.GetTableProperty(NUM_RETRIES), NUM_RETRIES_DEFAULT, true);
+	config.min_wait_ms = ParseInt<int64_t>(metadata.GetTableProperty(MIN_WAIT_MS), MIN_WAIT_MS_DEFAULT, false);
+	config.max_wait_ms = ParseInt<int64_t>(metadata.GetTableProperty(MAX_WAIT_MS), MAX_WAIT_MS_DEFAULT, false);
+	config.total_wait_ms = ParseInt<int64_t>(metadata.GetTableProperty(TOTAL_WAIT_MS), TOTAL_WAIT_MS_DEFAULT, false);
+	//! Guard against a misconfigured table where min > max.
+	if (config.min_wait_ms > config.max_wait_ms) {
+		config.min_wait_ms = config.max_wait_ms;
+	}
+	return config;
+}
+
+IcebergRetryConfig IcebergRetryConfig::MostLenient(const IcebergRetryConfig &other) const {
+	//! Multiple tables committed in one atomic transaction share a single retry loop. Take the most
+	//! retry-tolerant policy so no table's (more permissive) configuration is silently dropped: the
+	//! larger num-retries / max-wait / total-timeout, and the smaller min-wait.
+	IcebergRetryConfig merged;
+	merged.num_retries = MaxValue<idx_t>(num_retries, other.num_retries);
+	merged.min_wait_ms = MinValue<int64_t>(min_wait_ms, other.min_wait_ms);
+	merged.max_wait_ms = MaxValue<int64_t>(max_wait_ms, other.max_wait_ms);
+	merged.total_wait_ms = MaxValue<int64_t>(total_wait_ms, other.total_wait_ms);
+	//! Preserve the min<=max invariant FromTableMetadata guarantees (both inputs satisfy it, but the
+	//! cross-table min/max combination must too).
+	if (merged.min_wait_ms > merged.max_wait_ms) {
+		merged.min_wait_ms = merged.max_wait_ms;
+	}
+	return merged;
+}
+
+int64_t IcebergRetryConfig::BackoffMs(idx_t attempt) const {
+	//! min_wait * 2^attempt, clamped to max_wait. The doubling is guarded against signed-int64
+	//! overflow: table properties are user-supplied, so a large min/max-wait must not trigger UB.
+	//! Once `wait` would exceed max_wait_ms after doubling, we are already going to clamp anyway.
+	int64_t wait = min_wait_ms;
+	for (idx_t i = 0; i < attempt && wait < max_wait_ms; i++) {
+		if (wait > max_wait_ms / 2) {
+			//! Doubling would reach/exceed max_wait_ms (and could overflow); clamp and stop.
+			wait = max_wait_ms;
+			break;
+		}
+		wait *= 2;
+	}
+	if (wait > max_wait_ms) {
+		wait = max_wait_ms;
+	}
+	return wait;
+}
+
+int64_t IcebergRetryConfig::BackoffMsWithJitter(idx_t attempt, double unit_random) const {
+	auto base = BackoffMs(attempt);
+	if (base <= 0) {
+		return 0;
+	}
+	//! Clamp the random fraction defensively, then scale: result in [0, base]. Full jitter spreads
+	//! retries uniformly across the window so a herd of concurrent committers does not re-collide.
+	if (unit_random < 0.0) {
+		unit_random = 0.0;
+	} else if (unit_random > 1.0) {
+		unit_random = 1.0;
+	}
+	return static_cast<int64_t>(static_cast<double>(base) * unit_random);
+}
+
+int64_t IcebergRetryConfig::DecorrelatedBackoffMs(int64_t prev_sleep_ms, double unit_random) const {
+	if (unit_random < 0.0) {
+		unit_random = 0.0;
+	} else if (unit_random > 1.0) {
+		unit_random = 1.0;
+	}
+	//! Lower bound is min_wait; upper bound is prev_sleep*3, both clamped to max_wait. Guard the *3
+	//! against int64 overflow (prev_sleep is bounded by max_wait, which is user-supplied).
+	int64_t lo = min_wait_ms;
+	int64_t hi;
+	if (prev_sleep_ms > max_wait_ms / 3) {
+		hi = max_wait_ms;
+	} else {
+		hi = prev_sleep_ms * 3;
+	}
+	if (hi > max_wait_ms) {
+		hi = max_wait_ms;
+	}
+	if (hi < lo) {
+		hi = lo; // degenerate config (min > max already normalized in FromTableMetadata, but be safe)
+	}
+	int64_t span = hi - lo;
+	return lo + static_cast<int64_t>(static_cast<double>(span) * unit_random);
+}
+
+} // namespace duckdb

--- a/src/catalog/rest/api/iceberg_table_update.cpp
+++ b/src/catalog/rest/api/iceberg_table_update.cpp
@@ -6,10 +6,11 @@ namespace duckdb {
 
 IcebergCommitState::IcebergCommitState(const IcebergTableInformation &table_info, ClientContext &context)
     : table_info(table_info), context(context) {
-	next_sequence_number = table_info.table_metadata.last_sequence_number + 1;
-	if (table_info.table_metadata.has_next_row_id) {
-		next_row_id = table_info.table_metadata.next_row_id;
-	}
+	//! Baseline (sequence number / row id) is taken from the current table metadata. A retry
+	//! reconstructs IcebergCommitState from the refreshed metadata, so this runs once per attempt.
+	auto &metadata = table_info.table_metadata;
+	next_sequence_number = metadata.last_sequence_number + 1;
+	next_row_id = metadata.has_next_row_id ? metadata.next_row_id : 0;
 }
 
 IcebergTableUpdate::IcebergTableUpdate(IcebergTableUpdateType type, const IcebergTableInformation &table_info)

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -519,6 +519,13 @@ optional_ptr<CatalogEntry> IcebergTableInformation::GetLatestSchema(ClientContex
 	return GetSchemaVersion(context, nullptr);
 }
 
+optional_ptr<CatalogEntry> IcebergTableInformation::GetCurrentSchemaEntry() {
+	//! No snapshot-isolation rewind: resolve the entry for the current metadata's schema directly.
+	//! Used by the commit path, which always operates against the latest (refreshed) metadata.
+	D_ASSERT(!schema_versions.empty());
+	return schema_versions[table_metadata.GetCurrentSchemaId()].get();
+}
+
 string IcebergTableInformation::GetTableKey(const vector<string> &namespace_items, const string &table_name) {
 	if (namespace_items.empty()) {
 		return table_name;

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/main/client_data.hpp"
 #include "yyjson.hpp"
 
+#include "duckdb/common/multi_file/multi_file_reader.hpp"
 #include "planning/metadata_io/manifest/iceberg_manifest_reader.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
@@ -24,7 +25,14 @@
 #include "planning/metadata_io/avro/avro_scan.hpp"
 #include "iceberg_logging.hpp"
 #include "catalog/rest/api/table_update.hpp"
+#include "catalog/rest/api/iceberg_commit_exceptions.hpp"
+#include "catalog/rest/api/iceberg_retry.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_update.hpp"
+
+#include <thread>
+#include <chrono>
+#include <random>
+#include <algorithm>
 
 namespace duckdb {
 
@@ -336,8 +344,11 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 
 		for (auto &update : transaction_data.updates) {
 			if (update->type == IcebergTableUpdateType::ADD_SNAPSHOT) {
-				// we need to recreate the keys in the current context.
-				auto &ic_table_entry = table_info.GetLatestSchema(context)->Cast<IcebergTableEntry>();
+				// we need to recreate the keys in the current context. Use the CURRENT schema (no
+				// read-time snapshot-isolation rewind): a commit always targets the latest metadata,
+				// and the isolation path would mis-resolve / error (metadata-log) against a concurrent
+				// writer's fresher metadata during retry.
+				auto &ic_table_entry = table_info.GetCurrentSchemaEntry()->Cast<IcebergTableEntry>();
 				ic_table_entry.PrepareIcebergScanFromEntry(context);
 			}
 			update->CreateUpdate(db, context, commit_state);
@@ -379,6 +390,13 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 		if (transaction_data.set_schema_id) {
 			SetCurrentSchema update(table_info);
 			update.CreateUpdate(db, context, commit_state);
+		}
+
+		//! Carry the metadata files written this attempt over to the (persistent) transaction data so
+		//! CleanupFiles can delete them if the commit ultimately fails. Accumulates across retries:
+		//! each discarded attempt's manifests/manifest-lists are recorded and cleaned on abort.
+		for (auto &path : commit_state.written_metadata_paths) {
+			transaction_data.written_metadata_paths.push_back(std::move(path));
 		}
 
 		info.table_requests.emplace(updated_table.first, transaction.table_changes.size());
@@ -429,6 +447,19 @@ void IcebergTransaction::Commit() {
 			};
 		}
 		DoSchemaDeletes(*temp_con_context);
+	} catch (IcebergCommitException &ex) {
+		//! When the commit outcome is UNKNOWN (e.g. timeout / 5xx) the server may have applied the
+		//! commit. Deleting our data files would then corrupt the committed snapshot, so we must NOT
+		//! clean up -- surface the error and let an orphan-file maintenance job handle anything that
+		//! truly did not land. CONFLICT/FATAL are definite non-commits, so the
+		//! normal cleanup applies.
+		ErrorData error(ex);
+		if (ex.outcome != IcebergCommitOutcome::UNKNOWN) {
+			CleanupFiles();
+		}
+		DropSecrets(*temp_con_context);
+		temp_con.Rollback();
+		error.Throw("Failed to commit Iceberg transaction: ");
 	} catch (std::exception &ex) {
 		ErrorData error(ex);
 		CleanupFiles();
@@ -444,6 +475,422 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 	if (!alter_update.HasUpdates()) {
 		return;
 	}
+
+	//! Optimistic-concurrency commit. The whole transaction commit is the retry unit: on a
+	//! conflict we reload each table's metadata, regenerate manifests/snapshots against the refreshed
+	//! parent, and re-submit, with exponential backoff, up to commit.retry.num-retries. When the
+	//! transaction commits multiple tables atomically they share this one loop, so fold every table's
+	//! commit.retry.* into the most lenient policy rather than honoring an arbitrary "first" table.
+	IcebergRetryConfig retry_config {0, 100, 60000, 1800000};
+	bool have_config = false;
+	for (auto &it : alter_update.updated_tables) {
+		auto table_config = IcebergRetryConfig::FromTableMetadata(it.second.table_metadata);
+		retry_config = have_config ? retry_config.MostLenient(table_config) : table_config;
+		have_config = true;
+	}
+
+	//! Cap the cumulative time spent across retries (commit.retry.total-timeout-ms), mirroring Java.
+	auto retry_start = std::chrono::steady_clock::now();
+	//! Per-commit RNG for backoff jitter. Seeded from a real entropy source + this object's address
+	//! so thousands of concurrent writers (each its own process/thread) draw independent jitter and
+	//! do not wake in lockstep to re-collide.
+	std::mt19937_64 jitter_rng(std::random_device {}() ^
+	                           static_cast<uint64_t>(reinterpret_cast<uintptr_t>(this)) ^
+	                           static_cast<uint64_t>(
+	                               std::chrono::steady_clock::now().time_since_epoch().count()));
+	std::uniform_real_distribution<double> jitter_dist(0.0, 1.0);
+	//! Decorrelated-jitter state: starts at min_wait so the first retries are tight, then widens.
+	int64_t prev_sleep_ms = retry_config.min_wait_ms;
+
+	for (idx_t attempt = 0;; attempt++) {
+		try {
+			SubmitTableUpdates(alter_update, context);
+			break;
+		} catch (IcebergCommitException &ex) {
+			if (ex.outcome == IcebergCommitOutcome::UNKNOWN) {
+				//! Ambiguous outcome (timeout / 5xx): the commit may or may not have landed. Re-load
+				//! the table(s) and look for our stable snapshot id(s) to resolve it deterministically.
+				switch (CheckCommitStatus(alter_update, context)) {
+				case StatusCheckResult::ALL_COMMITTED:
+					//! It actually committed; treat as success.
+					for (auto &it : alter_update.updated_tables) {
+						alter_update.committed_tables.insert(it.first);
+					}
+					goto committed;
+				case StatusCheckResult::NONE_COMMITTED:
+					//! Provably not committed: fall through to the CONFLICT-style retry path below.
+					break;
+				case StatusCheckResult::UNKNOWN:
+					//! Cannot prove success or failure -> surface without cleaning up any files.
+					throw;
+				}
+			} else if (ex.outcome != IcebergCommitOutcome::CONFLICT) {
+				//! FATAL: definite, non-retryable failure -> abort.
+				throw;
+			}
+			if (attempt >= retry_config.num_retries) {
+				throw;
+			}
+			//! Reload metadata and reset per-table apply state. If no table's parent actually moved,
+			//! retrying would hit the same conflict, so stop and surface it.
+			if (!RefreshForRetry(alter_update, context)) {
+				throw;
+			}
+			//! Decide how long to wait before the next attempt. Prefer a server-supplied Retry-After
+			//! (e.g. a rate-limited 429/503): honoring it avoids hammering a server earlier than it
+			//! asked, which is exactly what relieves contention under a herd of concurrent writers.
+			//! Cap it at max_wait_ms so a hostile/huge value cannot stall the writer. With no
+			//! Retry-After, use decorrelated jitter: tight (near min_wait) for the first retries -- the
+			//! refresh+recommit window after a conflict is short, so retrying quickly usually wins --
+			//! widening only as repeated failures accumulate, which is when a herd needs spreading.
+			int64_t wait_ms;
+			if (ex.retry_after_ms >= 0) {
+				wait_ms = std::min(ex.retry_after_ms, retry_config.max_wait_ms);
+			} else {
+				wait_ms = retry_config.DecorrelatedBackoffMs(prev_sleep_ms, jitter_dist(jitter_rng));
+				prev_sleep_ms = wait_ms;
+			}
+			//! Enforce the total retry-time budget against the wait we are about to perform: if it
+			//! would exceed commit.retry.total-timeout-ms (measured from the first attempt), stop
+			//! instead of sleeping past the budget. Compare without adding (both values are
+			//! user/server-influenced and could overflow int64 if summed). Like Java's
+			//! Tasks.runTaskWithRetry, the budget only aborts *after* at least one retry (attempt > 0):
+			//! a misconfigured tiny total-timeout must not turn the very first conflict into a hard
+			//! failure that never retries at all.
+			auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+			                      std::chrono::steady_clock::now() - retry_start)
+			                      .count();
+			if (attempt > 0 && (wait_ms > retry_config.total_wait_ms ||
+			                    elapsed_ms > retry_config.total_wait_ms - wait_ms)) {
+				throw;
+			}
+			std::this_thread::sleep_for(std::chrono::milliseconds(wait_ms));
+		}
+	}
+committed:
+
+	//! NOTE: the per-table metadata cache is refreshed by the commit functions themselves, which
+	//! refill it from the commit response's LoadTableResult (the just-committed metadata). That is
+	//! strictly better than expiring it here (which would force the next operation to GET) -- the
+	//! next read/insert reuses the fresh post-commit metadata, mirroring Java's updateCurrentMetadata.
+	DropSecrets(context);
+}
+
+//! Reset every table's per-attempt apply state ahead of a retry, and advance its metadata to the
+//! latest committed state by re-loading it from the catalog. Returns true if every uncommitted table
+//! was successfully refreshed (so a retry can proceed); false only if a table could not be reloaded
+//! at all (then retrying is pointless and we surface the conflict).
+//!
+//! NOTE: we deliberately do NOT require the refreshed snapshot id to have *advanced*. Under heavy
+//! concurrency (e.g. thousands of writers appending to one table) a CONFLICT proves someone moved
+//! the ref, but a freshly-loaded snapshot can still read as unchanged due to catalog read-replica lag
+//! or caching. Refusing to retry in that case (the old behavior) would spuriously abort a writer that
+//! should just try again. The server-side assert-ref-snapshot-id on the next attempt is the real
+//! correctness guard: if nothing truly moved, the next attempt simply succeeds; if it did, we either
+//! succeed against the new parent or conflict again and keep retrying within the configured budget.
+//!
+//! This is the optimistic-concurrency re-base: we fetch fresh table metadata, re-point the
+//! transaction's view of the table at it (keeping our pending data files / transaction_data), and
+//! drop cached state so the next apply regenerates manifests/snapshot against the new parent. The
+//! commit happens on a dedicated commit-time connection, so re-pointing at the newest metadata here
+//! is correct rather than a snapshot-isolation violation.
+bool IcebergTransaction::RefreshForRetry(IcebergTransactionAlterUpdate &alter_update, ClientContext &context) {
+	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
+	for (auto &it : alter_update.updated_tables) {
+		auto &table_info = it.second;
+		if (!table_info.transaction_data) {
+			continue;
+		}
+		if (alter_update.committed_tables.count(it.first)) {
+			//! Already committed in a previous (single-table fallback) attempt; do not re-apply.
+			continue;
+		}
+
+		//! Fetch the latest metadata for this table.
+		auto &schema = table_info.schema;
+		auto load_result = IRCAPI::GetTable(context, ic_catalog, schema, table_info.name);
+		if (load_result.has_error) {
+			//! Cannot refresh -> cannot safely retry; let the caller surface the conflict.
+			return false;
+		}
+
+		//! Re-point this table at the freshly loaded metadata. Keep schema versions (they were set
+		//! up for this transaction); only the metadata/snapshot baseline moves forward.
+		table_info.InitializeFromLoadTableResult(*load_result.result_, false);
+
+		//! Delete the manifest / manifest-list files written by the attempt that just hit a CONFLICT.
+		//! A 409 is a definite non-commit, so these are guaranteed orphans -- removing them now avoids
+		//! leaking a losing attempt's metadata (the data files are kept; they are reused next attempt).
+		//! Skip when the catalog manages its own GC (allows_deletes == false).
+		auto &written = table_info.transaction_data->written_metadata_paths;
+		if (catalog.attach_options.allows_deletes && !written.empty()) {
+			auto &fs = FileSystem::GetFileSystem(context);
+			for (auto &path : written) {
+				if (fs.TryRemoveFile(path)) {
+					DUCKDB_LOG(context, IcebergLogType,
+					           "Iceberg retry cleanup, deleted losing-attempt metadata file: '%s'", path);
+				}
+			}
+		}
+		written.clear();
+
+		//! Drop cached parent manifest list / row-id baseline so the next apply re-reads them from
+		//! the refreshed snapshot, and refresh the catalog cache entry. Pass the live commit-time
+		//! context: the re-read resolves storage secrets, which needs an active transaction (the
+		//! transaction_data's own context, captured during the operator, is not active here).
+		table_info.transaction_data->RefreshForRetry(context);
+		ic_catalog.table_request_cache.Expire(context, it.first);
+
+		//! For DELETE/OVERWRITE, verify the data files we target still exist in the refreshed parent;
+		//! a concurrent removal makes a retry unsafe and throws (non-retryable). Done after the parent
+		//! manifest list was re-read above so it validates against the latest committed state.
+		ValidateRetrySafe(table_info, context);
+	}
+	//! Every uncommitted table refreshed successfully -> a retry can proceed.
+	return true;
+}
+
+//! Resolve an ambiguous (UNKNOWN) commit outcome by re-loading every uncommitted table and checking
+//! whether this transaction's stable snapshot id(s) are now present. Mirrors Java's status-check
+//! (`commit.status-check.*`), adapted to REST: we look for our own snapshot ids rather than a
+//! metadata-location, because this extension does not own metadata-file writing.
+//!
+//! ALL_COMMITTED: every uncommitted table has all of its pending snapshot ids present -> the commit
+//! actually landed despite the ambiguous transport failure. NONE_COMMITTED: no table has any of its
+//! ids -> the server provably did not apply anything, so the attempt can be retried as a conflict.
+//! UNKNOWN: a mix (or a load failure) -> we genuinely cannot tell; surface it and clean nothing.
+IcebergTransaction::StatusCheckResult
+IcebergTransaction::CheckCommitStatus(IcebergTransactionAlterUpdate &alter_update, ClientContext &context) {
+	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
+	idx_t expected = 0;  // pending snapshot ids across all uncommitted tables
+	idx_t found = 0;     // how many of them are present in the refreshed metadata
+
+	for (auto &it : alter_update.updated_tables) {
+		auto &table_info = it.second;
+		if (!table_info.transaction_data) {
+			continue;
+		}
+		if (alter_update.committed_tables.count(it.first)) {
+			continue;
+		}
+		auto &alters = table_info.transaction_data->alters;
+		if (alters.empty()) {
+			continue;
+		}
+
+		//! Re-load the latest committed metadata for this table.
+		APIResult<unique_ptr<const rest_api_objects::LoadTableResult>> load_result;
+		try {
+			load_result = IRCAPI::GetTable(context, ic_catalog, table_info.schema, table_info.name);
+		} catch (std::exception &) {
+			//! A transport-level failure here (GetTable throws rather than setting has_error) means we
+			//! still cannot determine whether the commit landed -> stay UNKNOWN so the caller surfaces
+			//! the ambiguity and never deletes possibly-committed data files.
+			return StatusCheckResult::UNKNOWN;
+		}
+		if (load_result.has_error) {
+			//! Cannot determine the table state -> cannot prove success or failure.
+			return StatusCheckResult::UNKNOWN;
+		}
+		auto refreshed = IcebergTableMetadata::FromTableMetadata(load_result.result_->metadata);
+
+		for (auto &add_snapshot : alters) {
+			auto sid = add_snapshot.get().GetSnapshotId();
+			expected++;
+			if (sid >= 0 && refreshed.snapshots.count(sid)) {
+				found++;
+			}
+		}
+	}
+
+	if (expected == 0) {
+		//! Nothing was pending (should not happen on this path); treat as not committed.
+		return StatusCheckResult::NONE_COMMITTED;
+	}
+	if (found == expected) {
+		return StatusCheckResult::ALL_COMMITTED;
+	}
+	if (found == 0) {
+		return StatusCheckResult::NONE_COMMITTED;
+	}
+	return StatusCheckResult::UNKNOWN;
+}
+
+//! Extract the data-file path a DELETE manifest entry applies to. V3 records it explicitly in
+//! `referenced_data_file`; V2 positional deletes do not (per spec) but store the data file path in
+//! the FILENAME_FIELD_ID column bounds (lower == upper for a single-file delete), which is exactly
+//! how we write them (iceberg_delete.cpp) and how the scan path associates them. Returns "" when the
+//! entry cannot be tied to a single data file (e.g. an equality delete, which has no referenced file).
+static string DeleteEntryReferencedDataFile(const IcebergManifestEntry &entry) {
+	auto &data_file = entry.data_file;
+	if (!data_file.referenced_data_file.empty()) {
+		return data_file.referenced_data_file;
+	}
+	auto lower = data_file.lower_bounds.find(MultiFileReader::FILENAME_FIELD_ID);
+	auto upper = data_file.upper_bounds.find(MultiFileReader::FILENAME_FIELD_ID);
+	if (lower == data_file.lower_bounds.end() || upper == data_file.upper_bounds.end()) {
+		return "";
+	}
+	if (lower->second.IsNull() || upper->second.IsNull()) {
+		return "";
+	}
+	auto lower_str = lower->second.ToString();
+	if (lower_str != upper->second.ToString()) {
+		//! Bounds span more than one data file -- cannot attribute to a single file conservatively.
+		return "";
+	}
+	return lower_str;
+}
+
+//! Before retrying a delete/overwrite, validate it is still safe to replay against the refreshed
+//! parent. Three checks, all local (no new catalog API), modeled on Java's validationHistory:
+//!  1. Ancestry/rollback guard: the refreshed parent must still descend from the snapshot we started
+//!     against (a concurrent rollback to unrelated history makes our computed deletes meaningless).
+//!  2. validateDataFilesExist: every data file we add deletes against must still be live in the
+//!     refreshed parent (a concurrent commit may have removed it entirely).
+//!  3. validateNoNewDeletes: no concurrent commit may have added a *new* delete against any of those
+//!     same data files after we started -- our positional/DV deletes were computed against the old
+//!     live-row set, so an overlapping concurrent delete could double-delete or invalidate positions.
+//! Pure appends (no deletes, no altered_manifests) have no conflict surface and return immediately.
+void IcebergTransaction::ValidateRetrySafe(IcebergTableInformation &table_info, ClientContext &context) {
+	auto &transaction_data = *table_info.transaction_data;
+
+	//! Collect the data files this transaction adds deletes against. Two sources, unioned:
+	//!  - altered_manifests: the V3 deletion-vector replacement path records invalidated data files.
+	//!  - the pending DELETE manifest entries (referenced via DeleteEntryReferencedDataFile, which
+	//!    handles both V3 referenced_data_file and V2 filename bounds), so we derive the targeted set
+	//!    directly from what we are about to commit -- covering V2 positional deletes too.
+	unordered_set<string> targeted;
+	for (auto &add_snapshot : transaction_data.alters) {
+		for (auto &path : add_snapshot.get().altered_manifests.GetInvalidatedFiles()) {
+			targeted.insert(path);
+		}
+		for (auto &manifest_list_entry : add_snapshot.get().GetManifestFiles()) {
+			if (manifest_list_entry.file.content != IcebergManifestContentType::DELETE) {
+				continue;
+			}
+			for (auto &entry : manifest_list_entry.manifest_entries) {
+				auto referenced = DeleteEntryReferencedDataFile(entry);
+				if (!referenced.empty()) {
+					targeted.insert(referenced);
+				}
+			}
+		}
+	}
+	if (targeted.empty()) {
+		//! Pure append (or nothing to remove): no conflict surface to validate.
+		return;
+	}
+
+	auto &metadata = table_info.table_metadata;
+
+	//! Ancestry / rollback guard: the refreshed parent must still descend from the snapshot this
+	//! transaction started against. If it does not (e.g. a concurrent rollback moved the ref to an
+	//! unrelated history), our delete/overwrite was computed against state no longer on the table's
+	//! line, so replaying it is unsafe -> fail non-retryable. Skipped when there was no starting
+	//! snapshot (first commit on an empty table has no parent to diverge from). Mirrors Java's
+	//! validationHistory ancestry check.
+	auto starting_id = transaction_data.starting_snapshot_id;
+	int64_t starting_sequence_number = -1;
+	if (starting_id >= 0) {
+		auto refreshed = metadata.GetLatestSnapshot();
+		auto refreshed_id = refreshed ? refreshed->snapshot_id : -1;
+		if (refreshed_id < 0 || !metadata.IsAncestorOf(starting_id, refreshed_id)) {
+			throw IcebergCommitException(
+			    IcebergCommitOutcome::FATAL,
+			    StringUtil::Format("Cannot retry commit on table '%s': the table history diverged from the snapshot "
+			                       "this statement started against (snapshot %lld is no longer an ancestor of the "
+			                       "current snapshot, e.g. a concurrent rollback). Re-run the statement.",
+			                       table_info.name, (long long)starting_id));
+		}
+		//! Remember the sequence number at our starting point: any delete with a higher sequence
+		//! number in the refreshed parent was added concurrently (check 3 below). Use a non-throwing
+		//! lookup: IsAncestorOf can match on the ancestor id without that id being a key in the map
+		//! (an elided snapshot reached as a parent link), and GetSnapshotById would throw. If absent,
+		//! leave starting_sequence_number = -1, which simply disables the sequence-based narrowing in
+		//! check 3 (still correct, just less precise).
+		auto starting_it = metadata.snapshots.find(starting_id);
+		if (starting_it != metadata.snapshots.end()) {
+			starting_sequence_number = starting_it->second.sequence_number;
+		}
+	}
+
+	//! Scan the refreshed parent's manifests once: collect live DATA files (for check 2) and any
+	//! DELETE entries that reference a targeted data file with a sequence number newer than our
+	//! starting point (for check 3). existing_manifest_list was re-read in RefreshForRetry.
+	//! All DATA+DELETE manifests are scanned in a single AvroScan (the multi-file reader routes each
+	//! manifest's entries back to its own vector slot), rather than one scan per manifest.
+	auto &fs = FileSystem::GetFileSystem(context);
+	IcebergSnapshotScanInfo snapshot_info;
+	snapshot_info.snapshot = metadata.GetLatestSnapshot();
+	snapshot_info.schema_id = metadata.GetCurrentSchemaId();
+
+	vector<IcebergManifestListEntry> to_scan;
+	for (auto &manifest_list_entry : transaction_data.existing_manifest_list) {
+		auto content = manifest_list_entry.file.content;
+		if (content == IcebergManifestContentType::DATA || content == IcebergManifestContentType::DELETE) {
+			to_scan.push_back(manifest_list_entry);
+		}
+	}
+
+	unordered_set<string> live_files;
+	if (!to_scan.empty()) {
+		IcebergOptions options;
+		auto scan = AvroScan::ScanManifest(snapshot_info, to_scan, options, fs, "", metadata, context);
+		auto reader = make_uniq<manifest_file::ManifestReader>(*scan);
+		while (!reader->Finished()) {
+			reader->Read();
+		}
+		for (auto &scanned : to_scan) {
+			bool is_data = scanned.file.content == IcebergManifestContentType::DATA;
+			for (auto &entry : scanned.manifest_entries) {
+				if (entry.status == IcebergManifestEntryStatusType::DELETED) {
+					continue;
+				}
+				if (is_data) {
+					live_files.insert(entry.data_file.file_path);
+					continue;
+				}
+				//! DELETE manifest entry: if it targets a file we also delete and was added after we
+				//! started, a concurrent commit raced us with an overlapping delete -> unsafe to retry.
+				auto referenced = DeleteEntryReferencedDataFile(entry);
+				if (referenced.empty() || !targeted.count(referenced)) {
+					continue;
+				}
+				if (starting_sequence_number >= 0) {
+					auto entry_sequence = entry.GetSequenceNumber(scanned.file);
+					if ((int64_t)entry_sequence <= starting_sequence_number) {
+						//! This delete existed at or before we started -- it is part of the state our
+						//! deletes already accounted for, not a concurrent addition.
+						continue;
+					}
+				}
+				throw IcebergCommitException(
+				    IcebergCommitOutcome::FATAL,
+				    StringUtil::Format(
+				        "Cannot retry commit on table '%s': a concurrent commit added a new delete for "
+				        "data file '%s', which this statement also deletes from. Re-run the statement "
+				        "against the current table state.",
+				        table_info.name, referenced));
+			}
+		}
+	}
+
+	//! Check 2: any targeted file that is no longer live was removed by a concurrent commit.
+	for (auto &path : targeted) {
+		if (!live_files.count(path)) {
+			throw IcebergCommitException(
+			    IcebergCommitOutcome::FATAL,
+			    StringUtil::Format("Cannot retry commit on table '%s': data file targeted for deletion was "
+			                       "concurrently removed: '%s'. Re-run the statement against the current table state.",
+			                       table_info.name, path));
+		}
+	}
+}
+
+//! A single commit attempt: build the REST request from the current (possibly refreshed) state and
+//! submit it. Re-applies all uncommitted tables; safe to call repeatedly during a retry loop.
+void IcebergTransaction::SubmitTableUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context) {
 	auto transaction_info = GetTransactionRequest(alter_update, context);
 	auto &transaction = transaction_info.request;
 
@@ -461,8 +908,16 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 		CommitTransactionToJSON(doc, root_object, transaction);
 		auto transaction_json = JsonDocToString(std::move(doc_p));
 		IRCAPI::CommitMultiTableUpdate(context, catalog, transaction_json);
+		//! The multi-table endpoint's response shape is catalog-dependent and not parsed into
+		//! per-table metadata here, so (unlike the single-table path, which refills the cache from its
+		//! response) expire the committed tables' cache entries to force a fresh read next time.
+		auto &ic_catalog = catalog.Cast<IcebergCatalog>();
+		bool expire_cache = ic_catalog.attach_options.max_table_staleness_micros.IsValid();
 		for (auto &it : alter_update.updated_tables) {
 			alter_update.committed_tables.insert(it.first);
+			if (expire_cache) {
+				ic_catalog.table_request_cache.Expire(context, it.first);
+			}
 		}
 	} else {
 		D_ASSERT(catalog.supported_urls.count("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}"));
@@ -476,13 +931,6 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 			alter_update.committed_tables.insert(it.first);
 		}
 	}
-	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
-	if (ic_catalog.attach_options.max_table_staleness_micros.IsValid()) {
-		for (auto &it : alter_update.committed_tables) {
-			ic_catalog.table_request_cache.Expire(context, it);
-		}
-	}
-	DropSecrets(context);
 }
 
 static yyjson_mut_val *CreateRenameComponentJSON(yyjson_mut_doc *doc, const IcebergSchemaEntry &schema,
@@ -690,6 +1138,15 @@ void IcebergTransaction::CleanupFiles() {
 							           "Iceberg Transaction Cleanup, deleted 'data_file': '%s'", data_file.file_path);
 						}
 					}
+				}
+			}
+			//! Also delete the manifest / manifest-list files this transaction wrote (across all
+			//! attempts). These are only reached when the commit did not succeed, so removing them
+			//! reclaims the metadata files instead of leaking them. Data files were handled above.
+			for (auto &path : transaction_data->written_metadata_paths) {
+				if (fs.TryRemoveFile(path)) {
+					DUCKDB_LOG(temp_context, IcebergLogType,
+					           "Iceberg Transaction Cleanup, deleted metadata file: '%s'", path);
 				}
 			}
 		}

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -24,14 +24,59 @@ IcebergTransactionData::IcebergTransactionData(ClientContext &context, const Ice
 	initial_schema_id = table_info.table_metadata.GetCurrentSchemaId();
 }
 
-void IcebergTransactionData::CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata) {
-	if (!alters.empty()) {
+void IcebergTransactionData::RefreshForRetry(ClientContext &context) {
+	//! A retry re-applies against the concurrently-updated table state. Reset the row-id baseline so
+	//! we do not reuse a value advanced by the failed attempt, then re-read the parent manifest list
+	//! from the refreshed metadata so carried-over data is not lost when regenerating the snapshot.
+	//! Uses the passed (commit-time) context: secret resolution for the manifest read needs an active
+	//! transaction, which the member `context` (captured during the operator) no longer has here.
+	lock_guard<mutex> guard(lock);
+	if (table_info.table_metadata.has_next_row_id) {
+		next_row_id = table_info.table_metadata.next_row_id;
+	} else {
+		next_row_id = 0;
+	}
+	manifest_list_cached = false;
+	existing_manifest_list.clear();
+	//! Re-populate immediately from the (already refreshed) metadata rather than lazily: the apply
+	//! path only reads existing_manifest_list, it never triggers the cache load.
+	CacheExistingManifestList(guard, table_info.table_metadata, context);
+
+	//! V3 row lineage: each pending snapshot's DATA manifests had their manifest-level first_row_id
+	//! materialized when staged, against the then-current next_row_id. A concurrent commit may have
+	//! advanced the table's next_row_id, so re-base every pending manifest onto the refreshed
+	//! baseline, in staged order, keeping the assignment contiguous (and consistent with the
+	//! snapshot first_row_id that apply derives from commit_state.next_row_id). No-op for V2.
+	if (table_info.table_metadata.iceberg_version >= 3) {
+		int64_t row_id_cursor = next_row_id;
+		for (auto &add_snapshot : alters) {
+			add_snapshot.get().ReassignFirstRowIds(row_id_cursor);
+		}
+	}
+}
+
+void IcebergTransactionData::CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata,
+                                                       ClientContext &context) {
+	if (manifest_list_cached) {
+		//! Already read for this transaction. (On a retry, RefreshForRetry resets this flag so we
+		//! re-read the parent manifest list from the refreshed snapshot.)
 		return;
 	}
+	manifest_list_cached = true;
+	existing_manifest_list.clear();
 
 	auto current_snapshot = metadata.GetLatestSnapshot();
 	if (!current_snapshot) {
 		return;
+	}
+
+	//! Capture the starting snapshot id exactly once -- on the first apply, before any retry. This
+	//! is the parent of our first attempt; the ancestry/rollback guard at retry time walks the
+	//! refreshed parent back to this id. RefreshForRetry deliberately does not reset the captured
+	//! flag, so this survives every retry even though the manifest-list cache is re-read.
+	if (!starting_snapshot_captured) {
+		starting_snapshot_captured = true;
+		starting_snapshot_id = current_snapshot->snapshot_id;
 	}
 
 	IcebergSnapshotScanInfo snapshot_info;
@@ -79,7 +124,7 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 
 	//! Generate a new snapshot id
 	auto &table_metadata = table_info.table_metadata;
-	CacheExistingManifestList(guard, table_metadata);
+	CacheExistingManifestList(guard, table_metadata, context);
 
 	IcebergManifestContentType manifest_content_type;
 	switch (operation) {
@@ -123,7 +168,7 @@ void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&de
 	auto &table_metadata = table_info.table_metadata;
 	auto last_sequence_number = table_metadata.last_sequence_number;
 
-	CacheExistingManifestList(guard, table_metadata);
+	CacheExistingManifestList(guard, table_metadata, context);
 
 	auto snapshot_id = IcebergSnapshot::NewSnapshotId();
 	const auto sequence_number = last_sequence_number + alters.size() + 1;
@@ -138,7 +183,8 @@ void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&de
 	    fs, snapshot_id, sequence_number, table_metadata, IcebergManifestContentType::DATA, std::move(data_files),
 	    next_row_id);
 
-	auto add_snapshot = make_uniq<IcebergAddSnapshot>(table_info);
+	//! An update writes both new data and deletes in one snapshot -> OVERWRITE (row-level), per B14.
+	auto add_snapshot = make_uniq<IcebergAddSnapshot>(table_info, IcebergSnapshotOperationType::OVERWRITE);
 	add_snapshot->AddManifestFile(std::move(delete_manifest_file));
 	add_snapshot->AddManifestFile(std::move(data_manifest_file));
 	add_snapshot->altered_manifests = std::move(altered_manifests);

--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -126,6 +126,26 @@ optional_ptr<const IcebergSnapshot> IcebergTableMetadata::GetSnapshotById(int64_
 	return snapshot;
 }
 
+bool IcebergTableMetadata::IsAncestorOf(int64_t ancestor_id, int64_t descendant_id) const {
+	//! Walk parent links from the descendant back toward the ancestor. A snapshot is its own
+	//! ancestor. Stop if a link is missing (elided snapshot) -- treat as "not provably an ancestor".
+	int64_t current = descendant_id;
+	while (true) {
+		if (current == ancestor_id) {
+			return true;
+		}
+		auto snapshot = FindSnapshotByIdInternal(current);
+		if (!snapshot || !snapshot->has_parent_snapshot) {
+			return false;
+		}
+		if (snapshot->parent_snapshot_id == current) {
+			//! Defensive: a self-referential parent would loop forever.
+			return false;
+		}
+		current = snapshot->parent_snapshot_id;
+	}
+}
+
 IcebergSnapshotScanInfo IcebergTableMetadata::GetSnapshot(const IcebergSnapshotLookup &lookup) const {
 	IcebergSnapshotScanInfo snapshot_info;
 	switch (lookup.GetSource()) {

--- a/src/core/metadata/manifest/iceberg_avro_codec.cpp
+++ b/src/core/metadata/manifest/iceberg_avro_codec.cpp
@@ -1,0 +1,305 @@
+#include "core/metadata/manifest/iceberg_avro_codec.hpp"
+
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+
+#include "miniz_wrapper.hpp"
+
+namespace duckdb {
+
+namespace iceberg_avro_codec {
+
+//===--------------------------------------------------------------------===//
+// Avro Object Container File (OCF) primitives
+//===--------------------------------------------------------------------===//
+// OCF layout (Avro spec):
+//   magic        : 4 bytes  = 'O','b','j', 0x01
+//   metadata     : Avro map<string,bytes>  (block-count [, byte-count]? entries..., 0 terminator)
+//   sync marker  : 16 bytes
+//   data blocks  : repeated { long object_count, long byte_count, <byte_count bytes>, 16-byte sync }
+// Integers are zig-zag varint ("long") encoded. The block payload is encoded with the codec named
+// by the "avro.codec" metadata key ("null" = raw, "deflate" = raw DEFLATE, no zlib/gzip wrapper).
+
+namespace {
+
+static const uint8_t AVRO_MAGIC[4] = {'O', 'b', 'j', 0x01};
+constexpr idx_t SYNC_SIZE = 16;
+
+//! Sequential reader over an in-memory Avro file.
+struct AvroReader {
+	AvroReader(const_data_ptr_t data, idx_t size) : data(data), size(size) {
+	}
+
+	const_data_ptr_t data;
+	idx_t size;
+	idx_t pos = 0;
+
+	void Require(idx_t n) {
+		//! n comes from a varint length in the file; guard against overflow (a corrupt/truncated file
+		//! could yield a huge length that wraps pos + n) as well as a plain out-of-bounds read.
+		if (n > size || pos > size - n) {
+			throw InvalidInputException("Corrupt Avro manifest: unexpected end of file while recompressing");
+		}
+	}
+
+	uint8_t ReadByte() {
+		Require(1);
+		return data[pos++];
+	}
+
+	//! Avro long: zig-zag + variable-length (LEB128-style, 7 bits per byte, MSB = continuation).
+	int64_t ReadLong() {
+		uint64_t value = 0;
+		int shift = 0;
+		while (true) {
+			auto b = ReadByte();
+			value |= (uint64_t)(b & 0x7F) << shift;
+			if (!(b & 0x80)) {
+				break;
+			}
+			shift += 7;
+			if (shift > 63) {
+				throw InvalidInputException("Corrupt Avro manifest: overlong varint while recompressing");
+			}
+		}
+		//! zig-zag decode
+		return (int64_t)((value >> 1) ^ (~(value & 1) + 1));
+	}
+
+	const_data_ptr_t ReadRaw(idx_t n) {
+		Require(n);
+		auto ptr = data + pos;
+		pos += n;
+		return ptr;
+	}
+};
+
+//! Sequential writer into a growable byte buffer.
+struct AvroWriter {
+	vector<data_t> buffer;
+
+	void WriteByte(uint8_t b) {
+		buffer.push_back(b);
+	}
+
+	void WriteLong(int64_t value) {
+		//! zig-zag encode
+		uint64_t zz = (uint64_t)((value << 1) ^ (value >> 63));
+		do {
+			uint8_t b = zz & 0x7F;
+			zz >>= 7;
+			if (zz) {
+				b |= 0x80;
+			}
+			buffer.push_back(b);
+		} while (zz);
+	}
+
+	void WriteRaw(const_data_ptr_t ptr, idx_t n) {
+		buffer.insert(buffer.end(), ptr, ptr + n);
+	}
+
+	void WriteString(const string &str) {
+		WriteLong((int64_t)str.size());
+		WriteRaw(const_data_ptr_cast(str.data()), str.size());
+	}
+
+	//! bytes = long length + raw bytes
+	void WriteBytes(const_data_ptr_t ptr, idx_t n) {
+		WriteLong((int64_t)n);
+		WriteRaw(ptr, n);
+	}
+};
+
+//! Raw DEFLATE (negative window bits => no zlib header/adler footer), matching Avro's "deflate"
+//! codec. Uses DuckDB's vendored miniz directly because MiniZStream::Compress adds a gzip wrapper.
+static vector<data_t> RawDeflate(const_data_ptr_t input, idx_t input_size) {
+	duckdb_miniz::mz_stream stream;
+	memset(&stream, 0, sizeof(stream));
+	//! Negative window bits => raw DEFLATE (no zlib header/adler footer), which is Avro's "deflate"
+	//! codec. MZ_DEFLATED / MZ_DEFAULT_WINDOW_BITS are macros (not namespaced); the levels/flush
+	//! values are enums in duckdb_miniz.
+	auto ret = duckdb_miniz::mz_deflateInit2(&stream, duckdb_miniz::MZ_DEFAULT_LEVEL, MZ_DEFLATED,
+	                                         -MZ_DEFAULT_WINDOW_BITS, 1, 0);
+	if (ret != duckdb_miniz::MZ_OK) {
+		throw InvalidInputException("Failed to initialize miniz for Avro deflate codec");
+	}
+
+	vector<data_t> out;
+	out.resize(duckdb_miniz::mz_deflateBound(&stream, input_size));
+
+	stream.next_in = reinterpret_cast<const unsigned char *>(input);
+	stream.avail_in = (unsigned int)input_size;
+	stream.next_out = reinterpret_cast<unsigned char *>(out.data());
+	stream.avail_out = (unsigned int)out.size();
+
+	ret = duckdb_miniz::mz_deflate(&stream, duckdb_miniz::MZ_FINISH);
+	if (ret != duckdb_miniz::MZ_STREAM_END) {
+		duckdb_miniz::mz_deflateEnd(&stream);
+		throw InvalidInputException("Failed to deflate Avro manifest block");
+	}
+	auto compressed_size = stream.total_out;
+	duckdb_miniz::mz_deflateEnd(&stream);
+
+	out.resize(compressed_size);
+	return out;
+}
+
+} // namespace
+
+string ResolveAvroCodec(const string &property_value, bool catalog_allows_deletes) {
+	//! Compression needs a deletable temp file (the COPY function cannot emit a codec). Catalogs that
+	//! forbid client deletes (e.g. S3 Tables) cannot clean it up, so force uncompressed there; they
+	//! manage their own storage optimization anyway.
+	if (!catalog_allows_deletes) {
+		return "null";
+	}
+	//! Default matches Java's TableProperties.AVRO_COMPRESSION default ("gzip" -> Avro "deflate").
+	if (property_value.empty()) {
+		return "deflate";
+	}
+	if (StringUtil::CIEquals(property_value, "gzip") || StringUtil::CIEquals(property_value, "deflate")) {
+		return "deflate";
+	}
+	if (StringUtil::CIEquals(property_value, "none") || StringUtil::CIEquals(property_value, "null") ||
+	    StringUtil::CIEquals(property_value, "uncompressed")) {
+		return "null";
+	}
+	//! Avro also defines snappy/zstd/bzip2, but DuckDB's vendored miniz only provides DEFLATE. Fail
+	//! loudly rather than silently writing an uncompressed file the user did not ask for.
+	throw NotImplementedException(
+	    "Unsupported value '%s' for 'write.manifest.compression-codec'; this extension supports 'gzip'/'deflate' and "
+	    "'none'/'uncompressed'",
+	    property_value);
+}
+
+bool RequiresRecompression(const string &avro_codec) {
+	return !avro_codec.empty() && !StringUtil::CIEquals(avro_codec, "null");
+}
+
+idx_t RecompressManifestFile(ClientContext &context, const string &source_path, const string &dest_path,
+                             const string &avro_codec) {
+	if (!StringUtil::CIEquals(avro_codec, "deflate")) {
+		throw NotImplementedException("Avro codec '%s' is not supported for manifest compression", avro_codec);
+	}
+
+	auto &fs = FileSystem::GetFileSystem(context);
+
+	//! Read the whole (small) uncompressed manifest into memory. Use the location-based Read, which
+	//! loops until every requested byte is read (or throws); the plain Read(buffer, n) can short-read
+	//! on object stores, which would leave the tail uninitialized and corrupt the parse.
+	vector<data_t> input;
+	{
+		auto handle = fs.OpenFile(source_path, FileFlags::FILE_FLAGS_READ);
+		auto file_size = handle->GetFileSize();
+		input.resize(file_size);
+		if (file_size > 0) {
+			handle->Read(input.data(), file_size, 0);
+		}
+	}
+
+	AvroReader reader(input.data(), input.size());
+
+	//! Magic.
+	auto magic = reader.ReadRaw(sizeof(AVRO_MAGIC));
+	if (memcmp(magic, AVRO_MAGIC, sizeof(AVRO_MAGIC)) != 0) {
+		throw InvalidInputException("Corrupt Avro manifest: bad magic while recompressing '%s'", source_path);
+	}
+
+	//! File metadata: a map<string,bytes>. Read all entries, overriding avro.codec to deflate.
+	//! A map is a sequence of blocks; each block is a (possibly negative) long count, optionally
+	//! followed by a byte-size long when count is negative, then that many key/value pairs, ending
+	//! with a 0 count.
+	vector<std::pair<string, vector<data_t>>> metadata;
+	while (true) {
+		auto block_count = reader.ReadLong();
+		if (block_count == 0) {
+			break;
+		}
+		if (block_count < 0) {
+			//! Negative count => the next long is the block byte size (which we can ignore).
+			block_count = -block_count;
+			reader.ReadLong();
+		}
+		for (int64_t i = 0; i < block_count; i++) {
+			auto key_len = reader.ReadLong();
+			auto key_ptr = reader.ReadRaw((idx_t)key_len);
+			string key(const_char_ptr_cast(key_ptr), (idx_t)key_len);
+
+			auto val_len = reader.ReadLong();
+			auto val_ptr = reader.ReadRaw((idx_t)val_len);
+			vector<data_t> val(val_ptr, val_ptr + (idx_t)val_len);
+
+			metadata.emplace_back(std::move(key), std::move(val));
+		}
+	}
+
+	//! Override (or add) avro.codec = deflate.
+	bool codec_set = false;
+	const string deflate = "deflate";
+	for (auto &entry : metadata) {
+		if (entry.first == "avro.codec") {
+			entry.second.assign(deflate.begin(), deflate.end());
+			codec_set = true;
+		}
+	}
+	if (!codec_set) {
+		vector<data_t> val(deflate.begin(), deflate.end());
+		metadata.emplace_back("avro.codec", std::move(val));
+	}
+
+	//! Sync marker (16 bytes), reused verbatim for every block we re-emit.
+	auto sync_ptr = reader.ReadRaw(SYNC_SIZE);
+	vector<data_t> sync(sync_ptr, sync_ptr + SYNC_SIZE);
+
+	//! Build the new file.
+	AvroWriter writer;
+	writer.WriteRaw(AVRO_MAGIC, sizeof(AVRO_MAGIC));
+
+	//! Metadata map: single block with all entries, then a 0 terminator.
+	writer.WriteLong((int64_t)metadata.size());
+	for (auto &entry : metadata) {
+		writer.WriteString(entry.first);
+		writer.WriteBytes(entry.second.data(), entry.second.size());
+	}
+	writer.WriteLong(0);
+	writer.WriteRaw(sync.data(), sync.size());
+
+	//! Data blocks: object_count, byte_count, payload, sync. Recompress each payload.
+	while (reader.pos < reader.size) {
+		auto object_count = reader.ReadLong();
+		auto byte_count = reader.ReadLong();
+		auto payload = reader.ReadRaw((idx_t)byte_count);
+		//! The original sync marker follows each block; consume and verify it matches.
+		auto block_sync = reader.ReadRaw(SYNC_SIZE);
+		if (memcmp(block_sync, sync.data(), SYNC_SIZE) != 0) {
+			throw InvalidInputException("Corrupt Avro manifest: sync marker mismatch while recompressing '%s'",
+			                            source_path);
+		}
+
+		auto compressed = RawDeflate(payload, (idx_t)byte_count);
+
+		writer.WriteLong(object_count);
+		writer.WriteLong((int64_t)compressed.size());
+		writer.WriteRaw(compressed.data(), compressed.size());
+		writer.WriteRaw(sync.data(), sync.size());
+	}
+
+	//! Write the compressed container as a brand-new file. FILE_CREATE_NEW (never reopening an
+	//! existing object for overwrite/truncate) is what object stores support; dest_path is a path no
+	//! one has written yet (the caller routes the COPY output to a separate temp source_path).
+	{
+		auto handle = fs.OpenFile(dest_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+		if (!writer.buffer.empty()) {
+			handle->Write(writer.buffer.data(), writer.buffer.size());
+		}
+		handle->Close();
+	}
+	//! We know exactly how many bytes we wrote -> return it so the caller avoids a size-probe (HEAD).
+	return writer.buffer.size();
+}
+
+} // namespace iceberg_avro_codec
+
+} // namespace duckdb

--- a/src/core/metadata/manifest/iceberg_manifest.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest.cpp
@@ -1,11 +1,13 @@
 #include "core/metadata/manifest/iceberg_manifest.hpp"
 
 #include "duckdb/storage/caching_file_system.hpp"
+#include "duckdb/function/copy_function.hpp"
 
 #include "catalog/rest/iceberg_table_set.hpp"
 #include "catalog/rest/api/iceberg_create_table_request.hpp"
 #include "catalog/rest/api/catalog_utils.hpp"
 #include "core/expression/iceberg_value.hpp"
+#include "core/metadata/manifest/iceberg_avro_codec.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
 
 namespace duckdb {
@@ -426,7 +428,7 @@ static LogicalType PartitionStructType(vector<IcebergExtendedPartitionInfo> exte
 
 idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManifestFile &manifest_file,
                   const vector<IcebergManifestEntry> &manifest_entries, CopyFunction &copy, DatabaseInstance &db,
-                  ClientContext &context) {
+                  ClientContext &context, const string &avro_codec) {
 	D_ASSERT(!manifest_entries.empty());
 	auto &allocator = db.GetBufferManager().GetBufferAllocator();
 	auto &path = manifest_file.manifest_path;
@@ -659,19 +661,58 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	CopyFunctionBindInput input(copy_info);
 	input.file_extension = "avro";
 
+	//! Honor write.manifest.compression-codec (default deflate, matching Java). The Avro COPY
+	//! function cannot emit a codec, so for a compressing codec we COPY to a temp path and recompress
+	//! into the final path (a single fresh write, never reopening/truncating -- object-store safe),
+	//! then delete the temp. The caller resolves the codec to "null" when the catalog forbids client
+	//! deletes (e.g. S3 Tables), so on those catalogs we never produce a temp and write the final
+	//! path directly -- no delete to fail.
+	const bool compress = iceberg_avro_codec::RequiresRecompression(avro_codec);
+	string copy_path = compress ? path + ".uncompressed.tmp" : path;
+
+	idx_t copy_bytes_written = 0;
+	bool have_copy_size = false;
 	{
 		ThreadContext thread_context(context);
 		ExecutionContext execution_context(context, thread_context, nullptr);
 		auto bind_data = copy.copy_to_bind(context, input, names, types);
 
-		auto global_state = copy.copy_to_initialize_global(context, *bind_data, path);
+		auto global_state = copy.copy_to_initialize_global(context, *bind_data, copy_path);
 		auto local_state = copy.copy_to_initialize_local(execution_context, *bind_data);
 
 		copy.copy_to_sink(execution_context, *bind_data, *global_state, *local_state, chunk);
 		copy.copy_to_combine(execution_context, *bind_data, *global_state, *local_state);
 		copy.copy_to_finalize(context, *bind_data, *global_state);
+
+		//! Capture the exact bytes the Avro COPY wrote, if it reports them (the avro extension
+		//! implements copy_to_get_written_statistics). This avoids a separate file-size probe (a HEAD
+		//! round trip on object stores) for the uncompressed path. Only meaningful when not
+		//! recompressing (the compressed path gets its size from RecompressManifestFile instead).
+		if (!compress && copy.copy_to_get_written_statistics) {
+			CopyFunctionFileStatistics stats;
+			copy.copy_to_get_written_statistics(context, *bind_data, *global_state, stats);
+			copy_bytes_written = stats.file_size_bytes;
+			have_copy_size = true;
+		}
 	}
 
+	if (compress) {
+		//! Recompress the temp into the final path, then remove the temp. This path is only taken when
+		//! the caller resolved a compressing codec, which it does only for delete-capable catalogs, so
+		//! the remove is safe here (S3 Tables and other delete-forbidden catalogs never reach this).
+		//! RecompressManifestFile returns the exact bytes written, so no size-probe (HEAD) is needed.
+		auto manifest_length = iceberg_avro_codec::RecompressManifestFile(context, copy_path, path, avro_codec);
+		FileSystem::GetFileSystem(context).RemoveFile(copy_path);
+		return manifest_length;
+	}
+
+	//! Uncompressed path: prefer the byte count the COPY reported (no extra request). Fall back to a
+	//! read-back GetFileSize only if the COPY did not provide statistics.
+	if (have_copy_size) {
+		return copy_bytes_written;
+	}
+	//! Fallback (a COPY function without written-statistics support): read the size back, which is a
+	//! metadata/HEAD round trip on object stores.
 	auto file_system = CachingFileSystem::Get(context);
 	auto file_handle = file_system.OpenFile(path, FileOpenFlags::FILE_FLAGS_READ);
 	auto manifest_length = file_handle->GetFileSize();

--- a/src/core/metadata/manifest/iceberg_manifest_list.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest_list.cpp
@@ -7,6 +7,7 @@
 
 #include "core/metadata/partition/iceberg_partition_spec.hpp"
 #include "core/expression/iceberg_value.hpp"
+#include "core/metadata/manifest/iceberg_avro_codec.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
 #include "core/expression/iceberg_transform.hpp"
 #include "planning/metadata_io/avro/avro_scan.hpp"
@@ -307,7 +308,7 @@ static Value FieldSummaryFieldIds() {
 }
 
 void WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManifestList &manifest_list,
-                 CopyFunction &copy, DatabaseInstance &db, ClientContext &context) {
+                 CopyFunction &copy, DatabaseInstance &db, ClientContext &context, const string &avro_codec) {
 	auto &allocator = db.GetBufferManager().GetBufferAllocator();
 
 	//! Create the types for the DataChunk
@@ -457,16 +458,32 @@ void WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManife
 	CopyFunctionBindInput input(copy_info);
 	input.file_extension = "avro";
 
+	//! Honor write.manifest.compression-codec. The Avro COPY cannot emit a codec, so for a
+	//! compressing codec we COPY to a temp path and recompress into the final path (a single fresh
+	//! write), then delete the temp. The caller resolves the codec to "null" when the catalog forbids
+	//! client deletes (e.g. S3 Tables), so on those catalogs no temp is produced and the final path is
+	//! written directly -- no delete to fail.
+	const bool compress = iceberg_avro_codec::RequiresRecompression(avro_codec);
+	const string final_path = manifest_list.GetPath();
+	string copy_path = compress ? final_path + ".uncompressed.tmp" : final_path;
+
 	ThreadContext thread_context(context);
 	ExecutionContext execution_context(context, thread_context, nullptr);
 	auto bind_data = copy.copy_to_bind(context, input, metadata.names, metadata.types);
 
-	auto global_state = copy.copy_to_initialize_global(context, *bind_data, manifest_list.GetPath());
+	auto global_state = copy.copy_to_initialize_global(context, *bind_data, copy_path);
 	auto local_state = copy.copy_to_initialize_local(execution_context, *bind_data);
 
 	copy.copy_to_sink(execution_context, *bind_data, *global_state, *local_state, data);
 	copy.copy_to_combine(execution_context, *bind_data, *global_state, *local_state);
 	copy.copy_to_finalize(context, *bind_data, *global_state);
+
+	if (compress) {
+		//! Only reached for a compressing codec, which the caller resolves only for delete-capable
+		//! catalogs, so removing the temp is safe here.
+		iceberg_avro_codec::RecompressManifestFile(context, copy_path, final_path, avro_codec);
+		FileSystem::GetFileSystem(context).RemoveFile(copy_path);
+	}
 }
 
 } // namespace manifest_list

--- a/src/core/metadata/manifest/iceberg_manifest_list.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest_list.cpp
@@ -37,7 +37,7 @@ IcebergManifestListEntry IcebergManifestListEntry::CreateFromEntries(FileSystem 
                                                                      const IcebergTableMetadata &table_metadata,
                                                                      IcebergManifestContentType manifest_content_type,
                                                                      vector<IcebergManifestEntry> &&manifest_entries,
-                                                                     int64_t &next_row_id) {
+                                                                     int64_t &next_row_id, int32_t partition_spec_id) {
 	//! create manifest file path
 	auto manifest_file_uuid = UUID::ToString(UUID::GenerateRandomUUID());
 	auto manifest_file_path = fs.JoinPath(table_metadata.GetMetadataPath(fs), manifest_file_uuid + "-m0.avro");
@@ -61,7 +61,10 @@ IcebergManifestListEntry IcebergManifestListEntry::CreateFromEntries(FileSystem 
 	manifest_file.added_rows_count = 0;
 	manifest_file.existing_rows_count = 0;
 	manifest_file.deleted_rows_count = 0;
-	manifest_file.partition_spec_id = table_metadata.default_spec_id;
+	//! Caller may pin the spec id (e.g. when merging a manifest that belongs to a historical spec);
+	//! otherwise default to the table's current default spec.
+	const int32_t effective_spec_id = partition_spec_id >= 0 ? partition_spec_id : table_metadata.default_spec_id;
+	manifest_file.partition_spec_id = effective_spec_id;
 
 	//! Add the files to the manifest
 	for (auto &manifest_entry : manifest_entries) {
@@ -97,12 +100,12 @@ IcebergManifestListEntry IcebergManifestListEntry::CreateFromEntries(FileSystem 
 	//! NOTE: this gets overwritten on commit
 	manifest_file.added_snapshot_id = snapshot_id;
 
-	// Compute partition field summaries (upper/lower bounds) for the manifest list entry
+	// Compute partition field summaries (upper/lower bounds) for the manifest list entry, using the
+	// manifest's own partition spec (which may be a historical spec when merging carried-over data).
 	if (table_metadata.HasPartitionSpec() && table_metadata.GetLatestPartitionSpec().IsPartitioned()) {
-		auto partition_spec_it = table_metadata.partition_specs.find(table_metadata.default_spec_id);
+		auto partition_spec_it = table_metadata.partition_specs.find(effective_spec_id);
 		if (partition_spec_it == table_metadata.partition_specs.end()) {
-			throw InternalException("Cannot find partition spec with id " +
-			                        std::to_string(table_metadata.default_spec_id));
+			throw InternalException("Cannot find partition spec with id " + std::to_string(effective_spec_id));
 		}
 		auto &partition_spec = partition_spec_it->second;
 		manifest_file.partitions.Create(table_metadata, partition_spec, manifest_entries);

--- a/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
+++ b/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
@@ -34,6 +34,10 @@ public:
 	IcebergManifestDeletes altered_manifests;
 
 private:
+	//! Repack the assembled manifest list into fewer manifests, in place.
+	void MergeManifestList(IcebergManifestList &new_manifest_list, int64_t snapshot_id, CopyFunction &avro_copy,
+	                       DatabaseInstance &db, IcebergCommitState &commit_state) const;
+
 	vector<IcebergManifestListEntry> manifest_files;
 	int32_t schema_id;
 	IcebergSnapshotOperationType operation;

--- a/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
+++ b/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
@@ -27,20 +27,40 @@ public:
 	void ConstructManifestList(IcebergManifestList &manifest_list, CopyFunction &avro_copy, DatabaseInstance &db,
 	                           IcebergCommitState &commit_state) const;
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+	//! Pure, repeatable core of CreateUpdate: builds the new manifest list + snapshot from the current
+	//! state in `commit_state` (parent snapshot, next sequence number, next row id) and writes them out.
+	//! Safe to call once per commit attempt during a retry loop, provided `commit_state` reflects the
+	//! freshly-refreshed metadata baseline (a retry reconstructs IcebergCommitState from it).
+	void ApplyTableChanges(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const;
 	const vector<IcebergManifestListEntry> &GetManifestFiles() const;
 	void AddManifestFile(IcebergManifestListEntry &&manifest_file);
-
-public:
-	IcebergManifestDeletes altered_manifests;
+	//! Reassign the V3 manifest-file-level first_row_id of this snapshot's pending DATA manifests,
+	//! advancing `next_row_id`. Used on retry: the row-id baseline was materialized when the snapshot
+	//! was first staged, but a concurrent commit may have advanced the table's next_row_id, so the
+	//! pending manifests must be re-based onto the refreshed baseline to keep row lineage contiguous.
+	//! No-op for V2 (no row lineage). DELETE manifests never carry a first_row_id.
+	void ReassignFirstRowIds(int64_t &next_row_id);
+	//! The snapshot id this update will commit. Generated once and kept stable across retry attempts
+	//! (Java memoizes the same way), so a status-check after an ambiguous commit can look for exactly
+	//! this id in the refreshed table to decide whether the commit landed.
+	int64_t GetSnapshotId() const;
 
 private:
 	//! Repack the assembled manifest list into fewer manifests, in place.
 	void MergeManifestList(IcebergManifestList &new_manifest_list, int64_t snapshot_id, CopyFunction &avro_copy,
 	                       DatabaseInstance &db, IcebergCommitState &commit_state) const;
 
+public:
+	IcebergManifestDeletes altered_manifests;
+
+private:
 	vector<IcebergManifestListEntry> manifest_files;
-	int32_t schema_id;
+	//! The logical operation this snapshot represents (APPEND/DELETE/OVERWRITE), declared by the
+	//! caller that staged the change. Written into the committed snapshot summary's "operation".
 	IcebergSnapshotOperationType operation;
+	int32_t schema_id;
+	//! Lazily assigned on first ApplyTableChanges and reused on every retry attempt. -1 = unassigned.
+	mutable int64_t snapshot_id = -1;
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/api/iceberg_commit_exceptions.hpp
+++ b/src/include/catalog/rest/api/iceberg_commit_exceptions.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/enums/http_status_code.hpp"
+
+#include <string>
+
+namespace duckdb {
+
+//! Classification of a failed commit request, used to drive the retry loop.
+enum class IcebergCommitOutcome : uint8_t {
+	//! Optimistic-concurrency conflict (HTTP 409). The table moved under us; refresh and retry.
+	CONFLICT,
+	//! We cannot tell whether the commit landed (timeout / connection reset / 5xx). Must NOT clean
+	//! up files; resolve via a status-check before deciding success/failure.
+	UNKNOWN,
+	//! Definite, non-retryable failure (e.g. 4xx other than 409, validation error).
+	FATAL
+};
+
+//! Map an HTTP status code to a commit outcome. Network-level failures that never produced a status
+//! code should be treated as UNKNOWN by the caller before reaching here.
+inline IcebergCommitOutcome ClassifyCommitStatus(HTTPStatusCode status) {
+	switch (status) {
+	case HTTPStatusCode::Conflict_409:
+		return IcebergCommitOutcome::CONFLICT;
+	case HTTPStatusCode::TooManyRequests_429:
+		//! Rate-limited: the server rejected the request before applying it (the commit definitely did
+		//! NOT land), so it is safe to retry directly like a conflict -- no status-check round-trip.
+		//! Treating it as UNKNOWN would add a GetTable call per 429, which under heavy concurrency (the
+		//! exact case that produces 429s) only worsens the rate limiting. The backoff+jitter before the
+		//! next attempt is what relieves the pressure. Mirrors Java's REST client (429 = retryable).
+		return IcebergCommitOutcome::CONFLICT;
+	case HTTPStatusCode::RequestTimeout_408:
+	case HTTPStatusCode::InternalServerError_500:
+	case HTTPStatusCode::BadGateway_502:
+	case HTTPStatusCode::ServiceUnavailable_503:
+	case HTTPStatusCode::GatewayTimeout_504:
+		//! Genuinely ambiguous: the request may have reached the server and been applied before the
+		//! failure surfaced. Retrying blindly could double-apply (e.g. append the same batch twice),
+		//! and cleaning up could delete a committed snapshot's files. Resolve via a status-check; never
+		//! clean up. (503 stays here: a gateway can return it after the backend already committed.)
+		return IcebergCommitOutcome::UNKNOWN;
+	default:
+		return IcebergCommitOutcome::FATAL;
+	}
+}
+
+//! Exception thrown by the commit functions carrying its retry classification. The retry driver
+//! catches this and decides whether to retry (CONFLICT), status-check (UNKNOWN), or abort (FATAL).
+class IcebergCommitException : public Exception {
+public:
+	IcebergCommitException(IcebergCommitOutcome outcome, const string &msg)
+	    : Exception(ExceptionType::TRANSACTION, msg), outcome(outcome) {
+	}
+	IcebergCommitException(IcebergCommitOutcome outcome, const string &msg, int64_t retry_after_ms)
+	    : Exception(ExceptionType::TRANSACTION, msg), outcome(outcome), retry_after_ms(retry_after_ms) {
+	}
+
+	IcebergCommitOutcome outcome;
+	//! Server-requested wait before retrying, in ms, parsed from a `Retry-After` response header.
+	//! -1 means the server gave no guidance (use the client's exponential backoff). When set, the
+	//! retry loop honors it (capped to the configured max wait) so a rate-limited server (e.g. S3
+	//! Tables under a herd of writers) is not hammered earlier than it asked for.
+	int64_t retry_after_ms = -1;
+};
+
+//! Parse a `Retry-After` header value into milliseconds. The HTTP spec allows either a number of
+//! seconds ("120") or an HTTP-date; we support the numeric form (what catalogs/load balancers send)
+//! and return -1 for an absent/unparseable/date value (caller falls back to exponential backoff).
+inline int64_t ParseRetryAfterMs(const string &value) {
+	if (value.empty()) {
+		return -1;
+	}
+	try {
+		size_t consumed = 0;
+		auto seconds = std::stoll(value, &consumed);
+		//! Require the whole value to be the integer (reject "Wed, 21 Oct..." HTTP-date form).
+		if (consumed != value.size() || seconds < 0) {
+			return -1;
+		}
+		//! Guard the *1000 against int64 overflow: Retry-After is untrusted server input, and a huge
+		//! value would wrap to a negative/tiny wait. Clamp to a day in ms (far above any sane
+		//! max-wait, which the retry loop caps it to anyway) instead of overflowing.
+		constexpr int64_t MAX_RETRY_AFTER_MS = 24LL * 60 * 60 * 1000;
+		if (seconds > MAX_RETRY_AFTER_MS / 1000) {
+			return MAX_RETRY_AFTER_MS;
+		}
+		return seconds * 1000;
+	} catch (...) {
+		return -1;
+	}
+}
+
+} // namespace duckdb

--- a/src/include/catalog/rest/api/iceberg_manifest_merge.hpp
+++ b/src/include/catalog/rest/api/iceberg_manifest_merge.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "duckdb/common/vector.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/function/copy_function.hpp"
+
+#include "core/metadata/manifest/iceberg_manifest_list.hpp"
+
+namespace duckdb {
+
+struct IcebergTableMetadata;
+struct IcebergCommitState;
+
+//! Origin of a manifest fed into the merge step. The min-count guard only applies to bins that
+//! contain at least one NEW_THIS_TRANSACTION manifest, so we must track this explicitly rather
+//! than rely on positional assumptions.
+enum class ManifestSource : uint8_t { NEW_THIS_TRANSACTION, CARRIED_OVER };
+
+//! A manifest handed to the merge step, tagged with its origin. The entry's `manifest_entries`
+//! may be empty (unloaded): the merge decision uses only manifest-file-level metadata.
+struct MergeInputManifest {
+	IcebergManifestListEntry entry;
+	ManifestSource source;
+};
+
+//! Resolved `commit.manifest.*` / `commit.manifest-merge.enabled` table properties.
+struct ManifestMergeConfig {
+	bool enabled;
+	idx_t min_count_to_merge;
+	int64_t target_size_bytes;
+
+	static ManifestMergeConfig FromTableMetadata(const IcebergTableMetadata &metadata);
+};
+
+//! First-fit bin-packing of weights against `target_weight`, packing from the tail to mirror
+//! Java/PyIceberg's `pack_end` (reverse -> first-fit -> reverse). Returns, for each bin, the list
+//! of input indices it contains, in original order. Pure logic, unit-testable, no IO.
+vector<vector<idx_t>> BinPackManifests(const vector<int64_t> &weights, int64_t target_weight);
+
+//! Read the manifest_entries of a manifest from its Avro file, reusing the vectorized manifest
+//! reader. Returns the list entry with `manifest_entries` populated. Shared by the delete-rewrite
+//! path and the merge path so both load entries identically.
+IcebergManifestListEntry ScanManifestEntries(const IcebergManifestListEntry &list_entry,
+                                             IcebergCommitState &commit_state, int32_t schema_id);
+
+//! Decide whether a bin should be physically merged into a single manifest.
+//!  - a single-manifest bin is never merged
+//!  - a bin that contains a new-this-transaction manifest is merged only once it reaches
+//!    `min_count_to_merge` (avoids repeatedly rewriting small new manifests)
+//!  - any other multi-manifest bin is merged
+bool ShouldMergeBin(const vector<MergeInputManifest> &input, const vector<idx_t> &bin, idx_t min_count_to_merge);
+
+//! Merge a set of manifests of a single content type (DATA or DELETE; the two are never mixed).
+//! Bins selected for merge have their entries read and rewritten into a single new manifest;
+//! everything else is passed through unchanged. Returns the resulting manifest-list entries.
+//!
+//! Sequence-number rules: entries pulled from already-committed manifests keep
+//! their original (historical) sequence numbers and are written EXISTING; entries that are new in
+//! this transaction keep status ADDED with inherited (NULL) sequence numbers and are never demoted.
+//! `snapshot_id` is the id of the snapshot being created; it is used to decide which DELETED entries
+//! to retain (only deletes made by this snapshot) -- mirroring Java's ManifestMergeManager.
+vector<IcebergManifestListEntry> MergeManifests(vector<MergeInputManifest> &&input,
+                                                IcebergManifestContentType content,
+                                                const ManifestMergeConfig &config, CopyFunction &avro_copy,
+                                                DatabaseInstance &db, IcebergCommitState &commit_state,
+                                                int32_t schema_id, int64_t snapshot_id);
+
+} // namespace duckdb

--- a/src/include/catalog/rest/api/iceberg_retry.hpp
+++ b/src/include/catalog/rest/api/iceberg_retry.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "duckdb/common/common.hpp"
+
+namespace duckdb {
+
+struct IcebergTableMetadata;
+
+//! Resolved `commit.retry.*` table properties controlling the optimistic-concurrency retry loop.
+//! Defaults mirror Apache Iceberg Java (the authoritative reference).
+struct IcebergRetryConfig {
+	idx_t num_retries;     // commit.retry.num-retries (default 4 -> 5 attempts total)
+	int64_t min_wait_ms;   // commit.retry.min-wait-ms (default 100)
+	int64_t max_wait_ms;   // commit.retry.max-wait-ms (default 60000)
+	int64_t total_wait_ms; // commit.retry.total-timeout-ms (default 1800000)
+
+	static IcebergRetryConfig FromTableMetadata(const IcebergTableMetadata &metadata);
+
+	//! Combine two configs into the most lenient (most retry-tolerant) of the two, taking the
+	//! larger num-retries / max-wait / total-timeout and the smaller min-wait. Used when a single
+	//! transaction commits multiple tables atomically: the retry loop is shared, so no table's
+	//! (more permissive) policy should be silently dropped in favor of an arbitrary "first" table.
+	IcebergRetryConfig MostLenient(const IcebergRetryConfig &other) const;
+
+	//! Exponential backoff (factor 2) for the given 0-based attempt index, clamped to [min, max].
+	//! Pure function, unit-testable. This is the *base* wait, before jitter.
+	int64_t BackoffMs(idx_t attempt) const;
+
+	//! Base backoff with full random jitter applied: returns a value in [0, BackoffMs(attempt)].
+	//! `unit_random` must be in [0,1) (e.g. from a uniform_real_distribution). Full jitter (AWS
+	//! "equal jitter"/"full jitter" literature) is what de-synchronizes a thundering herd of
+	//! concurrent writers (thousands of Lambdas) so they do not all wake and re-collide in lockstep.
+	//! Kept as a pure function (random source injected) so it stays unit-testable.
+	int64_t BackoffMsWithJitter(idx_t attempt, double unit_random) const;
+
+	//! Decorrelated jitter (AWS "Exponential Backoff And Jitter"): the next sleep is drawn from
+	//! [min_wait, prev_sleep*3], clamped to max_wait. Starting `prev_sleep` is min_wait, so the first
+	//! retries are TIGHT (near min_wait) -- a conflict's refresh+recommit window is short, so retrying
+	//! quickly usually wins -- and the window only widens as repeated failures accumulate, which is
+	//! exactly when a thundering herd needs spreading. `unit_random` in [0,1). Returns the new sleep;
+	//! the caller feeds it back as `prev_sleep` next iteration. Pure/unit-testable.
+	int64_t DecorrelatedBackoffMs(int64_t prev_sleep_ms, double unit_random) const;
+};
+
+} // namespace duckdb

--- a/src/include/catalog/rest/api/iceberg_table_update.hpp
+++ b/src/include/catalog/rest/api/iceberg_table_update.hpp
@@ -54,6 +54,11 @@ public:
 
 	//! All the 'manifest_file' entries we will write to the new manifest list
 	vector<IcebergManifestListEntry> manifests;
+	//! Paths of manifest / manifest-list files written while applying this commit. Tracked so that a
+	//! failed transaction (or a discarded retry attempt) can delete the metadata files it wrote,
+	//! instead of leaking them (the data files are cleaned separately). Never deleted on success --
+	//! they are referenced by the committed snapshot.
+	vector<string> written_metadata_paths;
 	rest_api_objects::CommitTableRequest table_change;
 };
 

--- a/src/include/catalog/rest/api/iceberg_table_update.hpp
+++ b/src/include/catalog/rest/api/iceberg_table_update.hpp
@@ -47,6 +47,11 @@ public:
 
 	ClientContext &context;
 
+	//! Resolved Avro codec for manifests written during this commit ("null"/"deflate"), decided once
+	//! per apply from write.manifest.compression-codec AND the catalog's delete capability. All
+	//! manifest/manifest-list writes in the apply path use it.
+	string manifest_avro_codec = "null";
+
 	//! All the 'manifest_file' entries we will write to the new manifest list
 	vector<IcebergManifestListEntry> manifests;
 	rest_api_objects::CommitTableRequest table_change;

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -39,6 +39,12 @@ public:
 
 public:
 	optional_ptr<CatalogEntry> GetLatestSchema(ClientContext &context);
+	//! The schema entry for the table's CURRENT metadata, with no read-time snapshot isolation /
+	//! metadata-log rewind. The commit path must use this: a commit always targets the latest
+	//! (refreshed) metadata, like Java's SnapshotProducer which refreshes then applies against it.
+	//! GetLatestSchema/GetSchemaVersion are for read queries (as-of transaction start) and would, in
+	//! the commit path, mis-resolve against a concurrent writer's "too fresh" metadata.
+	optional_ptr<CatalogEntry> GetCurrentSchemaEntry();
 	idx_t GetIcebergVersion() const;
 	optional_ptr<CatalogEntry> GetSchemaVersion(ClientContext &context, optional_ptr<BoundAtClause> at);
 	optional_ptr<CatalogEntry> CreateSchemaVersion(const IcebergTableSchema &table_schema);

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -81,6 +81,21 @@ public:
 		return access_mode;
 	}
 	void DoTableUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
+	//! Build the REST request from the current state and submit it once (one commit attempt).
+	void SubmitTableUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
+	//! Refresh table metadata + reset per-table apply state before a retry attempt. Returns true if
+	//! a retry has a chance of succeeding (parent advanced), false to fail fast.
+	bool RefreshForRetry(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
+	//! Outcome of resolving an ambiguous (UNKNOWN) commit by re-loading the table.
+	enum class StatusCheckResult { ALL_COMMITTED, NONE_COMMITTED, UNKNOWN };
+	//! After an ambiguous commit failure, re-load every uncommitted table and check whether this
+	//! transaction's stable snapshot id(s) are present. Used to resolve UNKNOWN deterministically.
+	StatusCheckResult CheckCommitStatus(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
+	//! Before retrying a DELETE/OVERWRITE, verify the data files this operation targets still exist in
+	//! the refreshed parent. If a concurrent commit already removed one, retrying would be unsafe
+	//! (lost/duplicated delete), so throw a non-retryable error. APPEND-only commits have nothing to
+	//! validate. Mirrors Java's validateDataFilesExist for the delete/overwrite path.
+	void ValidateRetrySafe(IcebergTableInformation &table_info, ClientContext &context);
 	void DoTableDeletes(IcebergTransactionDeleteUpdate &delete_update, ClientContext &context);
 	void DoTableRename(IcebergTransactionRenameUpdate &rename_update, ClientContext &context);
 	void DoSchemaCreates(ClientContext &context);

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -48,7 +48,20 @@ public:
 	void TableSetLocation();
 
 private:
-	void CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata);
+	//! Read the current snapshot's manifest list into existing_manifest_list. `context` must be a
+	//! context with an active transaction at call time, because resolving storage secrets (e.g. S3
+	//! SIGV4 / credential_chain) requires one. The operator phase passes its live context; the commit
+	//! retry passes the commit-time context (the member `context`, captured at construction during the
+	//! operator, is no longer transaction-active during commit).
+	void CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata,
+	                               ClientContext &context);
+
+public:
+	//! Drop the cached parent manifest list so the next apply re-reads it from the (refreshed)
+	//! current snapshot. Required for retry: on a commit conflict the parent has moved, and reusing
+	//! the stale cache would miss manifests added by the concurrent commit. `context`
+	//! must have an active transaction (the commit-time context), used for the manifest re-read.
+	void RefreshForRetry(ClientContext &context);
 
 public:
 	int32_t initial_schema_id;
@@ -60,6 +73,17 @@ public:
 	vector<unique_ptr<IcebergTableRequirement>> requirements;
 	//! Cached manifest list from the source snapshot
 	vector<IcebergManifestListEntry> existing_manifest_list;
+	//! Whether existing_manifest_list has been read for this transaction (reset on retry).
+	bool manifest_list_cached = false;
+
+	//! The snapshot id of the table at the time this transaction first started applying (the parent
+	//! of our very first attempt). Captured once and kept stable across retries (NOT reset by
+	//! RefreshForRetry, unlike manifest_list_cached). Used by the retry-time conflict validation to
+	//! (a) walk the refreshed parent's ancestry back to this id -- detecting a concurrent rollback
+	//! that would make a retry validate against unrelated history -- and (b) bound the set of
+	//! concurrently-added snapshots to inspect. -1 means "not yet captured".
+	int64_t starting_snapshot_id = -1;
+	bool starting_snapshot_captured = false;
 
 	//! Every insert/update/delete creates an alter of the table data
 	vector<reference<IcebergAddSnapshot>> alters;
@@ -67,6 +91,10 @@ public:
 	case_insensitive_map_t<string> transactional_delete_files;
 	//! Track the current row id for this transaction
 	int64_t next_row_id = 0;
+	//! Paths of manifest / manifest-list files written across all commit attempts for this table.
+	//! Used by CleanupFiles to delete metadata files left behind by a failed transaction or by
+	//! discarded retry attempts. Never used on a successful commit.
+	vector<string> written_metadata_paths;
 
 	//! If we perform an update that relies on the current schema id staying unchanged
 	bool assert_schema_id = false;

--- a/src/include/catalog/rest/transaction/iceberg_transaction_metadata.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_metadata.hpp
@@ -16,6 +16,9 @@ public:
 	bool IsEmpty() const {
 		return data_files.empty();
 	}
+	const unordered_set<string> &GetInvalidatedFiles() const {
+		return data_files;
+	}
 
 private:
 	//! The 'data_file.file_path' of invalidated data files

--- a/src/include/core/metadata/iceberg_table_metadata.hpp
+++ b/src/include/core/metadata/iceberg_table_metadata.hpp
@@ -58,6 +58,14 @@ public:
 	optional_ptr<const IcebergSnapshot> GetSnapshotById(int64_t snapshot_id) const;
 	optional_ptr<const IcebergSnapshot> GetSnapshotByTimestamp(timestamp_t timestamp) const;
 
+	//! Whether `descendant_id` is `ancestor_id`, or reachable from it by following parent_snapshot_id
+	//! links. Used by the retry-time guard to confirm the refreshed parent still descends from the
+	//! snapshot this transaction started against (a concurrent rollback would break this). If a link
+	//! in the chain is missing from the loaded `snapshots` map (e.g. the catalog elided an expired
+	//! snapshot), the walk stops and returns false -- callers treat "cannot prove ancestry" as a
+	//! conflict, which is the safe choice.
+	bool IsAncestorOf(int64_t ancestor_id, int64_t descendant_id) const;
+
 	//! Version extraction and identification
 	static bool UnsafeVersionGuessingEnabled(ClientContext &context);
 	static string GetTableVersionFromHint(const string &path, FileSystem &fs, string version_format);

--- a/src/include/core/metadata/manifest/iceberg_avro_codec.hpp
+++ b/src/include/core/metadata/manifest/iceberg_avro_codec.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "duckdb/common/string.hpp"
+#include "duckdb/main/client_context.hpp"
+
+namespace duckdb {
+
+//! Iceberg's `write.manifest.compression-codec` (Java default "gzip", which in Avro terms is the
+//! "deflate" object-container codec). The Avro COPY function this extension writes manifests through
+//! only emits the "null" (uncompressed) codec, so we post-process the freshly written file: parse the
+//! uncompressed Avro Object Container File, re-compress each data block with raw DEFLATE (via DuckDB's
+//! vendored miniz), and rewrite the container with `avro.codec=deflate`. The rewrite goes back through
+//! DuckDB's FileSystem, so object stores (S3/Azure/GCS) keep working.
+namespace iceberg_avro_codec {
+
+//! Parse `write.manifest.compression-codec` into the Avro codec name actually emitted. Returns
+//! "deflate" for "gzip"/"deflate", "null"/"" for uncompressed. Anything else throws (we do not
+//! silently write an unrequested codec). Default when the property is unset matches Java: "deflate".
+//!
+//! `catalog_allows_deletes` gates compression: emitting a compressed manifest requires writing a
+//! temporary uncompressed file and deleting it afterward (the Avro COPY function cannot emit a codec
+//! directly). Catalogs that forbid client deletes and manage their own storage (e.g. AWS S3 Tables,
+//! allows_deletes == false) cannot delete that temp, so for them we force "null" (write uncompressed
+//! directly, no temp). Those catalogs run their own compaction/GC, so uncompressed manifests are fine.
+string ResolveAvroCodec(const string &property_value, bool catalog_allows_deletes);
+
+//! Returns true if `avro_codec` denotes a compressing codec that requires the post-processing pass.
+bool RequiresRecompression(const string &avro_codec);
+
+//! Read the uncompressed Avro Object Container File at `source_path`, recompress every data block
+//! with the given codec ("deflate"), and write the result to `dest_path` as a brand-new file. The
+//! two paths must differ; writing a fresh `dest_path` (never reopening it for overwrite) keeps this
+//! working on object stores (S3/Azure/GCS), which do not support truncating or rewriting an existing
+//! object. The caller is responsible for choosing/cleaning up the temporary `source_path`. Reads and
+//! writes through `context`'s FileSystem. Throws on a malformed container (it only ever processes
+//! files this extension just wrote, so a failure indicates a real bug, not untrusted input).
+//! Returns the number of bytes written to `dest_path`, so the caller need not issue a separate
+//! size-probe (HEAD) request -- this mirrors Java's `ManifestWriter.length()`.
+idx_t RecompressManifestFile(ClientContext &context, const string &source_path, const string &dest_path,
+                             const string &avro_codec);
+
+} // namespace iceberg_avro_codec
+
+} // namespace duckdb

--- a/src/include/core/metadata/manifest/iceberg_manifest.hpp
+++ b/src/include/core/metadata/manifest/iceberg_manifest.hpp
@@ -193,9 +193,13 @@ static constexpr const int32_t REFERENCED_DATA_FILE = 143;
 static constexpr const int32_t CONTENT_OFFSET = 144;
 static constexpr const int32_t CONTENT_SIZE_IN_BYTES = 145;
 
+//! Write a manifest file. `avro_codec` is the already-resolved Avro codec ("null" = uncompressed,
+//! "deflate" = compressed). It is resolved by the caller (which knows whether the catalog allows the
+//! temp-file deletes that compression needs), defaulting to uncompressed so callers that do not opt
+//! in stay safe on every catalog.
 idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManifestFile &manifest_file,
                   const vector<IcebergManifestEntry> &entries, CopyFunction &copy_function, DatabaseInstance &db,
-                  ClientContext &context);
+                  ClientContext &context, const string &avro_codec = "null");
 
 } // namespace manifest_file
 

--- a/src/include/core/metadata/manifest/iceberg_manifest_list.hpp
+++ b/src/include/core/metadata/manifest/iceberg_manifest_list.hpp
@@ -198,8 +198,12 @@ static constexpr const int32_t FIELD_SUMMARY_UPPER_BOUND = 511;
 static constexpr const int32_t KEY_METADATA = 519;
 static constexpr const int32_t FIRST_ROW_ID = 520;
 
+//! Write a manifest list. `avro_codec` is the already-resolved Avro codec ("null" = uncompressed,
+//! "deflate" = compressed), resolved by the caller (see manifest_file::WriteToFile). Defaults to
+//! uncompressed so callers that do not opt in stay safe on every catalog.
 void WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManifestList &manifest_list,
-                 CopyFunction &copy_function, DatabaseInstance &db, ClientContext &context);
+                 CopyFunction &copy_function, DatabaseInstance &db, ClientContext &context,
+                 const string &avro_codec = "null");
 
 } // namespace manifest_list
 

--- a/src/include/core/metadata/manifest/iceberg_manifest_list.hpp
+++ b/src/include/core/metadata/manifest/iceberg_manifest_list.hpp
@@ -121,7 +121,8 @@ public:
 	static IcebergManifestListEntry
 	CreateFromEntries(FileSystem &fs, int64_t snapshot_id, sequence_number_t sequence_number,
 	                  const IcebergTableMetadata &table_metadata, IcebergManifestContentType manifest_content_type,
-	                  vector<IcebergManifestEntry> &&manifest_entries, int64_t &next_row_id);
+	                  vector<IcebergManifestEntry> &&manifest_entries, int64_t &next_row_id,
+	                  int32_t partition_spec_id = -1);
 
 public:
 	IcebergManifestFile file;
@@ -139,6 +140,9 @@ public:
 	const vector<IcebergManifestListEntry> &GetManifestFilesConst() const;
 	const string &GetPath() const {
 		return path;
+	}
+	sequence_number_t GetSequenceNumber() const {
+		return sequence_number;
 	}
 
 	void AddNewManifestFile(IcebergManifestListEntry &&manifest_list_entry) {

--- a/test/cpp/test_compression_logic.cpp
+++ b/test/cpp/test_compression_logic.cpp
@@ -1,0 +1,388 @@
+// Standalone unit tests for the pure-logic pieces of the manifest Avro compression implementation.
+// They do not depend on the DuckDB test harness or a catalog, so they build and run on their own
+// with a single command:
+//
+//   c++ -std=c++17 test/cpp/test_compression_logic.cpp -lz -o /tmp/t && /tmp/t
+//
+// Why mirrors: the DuckDB `unittest` binary only runs SQL logic tests, and the extension is a
+// dynamically-loaded module, so production C++ functions cannot be linked into a standalone binary
+// without pulling in all of DuckDB. The codec-resolution block below reproduces the production
+// ResolveAvroCodec function byte-for-byte and names the source file it mirrors; a divergence shows
+// up as a failing test during review. The Avro OCF recompression test is stronger than a mirror --
+// it performs a real DEFLATE/INFLATE round-trip over hand-built OCF bytes, so it validates actual
+// compression behavior. End-to-end coverage of the manifest write paths (which need a catalog)
+// lives in the catalog-required SQL tests run by the lakekeeper/polaris/nessie/fixture CI jobs.
+
+#include <cassert>
+#include <cctype>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <map>
+
+//===--------------------------------------------------------------------===//
+// Mirror of iceberg_avro_codec.cpp::ResolveAvroCodec. Returns "deflate"/"null"; throws (here:
+// returns "<error>") for unsupported. catalog_allows_deletes==false forces "null" (compression needs
+// a deletable temp file, which delete-forbidden catalogs like S3 Tables cannot remove).
+//===--------------------------------------------------------------------===//
+static std::string ResolveAvroCodec(const std::string &v, bool catalog_allows_deletes) {
+	auto ci_eq = [](const std::string &a, const char *b) {
+		std::string lb(b);
+		if (a.size() != lb.size()) {
+			return false;
+		}
+		for (size_t i = 0; i < a.size(); i++) {
+			if (std::tolower(static_cast<unsigned char>(a[i])) != std::tolower(static_cast<unsigned char>(lb[i]))) {
+				return false;
+			}
+		}
+		return true;
+	};
+	if (!catalog_allows_deletes) {
+		return "null";
+	}
+	if (v.empty()) {
+		return "deflate";
+	}
+	if (ci_eq(v, "gzip") || ci_eq(v, "deflate")) {
+		return "deflate";
+	}
+	if (ci_eq(v, "none") || ci_eq(v, "null") || ci_eq(v, "uncompressed")) {
+		return "null";
+	}
+	return "<error>";
+}
+
+//===--------------------------------------------------------------------===//
+// Real Avro OCF varint + recompression, ported verbatim from iceberg_avro_codec.cpp (with zlib
+// raw-deflate standing in for miniz raw-deflate -- both produce the same -15-window-bits stream).
+// The recompress test below feeds it a hand-built uncompressed OCF and decodes the result, so this
+// exercises the zigzag codec, metadata-map rewrite, block recompression, and DEFLATE round-trip.
+//===--------------------------------------------------------------------===//
+#include <zlib.h>
+
+namespace ocf {
+
+struct Writer {
+	std::vector<uint8_t> buf;
+	void WriteLong(int64_t value) {
+		uint64_t zz = (uint64_t)((value << 1) ^ (value >> 63));
+		do {
+			uint8_t b = zz & 0x7F;
+			zz >>= 7;
+			if (zz) {
+				b |= 0x80;
+			}
+			buf.push_back(b);
+		} while (zz);
+	}
+	void WriteRaw(const uint8_t *p, size_t n) {
+		buf.insert(buf.end(), p, p + n);
+	}
+	void WriteString(const std::string &s) {
+		WriteLong((int64_t)s.size());
+		WriteRaw((const uint8_t *)s.data(), s.size());
+	}
+};
+
+struct Reader {
+	const uint8_t *data;
+	size_t size, pos = 0;
+	Reader(const uint8_t *d, size_t s) : data(d), size(s) {
+	}
+	uint8_t ReadByte() {
+		if (pos >= size) {
+			throw std::string("eof");
+		}
+		return data[pos++];
+	}
+	int64_t ReadLong() {
+		uint64_t value = 0;
+		int shift = 0;
+		while (true) {
+			auto b = ReadByte();
+			value |= (uint64_t)(b & 0x7F) << shift;
+			if (!(b & 0x80)) {
+				break;
+			}
+			shift += 7;
+		}
+		return (int64_t)((value >> 1) ^ (~(value & 1) + 1));
+	}
+	const uint8_t *ReadRaw(size_t n) {
+		if (pos + n > size) {
+			throw std::string("eof");
+		}
+		auto p = data + pos;
+		pos += n;
+		return p;
+	}
+};
+
+static std::vector<uint8_t> RawDeflate(const uint8_t *in, size_t n) {
+	z_stream s;
+	memset(&s, 0, sizeof(s));
+	deflateInit2(&s, Z_DEFAULT_COMPRESSION, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY);
+	std::vector<uint8_t> out(deflateBound(&s, n));
+	s.next_in = (Bytef *)in;
+	s.avail_in = n;
+	s.next_out = out.data();
+	s.avail_out = out.size();
+	deflate(&s, Z_FINISH);
+	out.resize(s.total_out);
+	deflateEnd(&s);
+	return out;
+}
+static std::vector<uint8_t> RawInflate(const uint8_t *in, size_t n, size_t expected) {
+	z_stream s;
+	memset(&s, 0, sizeof(s));
+	inflateInit2(&s, -15);
+	std::vector<uint8_t> out(expected);
+	s.next_in = (Bytef *)in;
+	s.avail_in = n;
+	s.next_out = out.data();
+	s.avail_out = out.size();
+	inflate(&s, Z_FINISH);
+	out.resize(s.total_out);
+	inflateEnd(&s);
+	return out;
+}
+
+static const uint8_t MAGIC[4] = {'O', 'b', 'j', 0x01};
+
+// Recompress an uncompressed OCF (codec=null) to codec=deflate. Mirrors RecompressManifestFile.
+static std::vector<uint8_t> Recompress(const std::vector<uint8_t> &input) {
+	Reader reader(input.data(), input.size());
+	auto magic = reader.ReadRaw(4);
+	if (memcmp(magic, MAGIC, 4) != 0) {
+		throw std::string("magic");
+	}
+	std::vector<std::pair<std::string, std::vector<uint8_t>>> metadata;
+	while (true) {
+		auto block_count = reader.ReadLong();
+		if (block_count == 0) {
+			break;
+		}
+		if (block_count < 0) {
+			block_count = -block_count;
+			reader.ReadLong();
+		}
+		for (int64_t i = 0; i < block_count; i++) {
+			auto kl = reader.ReadLong();
+			auto kp = reader.ReadRaw(kl);
+			std::string key((const char *)kp, kl);
+			auto vl = reader.ReadLong();
+			auto vp = reader.ReadRaw(vl);
+			metadata.emplace_back(std::move(key), std::vector<uint8_t>(vp, vp + vl));
+		}
+	}
+	bool codec_set = false;
+	const std::string deflate_name = "deflate";
+	for (auto &e : metadata) {
+		if (e.first == "avro.codec") {
+			e.second.assign(deflate_name.begin(), deflate_name.end());
+			codec_set = true;
+		}
+	}
+	if (!codec_set) {
+		metadata.emplace_back("avro.codec", std::vector<uint8_t>(deflate_name.begin(), deflate_name.end()));
+	}
+	auto sync_ptr = reader.ReadRaw(16);
+	std::vector<uint8_t> sync(sync_ptr, sync_ptr + 16);
+
+	Writer writer;
+	writer.WriteRaw(MAGIC, 4);
+	writer.WriteLong((int64_t)metadata.size());
+	for (auto &e : metadata) {
+		writer.WriteString(e.first);
+		writer.WriteLong((int64_t)e.second.size());
+		writer.WriteRaw(e.second.data(), e.second.size());
+	}
+	writer.WriteLong(0);
+	writer.WriteRaw(sync.data(), sync.size());
+	while (reader.pos < reader.size) {
+		auto object_count = reader.ReadLong();
+		auto byte_count = reader.ReadLong();
+		auto payload = reader.ReadRaw(byte_count);
+		auto block_sync = reader.ReadRaw(16);
+		if (memcmp(block_sync, sync.data(), 16) != 0) {
+			throw std::string("sync");
+		}
+		auto compressed = RawDeflate(payload, byte_count);
+		writer.WriteLong(object_count);
+		writer.WriteLong((int64_t)compressed.size());
+		writer.WriteRaw(compressed.data(), compressed.size());
+		writer.WriteRaw(sync.data(), sync.size());
+	}
+	return writer.buf;
+}
+
+} // namespace ocf
+
+//===--------------------------------------------------------------------===//
+// Tests
+//===--------------------------------------------------------------------===//
+static int g_failures = 0;
+#define CHECK(cond)                                                                                                    \
+	do {                                                                                                               \
+		if (!(cond)) {                                                                                                 \
+			printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);                                                     \
+			g_failures++;                                                                                              \
+		}                                                                                                              \
+	} while (0)
+
+//===--------------------------------------------------------------------===//
+// Codec resolution
+//===--------------------------------------------------------------------===//
+static void TestResolveCodecDefault() {
+	CHECK(ResolveAvroCodec("", true) == "deflate"); // matches Java default
+}
+static void TestResolveCodecGzipDeflate() {
+	CHECK(ResolveAvroCodec("gzip", true) == "deflate");
+	CHECK(ResolveAvroCodec("GZIP", true) == "deflate");
+	CHECK(ResolveAvroCodec("deflate", true) == "deflate");
+}
+static void TestResolveCodecNone() {
+	CHECK(ResolveAvroCodec("none", true) == "null");
+	CHECK(ResolveAvroCodec("uncompressed", true) == "null");
+	CHECK(ResolveAvroCodec("null", true) == "null");
+}
+static void TestResolveCodecUnsupported() {
+	CHECK(ResolveAvroCodec("snappy", true) == "<error>"); // unsupported -> throws in production
+	CHECK(ResolveAvroCodec("zstd", true) == "<error>");
+}
+static void TestResolveCodecDeleteForbidden() {
+	// Catalogs that forbid client deletes (e.g. S3 Tables) must never get a compressing codec,
+	// regardless of the table property, because the temp-file-then-delete dance would fail there.
+	CHECK(ResolveAvroCodec("", false) == "null");
+	CHECK(ResolveAvroCodec("gzip", false) == "null");
+	CHECK(ResolveAvroCodec("deflate", false) == "null");
+	CHECK(ResolveAvroCodec("snappy", false) == "null"); // not even validated -> just uncompressed
+}
+
+//===--------------------------------------------------------------------===//
+// Avro OCF deflate recompression round-trip -- real DEFLATE, real OCF bytes
+//===--------------------------------------------------------------------===//
+// Build a minimal uncompressed OCF with codec=null, two data blocks, then recompress and verify the
+// blocks decode back to the original payloads and the codec metadata flipped to "deflate".
+static std::vector<uint8_t> BuildUncompressedOCF(const std::vector<std::vector<uint8_t>> &blocks,
+                                                 const std::vector<int64_t> &object_counts,
+                                                 const std::vector<uint8_t> &sync) {
+	ocf::Writer w;
+	w.WriteRaw(ocf::MAGIC, 4);
+	// metadata map: avro.schema + avro.codec=null
+	w.WriteLong(2);
+	std::string schema_key = "avro.schema", schema_val = "{\"type\":\"record\",\"name\":\"x\",\"fields\":[]}";
+	w.WriteString(schema_key);
+	w.WriteLong((int64_t)schema_val.size());
+	w.WriteRaw((const uint8_t *)schema_val.data(), schema_val.size());
+	std::string codec_key = "avro.codec", codec_val = "null";
+	w.WriteString(codec_key);
+	w.WriteLong((int64_t)codec_val.size());
+	w.WriteRaw((const uint8_t *)codec_val.data(), codec_val.size());
+	w.WriteLong(0);
+	w.WriteRaw(sync.data(), 16);
+	for (size_t i = 0; i < blocks.size(); i++) {
+		w.WriteLong(object_counts[i]);
+		w.WriteLong((int64_t)blocks[i].size());
+		w.WriteRaw(blocks[i].data(), blocks[i].size());
+		w.WriteRaw(sync.data(), 16);
+	}
+	return w.buf;
+}
+
+static void TestOCFRecompressRoundTrip() {
+	std::vector<uint8_t> sync(16);
+	for (int i = 0; i < 16; i++) {
+		sync[i] = (uint8_t)(i * 7 + 1);
+	}
+	std::vector<uint8_t> block0, block1;
+	for (int i = 0; i < 2000; i++) {
+		block0.push_back((uint8_t)(i % 251)); // compressible
+	}
+	for (int i = 0; i < 500; i++) {
+		block1.push_back((uint8_t)((i * 13 + 5) % 256));
+	}
+	std::vector<int64_t> counts = {100, 25};
+	auto uncompressed = BuildUncompressedOCF({block0, block1}, counts, sync);
+
+	std::vector<uint8_t> recompressed;
+	bool threw = false;
+	try {
+		recompressed = ocf::Recompress(uncompressed);
+	} catch (const std::string &e) {
+		threw = true;
+		printf("FAIL OCF recompress threw: %s\n", e.c_str());
+	}
+	CHECK(!threw);
+	CHECK(recompressed.size() < uncompressed.size()); // it actually compressed
+
+	// Decode the recompressed OCF and verify structure + payloads.
+	ocf::Reader r(recompressed.data(), recompressed.size());
+	auto magic = r.ReadRaw(4);
+	CHECK(memcmp(magic, ocf::MAGIC, 4) == 0);
+	// metadata map
+	std::map<std::string, std::string> meta;
+	auto bc = r.ReadLong();
+	CHECK(bc > 0);
+	for (int64_t i = 0; i < bc; i++) {
+		auto kl = r.ReadLong();
+		auto kp = r.ReadRaw(kl);
+		std::string key((const char *)kp, kl);
+		auto vl = r.ReadLong();
+		auto vp = r.ReadRaw(vl);
+		meta[key] = std::string((const char *)vp, vl);
+	}
+	CHECK(r.ReadLong() == 0);            // map terminator
+	CHECK(meta["avro.codec"] == "deflate"); // codec flipped
+	CHECK(meta.count("avro.schema") == 1);  // schema preserved
+	r.ReadRaw(16);                       // sync
+
+	// block 0
+	CHECK(r.ReadLong() == 100);
+	auto c0_len = r.ReadLong();
+	auto c0 = r.ReadRaw(c0_len);
+	auto d0 = ocf::RawInflate(c0, c0_len, block0.size());
+	CHECK(d0 == block0); // round-trips byte-identical
+	r.ReadRaw(16);
+	// block 1
+	CHECK(r.ReadLong() == 25);
+	auto c1_len = r.ReadLong();
+	auto c1 = r.ReadRaw(c1_len);
+	auto d1 = ocf::RawInflate(c1, c1_len, block1.size());
+	CHECK(d1 == block1);
+	r.ReadRaw(16);
+	CHECK(r.pos == r.size); // consumed exactly
+}
+
+static void TestOCFVarintZigzag() {
+	// The zigzag long encoding must round-trip for representative values (incl. negatives, which
+	// appear in Avro map block counts).
+	std::vector<int64_t> values = {0, 1, -1, 63, 64, -64, 100, -100, 1000000, -1000000, 9223372036854775807LL};
+	for (auto v : values) {
+		ocf::Writer w;
+		w.WriteLong(v);
+		ocf::Reader r(w.buf.data(), w.buf.size());
+		CHECK(r.ReadLong() == v);
+	}
+}
+
+int main() {
+	TestResolveCodecDefault();
+	TestResolveCodecGzipDeflate();
+	TestResolveCodecNone();
+	TestResolveCodecUnsupported();
+	TestResolveCodecDeleteForbidden();
+
+	TestOCFRecompressRoundTrip();
+	TestOCFVarintZigzag();
+
+	if (g_failures == 0) {
+		printf("All compression logic tests passed.\n");
+		return 0;
+	}
+	printf("%d test(s) failed.\n", g_failures);
+	return 1;
+}

--- a/test/cpp/test_merge_logic.cpp
+++ b/test/cpp/test_merge_logic.cpp
@@ -1,0 +1,231 @@
+// Standalone unit tests for the pure-logic pieces of the MergeAppend manifest bin-packing
+// implementation. They do not depend on the DuckDB test harness or a catalog, so they build and run
+// on their own with a single command:
+//
+//   c++ -std=c++17 test/cpp/test_merge_logic.cpp -o /tmp/t && /tmp/t
+//
+// Why mirrors: the DuckDB `unittest` binary only runs SQL logic tests, and the extension is a
+// dynamically-loaded module, so production C++ functions cannot be linked into a standalone binary
+// without pulling in all of DuckDB. The blocks below reproduce the production bin-packing and
+// merge-decision functions byte-for-byte and name the source file they mirror; a divergence shows up
+// as a failing test during review. End-to-end coverage of the manifest merge paths (which need a
+// catalog) lives in the catalog-required SQL tests run by the lakekeeper/polaris/nessie/fixture CI
+// jobs.
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+using idx_t = uint64_t;
+
+//===--------------------------------------------------------------------===//
+// Mirror of BinPackManifests (iceberg_manifest_merge.cpp): pack_end with lookback=1
+//===--------------------------------------------------------------------===//
+static std::vector<std::vector<idx_t>> BinPackManifests(const std::vector<int64_t> &weights, int64_t target_weight) {
+	constexpr idx_t LOOKBACK = 1;
+	struct OpenBin {
+		std::vector<idx_t> items;
+		int64_t weight = 0;
+	};
+	std::vector<std::vector<idx_t>> packed;
+	std::vector<OpenBin> open_bins;
+	for (idx_t rev = weights.size(); rev-- > 0;) {
+		auto weight = weights[rev];
+		OpenBin *target = nullptr;
+		for (auto &b : open_bins) {
+			if (b.weight + weight <= target_weight) {
+				target = &b;
+				break;
+			}
+		}
+		if (target) {
+			target->items.push_back(rev);
+			target->weight += weight;
+		} else {
+			OpenBin b;
+			b.items.push_back(rev);
+			b.weight = weight;
+			open_bins.push_back(std::move(b));
+			if (open_bins.size() > LOOKBACK) {
+				packed.push_back(std::move(open_bins.front().items));
+				open_bins.erase(open_bins.begin());
+			}
+		}
+	}
+	for (auto &b : open_bins) {
+		packed.push_back(std::move(b.items));
+	}
+	std::vector<std::vector<idx_t>> bins;
+	for (idx_t i = packed.size(); i-- > 0;) {
+		auto &bin = packed[i];
+		std::reverse(bin.begin(), bin.end());
+		bins.push_back(std::move(bin));
+	}
+	return bins;
+}
+
+//===--------------------------------------------------------------------===//
+// Mirror of ShouldMergeBin
+//===--------------------------------------------------------------------===//
+enum class ManifestSource { NEW_THIS_TRANSACTION, CARRIED_OVER };
+
+static bool ShouldMergeBin(const std::vector<ManifestSource> &sources, const std::vector<idx_t> &bin,
+                           idx_t min_count_to_merge) {
+	if (bin.size() <= 1) {
+		return false;
+	}
+	bool has_new = false;
+	for (auto idx : bin) {
+		if (sources[idx] == ManifestSource::NEW_THIS_TRANSACTION) {
+			has_new = true;
+			break;
+		}
+	}
+	if (has_new && bin.size() < min_count_to_merge) {
+		return false;
+	}
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Tests
+//===--------------------------------------------------------------------===//
+static int g_failures = 0;
+#define CHECK(cond)                                                                                                    \
+	do {                                                                                                               \
+		if (!(cond)) {                                                                                                 \
+			printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);                                                     \
+			g_failures++;                                                                                              \
+		}                                                                                                              \
+	} while (0)
+
+static idx_t TotalEntries(const std::vector<std::vector<idx_t>> &bins) {
+	idx_t n = 0;
+	for (auto &b : bins) {
+		n += b.size();
+	}
+	return n;
+}
+
+static void TestBinPackEmpty() {
+	auto bins = BinPackManifests({}, 100);
+	CHECK(bins.empty());
+}
+
+static void TestBinPackSingle() {
+	auto bins = BinPackManifests({50}, 100);
+	CHECK(bins.size() == 1);
+	CHECK(bins[0].size() == 1);
+	CHECK(bins[0][0] == 0);
+}
+
+static void TestBinPackAllFitOneBin() {
+	auto bins = BinPackManifests({10, 20, 30}, 100);
+	CHECK(bins.size() == 1);
+	CHECK(TotalEntries(bins) == 3);
+}
+
+static void TestBinPackExactFill() {
+	// 60 + 40 = 100 exactly -> one bin; 30 starts a new one.
+	auto bins = BinPackManifests({60, 40, 30}, 100);
+	CHECK(TotalEntries(bins) == 3);
+	// Every weight accounted for, no bin exceeds target.
+}
+
+static void TestBinPackCrossBin() {
+	auto bins = BinPackManifests({70, 70, 70}, 100);
+	// None pair fits together -> three bins.
+	CHECK(bins.size() == 3);
+}
+
+static void TestBinPackLookbackNoReorder() {
+	// lookback=1: with [10, 95, 10] and target 100, the middle 95 forces the first 10 into its own
+	// bin rather than being co-packed with the trailing 10 (which an unbounded first-fit would do).
+	// pack_end packs from the tail: tail 10 opens a bin (10); 95 cannot fit (10+95>100) so the
+	// tail-bin closes and 95 opens a new bin; leading 10 fits with 95? 95+10>100 no -> the 95 bin
+	// closes, 10 opens its own. Result: three singleton bins, preserving order (no distant merge).
+	auto bins = BinPackManifests({10, 95, 10}, 100);
+	CHECK(bins.size() == 3);
+	CHECK(bins[0].size() == 1 && bins[0][0] == 0);
+	CHECK(bins[1].size() == 1 && bins[1][0] == 1);
+	CHECK(bins[2].size() == 1 && bins[2][0] == 2);
+}
+
+static void TestBinPackAdjacentMerge() {
+	// Adjacent small manifests within target are packed together (pack_end groups from the tail).
+	auto bins = BinPackManifests({40, 40, 40}, 100);
+	// 40+40=80 fits, +40=120 no. From the tail: {40,40} then {40}. After pack_end reversal the
+	// leading singleton comes first, then the pair.
+	CHECK(bins.size() == 2);
+	idx_t total = 0;
+	for (auto &b : bins) {
+		total += b.size();
+	}
+	CHECK(total == 3);
+}
+
+static void TestBinPackNoLossNoDup() {
+	std::vector<int64_t> w = {10, 90, 5, 100, 1, 50, 49};
+	auto bins = BinPackManifests(w, 100);
+	// Every index appears exactly once.
+	std::vector<bool> seen(w.size(), false);
+	for (auto &b : bins) {
+		int64_t sum = 0;
+		for (auto idx : b) {
+			CHECK(!seen[idx]);
+			seen[idx] = true;
+			sum += w[idx];
+		}
+		CHECK(sum <= 100);
+	}
+	for (auto s : seen) {
+		CHECK(s);
+	}
+}
+
+static void TestShouldMergeSingle() {
+	std::vector<ManifestSource> src = {ManifestSource::CARRIED_OVER};
+	CHECK(!ShouldMergeBin(src, {0}, 2));
+}
+
+static void TestShouldMergeCarriedOverBelowMin() {
+	// All carried-over: no new-manifest guard, so any multi-manifest bin merges regardless of min.
+	std::vector<ManifestSource> src = {ManifestSource::CARRIED_OVER, ManifestSource::CARRIED_OVER};
+	CHECK(ShouldMergeBin(src, {0, 1}, 100));
+}
+
+static void TestShouldMergeNewBelowMin() {
+	// Contains a new manifest and bin size < min -> not merged.
+	std::vector<ManifestSource> src = {ManifestSource::NEW_THIS_TRANSACTION, ManifestSource::CARRIED_OVER};
+	CHECK(!ShouldMergeBin(src, {0, 1}, 3));
+}
+
+static void TestShouldMergeNewAtMin() {
+	// Contains a new manifest and bin size == min -> merged.
+	std::vector<ManifestSource> src = {ManifestSource::NEW_THIS_TRANSACTION, ManifestSource::CARRIED_OVER};
+	CHECK(ShouldMergeBin(src, {0, 1}, 2));
+}
+
+int main() {
+	TestBinPackEmpty();
+	TestBinPackSingle();
+	TestBinPackAllFitOneBin();
+	TestBinPackExactFill();
+	TestBinPackCrossBin();
+	TestBinPackLookbackNoReorder();
+	TestBinPackAdjacentMerge();
+	TestBinPackNoLossNoDup();
+	TestShouldMergeSingle();
+	TestShouldMergeCarriedOverBelowMin();
+	TestShouldMergeNewBelowMin();
+	TestShouldMergeNewAtMin();
+
+	if (g_failures == 0) {
+		printf("All merge logic tests passed.\n");
+		return 0;
+	}
+	printf("%d test(s) failed.\n", g_failures);
+	return 1;
+}

--- a/test/cpp/test_retry_logic.cpp
+++ b/test/cpp/test_retry_logic.cpp
@@ -1,0 +1,626 @@
+// Standalone unit tests for the pure-logic pieces of the commit-retry implementation: exponential /
+// jittered / decorrelated backoff, commit-status classification, Retry-After parsing and
+// consumption, retry-config parsing and cross-table folding, total-timeout enforcement, snapshot
+// ancestry walks, and delete-entry attribution / concurrent-delete detection. They do not depend on
+// the DuckDB test harness or a catalog, so they build and run on their own with a single command:
+//
+//   c++ -std=c++17 test/cpp/test_retry_logic.cpp -o /tmp/t && /tmp/t
+//
+// Why mirrors: the DuckDB `unittest` binary only runs SQL logic tests, and the extension is a
+// dynamically-loaded module, so production C++ functions cannot be linked into a standalone binary
+// without pulling in all of DuckDB. The blocks below reproduce each production function byte-for-byte
+// and name the source file they mirror; a divergence shows up as a failing test during review.
+// End-to-end coverage of the write/retry/validate paths (which need a catalog) lives in the
+// catalog-required SQL tests run by the lakekeeper/polaris/nessie/fixture CI jobs.
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <unordered_set>
+
+using idx_t = uint64_t;
+
+//===--------------------------------------------------------------------===//
+// Mirror of IcebergRetryConfig::BackoffMs
+//===--------------------------------------------------------------------===//
+static int64_t BackoffMs(int64_t min_wait_ms, int64_t max_wait_ms, idx_t attempt) {
+	int64_t wait = min_wait_ms;
+	for (idx_t i = 0; i < attempt && wait < max_wait_ms; i++) {
+		if (wait > max_wait_ms / 2) {
+			wait = max_wait_ms;
+			break;
+		}
+		wait *= 2;
+	}
+	if (wait > max_wait_ms) {
+		wait = max_wait_ms;
+	}
+	return wait;
+}
+
+//===--------------------------------------------------------------------===//
+// Mirror of IcebergRetryConfig::BackoffMsWithJitter
+//===--------------------------------------------------------------------===//
+static int64_t BackoffMsWithJitter(int64_t min_wait_ms, int64_t max_wait_ms, idx_t attempt, double unit_random) {
+	auto base = BackoffMs(min_wait_ms, max_wait_ms, attempt);
+	if (base <= 0) {
+		return 0;
+	}
+	if (unit_random < 0.0) {
+		unit_random = 0.0;
+	} else if (unit_random > 1.0) {
+		unit_random = 1.0;
+	}
+	return static_cast<int64_t>(static_cast<double>(base) * unit_random);
+}
+
+//===--------------------------------------------------------------------===//
+// Mirror of IcebergRetryConfig::DecorrelatedBackoffMs
+//===--------------------------------------------------------------------===//
+static int64_t DecorrelatedBackoffMs(int64_t min_wait_ms, int64_t max_wait_ms, int64_t prev_sleep_ms,
+                                     double unit_random) {
+	if (unit_random < 0.0) {
+		unit_random = 0.0;
+	} else if (unit_random > 1.0) {
+		unit_random = 1.0;
+	}
+	int64_t lo = min_wait_ms;
+	int64_t hi;
+	if (prev_sleep_ms > max_wait_ms / 3) {
+		hi = max_wait_ms;
+	} else {
+		hi = prev_sleep_ms * 3;
+	}
+	if (hi > max_wait_ms) {
+		hi = max_wait_ms;
+	}
+	if (hi < lo) {
+		hi = lo;
+	}
+	int64_t span = hi - lo;
+	return lo + static_cast<int64_t>(static_cast<double>(span) * unit_random);
+}
+
+//===--------------------------------------------------------------------===//
+// Mirror of IcebergRetryConfig::FromTableMetadata property parsing (iceberg_retry.cpp ParseInt +
+// FromTableMetadata): empty -> default; negative or (zero && !allow_zero) -> default; min>max
+// normalized to min=max. num-retries allows zero; the wait fields do not.
+//===--------------------------------------------------------------------===//
+struct RetryCfg {
+	idx_t num_retries;
+	int64_t min_wait_ms;
+	int64_t max_wait_ms;
+	int64_t total_wait_ms;
+};
+
+static int64_t ParseIntField(const std::string &value, int64_t fallback, bool allow_zero) {
+	if (value.empty()) {
+		return fallback;
+	}
+	try {
+		auto parsed = std::stoll(value);
+		if (parsed < 0 || (parsed == 0 && !allow_zero)) {
+			return fallback;
+		}
+		return parsed;
+	} catch (...) {
+		return fallback;
+	}
+}
+
+static RetryCfg ParseRetryConfig(const std::string &num, const std::string &min_w, const std::string &max_w,
+                                 const std::string &total_w) {
+	RetryCfg c;
+	c.num_retries = static_cast<idx_t>(ParseIntField(num, 4, true));
+	c.min_wait_ms = ParseIntField(min_w, 100, false);
+	c.max_wait_ms = ParseIntField(max_w, 60000, false);
+	c.total_wait_ms = ParseIntField(total_w, 1800000, false);
+	if (c.min_wait_ms > c.max_wait_ms) {
+		c.min_wait_ms = c.max_wait_ms;
+	}
+	return c;
+}
+
+//===--------------------------------------------------------------------===//
+// Mirror of IcebergRetryConfig::MostLenient (iceberg_retry.cpp): the cross-table fold takes the
+// larger num-retries / max-wait / total-timeout and the smaller min-wait, preserving min<=max.
+//===--------------------------------------------------------------------===//
+static RetryCfg MostLenient(const RetryCfg &a, const RetryCfg &b) {
+	RetryCfg m;
+	m.num_retries = a.num_retries > b.num_retries ? a.num_retries : b.num_retries;
+	m.min_wait_ms = a.min_wait_ms < b.min_wait_ms ? a.min_wait_ms : b.min_wait_ms;
+	m.max_wait_ms = a.max_wait_ms > b.max_wait_ms ? a.max_wait_ms : b.max_wait_ms;
+	m.total_wait_ms = a.total_wait_ms > b.total_wait_ms ? a.total_wait_ms : b.total_wait_ms;
+	if (m.min_wait_ms > m.max_wait_ms) {
+		m.min_wait_ms = m.max_wait_ms;
+	}
+	return m;
+}
+
+//===--------------------------------------------------------------------===//
+// Mirror of the total-timeout-ms enforcement in IcebergTransaction::DoTableUpdates
+// (iceberg_transaction.cpp): before sleeping, abort iff attempt>0 AND (wait alone exceeds the
+// budget OR cumulative elapsed would exceed it). The attempt>0 guard guarantees at least one retry
+// even with a tiny/misconfigured total-timeout. Comparison avoids summing (overflow-safe).
+//===--------------------------------------------------------------------===//
+static bool TotalTimeoutWouldAbort(idx_t attempt, int64_t wait_ms, int64_t elapsed_ms, int64_t total_wait_ms) {
+	if (attempt == 0) {
+		return false;
+	}
+	return wait_ms > total_wait_ms || elapsed_ms > total_wait_ms - wait_ms;
+}
+
+//===--------------------------------------------------------------------===//
+// Mirror of the Retry-After consumption in IcebergTransaction::DoTableUpdates: a server-supplied
+// Retry-After (>=0) takes precedence over computed backoff, capped at max_wait_ms; otherwise -1
+// signals "use decorrelated backoff".
+//===--------------------------------------------------------------------===//
+static int64_t ConsumeRetryAfter(int64_t retry_after_ms, int64_t max_wait_ms) {
+	if (retry_after_ms < 0) {
+		return -1; // no server guidance -> caller uses decorrelated backoff
+	}
+	return retry_after_ms < max_wait_ms ? retry_after_ms : max_wait_ms;
+}
+
+//===--------------------------------------------------------------------===//
+// Mirror of ClassifyCommitStatus (iceberg_commit_exceptions.hpp)
+//===--------------------------------------------------------------------===//
+enum class CommitOutcome { CONFLICT, UNKNOWN, FATAL };
+
+static CommitOutcome ClassifyCommitStatus(int status) {
+	switch (status) {
+	case 409:
+		return CommitOutcome::CONFLICT;
+	case 429: // too many requests: rejected before applying -> safe to retry like a conflict
+		return CommitOutcome::CONFLICT;
+	case 408: // request timeout
+	case 500: // internal server error
+	case 502: // bad gateway
+	case 503: // service unavailable (ambiguous for a non-idempotent POST commit)
+	case 504: // gateway timeout
+		return CommitOutcome::UNKNOWN;
+	default:
+		return CommitOutcome::FATAL;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Mirror of ParseRetryAfterMs (iceberg_commit_exceptions.hpp): numeric seconds -> ms; -1 otherwise.
+//===--------------------------------------------------------------------===//
+static int64_t ParseRetryAfterMs(const std::string &value) {
+	if (value.empty()) {
+		return -1;
+	}
+	try {
+		size_t consumed = 0;
+		auto seconds = std::stoll(value, &consumed);
+		if (consumed != value.size() || seconds < 0) {
+			return -1;
+		}
+		constexpr int64_t MAX_RETRY_AFTER_MS = 24LL * 60 * 60 * 1000;
+		if (seconds > MAX_RETRY_AFTER_MS / 1000) {
+			return MAX_RETRY_AFTER_MS;
+		}
+		return seconds * 1000;
+	} catch (...) {
+		return -1;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Mirror of IcebergTableMetadata::IsAncestorOf (iceberg_table_metadata.cpp).
+// snapshot_id -> parent_snapshot_id (-1 = no parent). Mirrors the walk exactly, including the
+// "missing link -> false" and "self-referential parent -> false" guards.
+//===--------------------------------------------------------------------===//
+struct SnapshotNode {
+	bool has_parent;
+	int64_t parent_id;
+};
+static bool IsAncestorOf(const std::unordered_map<int64_t, SnapshotNode> &snapshots, int64_t ancestor_id,
+                         int64_t descendant_id) {
+	int64_t current = descendant_id;
+	while (true) {
+		if (current == ancestor_id) {
+			return true;
+		}
+		auto it = snapshots.find(current);
+		if (it == snapshots.end() || !it->second.has_parent) {
+			return false;
+		}
+		if (it->second.parent_id == current) {
+			return false;
+		}
+		current = it->second.parent_id;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Mirror of iceberg_transaction.cpp::DeleteEntryReferencedDataFile. V3: referenced_data_file;
+// V2 fallback: FILENAME_FIELD_ID lower==upper bound; "" when not attributable to one file.
+//===--------------------------------------------------------------------===//
+struct FakeDeleteEntry {
+	std::string referenced_data_file;
+	bool has_filename_bounds = false;
+	std::string filename_lower;
+	std::string filename_upper;
+};
+static std::string DeleteEntryReferencedDataFile(const FakeDeleteEntry &e) {
+	if (!e.referenced_data_file.empty()) {
+		return e.referenced_data_file;
+	}
+	if (!e.has_filename_bounds) {
+		return "";
+	}
+	if (e.filename_lower != e.filename_upper) {
+		return "";
+	}
+	return e.filename_lower;
+}
+
+//===--------------------------------------------------------------------===//
+// Mirror of the validateNoNewDeletes decision (iceberg_transaction.cpp): a refreshed-parent DELETE
+// entry conflicts if it targets a file we also delete AND its sequence number is newer than our
+// starting snapshot's. status==DELETED entries are skipped.
+//===--------------------------------------------------------------------===//
+enum class EntryStatus { EXISTING, ADDED, DELETED };
+struct RefreshedDeleteEntry {
+	EntryStatus status;
+	std::string referenced;
+	int64_t sequence_number;
+};
+static bool HasConcurrentNewDelete(const std::unordered_set<std::string> &targeted,
+                                   const std::vector<RefreshedDeleteEntry> &entries, int64_t starting_seq) {
+	for (auto &e : entries) {
+		if (e.status == EntryStatus::DELETED) {
+			continue;
+		}
+		if (e.referenced.empty() || !targeted.count(e.referenced)) {
+			continue;
+		}
+		if (starting_seq >= 0 && e.sequence_number <= starting_seq) {
+			continue;
+		}
+		return true;
+	}
+	return false;
+}
+
+//===--------------------------------------------------------------------===//
+// Tests
+//===--------------------------------------------------------------------===//
+static int g_failures = 0;
+#define CHECK(cond)                                                                                                    \
+	do {                                                                                                               \
+		if (!(cond)) {                                                                                                 \
+			printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);                                                     \
+			g_failures++;                                                                                              \
+		}                                                                                                              \
+	} while (0)
+
+static void TestBackoffExponential() {
+	CHECK(BackoffMs(100, 60000, 0) == 100);
+	CHECK(BackoffMs(100, 60000, 1) == 200);
+	CHECK(BackoffMs(100, 60000, 2) == 400);
+	CHECK(BackoffMs(100, 60000, 3) == 800);
+}
+
+static void TestBackoffClamp() {
+	// 100 * 2^20 would overflow the cap; must clamp to max.
+	CHECK(BackoffMs(100, 60000, 20) == 60000);
+	CHECK(BackoffMs(100, 60000, 100) == 60000);
+}
+
+static void TestBackoffMinEqualsMax() {
+	CHECK(BackoffMs(500, 500, 5) == 500);
+	CHECK(BackoffMs(500, 500, 0) == 500);
+}
+
+static void TestBackoffNoOverflow() {
+	// Table properties are user-supplied: a huge min/max-wait must clamp without signed overflow
+	// (UB). With min near INT64_MAX the very first doubling would overflow; the guard must clamp.
+	const int64_t kHuge = 9223372036854775807LL; // INT64_MAX
+	CHECK(BackoffMs(kHuge, kHuge, 5) == kHuge);
+	CHECK(BackoffMs(kHuge / 2 + 1, kHuge, 1) == kHuge);
+	CHECK(BackoffMs(kHuge / 2 + 1, kHuge, 40) == kHuge);
+	// A large-but-doublable min still progresses then clamps, no overflow.
+	CHECK(BackoffMs(1LL << 40, 1LL << 50, 5) == (1LL << 45));
+	CHECK(BackoffMs(1LL << 40, 1LL << 50, 100) == (1LL << 50));
+}
+
+static void TestBackoffJitter() {
+	// Full jitter maps a unit-random [0,1] onto [0, base], so concurrent writers spread out instead
+	// of waking in lockstep. Endpoints and midpoint must be exact; out-of-range clamps.
+	CHECK(BackoffMsWithJitter(100, 60000, 3, 0.0) == 0);     // base 800 -> 0
+	CHECK(BackoffMsWithJitter(100, 60000, 3, 1.0) == 800);   // base 800 -> 800
+	CHECK(BackoffMsWithJitter(100, 60000, 3, 0.5) == 400);   // base 800 -> 400
+	CHECK(BackoffMsWithJitter(100, 60000, 0, 1.0) == 100);   // base 100 -> 100
+	CHECK(BackoffMsWithJitter(100, 60000, 0, 0.5) == 50);    // base 100 -> 50
+	// Clamp out-of-range randoms (defensive).
+	CHECK(BackoffMsWithJitter(100, 60000, 3, -1.0) == 0);
+	CHECK(BackoffMsWithJitter(100, 60000, 3, 2.0) == 800);
+	// Every jittered value stays within [0, base] across the unit interval.
+	for (int k = 0; k <= 100; k++) {
+		auto v = BackoffMsWithJitter(100, 60000, 5, k / 100.0); // base = 100*2^5 = 3200
+		CHECK(v >= 0 && v <= 3200);
+	}
+}
+
+static void TestDecorrelatedBackoff() {
+	const int64_t MIN = 100, MAX = 60000;
+	// First retry starts from prev=min: window [min, min*3] = [100, 300]. Tight, never below min.
+	CHECK(DecorrelatedBackoffMs(MIN, MAX, MIN, 0.0) == 100);  // lower bound = min_wait
+	CHECK(DecorrelatedBackoffMs(MIN, MAX, MIN, 1.0) == 300);  // upper bound = prev*3
+	CHECK(DecorrelatedBackoffMs(MIN, MAX, MIN, 0.5) == 200);  // midpoint
+	// Window widens with prev_sleep: prev=1000 -> [100, 3000].
+	CHECK(DecorrelatedBackoffMs(MIN, MAX, 1000, 0.0) == 100);
+	CHECK(DecorrelatedBackoffMs(MIN, MAX, 1000, 1.0) == 3000);
+	// Clamp to max_wait when prev*3 would exceed it.
+	CHECK(DecorrelatedBackoffMs(MIN, MAX, 50000, 1.0) == MAX);
+	// Never below min_wait, never above max_wait, across the unit interval and growing prev.
+	int64_t prev = MIN;
+	for (int i = 0; i < 50; i++) {
+		auto v = DecorrelatedBackoffMs(MIN, MAX, prev, (i % 11) / 10.0);
+		CHECK(v >= MIN && v <= MAX);
+		prev = v;
+	}
+	// Overflow guard: huge prev must clamp, not wrap.
+	CHECK(DecorrelatedBackoffMs(MIN, 9223372036854775807LL, 9223372036854775807LL / 2, 1.0) <= 9223372036854775807LL);
+}
+
+static void TestClassifyConflict() {
+	CHECK(ClassifyCommitStatus(409) == CommitOutcome::CONFLICT);
+	// 429 (rate limited): rejected before applying, safe to retry directly like a conflict (mirrors
+	// Java's REST retry strategy, which retries 429 even for non-idempotent POSTs).
+	CHECK(ClassifyCommitStatus(429) == CommitOutcome::CONFLICT);
+}
+
+static void TestClassifyUnknown() {
+	// For a non-idempotent commit POST these may have been applied before the failure surfaced ->
+	// must not blindly retry (double-apply) or clean up (delete a committed snapshot's files). Java
+	// likewise does NOT auto-retry these for POST; they go through commit-state-unknown handling.
+	CHECK(ClassifyCommitStatus(500) == CommitOutcome::UNKNOWN);
+	CHECK(ClassifyCommitStatus(502) == CommitOutcome::UNKNOWN);
+	CHECK(ClassifyCommitStatus(503) == CommitOutcome::UNKNOWN);
+	CHECK(ClassifyCommitStatus(504) == CommitOutcome::UNKNOWN);
+	CHECK(ClassifyCommitStatus(408) == CommitOutcome::UNKNOWN);
+}
+
+static void TestClassifyFatal() {
+	// Definite client errors are not retryable.
+	CHECK(ClassifyCommitStatus(400) == CommitOutcome::FATAL);
+	CHECK(ClassifyCommitStatus(401) == CommitOutcome::FATAL);
+	CHECK(ClassifyCommitStatus(403) == CommitOutcome::FATAL);
+	CHECK(ClassifyCommitStatus(404) == CommitOutcome::FATAL);
+}
+
+static void TestParseRetryAfter() {
+	// Numeric seconds -> ms.
+	CHECK(ParseRetryAfterMs("0") == 0);
+	CHECK(ParseRetryAfterMs("1") == 1000);
+	CHECK(ParseRetryAfterMs("120") == 120000);
+	// Absent / non-numeric / HTTP-date / negative -> -1 (fall back to exponential backoff).
+	CHECK(ParseRetryAfterMs("") == -1);
+	CHECK(ParseRetryAfterMs("Wed, 21 Oct 2015 07:28:00 GMT") == -1);
+	CHECK(ParseRetryAfterMs("12abc") == -1);
+	CHECK(ParseRetryAfterMs("-5") == -1);
+	// Overflow guard: a huge value must clamp to one day in ms, never wrap to negative/tiny.
+	CHECK(ParseRetryAfterMs("9999999999999999") == 24LL * 60 * 60 * 1000);
+	CHECK(ParseRetryAfterMs("86400") == 24LL * 60 * 60 * 1000); // exactly one day, not clamped lower
+}
+
+//===--------------------------------------------------------------------===//
+// Retry config parsing defaults / validation
+//===--------------------------------------------------------------------===//
+static void TestRetryConfigDefaults() {
+	auto c = ParseRetryConfig("", "", "", "");
+	CHECK(c.num_retries == 4);
+	CHECK(c.min_wait_ms == 100);
+	CHECK(c.max_wait_ms == 60000);
+	CHECK(c.total_wait_ms == 1800000);
+}
+static void TestRetryConfigNumRetriesZeroAllowed() {
+	// num-retries=0 is a legal "single attempt, no retries"; the wait fields reject 0 and fall back.
+	auto c = ParseRetryConfig("0", "0", "0", "0");
+	CHECK(c.num_retries == 0);
+	CHECK(c.min_wait_ms == 100);   // 0 not allowed -> default
+	CHECK(c.max_wait_ms == 60000); // 0 not allowed -> default
+}
+static void TestRetryConfigNegativeAndGarbage() {
+	auto c = ParseRetryConfig("-3", "abc", "-1", "x9");
+	CHECK(c.num_retries == 4);     // negative -> default
+	CHECK(c.min_wait_ms == 100);   // garbage -> default
+	CHECK(c.max_wait_ms == 60000); // negative -> default
+}
+static void TestRetryConfigMinGreaterThanMaxNormalized() {
+	auto c = ParseRetryConfig("4", "90000", "5000", "");
+	CHECK(c.max_wait_ms == 5000);
+	CHECK(c.min_wait_ms == 5000); // min clamped down to max
+}
+
+//===--------------------------------------------------------------------===//
+// MostLenient cross-table fold
+//===--------------------------------------------------------------------===//
+static void TestMostLenientTakesMaxRetriesAndWindow() {
+	RetryCfg a {4, 100, 60000, 1800000};
+	RetryCfg b {500, 50, 5000, 600000};
+	auto m = MostLenient(a, b);
+	CHECK(m.num_retries == 500);    // larger
+	CHECK(m.min_wait_ms == 50);     // smaller
+	CHECK(m.max_wait_ms == 60000);  // larger
+	CHECK(m.total_wait_ms == 1800000);
+}
+static void TestMostLenientPreservesMinLeMax() {
+	// a has a large min, b has a small max -> folded min must not exceed folded max.
+	RetryCfg a {4, 9000, 9000, 1000};
+	RetryCfg b {4, 100, 200, 1000};
+	auto m = MostLenient(a, b);
+	CHECK(m.max_wait_ms == 9000); // max of (9000,200)
+	CHECK(m.min_wait_ms == 100);  // min of (9000,100); already <= max
+	CHECK(m.min_wait_ms <= m.max_wait_ms);
+}
+
+//===--------------------------------------------------------------------===//
+// total-timeout-ms enforcement
+//===--------------------------------------------------------------------===//
+static void TestTotalTimeoutFirstAttemptNeverAborts() {
+	// attempt 0: even a tiny budget must not abort before the first retry sleeps.
+	CHECK(!TotalTimeoutWouldAbort(0, 100, 0, 1));
+	CHECK(!TotalTimeoutWouldAbort(0, 100000, 999999, 50));
+}
+static void TestTotalTimeoutAbortsWhenWaitExceedsBudget() {
+	// attempt>0, the single wait alone is larger than the whole budget.
+	CHECK(TotalTimeoutWouldAbort(1, 70000, 0, 60000));
+}
+static void TestTotalTimeoutAbortsWhenCumulativeExceeds() {
+	// attempt>0, already-elapsed + next wait would cross the budget.
+	CHECK(TotalTimeoutWouldAbort(2, 1000, 59500, 60000)); // 59500 > 60000-1000=59000
+	CHECK(!TotalTimeoutWouldAbort(2, 1000, 58000, 60000)); // 58000 <= 59000 -> proceed
+}
+
+//===--------------------------------------------------------------------===//
+// Retry-After consumption (cap at max_wait_ms; -1 means use backoff)
+//===--------------------------------------------------------------------===//
+static void TestConsumeRetryAfter() {
+	CHECK(ConsumeRetryAfter(-1, 60000) == -1);    // no server guidance
+	CHECK(ConsumeRetryAfter(2000, 60000) == 2000); // honored as-is
+	CHECK(ConsumeRetryAfter(0, 60000) == 0);       // zero is a valid immediate retry
+	CHECK(ConsumeRetryAfter(120000, 60000) == 60000); // capped at max_wait
+}
+
+//===--------------------------------------------------------------------===//
+// Ancestry / rollback guard
+//===--------------------------------------------------------------------===//
+static void TestAncestrySelf() {
+	std::unordered_map<int64_t, SnapshotNode> s = {{1, {false, -1}}};
+	CHECK(IsAncestorOf(s, 1, 1)); // a snapshot is its own ancestor
+}
+static void TestAncestryLinearChain() {
+	// 1 <- 2 <- 3 (3's parent is 2, 2's parent is 1)
+	std::unordered_map<int64_t, SnapshotNode> s = {{1, {false, -1}}, {2, {true, 1}}, {3, {true, 2}}};
+	CHECK(IsAncestorOf(s, 1, 3));  // 1 is an ancestor of 3
+	CHECK(IsAncestorOf(s, 2, 3));  // 2 is an ancestor of 3
+	CHECK(!IsAncestorOf(s, 3, 1)); // 3 is NOT an ancestor of 1 (wrong direction)
+}
+static void TestAncestryDivergedRollback() {
+	// Concurrent rollback: current snapshot 9 descends from 5, NOT from our starting snapshot 3.
+	std::unordered_map<int64_t, SnapshotNode> s = {
+	    {3, {true, 2}}, {2, {true, 1}}, {1, {false, -1}}, {5, {true, 1}}, {9, {true, 5}}};
+	CHECK(!IsAncestorOf(s, 3, 9)); // diverged -> must be detected (abort path)
+	CHECK(IsAncestorOf(s, 1, 9));  // shared root is still an ancestor
+}
+static void TestAncestryMissingLink() {
+	// 3's parent 2 was elided (not in the map) -> cannot prove ancestry -> false (safe).
+	std::unordered_map<int64_t, SnapshotNode> s = {{3, {true, 2}}};
+	CHECK(!IsAncestorOf(s, 1, 3));
+}
+static void TestAncestrySelfReferentialGuard() {
+	// A corrupt self-parent must not loop forever.
+	std::unordered_map<int64_t, SnapshotNode> s = {{3, {true, 3}}};
+	CHECK(!IsAncestorOf(s, 1, 3));
+}
+
+//===--------------------------------------------------------------------===//
+// Delete-entry referenced-data-file attribution (V2 + V3)
+//===--------------------------------------------------------------------===//
+static void TestDeleteAttribV3() {
+	FakeDeleteEntry e;
+	e.referenced_data_file = "s3://b/data/f.parquet";
+	CHECK(DeleteEntryReferencedDataFile(e) == "s3://b/data/f.parquet");
+}
+static void TestDeleteAttribV2FilenameBounds() {
+	FakeDeleteEntry e;
+	e.has_filename_bounds = true;
+	e.filename_lower = "s3://b/data/f.parquet";
+	e.filename_upper = "s3://b/data/f.parquet";
+	CHECK(DeleteEntryReferencedDataFile(e) == "s3://b/data/f.parquet");
+}
+static void TestDeleteAttribSpanningBounds() {
+	// lower != upper: spans multiple files, cannot attribute -> "".
+	FakeDeleteEntry e;
+	e.has_filename_bounds = true;
+	e.filename_lower = "s3://b/data/a.parquet";
+	e.filename_upper = "s3://b/data/z.parquet";
+	CHECK(DeleteEntryReferencedDataFile(e) == "");
+}
+static void TestDeleteAttribNone() {
+	FakeDeleteEntry e; // equality delete: no referenced file, no bounds
+	CHECK(DeleteEntryReferencedDataFile(e) == "");
+}
+
+//===--------------------------------------------------------------------===//
+// validateNoNewDeletes decision
+//===--------------------------------------------------------------------===//
+static void TestNoNewDeleteWhenPreexisting() {
+	std::unordered_set<std::string> targeted = {"f.parquet"};
+	// A delete on our file but at/below starting seq = part of the state we accounted for.
+	std::vector<RefreshedDeleteEntry> entries = {{EntryStatus::EXISTING, "f.parquet", 5}};
+	CHECK(!HasConcurrentNewDelete(targeted, entries, 5));
+	CHECK(!HasConcurrentNewDelete(targeted, entries, 10));
+}
+static void TestNewDeleteDetected() {
+	std::unordered_set<std::string> targeted = {"f.parquet"};
+	// A newer delete (seq 7 > starting 5) on our file = concurrent overlap -> conflict.
+	std::vector<RefreshedDeleteEntry> entries = {{EntryStatus::ADDED, "f.parquet", 7}};
+	CHECK(HasConcurrentNewDelete(targeted, entries, 5));
+}
+static void TestNewDeleteUnrelatedFile() {
+	std::unordered_set<std::string> targeted = {"f.parquet"};
+	// Newer delete but on a different file -> no conflict.
+	std::vector<RefreshedDeleteEntry> entries = {{EntryStatus::ADDED, "other.parquet", 7}};
+	CHECK(!HasConcurrentNewDelete(targeted, entries, 5));
+}
+static void TestNewDeleteSkipsDeletedStatus() {
+	std::unordered_set<std::string> targeted = {"f.parquet"};
+	// A DELETED-status entry (the delete file itself was removed) must not count.
+	std::vector<RefreshedDeleteEntry> entries = {{EntryStatus::DELETED, "f.parquet", 7}};
+	CHECK(!HasConcurrentNewDelete(targeted, entries, 5));
+}
+
+int main() {
+	TestBackoffExponential();
+	TestBackoffClamp();
+	TestBackoffMinEqualsMax();
+	TestBackoffNoOverflow();
+	TestBackoffJitter();
+	TestDecorrelatedBackoff();
+	TestClassifyConflict();
+	TestClassifyUnknown();
+	TestClassifyFatal();
+	TestParseRetryAfter();
+
+	TestRetryConfigDefaults();
+	TestRetryConfigNumRetriesZeroAllowed();
+	TestRetryConfigNegativeAndGarbage();
+	TestRetryConfigMinGreaterThanMaxNormalized();
+	TestMostLenientTakesMaxRetriesAndWindow();
+	TestMostLenientPreservesMinLeMax();
+	TestTotalTimeoutFirstAttemptNeverAborts();
+	TestTotalTimeoutAbortsWhenWaitExceedsBudget();
+	TestTotalTimeoutAbortsWhenCumulativeExceeds();
+	TestConsumeRetryAfter();
+
+	TestAncestrySelf();
+	TestAncestryLinearChain();
+	TestAncestryDivergedRollback();
+	TestAncestryMissingLink();
+	TestAncestrySelfReferentialGuard();
+
+	TestDeleteAttribV3();
+	TestDeleteAttribV2FilenameBounds();
+	TestDeleteAttribSpanningBounds();
+	TestDeleteAttribNone();
+
+	TestNoNewDeleteWhenPreexisting();
+	TestNewDeleteDetected();
+	TestNewDeleteUnrelatedFile();
+	TestNewDeleteSkipsDeletedStatus();
+
+	if (g_failures == 0) {
+		printf("All retry logic tests passed.\n");
+		return 0;
+	}
+	printf("%d test(s) failed.\n", g_failures);
+	return 1;
+}

--- a/test/sql/local/catalog_custom_setup/fixture/commit_status_check_fault_injection.test
+++ b/test/sql/local/catalog_custom_setup/fixture/commit_status_check_fault_injection.test
@@ -1,0 +1,107 @@
+# name: test/sql/local/catalog_custom_setup/fixture/commit_status_check_fault_injection.test
+# description: UNKNOWN-outcome commit status-check, end-to-end with fault injection.
+#   A mitmproxy addon (scripts/fault_injection_addon.py) lets the catalog actually apply the commit
+#   but rewrites its successful response to a 502 for a table named with the marker
+#   "inject_unknown_once". The extension must NOT treat this as a hard failure or clean up data files;
+#   its status-check must re-load the table, find the committed snapshot, and resolve the commit as
+#   success -- so the rows are present and nothing is lost. This exercises the
+#   IcebergCommitOutcome::UNKNOWN -> CheckCommitStatus -> ALL_COMMITTED path that SQL alone cannot
+#   trigger. Routed through a dedicated fault-injecting proxy (HTTP_FAULT_PROXY) so only this test sees
+#   the injected fault.
+# group: [fixture]
+
+require-env HTTP_FAULT_PROXY
+
+require-env FIXTURE_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# This test depends on connection behavior; do not silently swallow HTTP errors.
+set ignore_error_messages
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0,
+    http_proxy '${HTTP_FAULT_PROXY}',
+    VERIFY_SSL 0
+);
+
+statement ok
+SET ca_cert_file = '~/.mitmproxy/mitmproxy-ca-cert.pem';
+
+statement ok
+CREATE SECRET http_proxy (
+    TYPE HTTP,
+    http_proxy '${HTTP_FAULT_PROXY}'
+);
+
+statement ok
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181'
+);
+
+statement ok
+drop table if exists my_datalake.default.inject_unknown_once_tbl;
+
+statement ok
+create table my_datalake.default.inject_unknown_once_tbl (id INTEGER, data VARCHAR);
+
+# Snapshot the fault-proxy log length before the injected insert, so we can assert below that the
+# proxy actually rewrote the commit response to 502 (otherwise a mis-wired proxy / unmatched marker
+# would let a normal 200 through and this test would pass without exercising the UNKNOWN path).
+statement ok
+CREATE TABLE fault_log_tracker AS SELECT len(content) AS log_length FROM read_text('mitmproxy_fault.log');
+
+# This insert's commit response is rewritten to 502 by the proxy, but the catalog applied it. The
+# extension must resolve the ambiguous outcome via the status-check and report success.
+statement ok
+insert into my_datalake.default.inject_unknown_once_tbl values (1, 'a'), (2, 'b');
+
+# The fault was actually injected: the proxy logged the rewrite for this table's commit.
+query I
+SELECT regexp_matches(
+    substr((SELECT content FROM read_text('mitmproxy_fault.log')), (SELECT log_length FROM fault_log_tracker) + 1),
+    'ICEBERG_FAULT_INJECTED.*inject_unknown_once'
+);
+----
+true
+
+# The committed snapshot must be visible and complete: no data loss, no duplication from a spurious
+# retry, no corruption from an erroneous cleanup of the (actually committed) files.
+query II
+select id, data from my_datalake.default.inject_unknown_once_tbl order by id;
+----
+1	a
+2	b
+
+query I
+select count(*) from my_datalake.default.inject_unknown_once_tbl;
+----
+2
+
+# A subsequent normal commit (injection budget exhausted) still works, proving the table is in a
+# consistent state after the resolved-UNKNOWN commit.
+statement ok
+insert into my_datalake.default.inject_unknown_once_tbl values (3, 'c');
+
+query I
+select count(*) from my_datalake.default.inject_unknown_once_tbl;
+----
+3
+
+statement ok
+drop table my_datalake.default.inject_unknown_once_tbl;

--- a/test/sql/local/catalog_custom_setup/fixture/commit_status_check_none_committed.test
+++ b/test/sql/local/catalog_custom_setup/fixture/commit_status_check_none_committed.test
@@ -1,0 +1,108 @@
+# name: test/sql/local/catalog_custom_setup/fixture/commit_status_check_none_committed.test
+# description: UNKNOWN-outcome commit status-check, NONE_COMMITTED branch, end-to-end.
+#   A mitmproxy addon (scripts/fault_injection_addon.py) answers the FIRST commit POST for a table
+#   named with the marker "inject_fail_before_apply_once" with a 502 in the REQUEST hook, WITHOUT
+#   forwarding it to the catalog -- so the commit provably never applied. The extension classifies
+#   the 502 as UNKNOWN, runs its status-check, finds its snapshot id absent on reload (NONE_COMMITTED),
+#   and therefore safely RETRIES. The second attempt (injection budget exhausted) reaches the catalog
+#   and succeeds. This exercises the UNKNOWN -> CheckCommitStatus -> NONE_COMMITTED -> retry-to-success
+#   path (a transient 5xx that never reached/applied at the catalog), complementing the ALL_COMMITTED
+#   test (commit landed but response lost). Routed through a dedicated fault-injecting proxy so only
+#   this test sees the injected fault.
+# group: [fixture]
+
+require-env HTTP_FAULT_PROXY
+
+require-env FIXTURE_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# This test depends on connection behavior; do not silently swallow HTTP errors.
+set ignore_error_messages
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0,
+    http_proxy '${HTTP_FAULT_PROXY}',
+    VERIFY_SSL 0
+);
+
+statement ok
+SET ca_cert_file = '~/.mitmproxy/mitmproxy-ca-cert.pem';
+
+statement ok
+CREATE SECRET http_proxy (
+    TYPE HTTP,
+    http_proxy '${HTTP_FAULT_PROXY}'
+);
+
+statement ok
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181'
+);
+
+statement ok
+drop table if exists my_datalake.default.inject_fail_before_apply_once_tbl;
+
+statement ok
+create table my_datalake.default.inject_fail_before_apply_once_tbl (id INTEGER, data VARCHAR);
+
+# Snapshot the fault-proxy log length before the injected insert, so we can assert below that the
+# proxy actually short-circuited the first commit (otherwise a mis-wired proxy / unmatched marker
+# would let the commit through and this test would pass without exercising the NONE_COMMITTED path).
+statement ok
+CREATE TABLE fault_log_tracker AS SELECT len(content) AS log_length FROM read_text('mitmproxy_fault.log');
+
+# The first commit POST is rewritten to 502 before reaching the catalog (the commit does NOT apply).
+# The extension sees UNKNOWN, status-checks (snapshot absent -> NONE_COMMITTED), and retries; the
+# retry is not injected and succeeds. The statement therefore SUCCEEDS overall, with the row present
+# exactly once (no double-apply, no loss).
+statement ok
+insert into my_datalake.default.inject_fail_before_apply_once_tbl values (1, 'a'), (2, 'b');
+
+# The fault was actually injected from the REQUEST hook for this table's commit.
+query I
+SELECT regexp_matches(
+    substr((SELECT content FROM read_text('mitmproxy_fault.log')), (SELECT log_length FROM fault_log_tracker) + 1),
+    'ICEBERG_FAULT_INJECTED.*hook=request.*inject_fail_before_apply_once'
+);
+----
+true
+
+# The retried commit landed exactly once: both rows present, none duplicated by the retry.
+query II
+select id, data from my_datalake.default.inject_fail_before_apply_once_tbl order by id;
+----
+1	a
+2	b
+
+query I
+select count(*) from my_datalake.default.inject_fail_before_apply_once_tbl;
+----
+2
+
+# A subsequent normal commit (injection budget exhausted) still works, proving consistent state.
+statement ok
+insert into my_datalake.default.inject_fail_before_apply_once_tbl values (3, 'c');
+
+query I
+select count(*) from my_datalake.default.inject_fail_before_apply_once_tbl;
+----
+3
+
+statement ok
+drop table my_datalake.default.inject_fail_before_apply_once_tbl;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_commit_retry_config.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_commit_retry_config.test
@@ -1,0 +1,69 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_commit_retry_config.test
+# description: commit.retry.* table properties are accepted and a normal commit still succeeds
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.retry_tbl;
+
+# Set the full commit.retry.* family. These must be accepted and a non-conflicting commit must still
+# succeed normally (the retry loop runs the first attempt and breaks on success).
+statement ok
+create table my_datalake.default.retry_tbl (
+	id INTEGER,
+	data VARCHAR
+) WITH (
+	'commit.retry.num-retries' = '5',
+	'commit.retry.min-wait-ms' = '50',
+	'commit.retry.max-wait-ms' = '5000',
+	'commit.retry.total-timeout-ms' = '60000'
+);
+
+statement ok
+insert into my_datalake.default.retry_tbl values (1, 'a'), (2, 'b');
+
+statement ok
+insert into my_datalake.default.retry_tbl values (3, 'c');
+
+query II
+select id, data from my_datalake.default.retry_tbl order by id;
+----
+1	a
+2	b
+3	c
+
+# num-retries = 0 means "single attempt, no retries"; a normal commit must still succeed.
+statement ok
+drop table if exists my_datalake.default.retry_zero;
+
+statement ok
+create table my_datalake.default.retry_zero (
+	id INTEGER
+) WITH (
+	'commit.retry.num-retries' = '0'
+);
+
+statement ok
+insert into my_datalake.default.retry_zero values (1), (2), (3);
+
+query I
+select count(*) from my_datalake.default.retry_zero;
+----
+3
+
+statement ok
+drop table my_datalake.default.retry_tbl;
+
+statement ok
+drop table my_datalake.default.retry_zero;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression.test
@@ -1,0 +1,107 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression.test
+# description: write.manifest.compression-codec is honored when writing manifests. The Avro COPY writer
+#   emits uncompressed; the extension re-compresses the manifest / manifest-list to DEFLATE (default,
+#   matching Java) via a temp-file + fresh-write that stays object-store-safe. This exercises the WRITE
+#   side end-to-end through a real catalog, then reads it back to prove the compressed metadata chain is
+#   valid and rows round-trip.
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+# --- Default codec (deflate): a table created without the property must still commit and read back. ---
+statement ok
+drop table if exists my_datalake.default.codec_default;
+
+statement ok
+create table my_datalake.default.codec_default (id INTEGER, data VARCHAR);
+
+statement ok
+insert into my_datalake.default.codec_default values (1, 'a'), (2, 'b'), (3, 'c');
+
+# Reading back goes through the (deflate-compressed) manifest + manifest list -> data files. If the
+# recompression produced an invalid Avro container, this query would error or return wrong rows.
+query II
+select id, data from my_datalake.default.codec_default order by id;
+----
+1	a
+2	b
+3	c
+
+# iceberg_metadata parses the freshly written (compressed) manifests; a successful parse with the
+# expected entries proves the written container is spec-valid DEFLATE.
+query I
+select count(*) >= 1 from (
+	select distinct manifest_path from iceberg_metadata(my_datalake.default.codec_default)
+);
+----
+true
+
+# A second commit + read confirms multi-commit compressed-manifest writing keeps working.
+statement ok
+insert into my_datalake.default.codec_default values (4, 'd');
+
+query I
+select count(*) from my_datalake.default.codec_default;
+----
+4
+
+# --- Explicit deflate via the gzip alias (Iceberg's spelling) must behave identically. ---
+statement ok
+drop table if exists my_datalake.default.codec_gzip;
+
+statement ok
+create table my_datalake.default.codec_gzip (id INTEGER, data VARCHAR) WITH (
+	'write.manifest.compression-codec' = 'gzip'
+);
+
+statement ok
+insert into my_datalake.default.codec_gzip values (10, 'x'), (20, 'y');
+
+query II
+select id, data from my_datalake.default.codec_gzip order by id;
+----
+10	x
+20	y
+
+# --- Uncompressed (codec=none): the extension must skip recompression and write plain Avro that
+#     still reads back correctly. This covers the RequiresRecompression()==false branch. ---
+statement ok
+drop table if exists my_datalake.default.codec_none;
+
+statement ok
+create table my_datalake.default.codec_none (id INTEGER, data VARCHAR) WITH (
+	'write.manifest.compression-codec' = 'none'
+);
+
+statement ok
+insert into my_datalake.default.codec_none values (100, 'p'), (200, 'q');
+
+query II
+select id, data from my_datalake.default.codec_none order by id;
+----
+100	p
+200	q
+
+query I
+select count(*) from my_datalake.default.codec_none;
+----
+2
+
+statement ok
+drop table my_datalake.default.codec_default;
+
+statement ok
+drop table my_datalake.default.codec_gzip;
+
+statement ok
+drop table my_datalake.default.codec_none;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_merge_append.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_merge_append.test
@@ -1,0 +1,88 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_merge_append.test
+# description: Lowering commit.manifest.min-count-to-merge causes manifests to be merged on commit
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.merge_tbl;
+
+# An aggressive min-count-to-merge so a merge is observable after only a couple of commits.
+statement ok
+create table my_datalake.default.merge_tbl (
+	id INTEGER,
+	data VARCHAR
+) WITH (
+	'commit.manifest.min-count-to-merge' = '2',
+	'commit.manifest.target-size-bytes' = '8388608'
+);
+
+# Three separate commits -> three data manifests before any merge.
+statement ok
+insert into my_datalake.default.merge_tbl values (1, 'a'), (2, 'b');
+
+statement ok
+insert into my_datalake.default.merge_tbl values (3, 'c'), (4, 'd');
+
+statement ok
+insert into my_datalake.default.merge_tbl values (5, 'e'), (6, 'f');
+
+# Data equivalence: the merge is a pure physical reorganization, so all rows must still be readable
+# and correct regardless of how manifests were packed.
+query II
+select id, data from my_datalake.default.merge_tbl order by id;
+----
+1	a
+2	b
+3	c
+4	d
+5	e
+6	f
+
+query I
+select count(*) from my_datalake.default.merge_tbl;
+----
+6
+
+# After commits with a low min-count (=2), the three per-commit data manifests are bin-packed into a
+# single merged manifest. Assert the EXACT distinct manifest count (not just a <= bound, which would
+# also pass for degenerate 0/1-manifest states), so a regression that under- or over-merges is caught.
+query I
+select count(*) from (
+	select distinct manifest_path
+	from iceberg_metadata(my_datalake.default.merge_tbl)
+);
+----
+1
+
+# Merge correctness: entries pulled in from already-committed manifests are written with status
+# EXISTING (Java's ManifestWriter.existing), while genuinely-new entries stay ADDED. After the merge
+# above, the merged manifest must contain EXISTING entries (proof the status demotion happened) and
+# no row may be lost. Assert both statuses are present and the live row set is intact.
+query I
+select count(*) > 0 from iceberg_metadata(my_datalake.default.merge_tbl) where status = 'EXISTING';
+----
+true
+
+# A further insert + read still returns everything (multi-round merge does not lose/duplicate data).
+statement ok
+insert into my_datalake.default.merge_tbl values (7, 'g'), (8, 'h');
+
+query I
+select count(*) from my_datalake.default.merge_tbl;
+----
+8
+
+statement ok
+drop table my_datalake.default.merge_tbl;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_merge_append_disabled.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_merge_append_disabled.test
@@ -1,0 +1,59 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_merge_append_disabled.test
+# description: With commit.manifest-merge.enabled=false, behaves as FastAppend (data unchanged)
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.no_merge_tbl;
+
+statement ok
+create table my_datalake.default.no_merge_tbl (
+	id INTEGER,
+	data VARCHAR
+) WITH (
+	'commit.manifest-merge.enabled' = 'false',
+	'commit.manifest.min-count-to-merge' = '2'
+);
+
+statement ok
+insert into my_datalake.default.no_merge_tbl values (1, 'a'), (2, 'b');
+
+statement ok
+insert into my_datalake.default.no_merge_tbl values (3, 'c'), (4, 'd');
+
+statement ok
+insert into my_datalake.default.no_merge_tbl values (5, 'e'), (6, 'f');
+
+# Data is correct regardless of merge being disabled.
+query II
+select id, data from my_datalake.default.no_merge_tbl order by id;
+----
+1	a
+2	b
+3	c
+4	d
+5	e
+6	f
+
+# With merge disabled, FastAppend keeps one manifest per commit: three commits -> three manifests.
+query I
+select count(*) >= 3 from (
+	select distinct manifest_path
+	from iceberg_metadata(my_datalake.default.no_merge_tbl)
+);
+----
+true
+
+statement ok
+drop table my_datalake.default.no_merge_tbl;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_merge_append_v3_deletes.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_merge_append_v3_deletes.test
@@ -1,0 +1,87 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_merge_append_v3_deletes.test
+# description: Manifest merge on a V3 table with row-level deletes. Exercises merging across
+#   multiple commits including DELETE manifests / deletion vectors, and verifies the merge is a pure
+#   physical reorganization: all surviving rows remain correct after repeated merge rounds.
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.merge_v3;
+
+# V3 table (deletion vectors) with an aggressive merge threshold so merges are observable quickly.
+statement ok
+create table my_datalake.default.merge_v3 (
+	id INTEGER,
+	data VARCHAR
+) WITH (
+	'format-version' = 3,
+	'commit.manifest.min-count-to-merge' = '2',
+	'commit.manifest.target-size-bytes' = '8388608'
+);
+
+statement ok
+insert into my_datalake.default.merge_v3 values (1, 'a'), (2, 'b'), (3, 'c');
+
+statement ok
+insert into my_datalake.default.merge_v3 values (4, 'd'), (5, 'e'), (6, 'f');
+
+statement ok
+insert into my_datalake.default.merge_v3 values (7, 'g'), (8, 'h'), (9, 'i');
+
+# Delete some rows: produces DELETE manifests / deletion vectors that also participate in merging.
+statement ok
+delete from my_datalake.default.merge_v3 where id in (2, 5, 8);
+
+# Data correctness after merge + deletes: the deleted rows are gone, everything else survives.
+query II
+select id, data from my_datalake.default.merge_v3 order by id;
+----
+1	a
+3	c
+4	d
+6	f
+7	g
+9	i
+
+query I
+select count(*) from my_datalake.default.merge_v3;
+----
+6
+
+# Another insert after deletes (multi-round merge with mixed DATA/DELETE manifests) keeps data intact.
+statement ok
+insert into my_datalake.default.merge_v3 values (10, 'j'), (11, 'k');
+
+query I
+select count(*) from my_datalake.default.merge_v3;
+----
+8
+
+# A second delete round, then read: still correct (no lost/duplicated rows across merge rounds).
+statement ok
+delete from my_datalake.default.merge_v3 where id = 10;
+
+query II
+select id, data from my_datalake.default.merge_v3 order by id;
+----
+1	a
+3	c
+4	d
+6	f
+7	g
+9	i
+11	k
+
+statement ok
+drop table my_datalake.default.merge_v3;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_commit_retry_concurrent.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_commit_retry_concurrent.test
@@ -1,0 +1,65 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_commit_retry_concurrent.test
+# description: Commit retry end-to-end. Many connections insert into the SAME table at once.
+#   Each commit races against the others on the table's current snapshot; losers get a 409 conflict,
+#   refresh the metadata, regenerate manifests against the new parent, and retry (optimistic
+#   concurrency). The test passes only if EVERY concurrent insert eventually lands -- i.e. the retry
+#   loop actually re-bases and re-commits rather than dropping conflicting commits.
+# group: [transactions]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+# Requires a catalog that enforces serializable commits (real compare-and-swap on the table ref), so
+# a stale-parent commit gets a 409 the retry loop can re-base on. The apache/iceberg-rest-fixture used
+# by the fixture CI job is SQLite-backed and does NOT enforce this under true parallelism -- it returns
+# 200 to commits that should conflict, silently dropping them, which no client retry can recover. We
+# therefore gate this on the Lakekeeper (Postgres-backed) CI job, where concurrent commits behave like
+# a production catalog (also verified manually against AWS S3 Tables). Skips cleanly elsewhere.
+require-env LAKEKEEPER_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.retry_concurrent;
+
+# Generous retry budget so the slowest loser still gets enough attempts under contention.
+statement ok
+create table my_datalake.default.retry_concurrent (
+	thread_id INTEGER,
+	seq INTEGER
+) WITH (
+	'commit.retry.num-retries' = '10',
+	'commit.retry.min-wait-ms' = '20',
+	'commit.retry.max-wait-ms' = '2000'
+);
+
+# 8 connections, each inserting one row into the shared table concurrently. Without a working retry
+# loop, conflicting commits would fail; with it, all 8 must succeed.
+concurrentloop i 0 8
+
+statement ok
+insert into my_datalake.default.retry_concurrent values (${i}, 1);
+
+endloop
+
+# All 8 concurrent inserts committed -> retry re-based and re-committed every loser.
+query I
+select count(*) from my_datalake.default.retry_concurrent;
+----
+8
+
+# Every thread id is present exactly once: no commit was lost or duplicated by the retry path.
+query I
+select count(distinct thread_id) from my_datalake.default.retry_concurrent;
+----
+8
+
+statement ok
+drop table my_datalake.default.retry_concurrent;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_commit_retry_concurrent_delete.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_commit_retry_concurrent_delete.test
@@ -1,0 +1,115 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_commit_retry_concurrent_delete.test
+# description: Commit retry safety net end-to-end. Unlike concurrent
+#   appends (which always re-base and retry safely), concurrent DELETEs that target overlapping data
+#   files must NOT be silently retried -- a loser's positional/DV deletes were computed against a
+#   row set a concurrent delete already changed, so replaying them could double-delete or invalidate
+#   positions. The retry loop's ValidateRetrySafe must detect the concurrent delete on the refreshed
+#   parent and fail fast (FATAL, non-retryable) instead of producing a wrong result. This drives the
+#   three ValidateRetrySafe throw-sites end-to-end, which the offline logic tests only cover at the
+#   decision-predicate level.
+# group: [transactions]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+# Requires a catalog with real serializable-commit CAS (so concurrent deletes actually conflict and
+# the loser hits the retry path that ValidateRetrySafe guards). The SQLite-backed fixture catalog does
+# not enforce this under parallelism, so gate on the Lakekeeper (Postgres) CI job; also verified
+# manually against AWS S3 Tables. Skips cleanly elsewhere.
+require-env LAKEKEEPER_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.retry_cdel;
+
+# Generous append-retry budget; it does not let conflicting DELETEs through -- those abort via
+# ValidateRetrySafe regardless of the budget.
+statement ok
+create table my_datalake.default.retry_cdel (
+	id INTEGER,
+	grp INTEGER
+) WITH (
+	'commit.retry.num-retries' = '10',
+	'commit.retry.min-wait-ms' = '20',
+	'commit.retry.max-wait-ms' = '2000'
+);
+
+# 200 rows across 4 groups (grp = id % 4): 50 rows per group.
+statement ok
+insert into my_datalake.default.retry_cdel select i as id, i % 4 as grp from range(200) t(i);
+
+query I
+select count(*) from my_datalake.default.retry_cdel;
+----
+200
+
+# Four connections concurrently DELETE from the SAME group (grp = 0) with overlapping id ranges, so
+# every delete targets the same data files. Exactly one can win; the others hit a 409, refresh, and
+# ValidateRetrySafe sees the concurrent delete against a data file they also target -> each aborts
+# (a FATAL "Cannot retry commit ..." error) rather than silently re-applying a now-wrong delete.
+# Because losers ABORT (not retry-to-success), this loop intentionally produces errors on the losers;
+# ignore_error_messages above tolerates them. The invariant we assert is on the FINAL table state.
+concurrentloop i 0 4
+
+statement maybe
+delete from my_datalake.default.retry_cdel where grp = 0 and id < ${i} * 10 + 30;
+----
+Cannot retry commit
+
+endloop
+
+# Correctness invariant after the race: whichever delete won removed a *prefix* of grp=0 rows, and
+# every loser aborted cleanly without applying its delete. So the table must be in a consistent state:
+#  - no grp != 0 row was ever touched (all 150 of them survive),
+#  - the grp = 0 rows are EITHER all 50 still present (a delete that won removed a subset) OR a clean
+#    prefix was removed; in all cases NO row is double-counted and NO non-targeted row is lost.
+# The strongest portable assertion: the non-targeted groups are fully intact (proves no delete
+# corrupted unrelated data, and no loser's partially-applied delete leaked).
+query I
+select count(*) from my_datalake.default.retry_cdel where grp != 0;
+----
+150
+
+# Every surviving row is still unique and self-consistent (id % 4 == grp): a wrongly-replayed
+# concurrent delete or a corrupted manifest would surface as missing/duplicated/mismatched rows.
+query I
+select count(*) from my_datalake.default.retry_cdel where id % 4 != grp;
+----
+0
+
+query I
+select count(*) = count(distinct id) from my_datalake.default.retry_cdel;
+----
+true
+
+# The grp = 0 survivors are a contiguous suffix of the original prefix-delete (the winning delete
+# removed `id < K` for some K in {30,40,50,60}; everything >= K with grp=0 remains). Assert the
+# count is one of the legal single-winner outcomes (50 minus the number of grp=0 ids below K), i.e.
+# the remaining grp=0 rows are exactly those with id >= the smallest deleted-prefix boundary that won.
+# Regardless of which won, no grp=0 id below the winner's bound may remain AND none at/above may be
+# missing -- verified by: the set of present grp=0 ids equals {id : id%4==0 and id >= min_present}.
+query I
+select count(*) = 0 from (
+	-- any "hole" in the grp=0 survivors (a present id with a smaller grp=0 id missing) would mean a
+	-- non-prefix / double delete happened
+	select id from my_datalake.default.retry_cdel where grp = 0
+	except
+	select id from (
+		select i as id from range(200) t(i) where i % 4 = 0 and i >= (
+			select coalesce(min(id), 0) from my_datalake.default.retry_cdel where grp = 0
+		)
+	)
+);
+----
+true
+
+statement ok
+drop table my_datalake.default.retry_cdel;

--- a/test/sql/local/iceberg_scans/iceberg_manifest_compression_read.test
+++ b/test/sql/local/iceberg_scans/iceberg_manifest_compression_read.test
@@ -1,0 +1,31 @@
+# name: test/sql/local/iceberg_scans/iceberg_manifest_compression_read.test
+# description: The manifest/manifest-list reader must handle DEFLATE-compressed Avro (the Iceberg
+#   default written by Java/Spark, and what this extension writes for write.manifest.compression-codec).
+#   This locks the read side of manifest compression: the persistent lineitem_iceberg fixture's
+#   manifests are deflate-coded (verified out-of-band with fastavro), so reading its metadata exercises
+#   the deflate manifest path end-to-end through the production reader, no catalog required.
+# group: [iceberg_scans]
+
+require avro
+
+require parquet
+
+require iceberg
+
+# Reading the metadata of a table whose manifests are DEFLATE-compressed must succeed and return the
+# exact entries. (If the reader could not decode deflate manifests, this would error or mis-parse.)
+query IIIIIIII
+SELECT * FROM ICEBERG_METADATA('__WORKING_DIRECTORY__/data/persistent/iceberg/lineitem_iceberg', ALLOW_MOVED_PATHS=TRUE);
+----
+lineitem_iceberg/metadata/179b4fb1-0366-4f7d-ad35-99ee8da0abf5-m1.avro	2	DATA	ADDED	EXISTING	lineitem_iceberg/data/00000-5-dad9988f-2a3b-464c-adb6-6034de93da19-00001.parquet	PARQUET	51793
+lineitem_iceberg/metadata/179b4fb1-0366-4f7d-ad35-99ee8da0abf5-m0.avro	2	DATA	DELETED	EXISTING	lineitem_iceberg/data/00000-1-66fee7c2-c97c-4af9-963d-930afd99ace4-00001.parquet	PARQUET	60175
+
+# A full scan reads through the deflate manifest -> manifest list -> data files (and applies the
+# fixture's positional delete) and returns rows, proving the compressed metadata chain is fully
+# traversable, not just listable. The fixture's live data file has record_count=51793 with one
+# positional delete applied, so the scan returns slightly fewer; we assert the count lands in that
+# range rather than pinning a brittle golden value.
+query I
+SELECT count(*) > 0 AND count(*) <= 51793 FROM ICEBERG_SCAN('__WORKING_DIRECTORY__/data/persistent/iceberg/lineitem_iceberg', ALLOW_MOVED_PATHS=TRUE);
+----
+true


### PR DESCRIPTION
Implements **optimistic-concurrency commit retries ([#786](https://github.com/duckdb/duckdb-iceberg/issues/786))**: on a commit conflict, refresh each table, re-apply the staged changes against the new parent, and re-submit — instead of failing the transaction.

> [!NOTE]
> **Stacked on #1059 (compression) and #1060 (MergeAppend).** This branch is based on those, so the diff includes their commits until they merge; review the third commit (`Support optimistic-concurrency commit retries`) for this PR's changes. The retry loop re-runs `ApplyTableChanges` (the pure core extracted here), which internally calls the merge step from #1060 — but retry itself does not depend on merge being enabled.

## What it does

- **Retry loop** over the whole transaction commit: on conflict, each table's metadata is reloaded, manifests/snapshots are regenerated against the refreshed parent, and the commit is re-submitted. Data files are written once at sink and reused across attempts; only metadata is regenerated.
- **Backoff** with decorrelated jitter, `commit.retry.total-timeout-ms` enforcement, and `Retry-After` support. Multi-table commits fold every table's `commit.retry.*` into the most lenient policy.
- **Commit-status classification**: 409/429 → CONFLICT, 408/5xx/transport-throw → UNKNOWN, other → FATAL. An **UNKNOWN** outcome is resolved by a status-check that looks for this commit's stable snapshot id in the refreshed table, and **never cleans up files** (so a commit that actually landed is never corrupted).
- **`ValidateRetrySafe`** guards delete/overwrite retries (ancestry/rollback check, data-file existence, no concurrent new delete on a targeted file) and aborts non-retryable conflicts rather than double-applying. Pure appends skip it.
- Manifest / manifest-list files written by a failed or discarded attempt are tracked and cleaned up (subject to the catalog allowing client deletes); data files are never deleted between attempts.
- `CreateUpdate`'s body becomes a pure, repeatable `ApplyTableChanges`; the snapshot id is generated once and kept stable across attempts so the status-check can find it. Single-table commit refills the table cache from the commit response's `LoadTableResult`.

Controlled by `commit.retry.num-retries` / `min-wait-ms` / `max-wait-ms` / `total-timeout-ms` (the Iceberg property names).

## Testing

- Catalog-backed retry-config + concurrent-append / concurrent-delete SQL tests.
- mitmproxy **fault injection** for the UNKNOWN status-check: commit landed but response lost (ALL_COMMITTED), and never-reached-catalog retry-to-success (NONE_COMMITTED).
- Standalone C++ logic suite (`make test_logic`, in CI): backoff/jitter, status classification, Retry-After parsing, config folding, total-timeout, ancestry walk, delete attribution.

Full release build is green; the three C++ logic suites and the catalog-free read test pass locally.