### PR TITLE
Fix scan failure after schema-reducing alter

### DIFF
--- a/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
@@ -203,7 +203,14 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 
 	IcebergSnapshotScanInfo snapshot_info;
 	snapshot_info = metadata.GetSnapshot(snapshot_lookup);
-	if (snapshot_info.snapshot && snapshot_info.snapshot->GetSchemaId() > schema_id) {
+	// A snapshot can legitimately carry a higher schema id than the table's current schema: a
+	// schema-reducing alter (e.g. DROP COLUMN / DROP DEFAULT) can revert the current schema to an earlier,
+	// identical schema whose id is reused, while older snapshots stay tagged with the higher id. Scanning
+	// such a snapshot with the current schema is safe because iceberg projects data files by field id. Only
+	// reject the mismatch for a time-travel scan pinned to a historical schema, where reading a newer
+	// snapshot would be incorrect.
+	const bool scanning_current_schema = schema_id == static_cast<idx_t>(metadata.GetCurrentSchemaId());
+	if (snapshot_info.snapshot && snapshot_info.snapshot->GetSchemaId() > schema_id && !scanning_current_schema) {
 		throw InternalException("Tried to scan a snapshot created with a newer schema id (%d) than the schema id "
 		                        "selected for the scan (%d)",
 		                        snapshot_info.snapshot->GetSchemaId(), schema_id);

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
@@ -203,18 +203,6 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 
 	IcebergSnapshotScanInfo snapshot_info;
 	snapshot_info = metadata.GetSnapshot(snapshot_lookup);
-	// A snapshot can legitimately carry a higher schema id than the table's current schema: a
-	// schema-reducing alter (e.g. DROP COLUMN / DROP DEFAULT) can revert the current schema to an earlier,
-	// identical schema whose id is reused, while older snapshots stay tagged with the higher id. Scanning
-	// such a snapshot with the current schema is safe because iceberg projects data files by field id. Only
-	// reject the mismatch for a time-travel scan pinned to a historical schema, where reading a newer
-	// snapshot would be incorrect.
-	const bool scanning_current_schema = schema_id == static_cast<idx_t>(metadata.GetCurrentSchemaId());
-	if (snapshot_info.snapshot && snapshot_info.snapshot->GetSchemaId() > schema_id && !scanning_current_schema) {
-		throw InternalException("Tried to scan a snapshot created with a newer schema id (%d) than the schema id "
-		                        "selected for the scan (%d)",
-		                        snapshot_info.snapshot->GetSchemaId(), schema_id);
-	}
 	//! Override whatever schema id the lookup resulted in
 	//! The schema is preset by the IcebergCatalogEntry and we can not deviate from that
 	snapshot_info.schema_id = schema_id;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/test_add_existing_schema.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/test_add_existing_schema.test
@@ -48,6 +48,18 @@ select * from my_datalake.default.existing_schema_add order by all
 ----
 test	true	NULL
 
+# Snapshot written at the 3-column schema id.
+statement ok
+insert into my_datalake.default.existing_schema_add VALUES ('with_c', false, 42)
+
+query III
+select * from my_datalake.default.existing_schema_add order by all
+----
+test	true	NULL
+with_c	false	42
+
+# DROP COLUMN reuses the earlier 2-column schema, leaving the current schema id below the snapshot's.
+# Reading must still work (iceberg projects by field id).
 statement ok
 ALTER TABLE my_datalake.default.existing_schema_add DROP COLUMN c;
 
@@ -55,3 +67,4 @@ query II
 select * from my_datalake.default.existing_schema_add order by all
 ----
 test	true
+with_c	false


### PR DESCRIPTION
A schema-reducing alter (DROP COLUMN/DROP DEFAULT) can revert the current schema to an earlier, identical schema whose id is reused. Snapshots written under the higher id then exceed the current schema id, and the scan path rejected this valid state with an internal error. Allow it when scanning with the table's current schema (iceberg projects by field id);