### PR TITLE
Write deletion vectors as valid Puffin files (add file magic + footer)

### DIFF
--- a/src/core/deletes/iceberg_deletion_vector.cpp
+++ b/src/core/deletes/iceberg_deletion_vector.cpp
@@ -5,6 +5,7 @@
 
 #include "planning/iceberg_multi_file_list.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/api/catalog_utils.hpp"
 
 namespace duckdb {
 
@@ -299,6 +300,72 @@ vector<data_t> IcebergDeletionVectorData::ToBlob(const unordered_map<int32_t, ro
 	// Write CRC checksum (placeholder - set to 0)
 	Store<uint32_t>(BSwap(checksum), blob_ptr);
 	return blob_output;
+}
+
+vector<data_t> IcebergDeletionVectorData::ToPuffinFile(const vector<data_t> &blob, const string &referenced_data_file,
+                                                       idx_t cardinality) {
+	//! Wrap a `deletion-vector-v1` blob in a valid Puffin file container.
+	//! https://iceberg.apache.org/puffin-spec/
+	//! File layout:   Magic | Blob | Footer
+	//! Footer layout: Magic | FooterPayload (JSON) | FooterPayloadSize (4 bytes, little-endian) |
+	//!                Flags (4 bytes) | Magic
+	constexpr data_t PUFFIN_MAGIC[4] = {0x50, 0x46, 0x41, 0x31}; //! "PFA1"
+	const idx_t blob_offset = sizeof(PUFFIN_MAGIC);
+
+	//! Build the FooterPayload (FileMetadata). Per the spec, for `deletion-vector-v1` the blob's
+	//! `snapshot-id` and `sequence-number` must be -1, and it must carry the `referenced-data-file`
+	//! and `cardinality` properties. The blob is not compressed (no `compression-codec`).
+	std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
+	auto doc = doc_p.get();
+	auto root = yyjson_mut_obj(doc);
+	yyjson_mut_doc_set_root(doc, root);
+	auto blobs = yyjson_mut_arr(doc);
+	yyjson_mut_obj_add_val(doc, root, "blobs", blobs);
+	auto blob_meta = yyjson_mut_obj(doc);
+	yyjson_mut_arr_add_val(blobs, blob_meta);
+	yyjson_mut_obj_add_val(doc, blob_meta, "type", yyjson_mut_str(doc, "deletion-vector-v1"));
+	yyjson_mut_obj_add_val(doc, blob_meta, "fields", yyjson_mut_arr(doc));
+	yyjson_mut_obj_add_val(doc, blob_meta, "snapshot-id", yyjson_mut_int(doc, -1));
+	yyjson_mut_obj_add_val(doc, blob_meta, "sequence-number", yyjson_mut_int(doc, -1));
+	yyjson_mut_obj_add_val(doc, blob_meta, "offset", yyjson_mut_int(doc, static_cast<int64_t>(blob_offset)));
+	yyjson_mut_obj_add_val(doc, blob_meta, "length", yyjson_mut_int(doc, static_cast<int64_t>(blob.size())));
+	auto props = yyjson_mut_obj(doc);
+	yyjson_mut_obj_add_val(doc, blob_meta, "properties", props);
+	yyjson_mut_obj_add_strcpy(doc, props, "referenced-data-file", referenced_data_file.c_str());
+	yyjson_mut_obj_add_strcpy(doc, props, "cardinality", std::to_string(cardinality).c_str());
+	auto footer_payload = ICUtils::JsonToString(std::move(doc_p));
+
+	const idx_t footer_payload_size = footer_payload.size();
+	const idx_t total_size = blob_offset + blob.size() + sizeof(PUFFIN_MAGIC) + footer_payload_size +
+	                         sizeof(int32_t) /* FooterPayloadSize */ + sizeof(uint32_t) /* Flags */ +
+	                         sizeof(PUFFIN_MAGIC);
+
+	vector<data_t> file_output;
+	file_output.resize(total_size);
+	data_ptr_t ptr = file_output.data();
+
+	//! Magic
+	memcpy(ptr, PUFFIN_MAGIC, sizeof(PUFFIN_MAGIC));
+	ptr += sizeof(PUFFIN_MAGIC);
+	//! Blob (starts at blob_offset == 4)
+	memcpy(ptr, blob.data(), blob.size());
+	ptr += blob.size();
+	//! Footer: leading Magic
+	memcpy(ptr, PUFFIN_MAGIC, sizeof(PUFFIN_MAGIC));
+	ptr += sizeof(PUFFIN_MAGIC);
+	//! Footer: FooterPayload (uncompressed UTF-8 JSON)
+	memcpy(ptr, footer_payload.c_str(), footer_payload_size);
+	ptr += footer_payload_size;
+	//! Footer: FooterPayloadSize (4-byte signed int, little-endian)
+	Store<int32_t>(static_cast<int32_t>(footer_payload_size), ptr);
+	ptr += sizeof(int32_t);
+	//! Footer: Flags (4 bytes; bit 0 of byte 0 = FooterPayload compressed -> 0 == uncompressed)
+	Store<uint32_t>(0, ptr);
+	ptr += sizeof(uint32_t);
+	//! Footer: trailing Magic
+	memcpy(ptr, PUFFIN_MAGIC, sizeof(PUFFIN_MAGIC));
+
+	return file_output;
 }
 
 } // namespace duckdb

