### PR TITLE
feat: Order iceberg_scan and prune matching

### DIFF
--- a/src/function/scan/iceberg_scan.cpp
+++ b/src/function/scan/iceberg_scan.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/parser/tableref/emptytableref.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
+#include "duckdb/storage/table/row_group_reorderer.hpp"
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
@@ -71,6 +72,12 @@ BindInfo IcebergBindInfo(const optional_ptr<FunctionData> bind_data) {
 	return BindInfo(*table);
 }
 
+static void IcebergSetScanOrder(unique_ptr<RowGroupOrderOptions> order_options, optional_ptr<FunctionData> bind_data) {
+	auto &multi_file_data = bind_data->Cast<MultiFileBindData>();
+	auto &file_list = multi_file_data.file_list->Cast<IcebergMultiFileList>();
+	file_list.SetScanOrder(std::move(order_options));
+}
+
 //! FIXME: needs v1.5.1, causes a crash on v1.5.0
 // static bool IcebergScanSupportsPushdownType(const FunctionData &bind_data_p, idx_t column_id) {
 //	// Don't push down filters on the _row_id virtual column
@@ -104,6 +111,7 @@ TableFunctionSet IcebergFunctions::GetIcebergScanFunction(ExtensionLoader &loade
 		function.get_bind_info = IcebergBindInfo;
 		function.get_virtual_columns = IcebergVirtualColumns;
 		function.get_partition_stats = IcebergMultiFileReader::IcebergGetPartitionStats;
+		function.set_scan_order = IcebergSetScanOrder;
 		// function.supports_pushdown_type = IcebergScanSupportsPushdownType;
 
 		// Schema param is just confusing here

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -70,6 +70,7 @@ private:
 
 class IcebergTableEntry;
 struct IcebergMultiFileList;
+struct RowGroupOrderOptions;
 
 struct IcebergManifestScanningState {
 public:
@@ -156,6 +157,7 @@ public:
 	IcebergTableEntry *GetTable() const;
 	void SetTable(IcebergTableEntry *table);
 	void SetOptions(const IcebergOptions &options);
+	void SetScanOrder(unique_ptr<RowGroupOrderOptions> options);
 
 	void Bind(vector<LogicalType> &return_types, vector<Identifier> &names);
 	unique_ptr<IcebergMultiFileList> PushdownInternal(ClientContext &context, TableFilterSet &new_filters,
@@ -198,6 +200,10 @@ protected:
 	                       IcebergManifestContentType file_type) const;
 	// TODO: How to guarantee we only call this after the filter pushdown?
 	void InitializeFiles(lock_guard<mutex> &guard) const;
+
+	//! Reorder (and prune, when a LIMIT is present) the materialized data files by the
+	//! ORDER BY column's per-file min/max bounds, mirroring the native RowGroupReorderer.
+	void EnsureScanOrderApplied(lock_guard<mutex> &guard) const;
 
 	//! NOTE: this requires the lock because it modifies the 'data_files' vector, potentially invalidating references
 	optional_ptr<const BoundIcebergManifestEntry> GetDataFile(idx_t file_id, lock_guard<mutex> &guard) const;
@@ -245,6 +251,10 @@ private:
 	mutable vector<bool> delete_manifest_matches;
 
 private:
+	//! Set by the table function's set_scan_order callback when an ORDER BY ... LIMIT can drive scan order.
+	mutable unique_ptr<RowGroupOrderOptions> scan_order_options;
+	mutable bool scan_order_applied = false;
+
 	//! References to items inside the 'manifest_entries' of the list entries in the 'data_manifests'
 	mutable vector<BoundIcebergManifestEntry> data_manifest_entries;
 	//! Combination of committed + transaction data manifests

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/execution/execution_context.hpp"
 #include "duckdb/parallel/thread_context.hpp"
 #include "duckdb/parallel/event.hpp"
@@ -18,6 +19,7 @@
 #include "duckdb/execution/executor.hpp"
 #include "duckdb/optimizer/filter_combiner.hpp"
 #include "duckdb/function/scalar/struct_utils.hpp"
+#include "duckdb/storage/table/row_group_reorderer.hpp"
 
 #include "planning/iceberg_multi_file_reader.hpp"
 #include "function/iceberg_functions.hpp"
@@ -36,6 +38,8 @@
 #include "planning/metadata_io/manifest/iceberg_manifest_reader.hpp"
 #include "planning/metadata_io/manifest_list/iceberg_manifest_list_reader.hpp"
 #include "planning/metadata_io/manifest_list/bound_iceberg_manifest_list_entry.hpp"
+
+#include <algorithm>
 
 namespace duckdb {
 
@@ -296,6 +300,11 @@ void IcebergMultiFileList::SetOptions(const IcebergOptions &options) {
 	shared_state->options = options;
 }
 
+void IcebergMultiFileList::SetScanOrder(unique_ptr<RowGroupOrderOptions> options) {
+	scan_order_options = std::move(options);
+	scan_order_applied = false;
+}
+
 unique_ptr<ExpressionFilter> IcebergMultiFileList::GetFilterForColumnIndex(const IcebergTableFilters &filter_set,
                                                                            const ColumnIndex &column_index) const {
 	auto primary_index = column_index.GetPrimaryIndex();
@@ -393,6 +402,9 @@ unique_ptr<IcebergMultiFileList> IcebergMultiFileList::PushdownInternal(ClientCo
 	filtered_list->names = names;
 	filtered_list->types = types;
 	filtered_list->have_bound = true;
+	if (scan_order_options) {
+		filtered_list->scan_order_options = make_uniq<RowGroupOrderOptions>(*scan_order_options);
+	}
 	return filtered_list;
 }
 
@@ -965,10 +977,144 @@ optional_ptr<const BoundIcebergManifestEntry> IcebergMultiFileList::GetDataFile(
 	return data_manifest_entries[file_id];
 }
 
+namespace {
+
+bool ScanOrderCompare(const Value &v1, const Value &v2, OrderByStatistics stat_type) {
+	return (stat_type == OrderByStatistics::MAX && v1 < v2) || (stat_type == OrderByStatistics::MIN && v1 > v2);
+}
+
+struct IcebergOrderEntry {
+	idx_t entry_idx;
+	Value lower;
+	Value upper;
+	idx_t count;
+};
+
+} // namespace
+
+void IcebergMultiFileList::EnsureScanOrderApplied(lock_guard<mutex> &guard) const {
+	if (!scan_order_options || scan_order_applied) {
+		return;
+	}
+	scan_order_applied = true;
+
+	auto &opts = *scan_order_options;
+	//! Iceberg only stores reliable min/max for numeric/temporal columns; string bounds may be truncated.
+	if (opts.column_type != OrderByColumnType::NUMERIC || opts.column_idx.HasChildren()) {
+		return;
+	}
+
+	idx_t materialized = 0;
+	while (GetDataFile(materialized, guard)) {
+		materialized++;
+	}
+	if (data_manifest_entries.size() <= 1) {
+		return;
+	}
+
+	auto &schema_columns = GetSchema().columns;
+	idx_t schema_idx = opts.column_idx.GetPrimaryIndex();
+	if (schema_idx >= schema_columns.size()) {
+		return;
+	}
+	auto &order_column = *schema_columns[schema_idx];
+	int32_t field_id = order_column.id;
+
+	bool can_prune = opts.row_limit.IsValid();
+	vector<IcebergOrderEntry> order_entries;
+	order_entries.reserve(data_manifest_entries.size());
+	for (idx_t i = 0; i < data_manifest_entries.size(); i++) {
+		auto &data_file = data_manifest_entries[i].entry.data_file;
+		auto lower_it = data_file.lower_bounds.find(field_id);
+		auto upper_it = data_file.upper_bounds.find(field_id);
+		if (lower_it == data_file.lower_bounds.end() || upper_it == data_file.upper_bounds.end()) {
+			//! A file without usable bounds for the order column cannot be placed; leave order untouched.
+			return;
+		}
+		//! lower/upper bounds are stored as raw Iceberg-encoded blobs; decode to typed Values before comparing.
+		auto stats = IcebergPredicateStats::DeserializeBounds(lower_it->second, upper_it->second, order_column.name,
+		                                                      order_column.type);
+		if (!stats.has_lower_bounds || !stats.has_upper_bounds || stats.lower_bound.IsNull() ||
+		    stats.upper_bound.IsNull()) {
+			return;
+		}
+		auto null_it = data_file.null_value_counts.find(field_id);
+		if (null_it == data_file.null_value_counts.end() || null_it->second > 0) {
+			//! NULLs (or an omitted null count) interact with NULLS FIRST/LAST:
+			//! reordering stays safe, limit pruning does not.
+			can_prune = false;
+		}
+		order_entries.push_back({i, stats.lower_bound, stats.upper_bound, NumericCast<idx_t>(data_file.record_count)});
+	}
+
+	if (can_prune) {
+		for (idx_t i = 0; i < delete_manifest_matches.size(); i++) {
+			if (delete_manifest_matches[i]) {
+				//! record_count is pre-delete; pruning by it would drop files that still hold live rows.
+				can_prune = false;
+				break;
+			}
+		}
+	}
+
+	const auto stat_type = opts.order_by;
+	const bool ascending = opts.order_type == OrderType::ASCENDING;
+	auto primary = [&](const IcebergOrderEntry &e) -> const Value & {
+		return stat_type == OrderByStatistics::MAX ? e.upper : e.lower;
+	};
+	auto opposite = [&](const IcebergOrderEntry &e) -> const Value & {
+		return stat_type == OrderByStatistics::MAX ? e.lower : e.upper;
+	};
+
+	std::stable_sort(order_entries.begin(), order_entries.end(),
+	                 [&](const IcebergOrderEntry &a, const IcebergOrderEntry &b) {
+		                 return ascending ? primary(a) < primary(b) : primary(b) < primary(a);
+	                 });
+
+	idx_t keep = order_entries.size();
+	if (can_prune && opts.row_limit.GetIndex() > 0) {
+		const idx_t row_limit = opts.row_limit.GetIndex();
+		keep = 0;
+		//! Keep the prefix [0..k): prune the rest once the kept files hold >= row_limit rows that are each
+		//! guaranteed to outrank every remaining file. order_entries[k]'s primary bound is the best any pruned
+		//! file can reach, so a kept file qualifies in full only if its opposite bound already beats it.
+		for (idx_t k = 0; k < order_entries.size(); k++) {
+			const Value &frontier = primary(order_entries[k]);
+			idx_t guaranteed = 0;
+			for (idx_t j = 0; j < k; j++) {
+				if (!ScanOrderCompare(opposite(order_entries[j]), frontier, stat_type)) {
+					guaranteed += order_entries[j].count;
+				}
+				if (guaranteed >= row_limit) {
+					break;
+				}
+			}
+			if (guaranteed >= row_limit) {
+				break;
+			}
+			keep = k + 1;
+		}
+	}
+
+	if (keep < order_entries.size()) {
+		DUCKDB_LOG(context, IcebergLogType,
+		           "Iceberg Scan Order Pushdown, kept %llu of %llu 'data_file's for ORDER BY LIMIT %llu", keep,
+		           order_entries.size(), opts.row_limit.GetIndex());
+	}
+
+	vector<BoundIcebergManifestEntry> reordered;
+	reordered.reserve(keep);
+	for (idx_t i = 0; i < keep; i++) {
+		reordered.push_back(data_manifest_entries[order_entries[i].entry_idx]);
+	}
+	data_manifest_entries = std::move(reordered);
+}
+
 OpenFileInfo IcebergMultiFileList::GetFileInternal(idx_t file_id, lock_guard<mutex> &guard) const {
 	if (!view_initialized) {
 		InitializeFiles(guard);
 	}
+	EnsureScanOrderApplied(guard);
 
 	auto found_manifest_entry = GetDataFile(file_id, guard);
 	if (!found_manifest_entry) {

--- a/test/sql/local/iceberg_scans/scan_order_limit_pruning.test
+++ b/test/sql/local/iceberg_scans/scan_order_limit_pruning.test
@@ -1,0 +1,179 @@
+# name: test/sql/local/iceberg_scans/scan_order_limit_pruning.test
+# group: [iceberg_scans]
+
+require avro
+
+require parquet
+
+require iceberg
+
+# is_null_is_not_null has 3 data files with non-overlapping id bounds: [7,8] [4,6] [1,3].
+
+# Ground truth, computed with the scan-order optimization disabled.
+statement ok
+PRAGMA disabled_optimizers='row_group_pruner';
+
+statement ok
+create table oracle_desc as select id from iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null') order by id desc limit 5;
+
+statement ok
+create table oracle_asc as select id from iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null') order by id asc limit 5;
+
+statement ok
+PRAGMA disabled_optimizers='';
+
+# The optimized scan must return exactly the same top-N rows (both directions).
+query I
+select count(*) from (
+  (select id from iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null') order by id desc limit 5)
+  except
+  (select id from oracle_desc)
+);
+----
+0
+
+query I
+select count(*) from (
+  (select id from oracle_desc)
+  except
+  (select id from iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null') order by id desc limit 5)
+);
+----
+0
+
+query I
+select count(*) from (
+  (select id from iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null') order by id asc limit 5)
+  except
+  (select id from oracle_asc)
+);
+----
+0
+
+# Files whose bounds cannot contain a top-N row are skipped before scanning.
+statement ok
+CALL enable_logging('Iceberg');
+
+statement ok
+CALL truncate_duckdb_logs();
+
+statement ok
+select id from iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null') order by id desc limit 5;
+
+# The pushdown logs a summary only when it actually prunes files.
+query I
+SELECT count(*) >= 1
+FROM duckdb_logs()
+WHERE type = 'Iceberg' AND message LIKE '%Scan Order Pushdown, kept%';
+----
+true
+
+# Adversarial case: overlapping per-file bounds must NOT lead to pruning.
+# A large insert of scattered values produces several data files whose min/max
+# bounds overlap heavily. Because a file's bound value is not guaranteed to
+# repeat within that file, no file can be proven to fall entirely outside the
+# top-N, so every file must still be scanned and the result must stay correct.
+# hash() is deterministic, so the data (and the overlap) is reproducible.
+statement ok
+COPY (select (hash(range) % 1000000)::BIGINT a from range(3000000)) TO '{TEST_DIR}/scan_order_overlap' (FORMAT ICEBERG);
+
+# Sanity: the insert spread across more than one data file.
+query I
+SELECT count(*) > 1 FROM iceberg_metadata('{TEST_DIR}/scan_order_overlap');
+----
+true
+
+statement ok
+PRAGMA disabled_optimizers='row_group_pruner';
+
+statement ok
+create table overlap_oracle as select a from iceberg_scan('{TEST_DIR}/scan_order_overlap') order by a asc limit 10;
+
+statement ok
+PRAGMA disabled_optimizers='';
+
+query I
+select count(*) from (
+  (select a from iceberg_scan('{TEST_DIR}/scan_order_overlap') order by a asc limit 10)
+  except all
+  (select a from overlap_oracle)
+);
+----
+0
+
+query I
+select count(*) from (
+  (select a from overlap_oracle)
+  except all
+  (select a from iceberg_scan('{TEST_DIR}/scan_order_overlap') order by a asc limit 10)
+);
+----
+0
+
+statement ok
+CALL truncate_duckdb_logs();
+
+statement ok
+select a from iceberg_scan('{TEST_DIR}/scan_order_overlap') order by a asc limit 10;
+
+# Overlapping bounds: no file can be excluded, so nothing is pruned.
+query I
+SELECT count(*)
+FROM duckdb_logs()
+WHERE type = 'Iceberg' AND message LIKE '%Scan Order Pushdown, kept%';
+----
+0
+
+# Graceful degradation: small per-file overlap still prunes most files.
+# This is the realistic shape for a time-partitioned table with late-arriving
+# rows: values follow insertion order with only a little jitter, so adjacent
+# files overlap slightly while distant files stay disjoint. Pruning must back
+# off only near the frontier, not give up entirely.
+statement ok
+COPY (select (range + (hash(range) % 1000))::BIGINT a from range(8000000)) TO '{TEST_DIR}/scan_order_jitter' (FORMAT ICEBERG);
+
+query I
+SELECT count(*) > 1 FROM iceberg_metadata('{TEST_DIR}/scan_order_jitter');
+----
+true
+
+statement ok
+PRAGMA disabled_optimizers='row_group_pruner';
+
+statement ok
+create table jitter_oracle as select a from iceberg_scan('{TEST_DIR}/scan_order_jitter') order by a desc limit 10;
+
+statement ok
+PRAGMA disabled_optimizers='';
+
+query I
+select count(*) from (
+  (select a from iceberg_scan('{TEST_DIR}/scan_order_jitter') order by a desc limit 10)
+  except all
+  (select a from jitter_oracle)
+);
+----
+0
+
+query I
+select count(*) from (
+  (select a from jitter_oracle)
+  except all
+  (select a from iceberg_scan('{TEST_DIR}/scan_order_jitter') order by a desc limit 10)
+);
+----
+0
+
+statement ok
+CALL truncate_duckdb_logs();
+
+statement ok
+select a from iceberg_scan('{TEST_DIR}/scan_order_jitter') order by a desc limit 10;
+
+# Slight overlap still lets at least one file be pruned.
+query I
+SELECT count(*) >= 1
+FROM duckdb_logs()
+WHERE type = 'Iceberg' AND message LIKE '%Scan Order Pushdown, kept%';
+----
+true


### PR DESCRIPTION
Addresses duckdb/duckdb-iceberg#746: Top-N queries over time-sorted data (e.g. ORDER BY ts DESC LIMIT N) read every file before the limit filters them out.

Uses DuckDB core's set_scan_order table-function callback (used by native table_scan). When a LIMIT is present over an ORDER BY on a numeric/temporal column, reorder the data files by the order column's per-file bounds and drop files that cannot contain a top-N row, so the scan touches only the relevant files. 

When a WHERE is present the ordering also helps choose a more efficient order for expansion (done by existing core optimizers).

A fair amount of this was generated by AI. Let me know if this is helpful or not (this is quite a good win though for timeseries usecases)