### PR TITLE
Bump duckdb 1.6 submodule again

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: iceberg
-      duckdb_version: f8f27ba8a45300e2011c7d579946437ae6aab969
+      duckdb_version: 738d229e6b4c4722083d18ddf7caede4a45a658e
       ci_tools_version: main
       exclude_archs: 'windows_amd64_mingw'
       extra_toolchains: 'python3'
@@ -29,7 +29,7 @@ jobs:
     secrets: inherit
     with:
       extension_name: iceberg
-      duckdb_version: f8f27ba8a45300e2011c7d579946437ae6aab969
+      duckdb_version: 738d229e6b4c4722083d18ddf7caede4a45a658e
       ci_tools_version: main
       exclude_archs: 'windows_amd64_mingw'
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
@@ -40,6 +40,6 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
     with:
       extension_name: iceberg
-      duckdb_version: f8f27ba8a45300e2011c7d579946437ae6aab969
+      duckdb_version: 738d229e6b4c4722083d18ddf7caede4a45a658e
       ci_tools_version: main
       format_checks: 'format'

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: iceberg
-      duckdb_version: 738d229e6b4c4722083d18ddf7caede4a45a658e
+      duckdb_version: 2bfea2aa198bc1fcd4486707e7b8c1562aa6a67c
       ci_tools_version: main
       exclude_archs: 'windows_amd64_mingw'
       extra_toolchains: 'python3'
@@ -29,7 +29,7 @@ jobs:
     secrets: inherit
     with:
       extension_name: iceberg
-      duckdb_version: 738d229e6b4c4722083d18ddf7caede4a45a658e
+      duckdb_version: 2bfea2aa198bc1fcd4486707e7b8c1562aa6a67c
       ci_tools_version: main
       exclude_archs: 'windows_amd64_mingw'
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
@@ -40,6 +40,6 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
     with:
       extension_name: iceberg
-      duckdb_version: 738d229e6b4c4722083d18ddf7caede4a45a658e
+      duckdb_version: 2bfea2aa198bc1fcd4486707e7b8c1562aa6a67c
       ci_tools_version: main
       format_checks: 'format'

--- a/scripts/data_generators/tests/insert_test_big/__init__.py
+++ b/scripts/data_generators/tests/insert_test_big/__init__.py
@@ -1,9 +1,0 @@
-from scripts.data_generators.tests.base import IcebergTest
-import pathlib
-
-
-@IcebergTest.register()
-class Test(IcebergTest):
-    def __init__(self):
-        path = pathlib.PurePath(__file__)
-        super().__init__(path.parent.name)

--- a/scripts/data_generators/tests/insert_test_big/q00.sql
+++ b/scripts/data_generators/tests/insert_test_big/q00.sql
@@ -1,9 +1,0 @@
-CREATE or REPLACE TABLE default.insert_test_big (
-	col1 INTEGER,
-	col2 VARCHAR(17)
-)
-TBLPROPERTIES (
-    'format-version'='2',
-    'write.update.mode'='merge-on-read',
-    'write.parquet.compression-codec'='snappy'
-);

--- a/src/include/planning/iceberg_multi_file_reader.hpp
+++ b/src/include/planning/iceberg_multi_file_reader.hpp
@@ -75,11 +75,10 @@ public:
 	                          const vector<MultiFileColumnDefinition> &local_columns);
 	bool ParseOption(const string &key, const Value &val, MultiFileOptions &options, ClientContext &context) override;
 
-	unique_ptr<Expression>
+	MultiFileReaderVirtualColumnBinding
 	GetVirtualColumnExpression(ClientContext &context, MultiFileReaderData &reader_data,
-	                           const vector<MultiFileColumnDefinition> &local_columns, idx_t &column_id,
-	                           const LogicalType &type, MultiFileLocalIndex local_idx,
-	                           optional_ptr<MultiFileColumnDefinition> &global_column_reference) override;
+	                           const vector<MultiFileColumnDefinition> &local_columns, const idx_t column_id,
+	                           const LogicalType &type, MultiFileLocalIndex local_idx) override;
 
 public:
 	shared_ptr<TableFunctionInfo> function_info;