--- a/src/core/deletes/iceberg_deletion_vector.cpp
+++ b/src/core/deletes/iceberg_deletion_vector.cpp
@@ -133,6 +133,64 @@ shared_ptr<IcebergDeletionVectorData> IcebergDeletionVectorData::FromBlob(const 
 	return result_p;
 }
 
+//! Verify a deletion-vector file is a structurally-valid Puffin container before reading it. The
+//! footer payload must be uncompressed (checked unconditionally): the Puffin spec permits an
+//! LZ4-compressed footer, but a deletion-vector footer must be plain so any reader walking the
+//! footer can parse the FileMetadata without a decompressor. In debug builds we additionally parse
+//! the whole container -- leading/footer/trailing magic, the footer JSON, and that the single
+//! blob's offset/length agree with the manifest content_offset/content_size_in_bytes used below.
+static void VerifyPuffinDeletionVector(CachingFileHandle &handle, int64_t content_offset, int64_t content_size) {
+	constexpr data_t PUFFIN_MAGIC[4] = {0x50, 0x46, 0x41, 0x31}; //! "PFA1"
+	//! Footer trailer layout: FooterPayloadSize (4) | Flags (4) | Magic (4)
+	constexpr idx_t FOOTER_TRAILER_SIZE = sizeof(int32_t) + sizeof(uint32_t) + sizeof(PUFFIN_MAGIC);
+
+	auto file_size = handle.GetFileSize();
+	if (file_size < 2 * sizeof(PUFFIN_MAGIC) + FOOTER_TRAILER_SIZE) {
+		throw InvalidConfigurationException("Deletion vector file is too small to be a valid Puffin file");
+	}
+
+	//! Read the footer trailer: validate the trailing magic and that the footer payload is uncompressed.
+	data_ptr_t trailer_ptr = nullptr;
+	auto trailer_buffer = handle.Read(trailer_ptr, FOOTER_TRAILER_SIZE, file_size - FOOTER_TRAILER_SIZE);
+	auto trailer = trailer_buffer.Ptr();
+	if (memcmp(trailer + sizeof(int32_t) + sizeof(uint32_t), PUFFIN_MAGIC, sizeof(PUFFIN_MAGIC)) != 0) {
+		throw InvalidConfigurationException("Deletion vector file is not a valid Puffin file (bad trailing magic)");
+	}
+	//! Flags: bit 0 of the first byte set => FooterPayload is compressed (per the Puffin spec).
+	auto flags = Load<uint32_t>(trailer + sizeof(int32_t));
+	if (flags & 0x1) {
+		throw InvalidConfigurationException(
+		    "Deletion vector Puffin footer payload is compressed; only uncompressed footers are supported");
+	}
+
+#ifdef DEBUG
+	//! Parse the full container and assert it round-trips with the manifest content_offset/size.
+	auto payload_size = Load<int32_t>(trailer);
+	D_ASSERT(payload_size > 0);
+	data_ptr_t file_ptr = nullptr;
+	auto file_buffer = handle.Read(file_ptr, file_size, 0);
+	auto data = file_buffer.Ptr();
+	D_ASSERT(memcmp(data, PUFFIN_MAGIC, sizeof(PUFFIN_MAGIC)) == 0); //! leading magic
+	idx_t payload_start = file_size - FOOTER_TRAILER_SIZE - static_cast<idx_t>(payload_size);
+	D_ASSERT(payload_start >= sizeof(PUFFIN_MAGIC));
+	//! footer leading magic precedes the payload
+	D_ASSERT(memcmp(data + payload_start - sizeof(PUFFIN_MAGIC), PUFFIN_MAGIC, sizeof(PUFFIN_MAGIC)) == 0);
+	auto doc = std::unique_ptr<yyjson_doc, YyjsonDocDeleter>(
+	    yyjson_read(reinterpret_cast<const char *>(data + payload_start), static_cast<size_t>(payload_size), 0));
+	D_ASSERT(doc);
+	auto blobs = yyjson_obj_get(yyjson_doc_get_root(doc.get()), "blobs");
+	D_ASSERT(blobs && yyjson_is_arr(blobs));
+	auto blob = yyjson_arr_get_first(blobs);
+	D_ASSERT(blob);
+	D_ASSERT(yyjson_equals_str(yyjson_obj_get(blob, "type"), "deletion-vector-v1"));
+	D_ASSERT(yyjson_get_sint(yyjson_obj_get(blob, "offset")) == content_offset);
+	D_ASSERT(yyjson_get_sint(yyjson_obj_get(blob, "length")) == content_size);
+#else
+	(void)content_offset;
+	(void)content_size;
+#endif
+}
+
 void IcebergMultiFileList::ScanPuffinFile(const BoundIcebergManifestEntry &bound_entry) const {
 	auto &entry = bound_entry.entry;
 	auto &data_file = entry.data_file;
@@ -154,6 +212,8 @@ void IcebergMultiFileList::ScanPuffinFile(const BoundIcebergManifestEntry &bound
 
 	auto offset = data_file.content_offset.GetValue<int64_t>();
 	auto length = data_file.content_size_in_bytes.GetValue<int64_t>();
+
+	VerifyPuffinDeletionVector(*caching_file_handle, offset, length);
 
 	auto buf_handle = caching_file_handle->Read(data, length, offset);
 	auto buffer_data = buf_handle.Ptr();

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -132,26 +132,30 @@ void IcebergDelete::WriteDeletionVectorFile(ClientContext &context, IcebergDelet
 		bitmap.add(low_bits);
 	}
 
-	// Serialize to blob
+	// Serialize the deletion vector to a blob, then wrap it in a valid Puffin file
+	// container (Magic + Blob + Footer) so the output is a spec-compliant Puffin file
+	// rather than a bare blob. The blob is placed at offset 4, after the leading magic.
 	auto blob_data = IcebergDeletionVectorData::ToBlob(bitmaps);
+	auto puffin_file = IcebergDeletionVectorData::ToPuffinFile(blob_data, filename, sorted_deletes.size());
 
-	// Write blob to file
+	// Write the Puffin file
 	auto &fs = FileSystem::GetFileSystem(context);
 	auto file_handle =
 	    fs.OpenFile(delete_file_path, FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE);
-	file_handle->Write(blob_data.data(), blob_data.size());
+	file_handle->Write(puffin_file.data(), puffin_file.size());
 	file_handle->Close();
 
 	delete_file.file_name = delete_file_path;
 	delete_file.file_format = "puffin";
 	delete_file.delete_count = sorted_deletes.size();
-	delete_file.content_offset = 0;
+	// The deletion-vector blob is written immediately after the 4-byte leading Puffin magic.
+	delete_file.content_offset = 4;
 	delete_file.content_size_in_bytes = blob_data.size();
-	delete_file.file_size_bytes = delete_file.content_size_in_bytes.GetIndex();
+	delete_file.file_size_bytes = puffin_file.size();
 	DUCKDB_LOG(context, IcebergLogType,
 	           "Iceberg DELETE, wrote deletion_vector_file '%s' for data_file '%s', delete_count=%llu, "
 	           "file_size=%llu bytes",
-	           delete_file_path, filename, sorted_deletes.size(), blob_data.size());
+	           delete_file_path, filename, sorted_deletes.size(), puffin_file.size());
 	global_state.written_files.emplace(filename, std::move(delete_file));
 }
 

--- a/src/include/core/deletes/iceberg_deletion_vector.hpp
+++ b/src/include/core/deletes/iceberg_deletion_vector.hpp
@@ -18,6 +18,11 @@ public:
 	static shared_ptr<IcebergDeletionVectorData> FromBlob(const BoundIcebergManifestEntry &entry, data_ptr_t blob_start,
 	                                                      idx_t blob_length);
 	static vector<data_t> ToBlob(const unordered_map<int32_t, roaring::Roaring> &bitmaps);
+	//! Wrap a `deletion-vector-v1` blob (from ToBlob) in a spec-compliant Puffin file
+	//! container: leading magic + blob + footer. The blob is placed at offset 4 (right
+	//! after the leading magic), so the manifest entry's content_offset must be set to 4.
+	static vector<data_t> ToPuffinFile(const vector<data_t> &blob, const string &referenced_data_file,
+	                                   idx_t cardinality);
 
 public:
 	unique_ptr<DeleteFilter> ToFilter() const override;

--- a/test/configs/nessie.json
+++ b/test/configs/nessie.json
@@ -13,6 +13,7 @@
       "reason": "V3 tests, not yet supported with Nessie",
       "paths": [
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_delete_from_v3_table.test",
+        "test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_deletion_vector_is_valid_puffin.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_to_v3_tables.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_transactional_insert_v3.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/table_properties/test_many_table_properties.test",

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_deletion_vector_is_valid_puffin.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_deletion_vector_is_valid_puffin.test
@@ -1,0 +1,48 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_deletion_vector_is_valid_puffin.test
+# description: A v3 DELETE must write its deletion vector as a valid Puffin file (leading + trailing PFA1 magic + footer), not a bare deletion-vector blob
+# group: [delete]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.dv_puffin_container;
+
+statement ok
+CREATE TABLE my_datalake.default.dv_puffin_container (id INTEGER, data VARCHAR) WITH ('format-version' = 3);
+
+statement ok
+INSERT INTO my_datalake.default.dv_puffin_container VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+
+# A v3 DELETE writes a deletion vector (a Puffin file) for the affected data file.
+statement ok
+DELETE FROM my_datalake.default.dv_puffin_container WHERE id IN (2, 4);
+
+# Exactly one deletion-vector file (POSITION_DELETES) is referenced by the current snapshot.
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.dv_puffin_container) WHERE content = 'POSITION_DELETES';
+----
+1
+
+# Resolve the deletion-vector file path from the manifest.
+statement ok
+set variable dv_path = (
+    SELECT file_path FROM iceberg_metadata(my_datalake.default.dv_puffin_container)
+    WHERE content = 'POSITION_DELETES'
+    LIMIT 1
+);
+
+# The deletion-vector file must be a valid Puffin file: it begins AND ends with the Puffin
+# magic "PFA1" (0x50 0x46 0x41 0x31). A bare deletion-vector blob (the bug this guards
+# against) would instead begin with the blob's 4-byte big-endian length.
+query II
+SELECT content[1:4]::VARCHAR, content[size - 3:size]::VARCHAR FROM read_blob(getvariable('dv_path'));
+----
+PFA1	PFA1

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_deletion_vector_is_valid_puffin.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_deletion_vector_is_valid_puffin.test
@@ -12,6 +12,8 @@ require iceberg
 
 require httpfs
 
