### PR TITLE
Fix operator visitor pattern in pre-optimizer

### DIFF
--- a/src/planning/iceberg_optimizer.cpp
+++ b/src/planning/iceberg_optimizer.cpp
@@ -24,16 +24,16 @@ void GuaranteeEqualityDeleteColumnsOptimizer::VisitOperator(unique_ptr<LogicalOp
 		auto &child = op->children[child_index];
 		if (child->type != LogicalOperatorType::LOGICAL_GET) {
 			VisitOperator(child);
-			return;
+			continue;
 		}
 		auto &get = child->Cast<LogicalGet>();
 		if (get.function.name != "iceberg_scan" || !get.bind_data) {
 			VisitOperator(child);
-			return;
+			continue;
 		}
 		auto &mfbd = get.bind_data->Cast<MultiFileBindData>();
 		if (!mfbd.file_list) {
-			return;
+			continue;
 		}
 		auto &iceberg_list = mfbd.file_list->Cast<IcebergMultiFileList>();
 		auto delete_manifest_entries = iceberg_list.GetDeleteManifestEntries();
@@ -50,7 +50,7 @@ void GuaranteeEqualityDeleteColumnsOptimizer::VisitOperator(unique_ptr<LogicalOp
 		}
 
 		if (required_field_ids.empty()) {
-			return;
+			continue;
 		}
 
 		auto &schema_columns = iceberg_list.GetSchema().columns;
@@ -113,7 +113,7 @@ void GuaranteeEqualityDeleteColumnsOptimizer::VisitOperator(unique_ptr<LogicalOp
 			args.push_back(make_uniq<BoundColumnRefExpression>(col_type, bindings[local_idx]));
 		}
 		if (args.empty()) {
-			return;
+			continue;
 		}
 
 		auto &catalog = Catalog::GetSystemCatalog(context);

--- a/test/sql/local/equality_deletes_join.test
+++ b/test/sql/local/equality_deletes_join.test
@@ -1,0 +1,30 @@
+# name: test/sql/local/equality_deletes_join.test
+# description: Equality deletes must be applied even when the iceberg scan is not the first child of a join
+# group: [local]
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Keep the iceberg scan on the right side of the join so that the
+# GuaranteeEqualityDeleteColumnsOptimizer first visits the non-iceberg left
+# child. If that traversal stops at the left child instead of continuing to the
+# remaining children, the equality-delete columns of the right scan get pruned
+# and the deletes are silently not applied.
+statement ok
+set disabled_optimizers='join_order';
+
+# Only the `bir` column is selected, which is not an equality-delete column.
+# Without the guarantee filter on the iceberg scan the id/name columns are
+# pruned and the equality deletes can no longer be applied.
+query I
+SELECT t.bir
+FROM (VALUES (1)) v(x), ICEBERG_SCAN('__WORKING_DIRECTORY__/data/persistent/equality_deletes/warehouse/mydb/mytable') t
+ORDER BY ALL;
+----
+2025-01-04
+2025-01-05


### PR DESCRIPTION
The pre-optimizer would use `return` to early exit if the first child of an operator did not match. There's no guarantee though that an iceberg table with equality deletes is the first child of e.g. a join operator. The included test would trigger a segfault without this change.