--- a/src/planning/iceberg_multi_file_reader.cpp
+++ b/src/planning/iceberg_multi_file_reader.cpp
@@ -506,10 +506,9 @@ static unique_ptr<Expression> ConstructVirtualRowIdExpression(ClientContext &con
 	return function_expr;
 }
 
-unique_ptr<Expression> IcebergMultiFileReader::GetVirtualColumnExpression(
+MultiFileReaderVirtualColumnBinding IcebergMultiFileReader::GetVirtualColumnExpression(
     ClientContext &context, MultiFileReaderData &reader_data, const vector<MultiFileColumnDefinition> &local_columns,
-    idx_t &column_id, const LogicalType &type, MultiFileLocalIndex local_idx,
-    optional_ptr<MultiFileColumnDefinition> &global_column_reference) {
+    const idx_t column_id, const LogicalType &type, MultiFileLocalIndex local_idx) {
 	if (column_id == COLUMN_IDENTIFIER_ROW_ID) {
 		// row id column
 		// this is computed as row_id_start + file_row_number OR read from the file
@@ -528,13 +527,8 @@ unique_ptr<Expression> IcebergMultiFileReader::GetVirtualColumnExpression(
 			if (col.identifier.GetValue<int32_t>() == MultiFileReader::ROW_ID_FIELD_ID) {
 				if (entry == options.end()) {
 					//! There is no parent 'first_row_id' to inherit, simply reference the existing column
-					global_column_reference = row_id_column.get();
-					return nullptr;
+					return MultiFileReaderVirtualColumnBinding(*row_id_column.get());
 				}
-				auto &reader = *reader_data.reader;
-				// add a projection for the _row_id column we found in the local schema
-				reader.column_ids.push_back(MultiFileLocalColumnId(i));
-				reader.column_indexes.push_back(ColumnIndex(i));
 
 				auto computed_row_id =
 				    ConstructVirtualRowIdExpression(context, type, entry->second, local_idx.GetIndex() + 1);
@@ -544,19 +538,21 @@ unique_ptr<Expression> IcebergMultiFileReader::GetVirtualColumnExpression(
 				coalesce_expr->GetChildrenMutable().push_back(std::move(file_row_id));
 				coalesce_expr->GetChildrenMutable().push_back(std::move(computed_row_id));
 
-				// Transform virtual column to file_row_number for the reference
-				column_id = MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER;
-				return std::move(coalesce_expr);
+				vector<idx_t> column_ids;
+				column_ids.push_back(i);
+				column_ids.push_back(MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER);
+				return MultiFileReaderVirtualColumnBinding(std::move(coalesce_expr), std::move(column_ids));
 			}
 		}
 		if (entry == options.end()) {
 			//! No first-row-id can be found, version must be <3, just return null
-			return make_uniq<BoundConstantExpression>(Value(LogicalType::BIGINT));
+			return MultiFileReaderVirtualColumnBinding(Value(LogicalType::BIGINT));
 		}
 
-		// transform this virtual column to file_row_number
-		column_id = MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER;
-		return ConstructVirtualRowIdExpression(context, type, entry->second, local_idx.GetIndex());
+		vector<idx_t> column_ids;
+		column_ids.push_back(MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER);
+		return MultiFileReaderVirtualColumnBinding(
+		    ConstructVirtualRowIdExpression(context, type, entry->second, local_idx.GetIndex()), std::move(column_ids));
 	}
 	if (column_id == COLUMN_IDENTIFIER_LAST_SEQUENCE_NUMBER) {
 		// get the row id start for this file
@@ -573,15 +569,12 @@ unique_ptr<Expression> IcebergMultiFileReader::GetVirtualColumnExpression(
 			if (col.identifier.GetValue<int32_t>() == MultiFileReader::LAST_UPDATED_SEQUENCE_NUMBER_ID) {
 				if (entry == options.end()) {
 					//! There is no parent 'sequence_number' to inherit, simply reference the existing column
-					global_column_reference = last_updated_sequence_number_column.get();
-					return nullptr;
+					return MultiFileReaderVirtualColumnBinding(*last_updated_sequence_number_column.get());
 				}
 				auto &reader = *reader_data.reader;
 				// add a projection for the _row_id column we found in the local schema
 				reader.column_ids.push_back(MultiFileLocalColumnId(i));
 				reader.column_indexes.push_back(ColumnIndex(i));
-
-				column_id = MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER;
 
 				auto computed_sequence_number = make_uniq<BoundConstantExpression>(entry->second);
 				// Create COALESCE(_last_updated_sequence_number, computed_sequence_number)
@@ -590,18 +583,18 @@ unique_ptr<Expression> IcebergMultiFileReader::GetVirtualColumnExpression(
 				coalesce_expr->GetChildrenMutable().push_back(std::move(sequence_number));
 				coalesce_expr->GetChildrenMutable().push_back(std::move(computed_sequence_number));
 
-				// Transform virtual column to file_row_number for the reference
-				column_id = MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER;
-				return std::move(coalesce_expr);
+				vector<idx_t> column_ids;
+				column_ids.push_back(i);
+				column_ids.push_back(MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER);
+				return MultiFileReaderVirtualColumnBinding(std::move(coalesce_expr), std::move(column_ids));
 			}
 		}
 		if (entry == options.end()) {
-			return make_uniq<BoundConstantExpression>(Value(LogicalType::BIGINT));
+			return MultiFileReaderVirtualColumnBinding(Value(LogicalType::BIGINT));
 		}
-		return make_uniq<BoundConstantExpression>(entry->second);
+		return MultiFileReaderVirtualColumnBinding(entry->second);
 	}
-	return MultiFileReader::GetVirtualColumnExpression(context, reader_data, local_columns, column_id, type, local_idx,
-	                                                   global_column_reference);
+	return MultiFileReader::GetVirtualColumnExpression(context, reader_data, local_columns, column_id, type, local_idx);
 }
 
 vector<PartitionStatistics> IcebergMultiFileReader::IcebergGetPartitionStats(ClientContext &context,

--- a/src/planning/metadata_io/manifest_list/iceberg_manifest_list_reader.cpp
+++ b/src/planning/metadata_io/manifest_list/iceberg_manifest_list_reader.cpp
@@ -175,9 +175,9 @@ void ManifestListReader::ReadChunk(DataChunk &chunk, idx_t iceberg_version, vect
 		}
 
 		if (iceberg_version >= 3) {
-			int64_t first_row_id;
-			if (ReadOptionalField<int64_t>(first_row_id_format, i, first_row_id)) {
-				manifest.first_row_id = first_row_id;
+			int64_t first_row_id_value;
+			if (ReadOptionalField<int64_t>(first_row_id_format, i, first_row_id_value)) {
+				manifest.first_row_id = first_row_id_value;
 				manifest.has_first_row_id = true;
 			}
 		}

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/add_column/alter_add_column_time_travel.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/add_column/alter_add_column_time_travel.test
@@ -36,7 +36,7 @@ set variable pre_alter_snapshot = (
 	select {
 		'snapshot_id': snapshot_id
 	} from iceberg_snapshots(
-		my_datalake.default.alter_add_column_time_travel
+		'my_datalake.default.alter_add_column_time_travel'
 	) order by timestamp_ms
 	limit 1
 );

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/table_properties/test_upgrade_format_version_2_to_3.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/table_properties/test_upgrade_format_version_2_to_3.test
@@ -22,14 +22,20 @@ DROP TABLE IF EXISTS my_datalake.default.v2_to_v3_upgrade;
 
 # Create table explicitly as V2
 statement ok
-CREATE TABLE my_datalake.default.v2_to_v3_upgrade (id INT, val VARCHAR) WITH ('format-version'=2);
-
+CREATE TABLE my_datalake.default.v2_to_v3_upgrade (
+	id INT,
+	val VARCHAR
+) WITH (
+	'format-version'=2
+);
 
 # insert data and delete some with positional delete files
 # Insert 10 rows into one parquet file (snapshot 1, sequence 1)
 statement ok
-INSERT INTO my_datalake.default.v2_to_v3_upgrade
-    SELECT range AS id, 'row_' || range::VARCHAR AS val FROM range(10);
+INSERT INTO my_datalake.default.v2_to_v3_upgrade SELECT
+	range AS id,
+	'row_' || range::VARCHAR AS val
+FROM range(10);
 
 query II
 SELECT id, val FROM my_datalake.default.v2_to_v3_upgrade ORDER BY id;
@@ -93,7 +99,9 @@ SELECT _last_updated_sequence_number, _row_id, id FROM my_datalake.default.v2_to
 
 # Upgrade to V3
 statement ok
-ALTER TABLE my_datalake.default.v2_to_v3_upgrade SET ('format-version'=3);
+ALTER TABLE my_datalake.default.v2_to_v3_upgrade SET (
+	'format-version'=3
+);
 
 # Immediately after upgrade — no V3 snapshot written yet — row IDs are still NULL
 query III
@@ -114,8 +122,10 @@ SELECT _last_updated_sequence_number, _row_id, id FROM my_datalake.default.v2_to
 # 0-based positions within that file as row IDs: 1, 3, 5, 7, 9.
 # The 5 new V3 rows continue from row_id 10: row_ids 10–14.
 statement ok
-INSERT INTO my_datalake.default.v2_to_v3_upgrade
-    SELECT 10 + range AS id, 'new_row_' || range::VARCHAR AS val FROM range(5);
+INSERT INTO my_datalake.default.v2_to_v3_upgrade SELECT
+	10 + range AS id,
+	'new_row_' || range::VARCHAR AS val
+FROM range(5);
 
 # 10 rows total: 5 pre-upgrade + 5 post-upgrade
 query II
@@ -220,5 +230,3 @@ UPDATE my_datalake.default.v2_to_v3_upgrade set id = id + 100 where 1=1;
 
 statement ok
 DROP TABLE my_datalake.default.v2_to_v3_upgrade;
-
-mode unskip

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_big_insert.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_big_insert.test
@@ -20,6 +20,19 @@ set enable_logging=true
 statement ok
 set logging_level='debug'
 
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.insert_test_big;
+
+statement ok
+CREATE TABLE my_datalake.default.insert_test_big (
+	col1 INTEGER,
+	col2 VARCHAR(17)
+) WITH (
+    'format-version'='2',
+    'write.update.mode'='merge-on-read',
+    'write.parquet.compression-codec'='snappy'
+);
+
 # Default TARGET_FILE_SIZE = 8.4MB
 # We create ~18MB of data, which spreads out over 3 files
 query I

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/test_row_lineage_read_from_upgraded.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/test_row_lineage_read_from_upgraded.test
@@ -2,9 +2,6 @@
 # description: test integration with iceberg catalog read
 # group: [catalog_agnostic]
 
-# TODO: Needs https://github.com/duckdblabs/duckdb-internal/issues/9393
-mode skip
-
 require-env CATALOG_TEST_CONFIG_SETUP
 
 require avro
@@ -105,8 +102,15 @@ select _last_updated_sequence_number, _row_id, id, data from my_datalake.default
 5	NULL	6	replaced
 7	NULL	7	g_new
 
-# Filter on the '_row_id' can't be pushed down
-statement error
+query II
 select id, data from my_datalake.default.row_lineage_test_upgraded_insert where _row_id is NULL order by id;
 ----
-INTERNAL Error: Expected an expression that only references a single column, but found multiple!
+
+query II
+select id, data from my_datalake.default.row_lineage_test_upgraded_insert where _row_id is NOT NULL order by id;
+----
+1	replaced
+2	replaced_again
+4	d_u1
+6	replaced_again
+7	g_new


### PR DESCRIPTION
This PR supersedes #856 

Merge in a patch to the MultiFileReader required for filtering on the virtual `_row_id` column