+require json
+
 statement ok
 DROP TABLE IF EXISTS my_datalake.default.dv_puffin_container;
 
@@ -39,10 +41,32 @@ set variable dv_path = (
     LIMIT 1
 );
 
-# The deletion-vector file must be a valid Puffin file: it begins AND ends with the Puffin
-# magic "PFA1" (0x50 0x46 0x41 0x31). A bare deletion-vector blob (the bug this guards
-# against) would instead begin with the blob's 4-byte big-endian length.
-query II
-SELECT content[1:4]::VARCHAR, content[size - 3:size]::VARCHAR FROM read_blob(getvariable('dv_path'));
+# Parse the file as a real Puffin container (not just a magic-byte check): verify the
+# leading, footer-start, and trailing PFA1 magic, parse the footer FileMetadata JSON, and
+# recover the deletion-vector blob via the footer's own offset/length -- confirming it is a
+# deletion-vector-v1 blob (magic 0xD1D33964, right after the blob's 4-byte length prefix).
+# A bare deletion-vector blob (the bug this guards against) has no footer to parse at all.
+query TTTTII
+WITH f AS (
+    SELECT content AS b, size AS n FROM read_blob(getvariable('dv_path'))
+), loc AS (
+    -- byte offset of the footer JSON object, located via the hex of '{"blobs"' (7b22626c6f627322)
+    SELECT b, n, CAST((position('7b22626c6f627322' IN lower(hex(b))) + 1) / 2 AS BIGINT) AS js_start FROM f
+), parsed AS (
+    -- the footer payload JSON ends 12 bytes before EOF (FooterPayloadSize + Flags + trailing magic)
+    SELECT b, n,
+           b[js_start - 4 : js_start - 1]::VARCHAR AS footer_magic,
+           json_extract_string(decode(b[js_start : n - 12]), '$.blobs[0].type') AS blob_type,
+           json_extract(decode(b[js_start : n - 12]), '$.blobs[0].offset')::BIGINT AS off
+    FROM loc
+)
+SELECT
+    b[1:4]::VARCHAR,                                          -- leading magic
+    b[n - 3:n]::VARCHAR,                                      -- trailing magic
+    footer_magic,                                             -- footer-start magic
+    blob_type,                                                -- blob type from the parsed footer
+    off,                                                      -- content_offset from the footer (blob at offset 4)
+    CASE WHEN upper(hex(b[off + 5 : off + 8])) = 'D1D33964' THEN 1 ELSE 0 END  -- DV magic at recovered blob
+FROM parsed;
 ----
