### PR TITLE
Cast CTAS output to Iceberg storage types

### DIFF
--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
 
 #include "catalog/rest/iceberg_catalog.hpp"
@@ -29,6 +30,7 @@
 #include "core/expression/iceberg_transform.hpp"
 #include "storage/statistics/iceberg_variant_statistics.hpp"
 #include "catalog/rest/api/iceberg_type.hpp"
+#include "catalog/rest/api/iceberg_create_table_request.hpp"
 #include "common/iceberg_utils.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_update.hpp"
 #include "iceberg_logging.hpp"
@@ -1034,14 +1036,57 @@ static unique_ptr<IcebergTableMetadata> BuildPlaceholderMetadata(BoundCreateTabl
 	return metadata;
 }
 
+// CTAS stores columns using Iceberg storage types (e.g. HUGEINT -> DECIMAL(38,0)), which can differ from
+// the SELECT output. The write pipeline is typed with the storage types, so without a cast the append fails
+// with a type mismatch.
+static PhysicalOperator &CastCtasToIcebergStorageTypes(ClientContext &context, PhysicalPlanGenerator &planner,
+                                                       PhysicalOperator &plan, BoundCreateTableInfo &info,
+                                                       const IcebergTableMetadata &metadata) {
+	auto &create_info = info.Base().Cast<CreateTableInfo>();
+	int32_t last_column_id = 0;
+	auto storage_schema = IcebergCreateTableRequest::CreateIcebergSchema(context, metadata, create_info.columns,
+	                                                                     &create_info.constraints, last_column_id);
+	auto &src_types = plan.types;
+	D_ASSERT(src_types.size() == storage_schema->columns.size());
+
+	bool needs_cast = false;
+	vector<LogicalType> target_types;
+	target_types.reserve(src_types.size());
+	for (idx_t i = 0; i < src_types.size(); i++) {
+		auto &target = storage_schema->columns[i]->type;
+		if (target != src_types[i]) {
+			needs_cast = true;
+		}
+		target_types.push_back(target);
+	}
+	if (!needs_cast) {
+		return plan;
+	}
+
+	vector<unique_ptr<Expression>> expressions;
+	expressions.reserve(src_types.size());
+	for (idx_t i = 0; i < src_types.size(); i++) {
+		unique_ptr<Expression> expr = make_uniq<BoundReferenceExpression>(src_types[i], i);
+		if (target_types[i] != src_types[i]) {
+			expr = BoundCastExpression::AddCastToType(context, std::move(expr), target_types[i]);
+		}
+		expressions.push_back(std::move(expr));
+	}
+	auto &proj =
+	    planner.Make<PhysicalProjection>(std::move(target_types), std::move(expressions), plan.estimated_cardinality);
+	proj.children.push_back(plan);
+	return proj;
+}
+
 PhysicalOperator &IcebergCatalog::PlanCreateTableAs(ClientContext &context, PhysicalPlanGenerator &planner,
-                                                    LogicalCreateTable &op, PhysicalOperator &plan) {
+                                                    LogicalCreateTable &op, PhysicalOperator &plan_p) {
 	auto &schema = op.schema;
 	auto &ic_schema_entry = schema.Cast<IcebergSchemaEntry>();
 
 	// create a fake local iceberg table with desired columns
 	auto placeholder_metadata = BuildPlaceholderMetadata(*op.info);
 	auto &placeholder_schema = placeholder_metadata->GetLatestSchema();
+	auto &plan = CastCtasToIcebergStorageTypes(context, planner, plan_p, *op.info, *placeholder_metadata);
 	IcebergCopyInput copy_input(context, *placeholder_metadata, placeholder_schema);
 	auto &physical_copy_op = IcebergInsert::PlanCopyForInsert(context, planner, copy_input, &plan);
 	auto &physical_copy = physical_copy_op.Cast<PhysicalCopyToFile>();

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as.test
@@ -284,3 +284,27 @@ DROP TABLE IF EXISTS hugeint_agg;
 
 statement ok
 DROP TABLE IF EXISTS hugeint_insert_test;
+
+statement ok
+DROP TABLE IF EXISTS hugeint_nested;
+
+# Nested HUGEINT (inside LIST/STRUCT) must be cast recursively to the stored DECIMAL(38,0).
+statement ok
+CREATE TABLE hugeint_nested AS
+    SELECT [i::HUGEINT] AS lst, {'x': i::HUGEINT} AS strct FROM range(3) t(i);
+
+query II
+SELECT column_name, column_type FROM (DESCRIBE hugeint_nested) ORDER BY column_name;
+----
+lst	DECIMAL(38,0)[]
+strct	STRUCT(x DECIMAL(38,0))
+
+query II
+SELECT lst[1], strct.x FROM hugeint_nested ORDER BY lst[1];
+----
+0	0
+1	1
+2	2
+
+statement ok
+DROP TABLE IF EXISTS hugeint_nested;


### PR DESCRIPTION
CTAS derives its columns from the SELECT output types, but the table (and its write pipeline) is created with the Iceberg storage types. These differ for types that have no Iceberg equivalent (e.g. HUGEINT).

The CTAS write appends the SELECT chunks straight into a ColumnDataCollection typed with the storage types, so the types disagree (HUGEINT vs DECIMAL(38,0)). This trips D_ASSERT(types == input_types) in assertion builds; in release it is masked only because HUGEINT and DECIMAL(38,0) share the INT128 layout. 

**Fix:**
Insert a projection above the CTAS plan that casts each column to its Iceberg storage type before the write. The storage types come from IcebergCreateTableRequest::CreateIcebergSchema (the same source the table is created from), and the cast reuses BoundCastExpression::AddCastToType so nested types are handled recursively. The projection is skipped when no column needs a cast.