### PR TITLE
[IcebergScan] Allow file paths to start with `data`

### DIFF
--- a/src/common/iceberg_utils.cpp
+++ b/src/common/iceberg_utils.cpp
@@ -197,9 +197,14 @@ string IcebergUtils::GetFullPath(const string &iceberg_path, const string &relat
 		return fs.JoinPath(iceberg_path, relative_file_path.substr(found + 1));
 	}
 
-	found = lpath.rfind("/data/");
+	if (StringUtil::StartsWith(lpath, "data")) {
+		found = 0;
+	} else {
+		found = lpath.rfind("/data/") + 1;
+	}
+
 	if (found != string::npos) {
-		return fs.JoinPath(iceberg_path, relative_file_path.substr(found + 1));
+		return fs.JoinPath(iceberg_path, relative_file_path.substr(found));
 	}
 
 	throw InvalidConfigurationException("Could not create full path from Iceberg Path (%s) and the relative path (%s)",


### PR DESCRIPTION
Fixes a problem found with reading a provided test reproduction, just making `iceberg_scan` more permissive