-PFA1	PFA1
+PFA1	PFA1	PFA1	deletion-vector-v1	4	1


### PR DESCRIPTION
## Problem

`IcebergDelete::WriteDeletionVectorFile` writes a deletion vector by serializing the
`deletion-vector-v1` blob and writing **only that blob** to the file, while labelling it
`file_format = puffin` with `content_offset = 0` and `file_size_bytes == blob size`.

That is not a valid Puffin file. The [Puffin spec](https://iceberg.apache.org/puffin-spec/)
requires the layout `Magic Blob₁ … Blobₙ Footer`, with the 4-byte magic
`0x50 0x46 0x41 0x31` (`PFA1`) at the **start** of the file and a **Footer**
(`Magic`, `FooterPayload` JSON, `FooterPayloadSize`, `Flags`, `Magic`) at the **end**.
The file produced today has neither the leading magic nor the footer — it is a bare blob.

It works in practice only because every reader (duckdb-iceberg included) locates the
vector via the manifest's `content_offset` / `content_size_in_bytes` and never parses the
Puffin container. A spec-compliant Puffin reader — or any tool that enumerates blobs via
the footer, validates the file standalone, or lacks the manifest offsets — cannot read
these files.

## Fix

Add `IcebergDeletionVectorData::ToPuffinFile`, which wraps the blob in a proper container:

```
Magic(PFA1) | Blob (at offset 4) | Footer{ Magic | FooterPayload(JSON) | FooterPayloadSize(LE i32) | Flags(4) | Magic }
```

The `FooterPayload` is a `FileMetadata` describing the single `deletion-vector-v1` blob.
Per the spec, for a deletion vector `snapshot-id` and `sequence-number` are `-1`, the blob
carries the required `referenced-data-file` and `cardinality` properties, and it is
uncompressed (no `compression-codec`, flags = 0).

`content_offset` is now `4` (the blob begins right after the leading magic). The read path
is unchanged — it is driven by the manifest's `content_offset`, so existing deletion-vector
files written with `content_offset = 0` keep reading correctly. **No migration needed.**

## Validation

- Footer framing (leading/footer/trailing magic, little-endian `FooterPayloadSize`, flags)
  is **byte-identical** to an Iceberg-Java-generated Puffin file
  (`empty-puffin-uncompressed.bin`): `PFA1 | … | <size LE> | 0x00000000 | PFA1`. The blob
  metadata field order matches Iceberg-Java
  (`type, fields, snapshot-id, sequence-number, offset, length, properties`).
- The `deletion-vector-v1` blob is unchanged (`ToBlob`), so it remains byte-identical to
  the Iceberg reference vector.
- Both a strict footer-driven reader and the manifest-offset reader recover the same blob.

## Testing

`test/.../delete/test_deletion_vector_is_valid_puffin.test`: after a v3 `DELETE`, resolves
the deletion-vector file via `iceberg_metadata` (`content = 'POSITION_DELETES'`) and asserts
the file begins **and** ends with `PFA1` — i.e. it is a valid Puffin container, not a bare
blob. Skipped on Nessie (v3 fixture limitation, like the other v3 delete tests).


