### PR TITLE
Mark databases as modified for some table functions

### DIFF
--- a/src/function/metadata/iceberg_schema_properties_functions.cpp
+++ b/src/function/metadata/iceberg_schema_properties_functions.cpp
@@ -70,6 +70,13 @@ static unique_ptr<FunctionData> SetIcebergSchemaPropertiesBind(ClientContext &co
 		throw InvalidInputException("Cannot call set_iceberg_schema_properties on non-iceberg schema");
 	}
 	ret->iceberg_schema = iceberg_schema->Cast<IcebergSchemaEntry>();
+	// This mutates the catalog: declare the modification so the statement is treated as a write (e.g. so it
+	// is rejected against a read-only transaction, and so catalog-version tracking observes the change).
+	if (input.binder) {
+		DatabaseModificationType modification;
+		modification |= DatabaseModificationType::ALTER_TABLE;
+		input.binder->GetStatementProperties().RegisterDBModify(iceberg_schema->ParentCatalog(), context, modification);
+	}
 	auto map = Value(input.inputs[1]).DefaultCastAs(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
 
 	auto &map_children = MapValue::GetChildren(map);
@@ -95,6 +102,13 @@ static unique_ptr<FunctionData> RemoveIcebergSchemaPropertiesBind(ClientContext 
 		throw InvalidInputException("Cannot call remove_iceberg_schema_properties on non-iceberg schema");
 	}
 	ret->iceberg_schema = iceberg_schema->Cast<IcebergSchemaEntry>();
+	// This mutates the catalog: declare the modification so the statement is treated as a write (e.g. so it
+	// is rejected against a read-only transaction, and so catalog-version tracking observes the change).
+	if (input.binder) {
+		DatabaseModificationType modification;
+		modification |= DatabaseModificationType::ALTER_TABLE;
+		input.binder->GetStatementProperties().RegisterDBModify(iceberg_schema->ParentCatalog(), context, modification);
+	}
 
 	auto &remove_values = input.inputs[1];
 	auto &list_children = ListValue::GetChildren(remove_values);

--- a/src/function/metadata/iceberg_table_properties_functions.cpp
+++ b/src/function/metadata/iceberg_table_properties_functions.cpp
@@ -81,6 +81,13 @@ static unique_ptr<FunctionData> SetIcebergTablePropertiesBind(ClientContext &con
 		throw InvalidInputException("Cannot call set_iceberg_table_properties on non-iceberg table");
 	}
 	ret->iceberg_table = iceberg_table->Cast<IcebergTableEntry>();
+	// This mutates the catalog: declare the modification so the statement is treated as a write (e.g. so it
+	// is rejected against a read-only transaction, and so catalog-version tracking observes the change).
+	if (input.binder) {
+		DatabaseModificationType modification;
+		modification |= DatabaseModificationType::ALTER_TABLE;
+		input.binder->GetStatementProperties().RegisterDBModify(iceberg_table->ParentCatalog(), context, modification);
+	}
 	auto map = Value(input.inputs[1]).DefaultCastAs(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
 
 	auto &map_children = MapValue::GetChildren(map);
@@ -108,6 +115,13 @@ static unique_ptr<FunctionData> RemoveIcebergTablePropertiesBind(ClientContext &
 		throw InvalidInputException("Cannot call set_iceberg_table_properties on non-iceberg table");
 	}
 	ret->iceberg_table = iceberg_table->Cast<IcebergTableEntry>();
+	// This mutates the catalog: declare the modification so the statement is treated as a write (e.g. so it
+	// is rejected against a read-only transaction, and so catalog-version tracking observes the change).
+	if (input.binder) {
+		DatabaseModificationType modification;
+		modification |= DatabaseModificationType::ALTER_TABLE;
+		input.binder->GetStatementProperties().RegisterDBModify(iceberg_table->ParentCatalog(), context, modification);
+	}
 
 	auto &remove_values = input.inputs[1];
 	auto &list_children = ListValue::GetChildren(remove_values);

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/schema_properties/schema_properties_update_transaction.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/schema_properties/schema_properties_update_transaction.test
@@ -53,6 +53,30 @@ FROM iceberg_schema_properties(my_datalake.myschema123) WHERE key != 'location' 
 myprop1	1
 myprop3	3
 
+# set/remove_iceberg_schema_properties mutate the catalog, so they must be rejected inside a read-only
+# transaction. This only holds if the bind declares the modification (RegisterDBModify).
+statement ok
+BEGIN TRANSACTION READ ONLY;
+
+statement error
+CALL set_iceberg_schema_properties(my_datalake.myschema123, {'k' : 'v'});
+----
+<REGEX>:.*read-only.*
+
+statement ok
+ROLLBACK;
+
+statement ok
+BEGIN TRANSACTION READ ONLY;
+
+statement error
+CALL remove_iceberg_schema_properties(my_datalake.myschema123, ['myprop1']);
+----
+<REGEX>:.*read-only.*
+
+statement ok
+ROLLBACK;
+
 #cleanup
 statement ok
 DROP SCHEMA my_datalake.myschema123;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/table_properties/test_set_table_properties.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/table_properties/test_set_table_properties.test
@@ -116,3 +116,28 @@ statement error
 select * from iceberg_table_properties('default.test.blah.blah');
 ----
 <REGEX>:.*Invalid Input Error.*Too many identifiers.*
+
+# set/remove_iceberg_table_properties mutate the catalog, so they must be rejected inside a read-only
+# transaction. This only holds if the bind declares the modification (RegisterDBModify); otherwise the
+# property change slips past the read-only check and runs against a read-only transaction.
+statement ok
+BEGIN TRANSACTION READ ONLY;
+
+statement error
+CALL set_iceberg_table_properties(my_datalake.default.test, {'k' : 'v'});
+----
+<REGEX>:.*read-only.*
+
+statement ok
+ROLLBACK;
+
+statement ok
+BEGIN TRANSACTION READ ONLY;
+
+statement error
+CALL remove_iceberg_table_properties(my_datalake.default.test, ['write.delete.mode']);
+----
+<REGEX>:.*read-only.*
+
+statement ok
+ROLLBACK;


### PR DESCRIPTION
Some iceberg table functions do not update the modified databases property correctly. This fixes it.