### PR TITLE
Fix cloud testing workflows on main

### DIFF
--- a/.github/workflows/CloudTestingManual.yaml
+++ b/.github/workflows/CloudTestingManual.yaml
@@ -5,11 +5,7 @@ on:
       duckdb_ref:
         description: 'DuckDB branch name or commit hash'
         required: false
-        default: 'main'
-      duckdb_iceberg_ref:
-        description: 'duckdb-iceberg branch name or commit hash'
-        required: false
-        default: 'main'
+        default: 'v1.5-variegata'
       httpfs_fork:
         description: 'URL of a duckdb-httpfs fork. Leave empty to use default duckdb/duckdb-httpfs.'
         required: false
@@ -24,24 +20,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cloud-tests-main:
+  cloud-tests:
     name: Run Cloud tests on main
     uses: ./.github/workflows/CloudTestingReusable.yml
     with:
       duckdb_ref: ${{ github.event.inputs.duckdb_ref || 'main' }}
-      duckdb_iceberg_ref: ${{ github.event.inputs.duckdb_iceberg_ref || 'main' }}
       httpfs_fork: ${{ github.event.inputs.httpfs_fork || 'https://github.com/duckdb/duckdb-httpfs' }}
       httpfs_ref: ${{ github.event.inputs.httpfs_ref || '' }}
     secrets: inherit
-
-  cloud-tests-main:
-    name: Run Cloud tests on main
-    uses: ./.github/workflows/CloudTestingReusable.yml
-    with:
-      duckdb_ref: ${{ github.event.inputs.duckdb_ref || 'main' }}
-      duckdb_iceberg_ref: ${{ github.event.inputs.duckdb_iceberg_ref || 'main' }}
-      httpfs_fork: ${{ github.event.inputs.httpfs_fork || 'https://github.com/duckdb/duckdb-httpfs' }}
-      httpfs_ref: ${{ github.event.inputs.httpfs_ref || '' }}
-    secrets: inherit
-
-

--- a/.github/workflows/CloudTestingManual.yaml
+++ b/.github/workflows/CloudTestingManual.yaml
@@ -6,6 +6,10 @@ on:
         description: 'DuckDB branch name or commit hash'
         required: false
         default: 'main'
+      duckdb_iceberg_ref:
+        description: 'duckdb-iceberg branch name or commit hash'
+        required: false
+        default: 'main'
       httpfs_fork:
         description: 'URL of a duckdb-httpfs fork. Leave empty to use default duckdb/duckdb-httpfs.'
         required: false
@@ -25,6 +29,7 @@ jobs:
     uses: ./.github/workflows/CloudTestingReusable.yml
     with:
       duckdb_ref: ${{ github.event.inputs.duckdb_ref || 'main' }}
+      duckdb_iceberg_ref: ${{ github.event.inputs.duckdb_iceberg_ref || 'main' }}
       httpfs_fork: ${{ github.event.inputs.httpfs_fork || 'https://github.com/duckdb/duckdb-httpfs' }}
       httpfs_ref: ${{ github.event.inputs.httpfs_ref || '' }}
     secrets: inherit

--- a/.github/workflows/CloudTestingManual.yaml
+++ b/.github/workflows/CloudTestingManual.yaml
@@ -5,7 +5,7 @@ on:
       duckdb_ref:
         description: 'DuckDB branch name or commit hash'
         required: false
-        default: 'v1.5-variegata'
+        default: 'main'
       httpfs_fork:
         description: 'URL of a duckdb-httpfs fork. Leave empty to use default duckdb/duckdb-httpfs.'
         required: false

--- a/.github/workflows/CloudTestingReusable.yml
+++ b/.github/workflows/CloudTestingReusable.yml
@@ -7,6 +7,11 @@ on:
         required: false
         default: ''
         type: string
+      duckdb_iceberg_ref:
+        description: 'duckdb-iceberg branch name or commit hash'
+        required: false
+        default: ''
+        type: string
       httpfs_fork:
         description: 'URL of a duckdb-httpfs fork (e.g. https://github.com/myfork/duckdb-httpfs). Leave empty to use the default duckdb/duckdb-httpfs.'
         required: false
@@ -60,6 +65,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.duckdb_iceberg_ref || github.ref }}
           fetch-depth: 0
           submodules: 'true'
 

--- a/.github/workflows/CloudTestingReusable.yml
+++ b/.github/workflows/CloudTestingReusable.yml
@@ -60,7 +60,6 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.duckdb_iceberg_ref }}
           fetch-depth: 0
           submodules: 'true'
 

--- a/.github/workflows/CloudTestingScheduled.yml
+++ b/.github/workflows/CloudTestingScheduled.yml
@@ -13,18 +13,6 @@ jobs:
     uses: ./.github/workflows/CloudTestingReusable.yml
     with:
       duckdb_ref: ''
-      duckdb_iceberg_ref: 'main'
       httpfs_fork: 'https://github.com/duckdb/duckdb-httpfs'
       httpfs_ref: ''
     secrets: inherit
-
-  cloud-tests-main:
-    name: Run Cloud tests on main
-    uses: ./.github/workflows/CloudTestingReusable.yml
-    with:
-      duckdb_ref: ''
-      duckdb_iceberg_ref: 'main'
-      httpfs_fork: 'https://github.com/duckdb/duckdb-httpfs'
-      httpfs_ref: ''
-    secrets: inherit
-

--- a/.github/workflows/CloudTestingScheduled.yml
+++ b/.github/workflows/CloudTestingScheduled.yml
@@ -13,6 +13,7 @@ jobs:
     uses: ./.github/workflows/CloudTestingReusable.yml
     with:
       duckdb_ref: ''
+      duckdb_iceberg_ref: 'main'
       httpfs_fork: 'https://github.com/duckdb/duckdb-httpfs'
       httpfs_ref: ''
     secrets: inherit


### PR DESCRIPTION
## Summary

- Fixes workflow validation failures on `main` caused by duplicate `cloud-tests-main` job definitions in `CloudTestingScheduled.yml` and `CloudTestingManual.yaml` (introduced in ff1bc054).
- Keeps `main` as the default DuckDB and duckdb-iceberg ref for manual and scheduled cloud tests on the `main` branch.
- Properly wires `duckdb_iceberg_ref` through the reusable workflow: it is now declared as a `workflow_call` input, used at checkout, and exposed as a manual dispatch input so cloud tests can target a specific duckdb-iceberg branch.

## Context

Since ff1bc054, scheduled and manual cloud test workflows fail immediately at parse time:

```
'cloud-tests-main' is already defined
```

The reusable workflow also referenced `inputs.duckdb_iceberg_ref` without declaring it as a `workflow_call` input, so the passthrough never worked. This PR removes the duplicate jobs and restores the input correctly:
