### PR TITLE
feat(s3tables): support for AWS Lake Formation filters for S3 Tables

### DIFF
--- a/.github/workflows/CloudTestingManual.yaml
+++ b/.github/workflows/CloudTestingManual.yaml
@@ -5,11 +5,7 @@ on:
       duckdb_ref:
         description: 'DuckDB branch name or commit hash'
         required: false
-        default: 'main'
-      duckdb_iceberg_ref:
-        description: 'duckdb-iceberg branch name or commit hash'
-        required: false
-        default: 'main'
+        default: 'v1.5-variegata'
       httpfs_fork:
         description: 'URL of a duckdb-httpfs fork. Leave empty to use default duckdb/duckdb-httpfs.'
         required: false
@@ -24,24 +20,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cloud-tests-main:
+  cloud-tests:
     name: Run Cloud tests on main
     uses: ./.github/workflows/CloudTestingReusable.yml
     with:
       duckdb_ref: ${{ github.event.inputs.duckdb_ref || 'main' }}
-      duckdb_iceberg_ref: ${{ github.event.inputs.duckdb_iceberg_ref || 'main' }}
       httpfs_fork: ${{ github.event.inputs.httpfs_fork || 'https://github.com/duckdb/duckdb-httpfs' }}
       httpfs_ref: ${{ github.event.inputs.httpfs_ref || '' }}
     secrets: inherit
-
-  cloud-tests-main:
-    name: Run Cloud tests on main
-    uses: ./.github/workflows/CloudTestingReusable.yml
-    with:
-      duckdb_ref: ${{ github.event.inputs.duckdb_ref || 'main' }}
-      duckdb_iceberg_ref: ${{ github.event.inputs.duckdb_iceberg_ref || 'main' }}
-      httpfs_fork: ${{ github.event.inputs.httpfs_fork || 'https://github.com/duckdb/duckdb-httpfs' }}
-      httpfs_ref: ${{ github.event.inputs.httpfs_ref || '' }}
-    secrets: inherit
-
-

--- a/.github/workflows/CloudTestingReusable.yml
+++ b/.github/workflows/CloudTestingReusable.yml
@@ -111,6 +111,16 @@ jobs:
         run: |
           python3 scripts/create_s3_insert_table.py --action=delete-and-create --catalogs=s3tables,r2,glue
 
+      - name: Set up Lake Formation data filters
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ICEBERG_TEST_USER_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_ICEBERG_TEST_USER_SECRET }}
+          AWS_DEFAULT_REGION: ${{ secrets.S3_ICEBERG_TEST_USER_REGION }}
+          AWS_REGION: ${{ secrets.S3_ICEBERG_TEST_USER_REGION }}
+          ICEBERG_LF_REGION: ${{ secrets.S3_ICEBERG_TEST_USER_REGION }}
+        run: |
+          python3 scripts/setup_lf_data_filters.py --action=create
+
       - name: Run mitmproxy
         shell: bash
         run: |
@@ -157,6 +167,20 @@ jobs:
           NO_REGION_SET: 1
         run: |
           ./build/release/test/unittest --order lex test/sql/cloud/snowflake/no_vended_credentials_region.test
+
+      - name: Test Lake Formation cloud tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ICEBERG_TEST_USER_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_ICEBERG_TEST_USER_SECRET }}
+          AWS_DEFAULT_REGION: ${{ secrets.S3_ICEBERG_TEST_USER_REGION }}
+          ICEBERG_LF_REMOTE_AVAILABLE: 1
+          LAKEFORMATION_TEST_CONFIG_SETUP: 1
+          ICEBERG_LF_REGION: ${{ secrets.S3_ICEBERG_TEST_USER_REGION }}
+          ICEBERG_LF_CATALOG_ID: 840140254803:s3tablescatalog/duckdblabs-iceberg-testing
+          ICEBERG_LF_TEST_ROLE_ARN: arn:aws:iam::840140254803:role/pyiceberg-etl-role
+          ICEBERG_LF_SESSION_TAG: duckdb
+        run: |
+          ./build/release/test/unittest --order lex "$PWD/test/sql/cloud/lakeformation/*" --test-config test/configs/lakeformation.json
 
       - name: File issue if error
         if: ${{ contains(github.ref_name, 'main') && failure() }}

--- a/.github/workflows/CloudTestingReusable.yml
+++ b/.github/workflows/CloudTestingReusable.yml
@@ -60,7 +60,6 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.duckdb_iceberg_ref }}
           fetch-depth: 0
           submodules: 'true'
 

--- a/.github/workflows/CloudTestingScheduled.yml
+++ b/.github/workflows/CloudTestingScheduled.yml
@@ -13,18 +13,6 @@ jobs:
     uses: ./.github/workflows/CloudTestingReusable.yml
     with:
       duckdb_ref: ''
-      duckdb_iceberg_ref: 'main'
       httpfs_fork: 'https://github.com/duckdb/duckdb-httpfs'
       httpfs_ref: ''
     secrets: inherit
-
-  cloud-tests-main:
-    name: Run Cloud tests on main
-    uses: ./.github/workflows/CloudTestingReusable.yml
-    with:
-      duckdb_ref: ''
-      duckdb_iceberg_ref: 'main'
-      httpfs_fork: 'https://github.com/duckdb/duckdb-httpfs'
-      httpfs_ref: ''
-    secrets: inherit
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,16 @@ set(EXTENSION_SOURCES
 	src/storage/statistics/iceberg_statistics.cpp
 )
 
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+	list(APPEND EXTENSION_SOURCES
+		src/catalog/aws/lakeformation/lf_client.cpp
+		src/catalog/aws/lakeformation/lf_credentials.cpp
+		src/catalog/aws/lakeformation/lf_table_metadata.cpp
+		src/catalog/aws/lakeformation/lf_filter_parser.cpp
+		src/catalog/aws/lakeformation/lf_credential_cache.cpp
+	)
+endif()
+
 add_subdirectory(src/rest_catalog/objects)
 
 add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES} ${ALL_OBJECT_FILES})
@@ -129,7 +139,7 @@ build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES} ${ALL
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     find_package(CURL REQUIRED)
-    find_package(AWSSDK REQUIRED COMPONENTS core sso sts)
+    find_package(AWSSDK REQUIRED COMPONENTS core glue lakeformation sso sts)
     include_directories(${CURL_INCLUDE_DIRS})
 endif()
 

--- a/scripts/create_s3_insert_table.py
+++ b/scripts/create_s3_insert_table.py
@@ -10,6 +10,10 @@ import sys
 import duckdb
 from datetime import date
 
+REGION = "us-east-2"
+TABLE_BUCKET = "iceberg-testing"
+DATABASE_NAME = "test_inserts"
+
 
 def catalog_region(catalog_env: str, default: str) -> str:
     # DuckDB Labs CI sets AWS_DEFAULT_REGION for credentials but upstream hardcoded
@@ -24,9 +28,9 @@ def catalog_region(catalog_env: str, default: str) -> str:
 
 # DuckDB Labs defaults (must match upstream and test/sql/cloud/* fixtures).
 GLUE_REGION = catalog_region("ICEBERG_GLUE_REGION", "us-east-1")
-S3TABLES_REGION = catalog_region("ICEBERG_S3TABLES_REGION", "us-east-2")
+S3TABLES_REGION = catalog_region("ICEBERG_S3TABLES_REGION", REGION)
 ACCOUNT_ID = os.getenv("ICEBERG_ACCOUNT_ID", os.getenv("ICEBERG_LF_ACCOUNT_ID", "840140254803"))
-S3TABLES_BUCKET = os.getenv("ICEBERG_S3TABLES_BUCKET", "iceberg-testing")
+S3TABLES_BUCKET = os.getenv("ICEBERG_S3TABLES_BUCKET", TABLE_BUCKET)
 GLUE_WAREHOUSE = os.getenv(
     "ICEBERG_GLUE_WAREHOUSE",
     os.getenv(
@@ -35,7 +39,7 @@ GLUE_WAREHOUSE = os.getenv(
     ),
 )
 
-DATABASE_NAME = os.getenv("ICEBERG_LF_DATABASE", "test_inserts")
+DATABASE_NAME = os.getenv("ICEBERG_LF_DATABASE", DATABASE_NAME)
 TABLE_NAME = "basic_insert_test"
 PARTITIONED_TABLE_NAME = os.getenv("ICEBERG_LF_PARTITIONED_TABLE", "basic_insert_test_partitioned")
 NO_LF_GRANT_TABLE_NAME = os.getenv("ICEBERG_LF_NO_GRANT_TABLE", "no_lf_grant_test")

--- a/scripts/create_s3_insert_table.py
+++ b/scripts/create_s3_insert_table.py
@@ -1,19 +1,44 @@
 from pyiceberg.catalog import load_catalog
 from pyiceberg.catalog.rest import RestCatalog
+from pyiceberg.partitioning import PartitionField, PartitionSpec
+from pyiceberg.schema import Schema
+from pyiceberg.transforms import IdentityTransform
+from pyiceberg.types import DateType, LongType, NestedField, StringType
 import os
 import pyarrow as pa
 import sys
 import duckdb
 from datetime import date
 
-REGION = "us-east-2"
-DATABASE = "iceberg-testing"
-database_name = "iceberg-testing"
-TABLE_BUCKET = "iceberg-testing"
+
+def catalog_region(catalog_env: str, default: str) -> str:
+    # DuckDB Labs CI sets AWS_DEFAULT_REGION for credentials but upstream hardcoded
+    # per-catalog regions. Only honor explicit ICEBERG_* overrides (or ICEBERG_AWS_REGION
+    # for local dev where glue and s3tables share one region).
+    return (
+        os.getenv(catalog_env)
+        or os.getenv("ICEBERG_AWS_REGION")
+        or default
+    )
 
 
-DATABASE_NAME = "test_inserts"
+# DuckDB Labs defaults (must match upstream and test/sql/cloud/* fixtures).
+GLUE_REGION = catalog_region("ICEBERG_GLUE_REGION", "us-east-1")
+S3TABLES_REGION = catalog_region("ICEBERG_S3TABLES_REGION", "us-east-2")
+ACCOUNT_ID = os.getenv("ICEBERG_ACCOUNT_ID", os.getenv("ICEBERG_LF_ACCOUNT_ID", "840140254803"))
+S3TABLES_BUCKET = os.getenv("ICEBERG_S3TABLES_BUCKET", "iceberg-testing")
+GLUE_WAREHOUSE = os.getenv(
+    "ICEBERG_GLUE_WAREHOUSE",
+    os.getenv(
+        "ICEBERG_LF_CATALOG_ID",
+        f"{ACCOUNT_ID}:s3tablescatalog/duckdblabs-iceberg-testing",
+    ),
+)
+
+DATABASE_NAME = os.getenv("ICEBERG_LF_DATABASE", "test_inserts")
 TABLE_NAME = "basic_insert_test"
+PARTITIONED_TABLE_NAME = os.getenv("ICEBERG_LF_PARTITIONED_TABLE", "basic_insert_test_partitioned")
+NO_LF_GRANT_TABLE_NAME = os.getenv("ICEBERG_LF_NO_GRANT_TABLE", "no_lf_grant_test")
 
 
 def get_glue_catalog():
@@ -21,11 +46,11 @@ def get_glue_catalog():
         "glue_catalog",
         **{
             "type": "rest",
-            "warehouse": "840140254803:s3tablescatalog/duckdblabs-iceberg-testing",
-            "uri": f"https://glue.us-east-1.amazonaws.com/iceberg",
+            "warehouse": GLUE_WAREHOUSE,
+            "uri": f"https://glue.{GLUE_REGION}.amazonaws.com/iceberg",
             "rest.sigv4-enabled": "true",
             "rest.signing-name": "glue",
-            "rest.signing-region": "us-east-1",
+            "rest.signing-region": GLUE_REGION,
         },
     )
     return rest_catalog
@@ -36,11 +61,11 @@ def get_s3tables_catalog():
         "s3tables_catalog",
         **{
             "type": "rest",
-            "warehouse": "arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing",
-            "uri": f"https://s3tables.{REGION}.amazonaws.com/iceberg",
+            "warehouse": f"arn:aws:s3tables:{S3TABLES_REGION}:{ACCOUNT_ID}:bucket/{S3TABLES_BUCKET}",
+            "uri": f"https://s3tables.{S3TABLES_REGION}.amazonaws.com/iceberg",
             "rest.sigv4-enabled": "true",
             "rest.signing-name": "s3tables",
-            "rest.signing-region": REGION,
+            "rest.signing-region": S3TABLES_REGION,
         },
     )
     return rest_catalog
@@ -88,25 +113,47 @@ def main():
 
     for catalog in catalogs:
         print(f"---- {catalog.name} ----")
+        glue_catalog = catalog.name == "glue_catalog"
         if action == "delete-and-create":
-            delete_table(catalog)
-            create_table(catalog)
+            delete_table(catalog, TABLE_NAME)
+            if glue_catalog:
+                delete_table(catalog, PARTITIONED_TABLE_NAME)
+                delete_table(catalog, NO_LF_GRANT_TABLE_NAME)
+            create_table(catalog, TABLE_NAME)
+            if glue_catalog:
+                create_partitioned_table(catalog)
+                create_table(catalog, NO_LF_GRANT_TABLE_NAME)
         elif action == "delete":
-            delete_table(catalog)
+            delete_table(catalog, TABLE_NAME)
+            if glue_catalog:
+                delete_table(catalog, PARTITIONED_TABLE_NAME)
+                delete_table(catalog, NO_LF_GRANT_TABLE_NAME)
         elif action == "create":
-            create_table(catalog)
+            create_table(catalog, TABLE_NAME)
+            if glue_catalog:
+                create_partitioned_table(catalog)
+                create_table(catalog, NO_LF_GRANT_TABLE_NAME)
         else:
             print(f"did not recognize option {action}")
             exit(1)
 
 
+def create_basic_iceberg_schema() -> Schema:
+    return Schema(
+        NestedField(1, "id", LongType(), required=True),
+        NestedField(2, "name", StringType(), required=True),
+        NestedField(3, "address", StringType(), required=True),
+        NestedField(4, "date", DateType(), required=True),
+    )
+
+
 def create_basic_schema() -> pa.Schema:
     return pa.schema(
         [
-            pa.field("id", pa.int64()),
-            pa.field("name", pa.string()),
-            pa.field("address", pa.string()),
-            pa.field("date", pa.date32()),
+            pa.field("id", pa.int64(), nullable=False),
+            pa.field("name", pa.string(), nullable=False),
+            pa.field("address", pa.string(), nullable=False),
+            pa.field("date", pa.date32(), nullable=False),
         ]
     )
 
@@ -119,8 +166,7 @@ def get_tables(rest_catalog, namespace):
     return rest_catalog.list_tables(namespace)
 
 
-def delete_table(rest_catalog):
-    global DATABASE_NAME, TABLE_NAME
+def ensure_namespace(rest_catalog):
     namespaces = list(map(lambda t: t[0], get_namespaces(rest_catalog)))
     if DATABASE_NAME not in namespaces:
         print(f"schema {DATABASE_NAME} does not exist")
@@ -128,56 +174,87 @@ def delete_table(rest_catalog):
         print(f"creating namespace {DATABASE_NAME}")
         rest_catalog.create_namespace(f"{DATABASE_NAME}")
 
+
+def sample_data(table_schema):
+    return pa.Table.from_arrays(
+        [
+            pa.array([1, 2, 3], type=pa.int64()),
+            pa.array(["Alice", "Bob", "Charlie"], type=pa.string()),
+            pa.array(["Smith", "Jones", "Brown"], type=pa.string()),
+            pa.array(
+                [
+                    date(1990, 1, 1),
+                    date(1985, 6, 15),
+                    date(2000, 12, 31),
+                ],
+                type=pa.date32(),
+            ),
+        ],
+        schema=table_schema,
+    )
+
+
+def delete_table(rest_catalog, table_name):
+    ensure_namespace(rest_catalog)
+
     namespace = (DATABASE_NAME,)  # Tuple format
-    # List tables in the namespace
     tables = list(map(lambda t: t[1], get_tables(rest_catalog, namespace)))
 
-    if TABLE_NAME not in tables:
-        print(f"table {TABLE_NAME} does not exist in database {DATABASE_NAME}, skipping delete")
+    if table_name not in tables:
+        print(f"table {table_name} does not exist in database {DATABASE_NAME}, skipping delete")
         return
 
-    identifier = (f"{DATABASE_NAME}", f"{TABLE_NAME}")
-    # Drop the table
+    identifier = (f"{DATABASE_NAME}", f"{table_name}")
     rest_catalog.drop_table(identifier, purge_requested=True)
-    print(f"{rest_catalog.name}: table {TABLE_NAME} dropped succesfully")
+    print(f"{rest_catalog.name}: table {table_name} dropped succesfully")
 
 
-def create_table(rest_catalog):
-    global DATABASE_NAME, TABLE_NAME
-    namespaces = list(map(lambda t: t[0], get_namespaces(rest_catalog)))
-    if DATABASE_NAME not in namespaces:
-        print(f"schema {DATABASE_NAME} does not exist")
-        print(f"known namespaces: " + str(get_namespaces(rest_catalog)))
-        print(f"creating namespace {DATABASE_NAME}")
+def create_table(rest_catalog, table_name):
+    ensure_namespace(rest_catalog)
 
-    namespace = (DATABASE_NAME,)  # Tuple format
-    # List tables in the namespace
+    namespace = (DATABASE_NAME,)
     tables = list(map(lambda t: t[1], get_tables(rest_catalog, namespace)))
-    if TABLE_NAME in tables:
-        print(f"{rest_catalog.name}: table {TABLE_NAME} already exists in database {DATABASE_NAME}")
+    if table_name in tables:
+        print(f"{rest_catalog.name}: table {table_name} already exists in database {DATABASE_NAME}")
         return
 
     table_schema = create_basic_schema()
-    rest_catalog.create_table(identifier=f"{DATABASE_NAME}.{TABLE_NAME}", schema=table_schema)
+    rest_catalog.create_table(identifier=f"{DATABASE_NAME}.{table_name}", schema=table_schema)
 
-    basic_table = rest_catalog.load_table(f"{DATABASE_NAME}.{TABLE_NAME}")
-    data = [
-        pa.array([1, 2, 3], type=pa.int32()),
-        pa.array(["Alice", "Bob", "Charlie"], type=pa.string()),
-        pa.array(["Smith", "Jones", "Brown"], type=pa.string()),
-        pa.array(
-            [
-                date(1990, 1, 1),
-                date(1985, 6, 15),
-                date(2000, 12, 31),
-            ],
-            type=pa.date32(),
-        ),
-    ]
+    basic_table = rest_catalog.load_table(f"{DATABASE_NAME}.{table_name}")
+    basic_table.append(sample_data(table_schema))
+    print(f"{rest_catalog.name}: appended data to {table_name}")
 
-    table_data = pa.Table.from_arrays(data, schema=table_schema)
-    basic_table.append(table_data)
-    print(f"{rest_catalog.name}: appended data to {TABLE_NAME}")
+
+def create_partitioned_table(rest_catalog):
+    ensure_namespace(rest_catalog)
+
+    namespace = (DATABASE_NAME,)
+    tables = list(map(lambda t: t[1], get_tables(rest_catalog, namespace)))
+    if PARTITIONED_TABLE_NAME in tables:
+        print(
+            f"{rest_catalog.name}: table {PARTITIONED_TABLE_NAME} already exists in database {DATABASE_NAME}"
+        )
+        return
+
+    table_schema = create_basic_iceberg_schema()
+    partition_spec = PartitionSpec(
+        PartitionField(
+            source_id=table_schema.find_field("date").field_id,
+            field_id=1000,
+            transform=IdentityTransform(),
+            name="date",
+        )
+    )
+    rest_catalog.create_table(
+        identifier=f"{DATABASE_NAME}.{PARTITIONED_TABLE_NAME}",
+        schema=table_schema,
+        partition_spec=partition_spec,
+    )
+
+    partitioned_table = rest_catalog.load_table(f"{DATABASE_NAME}.{PARTITIONED_TABLE_NAME}")
+    partitioned_table.append(sample_data(create_basic_schema()))
+    print(f"{rest_catalog.name}: appended data to {PARTITIONED_TABLE_NAME}")
 
 
 if __name__ == "__main__":

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,6 +2,8 @@ pyspark==4.0.1
 duckdb==1.4.0
 pydantic==2.9.0
 pyiceberg==0.9.1
+boto3
+botocore[crt]
 pyarrow==24.0.0
 pytest==9.0.3
 mitmproxy==12.2.1

--- a/scripts/setup_lf_data_filters.py
+++ b/scripts/setup_lf_data_filters.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Provision Lake Formation data filters and grants for duckdb-iceberg cloud tests.
+
+Requires AWS credentials with permissions to manage Lake Formation data filters and grants.
+"""
+
+import argparse
+import os
+import sys
+
+import boto3
+
+REGION = os.getenv(
+    "ICEBERG_LF_REGION",
+    os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-east-1")),
+)
+ACCOUNT_ID = os.getenv("ICEBERG_LF_ACCOUNT_ID", "840140254803")
+CATALOG_ID = os.getenv("ICEBERG_LF_CATALOG_ID", f"{ACCOUNT_ID}:s3tablescatalog/duckdblabs-iceberg-testing")
+DATABASE = os.getenv("ICEBERG_LF_DATABASE", "test_inserts")
+UNPARTITIONED_TABLE = os.getenv("ICEBERG_LF_UNPARTITIONED_TABLE", "basic_insert_test")
+PARTITIONED_TABLE = os.getenv("ICEBERG_LF_PARTITIONED_TABLE", "basic_insert_test_partitioned")
+SESSION_TAG = os.getenv("ICEBERG_LF_SESSION_TAG", "duckdb")
+ROLE_ARN = os.getenv(
+    "ICEBERG_LF_TEST_ROLE_ARN",
+    f"arn:aws:iam::{ACCOUNT_ID}:role/pyiceberg-etl-role",
+)
+
+
+def get_clients():
+    session = boto3.Session(region_name=REGION)
+    return session.client("lakeformation"), session.client("glue")
+
+
+def enable_application_integration(lf_client):
+    settings = lf_client.get_data_lake_settings()["DataLakeSettings"]
+    settings["AllowExternalDataFiltering"] = True
+    settings["AuthorizedSessionTagValueList"] = list(
+        set(settings.get("AuthorizedSessionTagValueList", []) + [SESSION_TAG])
+    )
+    allowlist = settings.get("ExternalDataFilteringAllowList", [])
+    account_principal = {"DataLakePrincipalIdentifier": ACCOUNT_ID}
+    if account_principal not in allowlist:
+        allowlist.append(account_principal)
+    settings["ExternalDataFilteringAllowList"] = allowlist
+    lf_client.put_data_lake_settings(DataLakeSettings=settings)
+
+
+def create_row_filter(lf_client, name, database, table, expression, column_names=None):
+    row_filter = {"FilterExpression": expression}
+    if expression.lower() in ("all", "allrows", "all_rows_wildcard"):
+        row_filter = {"AllRowsWildcard": {}}
+    table_data = {
+        "TableCatalogId": CATALOG_ID,
+        "DatabaseName": database,
+        "TableName": table,
+        "Name": name,
+        "RowFilter": row_filter,
+    }
+    if column_names is not None:
+        table_data["ColumnNames"] = column_names
+    else:
+        table_data["ColumnWildcard"] = {}
+    lf_client.create_data_cells_filter(TableData=table_data)
+
+
+def grant_filtered_select(lf_client, database, table, filter_name):
+    lf_client.grant_permissions(
+        Principal={"DataLakePrincipalIdentifier": ROLE_ARN},
+        Resource={
+            "DataCellsFilter": {
+                "TableCatalogId": CATALOG_ID,
+                "DatabaseName": database,
+                "TableName": table,
+                "Name": filter_name,
+            }
+        },
+        Permissions=["SELECT"],
+    )
+
+
+def delete_filter_if_exists(lf_client, database, table, filter_name):
+    try:
+        lf_client.delete_data_cells_filter(
+            TableCatalogId=CATALOG_ID,
+            DatabaseName=database,
+            TableName=table,
+            Name=filter_name,
+        )
+    except lf_client.exceptions.EntityNotFoundException:
+        pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Setup Lake Formation data filters for cloud tests")
+    parser.add_argument("--action", choices=["create", "delete"], default="create")
+    args = parser.parse_args()
+
+    lf_client, _glue_client = get_clients()
+
+    filters = {
+        "duckdb_lf_unpartitioned": (DATABASE, UNPARTITIONED_TABLE, "id < 3", None),
+        "duckdb_lf_partitioned": (DATABASE, PARTITIONED_TABLE, "id < 3", None),
+        "duckdb_lf_column_restricted": (DATABASE, UNPARTITIONED_TABLE, "all_rows_wildcard", ["id"]),
+    }
+
+    if args.action == "delete":
+        for filter_name, (database, table, _, __) in filters.items():
+            delete_filter_if_exists(lf_client, database, table, filter_name)
+        print("Deleted Lake Formation test filters")
+        return
+
+    enable_application_integration(lf_client)
+    for filter_name, (database, table, expression, column_names) in filters.items():
+        delete_filter_if_exists(lf_client, database, table, filter_name)
+        create_row_filter(lf_client, filter_name, database, table, expression, column_names)
+        grant_filtered_select(lf_client, database, table, filter_name)
+        print(f"Created filter {filter_name} on {database}.{table}: {expression}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        print(f"setup_lf_data_filters failed: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/src/catalog/aws/lakeformation/lf_client.cpp
+++ b/src/catalog/aws/lakeformation/lf_client.cpp
@@ -1,0 +1,221 @@
+#include "catalog/aws/lakeformation/lf_client.hpp"
+
+#include "catalog/aws/lakeformation/lf_table_metadata.hpp"
+#include "catalog/rest/iceberg_catalog.hpp"
+#include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/api/catalog_utils.hpp"
+#include "duckdb/common/string_util.hpp"
+
+#ifndef EMSCRIPTEN
+
+#include <aws/glue/GlueClient.h>
+#include <aws/glue/model/GetUnfilteredPartitionsMetadataRequest.h>
+#include <aws/glue/model/GetUnfilteredTableMetadataRequest.h>
+#include <aws/lakeformation/LakeFormationClient.h>
+#include <aws/lakeformation/model/GetTemporaryGluePartitionCredentialsRequest.h>
+#include <aws/lakeformation/model/GetTemporaryGlueTableCredentialsRequest.h>
+
+#include <aws/lakeformation/model/PartitionValueList.h>
+#include <aws/glue/model/UnfilteredPartition.h>
+
+namespace duckdb {
+
+namespace {
+
+static string GetDatabaseName(IcebergSchemaEntry &schema) {
+	auto schema_component = IRCPathComponent::NamespaceComponent(schema.namespace_items);
+	return schema_component.encoded;
+}
+
+static string ExtractAccountId(const string &warehouse) {
+	auto colon_pos = warehouse.find(':');
+	if (colon_pos == string::npos) {
+		return "";
+	}
+	return warehouse.substr(0, colon_pos);
+}
+
+static ::Aws::LakeFormation::Model::QuerySessionContext
+BuildQuerySessionContext(const LakeFormationTablePolicy &policy) {
+	::Aws::LakeFormation::Model::QuerySessionContext context;
+	if (!policy.query_authorization_id.empty()) {
+		context.SetQueryAuthorizationId(policy.query_authorization_id);
+	}
+	return context;
+}
+
+static vector<::Aws::LakeFormation::Model::Permission> DefaultPermissions() {
+	return {::Aws::LakeFormation::Model::Permission::SELECT};
+}
+
+static vector<::Aws::LakeFormation::Model::PermissionType> SupportedPermissionTypes() {
+	return {::Aws::LakeFormation::Model::PermissionType::CELL_FILTER_PERMISSION};
+}
+
+static LakeFormationTemporaryCredentials ParseTemporaryCredentials(
+    const ::Aws::LakeFormation::Model::GetTemporaryGlueTableCredentialsResult &result) {
+	LakeFormationTemporaryCredentials credentials;
+	credentials.access_key_id = result.GetAccessKeyId();
+	credentials.secret_access_key = result.GetSecretAccessKey();
+	credentials.session_token = result.GetSessionToken();
+	credentials.expiration = result.GetExpiration().ToGmtString(::Aws::Utils::DateFormat::ISO_8601);
+	return credentials;
+}
+
+} // namespace
+
+LakeFormationClient::LakeFormationClient(ClientContext &context, IcebergCatalog &catalog)
+    : context(context), catalog(catalog), client_config(BuildLakeFormationClientConfig(context, catalog)) {
+}
+
+LakeFormationTableIdentifiers LakeFormationClient::GetTableIdentifiers(IcebergSchemaEntry &schema,
+                                                                         const string &table_name) const {
+	LakeFormationTableIdentifiers identifiers;
+	identifiers.catalog_id = catalog.GetWarehouse();
+	identifiers.database_name = GetDatabaseName(schema);
+	identifiers.table_name = table_name;
+	identifiers.region = client_config.region;
+
+	auto account_id = ExtractAccountId(identifiers.catalog_id);
+	if (account_id.empty()) {
+		throw InvalidConfigurationException("Could not extract AWS account id from warehouse '%s'",
+		                                    identifiers.catalog_id);
+	}
+	identifiers.table_arn = StringUtil::Format("arn:aws:glue:%s:%s:table/%s/%s", identifiers.region, account_id,
+	                                           identifiers.database_name, identifiers.table_name);
+	return identifiers;
+}
+
+LakeFormationTablePolicy LakeFormationClient::FetchTablePolicy(IcebergSchemaEntry &schema, const string &table_name,
+                                                               const IcebergTableSchema &iceberg_schema,
+                                                               const IcebergTableMetadata &table_metadata) {
+	auto identifiers = GetTableIdentifiers(schema, table_name);
+
+	// LF-filtered reads use two AWS services: Glue returns the caller's effective row/column
+	// policy (GetUnfiltered*), while Lake Formation later vends scoped S3 credentials
+	// (GetTemporaryGlue*). Both calls require CELL_FILTER_PERMISSION so Glue knows we
+	// participate in the data-filter application integration flow.
+	::Aws::Glue::GlueClient glue_client(client_config.credentials_provider, client_config.aws_config);
+	::Aws::Glue::Model::GetUnfilteredTableMetadataRequest request;
+	request.SetCatalogId(identifiers.catalog_id);
+	request.SetDatabaseName(identifiers.database_name);
+	request.SetName(identifiers.table_name);
+	request.SetSupportedPermissionTypes({::Aws::Glue::Model::PermissionType::CELL_FILTER_PERMISSION});
+
+	auto outcome = glue_client.GetUnfilteredTableMetadata(request);
+	if (!outcome.IsSuccess()) {
+		throw InvalidConfigurationException("GetUnfilteredTableMetadata failed: %s",
+		                                  outcome.GetError().GetMessage());
+	}
+
+	auto policy = ParseUnfilteredTableMetadata(outcome.GetResult());
+	ValidateLakeFormationPolicyV1(policy, iceberg_schema);
+
+	if (!table_metadata.partition_specs.empty()) {
+		// Partitioned tables need a second Glue call. LF can return per-partition
+		// credentials, so we record partition identity here even though row-filter SQL
+		// currently comes from the table-level policy.
+		::Aws::Glue::Model::GetUnfilteredPartitionsMetadataRequest partitions_request;
+		partitions_request.SetCatalogId(identifiers.catalog_id);
+		partitions_request.SetDatabaseName(identifiers.database_name);
+		partitions_request.SetTableName(identifiers.table_name);
+		partitions_request.SetSupportedPermissionTypes({::Aws::Glue::Model::PermissionType::CELL_FILTER_PERMISSION});
+
+		auto partitions_outcome = glue_client.GetUnfilteredPartitionsMetadata(partitions_request);
+		if (!partitions_outcome.IsSuccess()) {
+			throw InvalidConfigurationException("GetUnfilteredPartitionsMetadata failed: %s",
+			                                  partitions_outcome.GetError().GetMessage());
+		}
+		policy.is_partitioned = true;
+		for (auto &partition : partitions_outcome.GetResult().GetUnfilteredPartitions()) {
+			policy.partition_policies.push_back(ParseUnfilteredPartitionMetadata(partition));
+		}
+	}
+
+	return policy;
+}
+
+LakeFormationTemporaryCredentials
+LakeFormationClient::GetTableCredentials(const LakeFormationTableIdentifiers &identifiers,
+                                         const LakeFormationTablePolicy &policy, const string &s3_path) {
+	string cache_key = StringUtil::Format("table:%s:%s:%s", identifiers.catalog_id, identifiers.database_name,
+	                                      identifiers.table_name);
+	// LF temporary credentials are short-lived; cache within a scan to avoid
+	// repeated GetTemporaryGlue* calls for the same table or partition.
+	if (auto cached = credential_cache.Get(cache_key)) {
+		return *cached;
+	}
+
+	::Aws::LakeFormation::LakeFormationClient lf_client(client_config.credentials_provider, client_config.aws_config);
+	::Aws::LakeFormation::Model::GetTemporaryGlueTableCredentialsRequest request;
+	request.SetTableArn(identifiers.table_arn);
+	request.SetPermissions(DefaultPermissions());
+	request.SetSupportedPermissionTypes(SupportedPermissionTypes());
+	// QueryAuthorizationId links this credential request back to the earlier
+	// GetUnfilteredTableMetadata response for the same filtered scan session.
+	request.SetQuerySessionContext(BuildQuerySessionContext(policy));
+	if (!s3_path.empty()) {
+		request.SetS3Path(s3_path);
+	}
+
+	auto outcome = lf_client.GetTemporaryGlueTableCredentials(request);
+	if (!outcome.IsSuccess()) {
+		throw InvalidConfigurationException("GetTemporaryGlueTableCredentials failed: %s",
+		                                  outcome.GetError().GetMessage());
+	}
+
+	auto credentials = ParseTemporaryCredentials(outcome.GetResult());
+	credential_cache.Put(cache_key, credentials);
+	return credentials;
+}
+
+LakeFormationTemporaryCredentials
+LakeFormationClient::GetPartitionCredentials(const LakeFormationTableIdentifiers &identifiers,
+                                               const LakeFormationTablePolicy &policy,
+                                               const vector<Value> &partition_values, const string &s3_path) {
+	string partition_key;
+	for (auto &value : partition_values) {
+		partition_key += value.ToString() + "|";
+	}
+	string cache_key = StringUtil::Format("partition:%s:%s:%s:%s", identifiers.catalog_id, identifiers.database_name,
+	                                      identifiers.table_name, partition_key);
+	if (auto cached = credential_cache.Get(cache_key)) {
+		return *cached;
+	}
+
+	::Aws::LakeFormation::LakeFormationClient lf_client(client_config.credentials_provider, client_config.aws_config);
+	::Aws::LakeFormation::Model::GetTemporaryGluePartitionCredentialsRequest request;
+	request.SetTableArn(identifiers.table_arn);
+	request.SetPermissions(DefaultPermissions());
+	request.SetSupportedPermissionTypes(SupportedPermissionTypes());
+	// Unlike table credentials, partition credential requests identify the slice
+	// explicitly; QuerySessionContext is not used on this API path.
+
+	::Aws::LakeFormation::Model::PartitionValueList partition_values_list;
+	vector<::Aws::String> values;
+	for (auto &value : partition_values) {
+		values.push_back(value.ToString());
+	}
+	partition_values_list.SetValues(values);
+	request.SetPartition(partition_values_list);
+
+	auto outcome = lf_client.GetTemporaryGluePartitionCredentials(request);
+	if (!outcome.IsSuccess()) {
+		throw InvalidConfigurationException("GetTemporaryGluePartitionCredentials failed: %s",
+		                                  outcome.GetError().GetMessage());
+	}
+
+	LakeFormationTemporaryCredentials credentials;
+	credentials.access_key_id = outcome.GetResult().GetAccessKeyId();
+	credentials.secret_access_key = outcome.GetResult().GetSecretAccessKey();
+	credentials.session_token = outcome.GetResult().GetSessionToken();
+	credentials.expiration =
+	    outcome.GetResult().GetExpiration().ToGmtString(::Aws::Utils::DateFormat::ISO_8601);
+	credential_cache.Put(cache_key, credentials);
+	return credentials;
+}
+
+} // namespace duckdb
+
+#endif

--- a/src/catalog/aws/lakeformation/lf_client.cpp
+++ b/src/catalog/aws/lakeformation/lf_client.cpp
@@ -53,8 +53,8 @@ static vector<::Aws::LakeFormation::Model::PermissionType> SupportedPermissionTy
 	return {::Aws::LakeFormation::Model::PermissionType::CELL_FILTER_PERMISSION};
 }
 
-static LakeFormationTemporaryCredentials ParseTemporaryCredentials(
-    const ::Aws::LakeFormation::Model::GetTemporaryGlueTableCredentialsResult &result) {
+static LakeFormationTemporaryCredentials
+ParseTemporaryCredentials(const ::Aws::LakeFormation::Model::GetTemporaryGlueTableCredentialsResult &result) {
 	LakeFormationTemporaryCredentials credentials;
 	credentials.access_key_id = result.GetAccessKeyId();
 	credentials.secret_access_key = result.GetSecretAccessKey();
@@ -70,7 +70,7 @@ LakeFormationClient::LakeFormationClient(ClientContext &context, IcebergCatalog 
 }
 
 LakeFormationTableIdentifiers LakeFormationClient::GetTableIdentifiers(IcebergSchemaEntry &schema,
-                                                                         const string &table_name) const {
+                                                                       const string &table_name) const {
 	LakeFormationTableIdentifiers identifiers;
 	identifiers.catalog_id = catalog.GetWarehouse();
 	identifiers.database_name = GetDatabaseName(schema);
@@ -105,8 +105,7 @@ LakeFormationTablePolicy LakeFormationClient::FetchTablePolicy(IcebergSchemaEntr
 
 	auto outcome = glue_client.GetUnfilteredTableMetadata(request);
 	if (!outcome.IsSuccess()) {
-		throw InvalidConfigurationException("GetUnfilteredTableMetadata failed: %s",
-		                                  outcome.GetError().GetMessage());
+		throw InvalidConfigurationException("GetUnfilteredTableMetadata failed: %s", outcome.GetError().GetMessage());
 	}
 
 	auto policy = ParseUnfilteredTableMetadata(outcome.GetResult());
@@ -125,7 +124,7 @@ LakeFormationTablePolicy LakeFormationClient::FetchTablePolicy(IcebergSchemaEntr
 		auto partitions_outcome = glue_client.GetUnfilteredPartitionsMetadata(partitions_request);
 		if (!partitions_outcome.IsSuccess()) {
 			throw InvalidConfigurationException("GetUnfilteredPartitionsMetadata failed: %s",
-			                                  partitions_outcome.GetError().GetMessage());
+			                                    partitions_outcome.GetError().GetMessage());
 		}
 		policy.is_partitioned = true;
 		for (auto &partition : partitions_outcome.GetResult().GetUnfilteredPartitions()) {
@@ -139,8 +138,8 @@ LakeFormationTablePolicy LakeFormationClient::FetchTablePolicy(IcebergSchemaEntr
 LakeFormationTemporaryCredentials
 LakeFormationClient::GetTableCredentials(const LakeFormationTableIdentifiers &identifiers,
                                          const LakeFormationTablePolicy &policy, const string &s3_path) {
-	string cache_key = StringUtil::Format("table:%s:%s:%s", identifiers.catalog_id, identifiers.database_name,
-	                                      identifiers.table_name);
+	string cache_key =
+	    StringUtil::Format("table:%s:%s:%s", identifiers.catalog_id, identifiers.database_name, identifiers.table_name);
 	// LF temporary credentials are short-lived; cache within a scan to avoid
 	// repeated GetTemporaryGlue* calls for the same table or partition.
 	if (auto cached = credential_cache.Get(cache_key)) {
@@ -162,7 +161,7 @@ LakeFormationClient::GetTableCredentials(const LakeFormationTableIdentifiers &id
 	auto outcome = lf_client.GetTemporaryGlueTableCredentials(request);
 	if (!outcome.IsSuccess()) {
 		throw InvalidConfigurationException("GetTemporaryGlueTableCredentials failed: %s",
-		                                  outcome.GetError().GetMessage());
+		                                    outcome.GetError().GetMessage());
 	}
 
 	auto credentials = ParseTemporaryCredentials(outcome.GetResult());
@@ -172,8 +171,8 @@ LakeFormationClient::GetTableCredentials(const LakeFormationTableIdentifiers &id
 
 LakeFormationTemporaryCredentials
 LakeFormationClient::GetPartitionCredentials(const LakeFormationTableIdentifiers &identifiers,
-                                               const LakeFormationTablePolicy &policy,
-                                               const vector<Value> &partition_values, const string &s3_path) {
+                                             const LakeFormationTablePolicy &policy,
+                                             const vector<Value> &partition_values, const string &s3_path) {
 	string partition_key;
 	for (auto &value : partition_values) {
 		partition_key += value.ToString() + "|";
@@ -203,15 +202,14 @@ LakeFormationClient::GetPartitionCredentials(const LakeFormationTableIdentifiers
 	auto outcome = lf_client.GetTemporaryGluePartitionCredentials(request);
 	if (!outcome.IsSuccess()) {
 		throw InvalidConfigurationException("GetTemporaryGluePartitionCredentials failed: %s",
-		                                  outcome.GetError().GetMessage());
+		                                    outcome.GetError().GetMessage());
 	}
 
 	LakeFormationTemporaryCredentials credentials;
 	credentials.access_key_id = outcome.GetResult().GetAccessKeyId();
 	credentials.secret_access_key = outcome.GetResult().GetSecretAccessKey();
 	credentials.session_token = outcome.GetResult().GetSessionToken();
-	credentials.expiration =
-	    outcome.GetResult().GetExpiration().ToGmtString(::Aws::Utils::DateFormat::ISO_8601);
+	credentials.expiration = outcome.GetResult().GetExpiration().ToGmtString(::Aws::Utils::DateFormat::ISO_8601);
 	credential_cache.Put(cache_key, credentials);
 	return credentials;
 }

--- a/src/catalog/aws/lakeformation/lf_credential_cache.cpp
+++ b/src/catalog/aws/lakeformation/lf_credential_cache.cpp
@@ -1,0 +1,39 @@
+#include "catalog/aws/lakeformation/lf_credential_cache.hpp"
+
+#include "duckdb/common/chrono.hpp"
+#include "duckdb/common/types/timestamp.hpp"
+
+namespace duckdb {
+
+static bool CredentialsExpired(const LakeFormationTemporaryCredentials &credentials) {
+	if (credentials.expiration.empty()) {
+		return false;
+	}
+	timestamp_t expiration;
+	auto result = Timestamp::TryConvertTimestamp(credentials.expiration.c_str(), credentials.expiration.size(),
+	                                             expiration, false);
+	if (result != TimestampCastResult::SUCCESS) {
+		return false;
+	}
+	return Timestamp::GetCurrentTimestamp() >= expiration;
+}
+
+optional_ptr<const LakeFormationTemporaryCredentials> LakeFormationCredentialCache::Get(const string &cache_key) {
+	lock_guard<mutex> guard(lock);
+	auto entry = entries.find(cache_key);
+	if (entry == entries.end()) {
+		return nullptr;
+	}
+	if (CredentialsExpired(entry->second)) {
+		entries.erase(entry);
+		return nullptr;
+	}
+	return &entry->second;
+}
+
+void LakeFormationCredentialCache::Put(const string &cache_key, LakeFormationTemporaryCredentials credentials) {
+	lock_guard<mutex> guard(lock);
+	entries[cache_key] = std::move(credentials);
+}
+
+} // namespace duckdb

--- a/src/catalog/aws/lakeformation/lf_credentials.cpp
+++ b/src/catalog/aws/lakeformation/lf_credentials.cpp
@@ -41,8 +41,8 @@ public:
 	    : base_provider(std::move(base_provider)), role_arn(role_arn), session_tag(session_tag) {
 		::Aws::Client::ClientConfiguration config;
 		config.region = region;
-		sts_client = Aws::MakeShared<::Aws::STS::STSClient>("LakeFormationTaggedAssumeRoleProvider", base_provider,
-		                                                    config);
+		sts_client =
+		    Aws::MakeShared<::Aws::STS::STSClient>("LakeFormationTaggedAssumeRoleProvider", base_provider, config);
 	}
 
 	Aws::Auth::AWSCredentials GetAWSCredentials() override {
@@ -53,7 +53,7 @@ public:
 		auto outcome = sts_client->AssumeRole(request);
 		if (!outcome.IsSuccess()) {
 			throw InvalidConfigurationException("Failed to assume role for Lake Formation integration: %s",
-			                                  outcome.GetError().GetMessage());
+			                                    outcome.GetError().GetMessage());
 		}
 		auto &creds = outcome.GetResult().GetCredentials();
 		return Aws::Auth::AWSCredentials(creds.GetAccessKeyId(), creds.GetSecretAccessKey(), creds.GetSessionToken());

--- a/src/catalog/aws/lakeformation/lf_credentials.cpp
+++ b/src/catalog/aws/lakeformation/lf_credentials.cpp
@@ -1,0 +1,132 @@
+#include "catalog/aws/lakeformation/lf_credentials.hpp"
+
+#include "catalog/rest/iceberg_catalog.hpp"
+#include "catalog/rest/storage/authorization/sigv4.hpp"
+#include "catalog/rest/storage/aws.hpp"
+
+#ifndef EMSCRIPTEN
+
+#include <aws/core/Aws.h>
+#include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/sts/STSClient.h>
+#include <aws/sts/model/AssumeRoleRequest.h>
+
+namespace duckdb {
+
+namespace {
+
+class DuckDBSecretCredentialProvider : public Aws::Auth::AWSCredentialsProvider {
+public:
+	DuckDBSecretCredentialProvider(const string &key_id, const string &secret, const string &session_token) {
+		credentials.SetAWSAccessKeyId(key_id.c_str());
+		credentials.SetAWSSecretKey(secret.c_str());
+		credentials.SetSessionToken(session_token.c_str());
+	}
+
+	Aws::Auth::AWSCredentials GetAWSCredentials() override {
+		return credentials;
+	}
+
+private:
+	Aws::Auth::AWSCredentials credentials;
+};
+
+class LakeFormationTaggedAssumeRoleProvider : public Aws::Auth::AWSCredentialsProvider {
+public:
+	// LF application integration requires the assumed role session to carry the
+	// LakeFormationAuthorizedCaller tag (configured via LF_SESSION_TAG on attach).
+	// Glue/LF APIs are then called with those tagged credentials.
+	LakeFormationTaggedAssumeRoleProvider(std::shared_ptr<Aws::Auth::AWSCredentialsProvider> base_provider,
+	                                      const string &role_arn, const string &session_tag, const string &region)
+	    : base_provider(std::move(base_provider)), role_arn(role_arn), session_tag(session_tag) {
+		::Aws::Client::ClientConfiguration config;
+		config.region = region;
+		sts_client = Aws::MakeShared<::Aws::STS::STSClient>("LakeFormationTaggedAssumeRoleProvider", base_provider,
+		                                                    config);
+	}
+
+	Aws::Auth::AWSCredentials GetAWSCredentials() override {
+		Aws::STS::Model::AssumeRoleRequest request;
+		request.SetRoleArn(role_arn);
+		request.SetRoleSessionName("duckdb-lakeformation");
+		request.AddTags(Aws::STS::Model::Tag().WithKey("LakeFormationAuthorizedCaller").WithValue(session_tag));
+		auto outcome = sts_client->AssumeRole(request);
+		if (!outcome.IsSuccess()) {
+			throw InvalidConfigurationException("Failed to assume role for Lake Formation integration: %s",
+			                                  outcome.GetError().GetMessage());
+		}
+		auto &creds = outcome.GetResult().GetCredentials();
+		return Aws::Auth::AWSCredentials(creds.GetAccessKeyId(), creds.GetSecretAccessKey(), creds.GetSessionToken());
+	}
+
+private:
+	std::shared_ptr<Aws::Auth::AWSCredentialsProvider> base_provider;
+	std::shared_ptr<Aws::STS::STSClient> sts_client;
+	string role_arn;
+	string session_tag;
+};
+
+static void InitAWSAPI() {
+	static bool loaded = false;
+	if (!loaded) {
+		Aws::SDKOptions options;
+		Aws::InitAPI(options);
+		loaded = true;
+	}
+}
+
+} // namespace
+
+LakeFormationClientConfig BuildLakeFormationClientConfig(ClientContext &context, IcebergCatalog &catalog) {
+	InitAWSAPI();
+	LakeFormationClientConfig result;
+	if (catalog.auth_handler->type != IcebergAuthorizationType::SIGV4) {
+		throw InvalidConfigurationException(
+		    "Lake Formation data filters require SIGV4 authorization on the Iceberg catalog");
+	}
+	auto &sigv4 = catalog.auth_handler->Cast<SIGV4Authorization>();
+	auto secret_entry = IcebergCatalog::GetStorageSecret(context, sigv4.secret);
+	auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*secret_entry->secret);
+
+	result.region = kv_secret.TryGetValue("region").ToString();
+	if (result.region.empty() && !sigv4.sigv4_region.empty()) {
+		result.region = sigv4.sigv4_region;
+	}
+	if (result.region.empty()) {
+		throw InvalidConfigurationException("Lake Formation integration requires a region in the catalog secret");
+	}
+
+	auto key_id = kv_secret.TryGetValue("key_id").ToString();
+	auto secret = kv_secret.TryGetValue("secret").ToString();
+	auto session_token =
+	    kv_secret.TryGetValue("session_token").IsNull() ? "" : kv_secret.TryGetValue("session_token").ToString();
+
+	std::shared_ptr<::Aws::Auth::AWSCredentialsProvider> provider =
+	    std::make_shared<DuckDBSecretCredentialProvider>(key_id, secret, session_token);
+
+	auto assume_role_arn = kv_secret.TryGetValue("assume_role_arn");
+	// When a data-filter grant targets a role, the catalog secret's base credentials
+	// assume that role with the LF session tag before any Glue/LF SDK calls.
+	if (!assume_role_arn.IsNull() && !catalog.attach_options.lf_session_tag.empty()) {
+		provider = std::make_shared<LakeFormationTaggedAssumeRoleProvider>(
+		    provider, assume_role_arn.ToString(), catalog.attach_options.lf_session_tag, result.region);
+	}
+
+	result.credentials_provider = std::move(provider);
+	result.aws_config.region = result.region;
+	return result;
+}
+
+} // namespace duckdb
+
+#else
+
+namespace duckdb {
+
+LakeFormationClientConfig BuildLakeFormationClientConfig(ClientContext &context, IcebergCatalog &catalog) {
+	throw NotImplementedException("Lake Formation integration is not available in duckdb-wasm builds");
+}
+
+} // namespace duckdb
+
+#endif

--- a/src/catalog/aws/lakeformation/lf_filter_parser.cpp
+++ b/src/catalog/aws/lakeformation/lf_filter_parser.cpp
@@ -1,0 +1,64 @@
+#include "catalog/aws/lakeformation/lf_filter_parser.hpp"
+
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/query_node/select_node.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression_binder/where_binder.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
+
+namespace duckdb {
+
+namespace {
+
+static unique_ptr<ParsedExpression> ExtractWhereExpression(const string &row_filter_sql) {
+	Parser parser;
+	auto query = StringUtil::Format("SELECT * FROM lf_filter_source WHERE %s", row_filter_sql);
+	parser.ParseQuery(query);
+	if (parser.statements.size() != 1) {
+		throw ParserException("Lake Formation row filter could not be parsed: %s", row_filter_sql);
+	}
+	auto &statement = parser.statements[0];
+	if (statement->type != StatementType::SELECT_STATEMENT) {
+		throw ParserException("Lake Formation row filter must be a filter expression: %s", row_filter_sql);
+	}
+	auto &select_node = statement->Cast<SelectStatement>().node->Cast<SelectNode>();
+	if (!select_node.where_clause) {
+		throw ParserException("Lake Formation row filter is empty");
+	}
+	return std::move(select_node.where_clause);
+}
+
+} // namespace
+
+LakeFormationFilterParseResult ParseLakeFormationRowFilter(ClientContext &context, const string &row_filter_sql,
+                                                           const IcebergTableSchema &schema) {
+	LakeFormationFilterParseResult result;
+	if (row_filter_sql.empty()) {
+		return result;
+	}
+
+	// LF filter expressions are SQL fragments (e.g. "id < 3"); wrap them so DuckDB's
+	// parser and binder can treat them like a regular WHERE clause over table columns.
+	result.parsed_filter = ExtractWhereExpression(row_filter_sql);
+
+	vector<string> names;
+	vector<LogicalType> types;
+	for (auto &col : schema.columns) {
+		names.push_back(col->name);
+		types.push_back(col->type);
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	binder->bind_context.AddGenericBinding(TableIndex(0), "lf_filter_source", names, types);
+
+	WhereBinder where_binder(*binder, context);
+	auto bound_expr = where_binder.Bind(result.parsed_filter);
+
+	result.bound_filter = std::move(bound_expr);
+	if (!schema.columns.empty()) {
+		result.table_filters.PushFilter(0, make_uniq<ExpressionFilter>(result.bound_filter->Copy()));
+	}
+	return result;
+}
+
+} // namespace duckdb

--- a/src/catalog/aws/lakeformation/lf_filter_parser.cpp
+++ b/src/catalog/aws/lakeformation/lf_filter_parser.cpp
@@ -41,15 +41,15 @@ LakeFormationFilterParseResult ParseLakeFormationRowFilter(ClientContext &contex
 	// parser and binder can treat them like a regular WHERE clause over table columns.
 	result.parsed_filter = ExtractWhereExpression(row_filter_sql);
 
-	vector<string> names;
+	vector<Identifier> names;
 	vector<LogicalType> types;
 	for (auto &col : schema.columns) {
-		names.push_back(col->name);
+		names.emplace_back(col->name);
 		types.push_back(col->type);
 	}
 
 	auto binder = Binder::CreateBinder(context);
-	binder->bind_context.AddGenericBinding(TableIndex(0), "lf_filter_source", names, types);
+	binder->bind_context.AddGenericBinding(TableIndex(0), Identifier("lf_filter_source"), names, types);
 
 	WhereBinder where_binder(*binder, context);
 	auto bound_expr = where_binder.Bind(result.parsed_filter);

--- a/src/catalog/aws/lakeformation/lf_table_metadata.cpp
+++ b/src/catalog/aws/lakeformation/lf_table_metadata.cpp
@@ -80,9 +80,8 @@ namespace duckdb {
 void ValidateLakeFormationPolicyV1(const LakeFormationTablePolicy &policy, const IcebergTableSchema &schema) {
 	// Fail closed on grant shapes Glue can express but we do not enforce yet.
 	if (!policy.cell_filters.empty()) {
-		throw NotImplementedException(
-		    "Lake Formation cell-level data filters are not supported in v1. "
-		    "Only row-level filters are supported when using LAKE_FORMATION_DATA_FILTERS.");
+		throw NotImplementedException("Lake Formation cell-level data filters are not supported in v1. "
+		                              "Only row-level filters are supported when using LAKE_FORMATION_DATA_FILTERS.");
 	}
 	if (!policy.all_columns_authorized) {
 		case_insensitive_set_t authorized;
@@ -91,9 +90,8 @@ void ValidateLakeFormationPolicyV1(const LakeFormationTablePolicy &policy, const
 		}
 		for (auto &col : schema.columns) {
 			if (authorized.find(col->name) == authorized.end()) {
-				throw NotImplementedException(
-				    "Lake Formation column-level permissions are not supported in v1. "
-				    "Grant access to all columns or use row-level filters only.");
+				throw NotImplementedException("Lake Formation column-level permissions are not supported in v1. "
+				                              "Grant access to all columns or use row-level filters only.");
 			}
 		}
 	}

--- a/src/catalog/aws/lakeformation/lf_table_metadata.cpp
+++ b/src/catalog/aws/lakeformation/lf_table_metadata.cpp
@@ -1,0 +1,102 @@
+#include "catalog/aws/lakeformation/lf_table_metadata.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+
+#ifndef EMSCRIPTEN
+
+#include <aws/glue/model/GetUnfilteredTableMetadataResult.h>
+#include <aws/glue/model/UnfilteredPartition.h>
+
+namespace duckdb {
+
+static bool IsAllRowsWildcard(const string &filter) {
+	string trimmed = filter;
+	StringUtil::Trim(trimmed);
+	trimmed = StringUtil::Lower(trimmed);
+	return trimmed.empty() || trimmed == "all" || trimmed == "allrows" || trimmed == "all_rows_wildcard";
+}
+
+LakeFormationTablePolicy
+ParseUnfilteredTableMetadata(const ::Aws::Glue::Model::GetUnfilteredTableMetadataResult &result) {
+	// Glue evaluates Lake Formation grants and returns the effective filter policy for
+	// the caller. We never talk to LF for policy discovery; only for temporary creds.
+	LakeFormationTablePolicy policy;
+	if (!result.GetIsRegisteredWithLakeFormation()) {
+		throw InvalidConfigurationException(
+		    "Table is not registered with Lake Formation; cannot use LAKE_FORMATION_DATA_FILTERS mode");
+	}
+
+	if (!result.GetQueryAuthorizationId().empty()) {
+		// Must be passed back to GetTemporaryGlueTableCredentials for the same scan.
+		policy.query_authorization_id = result.GetQueryAuthorizationId();
+	}
+
+	for (auto &column : result.GetAuthorizedColumns()) {
+		policy.authorized_columns.push_back(column);
+	}
+	policy.all_columns_authorized = policy.authorized_columns.empty();
+
+	for (auto &cell_filter : result.GetCellFilters()) {
+		// Cell filters (column-scoped row filters) are returned separately from the
+		// table-level RowFilter string; v1 only supports plain row filters.
+		LakeFormationCellFilter filter;
+		if (cell_filter.ColumnNameHasBeenSet()) {
+			filter.column_name = cell_filter.GetColumnName();
+		}
+		if (cell_filter.RowFilterExpressionHasBeenSet()) {
+			filter.row_filter_expression = cell_filter.GetRowFilterExpression();
+		}
+		policy.cell_filters.push_back(std::move(filter));
+	}
+
+	if (!result.GetRowFilter().empty()) {
+		auto expression = result.GetRowFilter();
+		if (!IsAllRowsWildcard(expression)) {
+			policy.row_filter_sql = expression;
+		}
+	}
+
+	policy.loaded = true;
+	return policy;
+}
+
+LakeFormationPartitionPolicy
+ParseUnfilteredPartitionMetadata(const ::Aws::Glue::Model::UnfilteredPartition &unfiltered) {
+	LakeFormationPartitionPolicy policy;
+	auto &partition = unfiltered.GetPartition();
+	for (auto &value : partition.GetValues()) {
+		policy.partition_values.emplace_back(value);
+	}
+	return policy;
+}
+
+} // namespace duckdb
+
+#endif
+
+namespace duckdb {
+
+void ValidateLakeFormationPolicyV1(const LakeFormationTablePolicy &policy, const IcebergTableSchema &schema) {
+	// Fail closed on grant shapes Glue can express but we do not enforce yet.
+	if (!policy.cell_filters.empty()) {
+		throw NotImplementedException(
+		    "Lake Formation cell-level data filters are not supported in v1. "
+		    "Only row-level filters are supported when using LAKE_FORMATION_DATA_FILTERS.");
+	}
+	if (!policy.all_columns_authorized) {
+		case_insensitive_set_t authorized;
+		for (auto &col : policy.authorized_columns) {
+			authorized.insert(col);
+		}
+		for (auto &col : schema.columns) {
+			if (authorized.find(col->name) == authorized.end()) {
+				throw NotImplementedException(
+				    "Lake Formation column-level permissions are not supported in v1. "
+				    "Grant access to all columns or use row-level filters only.");
+			}
+		}
+	}
+}
+
+} // namespace duckdb

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
@@ -22,6 +22,7 @@
 #include "rest_catalog/objects/list.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
 #include "common/iceberg_default.hpp"
+#include "catalog/aws/lakeformation/lf_filter_parser.hpp"
 
 namespace duckdb {
 class OAuth2Authorization;
@@ -50,6 +51,18 @@ void AddHTTPSecretsToOptions(SecretEntry &http_secret_entry, case_insensitive_ma
 void IcebergTableEntry::PrepareIcebergScanFromEntry(ClientContext &context) const {
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	auto &secret_manager = SecretManager::Get(context);
+
+	if (ic_catalog.attach_options.access_mode == IRCAccessDelegationMode::LF_FILTERED) {
+#ifndef EMSCRIPTEN
+		// LF mode replaces catalog vended credentials: exchange the caller's Glue/LF
+		// identity for scoped S3 keys before the scan touches object storage.
+		auto table_credentials = table_info.GetLakeFormationCredentials(context);
+		if (table_credentials.config) {
+			(void)secret_manager.CreateSecret(context, *table_credentials.config);
+		}
+#endif
+		return;
+	}
 
 	if (ic_catalog.attach_options.access_mode != IRCAccessDelegationMode::VENDED_CREDENTIALS) {
 		// assume secret already exists
@@ -248,6 +261,23 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 	D_ASSERT(file_bind_data.file_list);
 	auto &ic_file_list = file_bind_data.file_list->Cast<IcebergMultiFileList>();
 	ic_file_list.SetTable(this);
+
+#ifndef EMSCRIPTEN
+	auto &ic_catalog = table_info.catalog.Cast<IcebergCatalog>();
+	if (ic_catalog.attach_options.access_mode == IRCAccessDelegationMode::LF_FILTERED &&
+	    !table_info.lf_policy.row_filter_sql.empty()) {
+		// Glue returns row-filter SQL as a string; compile it into mandatory scan filters
+		// so user predicates cannot widen the LF grant (also reinforced in the optimizer).
+		auto filter_result =
+		    ParseLakeFormationRowFilter(context, table_info.lf_policy.row_filter_sql, iceberg_schema);
+		scan_info->mandatory_lf_filter_parsed = std::move(filter_result.parsed_filter);
+		scan_info->mandatory_lf_filter_bound = std::move(filter_result.bound_filter);
+		for (auto &entry : filter_result.table_filters) {
+			ic_file_list.table_filters.PushFilter(entry.first, entry.second->Copy());
+		}
+	}
+#endif
+
 	return iceberg_scan_function;
 }
 

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
@@ -52,7 +52,7 @@ void IcebergTableEntry::PrepareIcebergScanFromEntry(ClientContext &context) cons
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	auto &secret_manager = SecretManager::Get(context);
 
-	if (ic_catalog.attach_options.access_mode == IRCAccessDelegationMode::LF_FILTERED) {
+	if (ic_catalog.attach_options.access_mode == IRCAccessDelegationMode::LAKE_FORMATION) {
 #ifndef EMSCRIPTEN
 		// LF mode replaces catalog vended credentials: exchange the caller's Glue/LF
 		// identity for scoped S3 keys before the scan touches object storage.
@@ -264,7 +264,7 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 
 #ifndef EMSCRIPTEN
 	auto &ic_catalog = table_info.catalog.Cast<IcebergCatalog>();
-	if (ic_catalog.attach_options.access_mode == IRCAccessDelegationMode::LF_FILTERED &&
+	if (ic_catalog.attach_options.access_mode == IRCAccessDelegationMode::LAKE_FORMATION &&
 	    !table_info.lf_policy.row_filter_sql.empty()) {
 		// Glue returns row-filter SQL as a string; compile it into mandatory scan filters
 		// so user predicates cannot widen the LF grant (also reinforced in the optimizer).
@@ -273,7 +273,7 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 		scan_info->mandatory_lf_filter_parsed = std::move(filter_result.parsed_filter);
 		scan_info->mandatory_lf_filter_bound = std::move(filter_result.bound_filter);
 		for (auto &entry : filter_result.table_filters) {
-			ic_file_list.table_filters.PushFilter(entry.first, entry.second->Copy());
+			ic_file_list.PushTableFilter(entry.first, entry.second->Copy());
 		}
 	}
 #endif

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
@@ -268,8 +268,7 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 	    !table_info.lf_policy.row_filter_sql.empty()) {
 		// Glue returns row-filter SQL as a string; compile it into mandatory scan filters
 		// so user predicates cannot widen the LF grant (also reinforced in the optimizer).
-		auto filter_result =
-		    ParseLakeFormationRowFilter(context, table_info.lf_policy.row_filter_sql, iceberg_schema);
+		auto filter_result = ParseLakeFormationRowFilter(context, table_info.lf_policy.row_filter_sql, iceberg_schema);
 		scan_info->mandatory_lf_filter_parsed = std::move(filter_result.parsed_filter);
 		scan_info->mandatory_lf_filter_bound = std::move(filter_result.bound_filter);
 		for (auto &entry : filter_result.table_filters) {

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -757,8 +757,8 @@ static vector<Value> PartitionValuesFromInfo(const IcebergTableMetadata &metadat
 
 static IRCAPITableCredentials
 BuildLakeFormationSecretCredentials(ClientContext &context, IcebergTableInformation &table,
-                                  const LakeFormationTemporaryCredentials &lf_credentials, const string &secret_name,
-                                  const string &storage_scope) {
+                                    const LakeFormationTemporaryCredentials &lf_credentials, const string &secret_name,
+                                    const string &storage_scope) {
 	IRCAPITableCredentials result;
 	auto &catalog = table.catalog;
 
@@ -821,8 +821,9 @@ void IcebergTableInformation::LoadLakeFormationPolicy(ClientContext &context) {
 	lf_policy = lf_client.FetchTablePolicy(schema, name, *iceberg_schema, table_metadata);
 }
 
-IRCAPITableCredentials IcebergTableInformation::GetLakeFormationCredentials(ClientContext &context,
-                                                                            optional_ptr<const vector<Value>> partition_values) {
+IRCAPITableCredentials
+IcebergTableInformation::GetLakeFormationCredentials(ClientContext &context,
+                                                     optional_ptr<const vector<Value>> partition_values) {
 	LoadLakeFormationPolicy(context);
 
 	auto transaction_id = MetaTransaction::Get(context).global_transaction_id;
@@ -856,9 +857,8 @@ IRCAPITableCredentials IcebergTableInformation::GetLakeFormationCredentials(Clie
 	return BuildLakeFormationSecretCredentials(context, *this, lf_credentials, secret_base_name, storage_scope);
 }
 
-void IcebergTableInformation::EnsureLakeFormationPartitionCredentials(ClientContext &context,
-                                                                     const vector<IcebergPartitionInfo> &partition_info,
-                                                                     const string &file_path) {
+void IcebergTableInformation::EnsureLakeFormationPartitionCredentials(
+    ClientContext &context, const vector<IcebergPartitionInfo> &partition_info, const string &file_path) {
 	if (catalog.attach_options.access_mode != IRCAccessDelegationMode::LAKE_FORMATION) {
 		return;
 	}
@@ -881,14 +881,14 @@ void IcebergTableInformation::LoadLakeFormationPolicy(ClientContext &context) {
 	throw NotImplementedException("Lake Formation integration is not available in duckdb-wasm builds");
 }
 
-IRCAPITableCredentials IcebergTableInformation::GetLakeFormationCredentials(ClientContext &context,
-                                                                            optional_ptr<const vector<Value>> partition_values) {
+IRCAPITableCredentials
+IcebergTableInformation::GetLakeFormationCredentials(ClientContext &context,
+                                                     optional_ptr<const vector<Value>> partition_values) {
 	throw NotImplementedException("Lake Formation integration is not available in duckdb-wasm builds");
 }
 
-void IcebergTableInformation::EnsureLakeFormationPartitionCredentials(ClientContext &context,
-                                                                     const vector<IcebergPartitionInfo> &partition_info,
-                                                                     const string &file_path) {
+void IcebergTableInformation::EnsureLakeFormationPartitionCredentials(
+    ClientContext &context, const vector<IcebergPartitionInfo> &partition_info, const string &file_path) {
 }
 
 #endif

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -790,8 +790,8 @@ BuildLakeFormationSecretCredentials(ClientContext &context, IcebergTableInformat
 	auto &info = *result.config;
 	info.on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
 	info.persist_type = SecretPersistType::TEMPORARY;
-	info.name = secret_name;
-	info.type = "s3";
+	info.name = Identifier(secret_name);
+	info.type = Identifier("s3");
 	info.provider = "config";
 	info.storage_type = "memory";
 	info.options = config_options;
@@ -805,7 +805,7 @@ void IcebergTableInformation::LoadLakeFormationPolicy(ClientContext &context) {
 	if (lf_policy.loaded) {
 		return;
 	}
-	if (catalog.attach_options.access_mode != IRCAccessDelegationMode::LF_FILTERED) {
+	if (catalog.attach_options.access_mode != IRCAccessDelegationMode::LAKE_FORMATION) {
 		return;
 	}
 	// Glue catalog metadata (IRC) gives us Iceberg schema/location; Glue LF APIs give us
@@ -859,7 +859,7 @@ IRCAPITableCredentials IcebergTableInformation::GetLakeFormationCredentials(Clie
 void IcebergTableInformation::EnsureLakeFormationPartitionCredentials(ClientContext &context,
                                                                      const vector<IcebergPartitionInfo> &partition_info,
                                                                      const string &file_path) {
-	if (catalog.attach_options.access_mode != IRCAccessDelegationMode::LF_FILTERED) {
+	if (catalog.attach_options.access_mode != IRCAccessDelegationMode::LAKE_FORMATION) {
 		return;
 	}
 	if (partition_info.empty()) {

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -22,6 +22,12 @@
 #include "catalog/rest/storage/authorization/sigv4_utils.hpp"
 #include "core/expression/iceberg_transform.hpp"
 #include "duckdb/parser/column_definition.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/transaction/meta_transaction.hpp"
+
+#ifndef EMSCRIPTEN
+#include "catalog/aws/lakeformation/lf_client.hpp"
+#endif
 
 #include <climits>
 
@@ -718,5 +724,173 @@ void IcebergTableInformation::InitializeFromLoadTableResult(const rest_api_objec
 		}
 	}
 }
+
+#ifndef EMSCRIPTEN
+
+static vector<Value> PartitionValuesFromInfo(const IcebergTableMetadata &metadata,
+                                             const vector<IcebergPartitionInfo> &partition_info) {
+	vector<Value> result;
+	if (partition_info.empty()) {
+		return result;
+	}
+	auto spec_id = metadata.default_spec_id;
+	auto spec_it = metadata.partition_specs.find(spec_id);
+	if (spec_it == metadata.partition_specs.end()) {
+		throw InvalidInputException("Partition spec %d not found in table metadata", spec_id);
+	}
+	auto &spec = spec_it->second;
+	for (auto &field : spec.fields) {
+		bool found = false;
+		for (auto &part : partition_info) {
+			if (part.field_id == field.partition_field_id) {
+				result.push_back(part.value);
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			result.emplace_back(LogicalType::VARCHAR);
+		}
+	}
+	return result;
+}
+
+static IRCAPITableCredentials
+BuildLakeFormationSecretCredentials(ClientContext &context, IcebergTableInformation &table,
+                                  const LakeFormationTemporaryCredentials &lf_credentials, const string &secret_name,
+                                  const string &storage_scope) {
+	IRCAPITableCredentials result;
+	auto &catalog = table.catalog;
+
+	case_insensitive_map_t<Value> config_options;
+	if (catalog.auth_handler->type == IcebergAuthorizationType::SIGV4) {
+		auto &sigv4_auth = catalog.auth_handler->Cast<SIGV4Authorization>();
+		auto catalog_credentials = IcebergCatalog::GetStorageSecret(context, sigv4_auth.secret);
+		if (catalog_credentials) {
+			auto kv_secret = dynamic_cast<const KeyValueSecret &>(*catalog_credentials->secret);
+			if (!kv_secret.TryGetValue("region").IsNull()) {
+				config_options.emplace("region", kv_secret.TryGetValue("region"));
+			}
+		}
+		if (!sigv4_auth.sigv4_region.empty()) {
+			config_options.emplace("region", Value(sigv4_auth.sigv4_region));
+		}
+	}
+
+	config_options.emplace("key_id", Value(lf_credentials.access_key_id));
+	config_options.emplace("secret", Value(lf_credentials.secret_access_key));
+	config_options.emplace("session_token", Value(lf_credentials.session_token));
+
+	if (StringUtil::StartsWith(catalog.uri, "glue")) {
+		auto region = config_options["region"].ToString();
+		config_options.emplace("endpoint", Value("s3." + region + ".amazonaws.com"));
+	}
+
+	result.config = make_uniq<CreateSecretInput>();
+	auto &info = *result.config;
+	info.on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
+	info.persist_type = SecretPersistType::TEMPORARY;
+	info.name = secret_name;
+	info.type = "s3";
+	info.provider = "config";
+	info.storage_type = "memory";
+	info.options = config_options;
+	if (!storage_scope.empty()) {
+		info.scope = {storage_scope};
+	}
+	return result;
+}
+
+void IcebergTableInformation::LoadLakeFormationPolicy(ClientContext &context) {
+	if (lf_policy.loaded) {
+		return;
+	}
+	if (catalog.attach_options.access_mode != IRCAccessDelegationMode::LF_FILTERED) {
+		return;
+	}
+	// Glue catalog metadata (IRC) gives us Iceberg schema/location; Glue LF APIs give us
+	// the caller's data-filter grant. Load once per table and cache on table_info.
+	auto latest_schema = GetLatestSchema(context);
+	if (!latest_schema) {
+		throw InvalidConfigurationException("Cannot load Lake Formation policy before table schema is available");
+	}
+	auto &table_entry = latest_schema->Cast<IcebergTableEntry>();
+	auto iceberg_schema = table_metadata.GetSchemaFromId(table_entry.schema_id.GetIndex());
+	LakeFormationClient lf_client(context, catalog);
+	lf_identifiers = lf_client.GetTableIdentifiers(schema, name);
+	lf_policy = lf_client.FetchTablePolicy(schema, name, *iceberg_schema, table_metadata);
+}
+
+IRCAPITableCredentials IcebergTableInformation::GetLakeFormationCredentials(ClientContext &context,
+                                                                            optional_ptr<const vector<Value>> partition_values) {
+	LoadLakeFormationPolicy(context);
+
+	auto transaction_id = MetaTransaction::Get(context).global_transaction_id;
+	auto &transaction = IcebergTransaction::Get(context, catalog);
+	auto secret_base_name =
+	    StringUtil::Format("__internal_ic_lf_%s__%s__%s__%s", table_id, schema.name, name, to_string(transaction_id));
+	transaction.created_secrets.insert(secret_base_name);
+
+	const auto &table_location = table_metadata.GetLocation();
+	string storage_scope = table_location;
+	if (!storage_scope.empty() && !StringUtil::EndsWith(storage_scope, "/")) {
+		storage_scope += "/";
+	}
+
+	LakeFormationClient lf_client(context, catalog);
+	LakeFormationTemporaryCredentials lf_credentials;
+	if (partition_values && !partition_values->empty()) {
+		// Partitioned tables: LF scopes credentials per partition value list, not just
+		// per table ARN. Each distinct partition gets its own temporary secret.
+		string partition_key;
+		for (auto &value : *partition_values) {
+			partition_key += value.ToString() + "_";
+		}
+		auto secret_name = StringUtil::Format("%s_partition_%s", secret_base_name, partition_key);
+		lf_credentials =
+		    lf_client.GetPartitionCredentials(lf_identifiers, lf_policy, *partition_values, table_location);
+		return BuildLakeFormationSecretCredentials(context, *this, lf_credentials, secret_name, storage_scope);
+	}
+
+	lf_credentials = lf_client.GetTableCredentials(lf_identifiers, lf_policy, table_location);
+	return BuildLakeFormationSecretCredentials(context, *this, lf_credentials, secret_base_name, storage_scope);
+}
+
+void IcebergTableInformation::EnsureLakeFormationPartitionCredentials(ClientContext &context,
+                                                                     const vector<IcebergPartitionInfo> &partition_info,
+                                                                     const string &file_path) {
+	if (catalog.attach_options.access_mode != IRCAccessDelegationMode::LF_FILTERED) {
+		return;
+	}
+	if (partition_info.empty()) {
+		return;
+	}
+	// Called while enumerating manifest data files: S3 reads must use credentials
+	// vended for that file's partition, which may differ from the table-level secret.
+	auto partition_values = PartitionValuesFromInfo(table_metadata, partition_info);
+	auto table_credentials = GetLakeFormationCredentials(context, partition_values);
+	auto &secret_manager = SecretManager::Get(context);
+	if (table_credentials.config) {
+		(void)secret_manager.CreateSecret(context, *table_credentials.config);
+	}
+}
+
+#else
+
+void IcebergTableInformation::LoadLakeFormationPolicy(ClientContext &context) {
+	throw NotImplementedException("Lake Formation integration is not available in duckdb-wasm builds");
+}
+
+IRCAPITableCredentials IcebergTableInformation::GetLakeFormationCredentials(ClientContext &context,
+                                                                            optional_ptr<const vector<Value>> partition_values) {
+	throw NotImplementedException("Lake Formation integration is not available in duckdb-wasm builds");
+}
+
+void IcebergTableInformation::EnsureLakeFormationPartitionCredentials(ClientContext &context,
+                                                                     const vector<IcebergPartitionInfo> &partition_info,
+                                                                     const string &file_path) {
+}
+
+#endif
 
 } // namespace duckdb

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -647,7 +647,8 @@ unique_ptr<Catalog> IcebergCatalog::Attach(optional_ptr<StorageExtensionInfo> st
 			    "LAKE_FORMATION_DATA_FILTERS cannot be combined with access_delegation_mode 'vended_credentials'");
 		}
 		if (lf_session_tag.empty()) {
-			throw InvalidConfigurationException("LF_SESSION_TAG is required when LAKE_FORMATION_DATA_FILTERS is enabled");
+			throw InvalidConfigurationException(
+			    "LF_SESSION_TAG is required when LAKE_FORMATION_DATA_FILTERS is enabled");
 		}
 		attach_options.lf_session_tag = std::move(lf_session_tag);
 	}

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -624,18 +624,18 @@ unique_ptr<Catalog> IcebergCatalog::Attach(optional_ptr<StorageExtensionInfo> st
 		} else if (access_mode_string == "none") {
 			attach_options.access_mode = IRCAccessDelegationMode::NONE;
 		} else if (access_mode_string == "lf_filtered") {
-			attach_options.access_mode = IRCAccessDelegationMode::LF_FILTERED;
+			throw InvalidConfigurationException(
+			    "access_delegation_mode 'lf_filtered' is not supported; use LAKE_FORMATION_DATA_FILTERS true instead");
 		} else {
 			throw InvalidInputException(
-			    "Unrecognized access mode '%s'. Supported options are 'vended_credentials', 'none', and 'lf_filtered'",
+			    "Unrecognized access mode '%s'. Supported options are 'vended_credentials' and 'none'",
 			    access_mode_string);
 		}
 	}
 	if (lake_formation_data_filters) {
-		attach_options.lake_formation_data_filters = true;
-		attach_options.access_mode = IRCAccessDelegationMode::LF_FILTERED;
+		attach_options.access_mode = IRCAccessDelegationMode::LAKE_FORMATION;
 	}
-	if (attach_options.access_mode == IRCAccessDelegationMode::LF_FILTERED) {
+	if (attach_options.access_mode == IRCAccessDelegationMode::LAKE_FORMATION) {
 		// LF data filters are a Glue-only path: catalog REST still talks to the Glue
 		// Iceberg endpoint, but object access goes through LF temporary credentials.
 		if (endpoint_type == IcebergEndpointType::AWS_S3TABLES) {

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -530,6 +530,8 @@ unique_ptr<Catalog> IcebergCatalog::Attach(optional_ptr<StorageExtensionInfo> st
 	string endpoint_type_string;
 	string authorization_type_string;
 	string access_mode_string;
+	bool lake_formation_data_filters = false;
+	string lf_session_tag;
 	case_insensitive_set_t set_by_attach_options;
 	//! First handle generic attach options
 	for (auto &entry : info.options) {
@@ -579,6 +581,10 @@ unique_ptr<Catalog> IcebergCatalog::Attach(optional_ptr<StorageExtensionInfo> st
 				throw ConversionException("Could not get interval information from %s", interval_option.ToString());
 			}
 			attach_options.max_table_staleness_micros = interval_in_micros;
+		} else if (lower_name == "lake_formation_data_filters") {
+			lake_formation_data_filters = entry.second.DefaultCastAs(LogicalType::BOOLEAN).GetValue<bool>();
+		} else if (lower_name == "lf_session_tag") {
+			lf_session_tag = entry.second.ToString();
 		} else {
 			attach_options.options.emplace(std::move(entry));
 		}
@@ -617,11 +623,33 @@ unique_ptr<Catalog> IcebergCatalog::Attach(optional_ptr<StorageExtensionInfo> st
 			attach_options.access_mode = IRCAccessDelegationMode::VENDED_CREDENTIALS;
 		} else if (access_mode_string == "none") {
 			attach_options.access_mode = IRCAccessDelegationMode::NONE;
+		} else if (access_mode_string == "lf_filtered") {
+			attach_options.access_mode = IRCAccessDelegationMode::LF_FILTERED;
 		} else {
 			throw InvalidInputException(
-			    "Unrecognized access mode '%s'. Supported options are 'vended_credentials' and 'none'",
+			    "Unrecognized access mode '%s'. Supported options are 'vended_credentials', 'none', and 'lf_filtered'",
 			    access_mode_string);
 		}
+	}
+	if (lake_formation_data_filters) {
+		attach_options.lake_formation_data_filters = true;
+		attach_options.access_mode = IRCAccessDelegationMode::LF_FILTERED;
+	}
+	if (attach_options.access_mode == IRCAccessDelegationMode::LF_FILTERED) {
+		// LF data filters are a Glue-only path: catalog REST still talks to the Glue
+		// Iceberg endpoint, but object access goes through LF temporary credentials.
+		if (endpoint_type == IcebergEndpointType::AWS_S3TABLES) {
+			throw InvalidConfigurationException(
+			    "LAKE_FORMATION_DATA_FILTERS is only supported with ENDPOINT_TYPE 'GLUE'");
+		}
+		if (!access_mode_string.empty() && access_mode_string == "vended_credentials") {
+			throw InvalidConfigurationException(
+			    "LAKE_FORMATION_DATA_FILTERS cannot be combined with access_delegation_mode 'vended_credentials'");
+		}
+		if (lf_session_tag.empty()) {
+			throw InvalidConfigurationException("LF_SESSION_TAG is required when LAKE_FORMATION_DATA_FILTERS is enabled");
+		}
+		attach_options.lf_session_tag = std::move(lf_session_tag);
 	}
 	if (attach_options.authorization_type == IcebergAuthorizationType::INVALID) {
 		attach_options.authorization_type = IcebergAuthorizationType::OAUTH2;

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -44,6 +44,13 @@ bool IcebergTableSet::FillEntry(ClientContext &context, IcebergTableInformation 
 		if (cached_result) {
 			// Use the cached result instead of making a new request
 			table.InitializeFromLoadTableResult(*cached_result->load_table_result);
+#ifndef EMSCRIPTEN
+			if (ic_catalog.attach_options.access_mode == IRCAccessDelegationMode::LF_FILTERED) {
+				// IRC cache has Iceberg metadata only; LF policy is caller-specific and
+				// must be refreshed from Glue even when the table load is served from cache.
+				table.LoadLakeFormationPolicy(context);
+			}
+#endif
 			return true;
 		}
 	}
@@ -75,6 +82,12 @@ bool IcebergTableSet::FillEntry(ClientContext &context, IcebergTableInformation 
 		auto &load_table_result = *cached_table_result->load_table_result;
 		table.InitializeFromLoadTableResult(load_table_result);
 	}
+#ifndef EMSCRIPTEN
+	if (ic_catalog.attach_options.access_mode == IRCAccessDelegationMode::LF_FILTERED) {
+		// LF policy is caller-specific and not included in IRC GetTable responses.
+		table.LoadLakeFormationPolicy(context);
+	}
+#endif
 	return true;
 }
 

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -45,7 +45,7 @@ bool IcebergTableSet::FillEntry(ClientContext &context, IcebergTableInformation 
 			// Use the cached result instead of making a new request
 			table.InitializeFromLoadTableResult(*cached_result->load_table_result);
 #ifndef EMSCRIPTEN
-			if (ic_catalog.attach_options.access_mode == IRCAccessDelegationMode::LF_FILTERED) {
+			if (ic_catalog.attach_options.access_mode == IRCAccessDelegationMode::LAKE_FORMATION) {
 				// IRC cache has Iceberg metadata only; LF policy is caller-specific and
 				// must be refreshed from Glue even when the table load is served from cache.
 				table.LoadLakeFormationPolicy(context);
@@ -83,7 +83,7 @@ bool IcebergTableSet::FillEntry(ClientContext &context, IcebergTableInformation 
 		table.InitializeFromLoadTableResult(load_table_result);
 	}
 #ifndef EMSCRIPTEN
-	if (ic_catalog.attach_options.access_mode == IRCAccessDelegationMode::LF_FILTERED) {
+	if (ic_catalog.attach_options.access_mode == IRCAccessDelegationMode::LAKE_FORMATION) {
 		// LF policy is caller-specific and not included in IRC GetTable responses.
 		table.LoadLakeFormationPolicy(context);
 	}

--- a/src/include/catalog/aws/lakeformation/lf_client.hpp
+++ b/src/include/catalog/aws/lakeformation/lf_client.hpp
@@ -30,12 +30,12 @@ public:
 	                                          const IcebergTableSchema &iceberg_schema,
 	                                          const IcebergTableMetadata &table_metadata);
 	LakeFormationTemporaryCredentials GetTableCredentials(const LakeFormationTableIdentifiers &identifiers,
-	                                                     const LakeFormationTablePolicy &policy,
-	                                                     const string &s3_path = "");
+	                                                      const LakeFormationTablePolicy &policy,
+	                                                      const string &s3_path = "");
 	LakeFormationTemporaryCredentials GetPartitionCredentials(const LakeFormationTableIdentifiers &identifiers,
-	                                                        const LakeFormationTablePolicy &policy,
-	                                                        const vector<Value> &partition_values,
-	                                                        const string &s3_path = "");
+	                                                          const LakeFormationTablePolicy &policy,
+	                                                          const vector<Value> &partition_values,
+	                                                          const string &s3_path = "");
 
 private:
 	ClientContext &context;

--- a/src/include/catalog/aws/lakeformation/lf_client.hpp
+++ b/src/include/catalog/aws/lakeformation/lf_client.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "catalog/aws/lakeformation/lf_types.hpp"
+#include "catalog/aws/lakeformation/lf_credentials.hpp"
+#include "catalog/aws/lakeformation/lf_credential_cache.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
+
+#include "duckdb/main/client_context.hpp"
+
+namespace duckdb {
+
+class IcebergCatalog;
+class IcebergSchemaEntry;
+class IcebergTableInformation;
+
+struct LakeFormationTableIdentifiers {
+	string catalog_id;
+	string database_name;
+	string table_name;
+	string table_arn;
+	string region;
+};
+
+class LakeFormationClient {
+public:
+	explicit LakeFormationClient(ClientContext &context, IcebergCatalog &catalog);
+
+	LakeFormationTableIdentifiers GetTableIdentifiers(IcebergSchemaEntry &schema, const string &table_name) const;
+	LakeFormationTablePolicy FetchTablePolicy(IcebergSchemaEntry &schema, const string &table_name,
+	                                          const IcebergTableSchema &iceberg_schema,
+	                                          const IcebergTableMetadata &table_metadata);
+	LakeFormationTemporaryCredentials GetTableCredentials(const LakeFormationTableIdentifiers &identifiers,
+	                                                     const LakeFormationTablePolicy &policy,
+	                                                     const string &s3_path = "");
+	LakeFormationTemporaryCredentials GetPartitionCredentials(const LakeFormationTableIdentifiers &identifiers,
+	                                                        const LakeFormationTablePolicy &policy,
+	                                                        const vector<Value> &partition_values,
+	                                                        const string &s3_path = "");
+
+private:
+	ClientContext &context;
+	IcebergCatalog &catalog;
+	LakeFormationClientConfig client_config;
+	LakeFormationCredentialCache credential_cache;
+};
+
+} // namespace duckdb

--- a/src/include/catalog/aws/lakeformation/lf_credential_cache.hpp
+++ b/src/include/catalog/aws/lakeformation/lf_credential_cache.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "catalog/aws/lakeformation/lf_types.hpp"
+
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unordered_map.hpp"
+
+namespace duckdb {
+
+class LakeFormationCredentialCache {
+public:
+	optional_ptr<const LakeFormationTemporaryCredentials> Get(const string &cache_key);
+	void Put(const string &cache_key, LakeFormationTemporaryCredentials credentials);
+
+private:
+	mutex lock;
+	unordered_map<string, LakeFormationTemporaryCredentials> entries;
+};
+
+} // namespace duckdb

--- a/src/include/catalog/aws/lakeformation/lf_credentials.hpp
+++ b/src/include/catalog/aws/lakeformation/lf_credentials.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "duckdb/main/client_context.hpp"
+
+#ifndef EMSCRIPTEN
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/client/ClientConfiguration.h>
+#endif
+
+namespace duckdb {
+
+class IcebergCatalog;
+
+struct LakeFormationClientConfig {
+	string region;
+#ifndef EMSCRIPTEN
+	std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider;
+	Aws::Client::ClientConfiguration aws_config;
+#endif
+};
+
+LakeFormationClientConfig BuildLakeFormationClientConfig(ClientContext &context, IcebergCatalog &catalog);
+
+} // namespace duckdb

--- a/src/include/catalog/aws/lakeformation/lf_filter_parser.hpp
+++ b/src/include/catalog/aws/lakeformation/lf_filter_parser.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "duckdb/parser/parsed_expression.hpp"
+#include "duckdb/planner/expression.hpp"
+#include "planning/iceberg_multi_file_list.hpp"
+
+#include "core/metadata/schema/iceberg_table_schema.hpp"
+
+namespace duckdb {
+
+struct LakeFormationFilterParseResult {
+	unique_ptr<ParsedExpression> parsed_filter;
+	unique_ptr<Expression> bound_filter;
+	IcebergTableFilters table_filters;
+};
+
+LakeFormationFilterParseResult ParseLakeFormationRowFilter(ClientContext &context, const string &row_filter_sql,
+                                                           const IcebergTableSchema &schema);
+
+} // namespace duckdb

--- a/src/include/catalog/aws/lakeformation/lf_table_metadata.hpp
+++ b/src/include/catalog/aws/lakeformation/lf_table_metadata.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "catalog/aws/lakeformation/lf_types.hpp"
+
+#include "core/metadata/schema/iceberg_table_schema.hpp"
+
+#ifndef EMSCRIPTEN
+#include <aws/glue/model/GetUnfilteredTableMetadataResult.h>
+#include <aws/glue/model/UnfilteredPartition.h>
+#endif
+
+namespace duckdb {
+
+#ifndef EMSCRIPTEN
+LakeFormationTablePolicy
+ParseUnfilteredTableMetadata(const ::Aws::Glue::Model::GetUnfilteredTableMetadataResult &result);
+
+LakeFormationPartitionPolicy
+ParseUnfilteredPartitionMetadata(const ::Aws::Glue::Model::UnfilteredPartition &unfiltered);
+#endif
+
+void ValidateLakeFormationPolicyV1(const LakeFormationTablePolicy &policy, const IcebergTableSchema &schema);
+
+} // namespace duckdb

--- a/src/include/catalog/aws/lakeformation/lf_types.hpp
+++ b/src/include/catalog/aws/lakeformation/lf_types.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/common/types/value.hpp"
+
+namespace duckdb {
+
+struct LakeFormationCellFilter {
+	string column_name;
+	string row_filter_expression;
+};
+
+struct LakeFormationPartitionPolicy {
+	vector<Value> partition_values;
+	string row_filter_sql;
+};
+
+struct LakeFormationTablePolicy {
+	string row_filter_sql;
+	vector<string> authorized_columns;
+	bool all_columns_authorized = true;
+	vector<LakeFormationCellFilter> cell_filters;
+	string query_authorization_id;
+	vector<LakeFormationPartitionPolicy> partition_policies;
+	bool is_partitioned = false;
+	bool loaded = false;
+};
+
+struct LakeFormationTemporaryCredentials {
+	string access_key_id;
+	string secret_access_key;
+	string session_token;
+	string expiration;
+};
+
+} // namespace duckdb

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -5,9 +5,15 @@
 
 #include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
 #include "core/metadata/manifest/iceberg_manifest.hpp"
+#include "core/metadata/manifest/iceberg_manifest.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "rest_catalog/objects/storage_credential.hpp"
+#include "catalog/aws/lakeformation/lf_types.hpp"
+
+#ifndef EMSCRIPTEN
+#include "catalog/aws/lakeformation/lf_client.hpp"
+#endif
 
 namespace duckdb {
 class IcebergTableSchema;
@@ -52,6 +58,12 @@ public:
 	                                               const IcebergTableSchema &schema, int32_t spec_id,
 	                                               idx_t base_partition_field_id);
 	IRCAPITableCredentials GetVendedCredentials(ClientContext &context);
+	IRCAPITableCredentials GetLakeFormationCredentials(ClientContext &context,
+	                                                   optional_ptr<const vector<Value>> partition_values = nullptr);
+	void LoadLakeFormationPolicy(ClientContext &context);
+	void EnsureLakeFormationPartitionCredentials(ClientContext &context,
+	                                             const vector<IcebergPartitionInfo> &partition_info,
+	                                             const string &file_path);
 	const string &BaseFilePath() const;
 
 	IcebergTransactionData &GetOrCreateTransactionData(IcebergTransaction &transaction);
@@ -90,6 +102,11 @@ public:
 	// dummy entry to hold existence of a table, but no schema versions
 	unique_ptr<IcebergTableEntry> dummy_entry;
 	unique_ptr<IcebergTransactionData> transaction_data;
+
+	LakeFormationTablePolicy lf_policy;
+#ifndef EMSCRIPTEN
+	LakeFormationTableIdentifiers lf_identifiers;
+#endif
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/storage/iceberg_authorization.hpp
+++ b/src/include/catalog/rest/storage/iceberg_authorization.hpp
@@ -13,7 +13,7 @@ enum class IcebergEndpointType : uint8_t { AWS_S3TABLES, AWS_GLUE, INVALID };
 
 enum class IcebergAuthorizationType : uint8_t { OAUTH2, SIGV4, NONE, INVALID };
 
-enum class IRCAccessDelegationMode : uint8_t { NONE, VENDED_CREDENTIALS };
+enum class IRCAccessDelegationMode : uint8_t { NONE, VENDED_CREDENTIALS, LF_FILTERED };
 
 struct IcebergAttachOptions {
 	string endpoint;
@@ -37,6 +37,8 @@ struct IcebergAttachOptions {
 	unordered_map<string, Value> options;
 	// max staleness for cached table metadata in minutes (optional - if not set, always request fresh metadata)
 	optional_idx max_table_staleness_micros;
+	bool lake_formation_data_filters = false;
+	string lf_session_tag;
 };
 
 //! Hold the pre-initialized HTTPClient for a given connection

--- a/src/include/catalog/rest/storage/iceberg_authorization.hpp
+++ b/src/include/catalog/rest/storage/iceberg_authorization.hpp
@@ -13,7 +13,7 @@ enum class IcebergEndpointType : uint8_t { AWS_S3TABLES, AWS_GLUE, INVALID };
 
 enum class IcebergAuthorizationType : uint8_t { OAUTH2, SIGV4, NONE, INVALID };
 
-enum class IRCAccessDelegationMode : uint8_t { NONE, VENDED_CREDENTIALS, LF_FILTERED };
+enum class IRCAccessDelegationMode : uint8_t { NONE, VENDED_CREDENTIALS, LAKE_FORMATION };
 
 struct IcebergAttachOptions {
 	string endpoint;
@@ -37,7 +37,6 @@ struct IcebergAttachOptions {
 	unordered_map<string, Value> options;
 	// max staleness for cached table metadata in minutes (optional - if not set, always request fresh metadata)
 	optional_idx max_table_staleness_micros;
-	bool lake_formation_data_filters = false;
 	string lf_session_tag;
 };
 

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -154,8 +154,10 @@ public:
 	const IcebergSnapshotScanInfo &GetSnapshot() const;
 	const IcebergTableSchema &GetSchema() const;
 	IcebergTableEntry *GetTable() const;
+	const shared_ptr<IcebergScanInfo> &GetScanInfo() const;
 	void SetTable(IcebergTableEntry *table);
 	void SetOptions(const IcebergOptions &options);
+	void PushTableFilter(column_t column_idx, unique_ptr<ExpressionFilter> filter);
 
 	void Bind(vector<LogicalType> &return_types, vector<Identifier> &names);
 	unique_ptr<IcebergMultiFileList> PushdownInternal(ClientContext &context, TableFilterSet &new_filters,

--- a/src/include/planning/iceberg_optimizer.hpp
+++ b/src/include/planning/iceberg_optimizer.hpp
@@ -21,6 +21,15 @@ public:
 	void VisitOperator(unique_ptr<LogicalOperator> &op);
 };
 
+class LakeFormationRowFilterOptimizer {
+public:
+	ClientContext &context;
+
+public:
+	LakeFormationRowFilterOptimizer(ClientContext &context);
+	void VisitOperator(unique_ptr<LogicalOperator> &op);
+};
+
 class IcebergOptimizer {
 public:
 	static OptimizerExtension Create();

--- a/src/include/planning/snapshot/iceberg_scan_info.hpp
+++ b/src/include/planning/snapshot/iceberg_scan_info.hpp
@@ -9,6 +9,9 @@
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "planning/snapshot/iceberg_snapshot_scan_info.hpp"
 
+#include "duckdb/parser/parsed_expression.hpp"
+#include "duckdb/planner/expression.hpp"
+
 namespace duckdb {
 
 struct IcebergTransactionData;
@@ -38,6 +41,9 @@ public:
 
 	IcebergSnapshotScanInfo snapshot_info;
 	const IcebergTableSchema &schema;
+
+	unique_ptr<ParsedExpression> mandatory_lf_filter_parsed;
+	unique_ptr<Expression> mandatory_lf_filter_bound;
 };
 
 } // namespace duckdb

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -291,12 +291,20 @@ IcebergTableEntry *IcebergMultiFileList::GetTable() const {
 	return shared_state->table;
 }
 
+const shared_ptr<IcebergScanInfo> &IcebergMultiFileList::GetScanInfo() const {
+	return shared_state->scan_info;
+}
+
 void IcebergMultiFileList::SetTable(IcebergTableEntry *table) {
 	shared_state->table = table;
 }
 
 void IcebergMultiFileList::SetOptions(const IcebergOptions &options) {
 	shared_state->options = options;
+}
+
+void IcebergMultiFileList::PushTableFilter(column_t column_idx, unique_ptr<ExpressionFilter> filter) {
+	table_filters.PushFilter(column_idx, std::move(filter));
 }
 
 unique_ptr<ExpressionFilter> IcebergMultiFileList::GetFilterForColumnIndex(const IcebergTableFilters &filter_set,
@@ -997,7 +1005,8 @@ OpenFileInfo IcebergMultiFileList::GetFileInternal(idx_t file_id, lock_guard<mut
 	}
 
 #ifndef EMSCRIPTEN
-	if (table && table->table_info.catalog.attach_options.access_mode == IRCAccessDelegationMode::LF_FILTERED &&
+	auto table = GetTable();
+	if (table && table->table_info.catalog.attach_options.access_mode == IRCAccessDelegationMode::LAKE_FORMATION &&
 	    !data_file.partition_info.empty()) {
 		// Table-level LF credentials may not cover every partition's S3 prefix; refresh
 		// secrets lazily as we discover files in each partition during manifest walks.

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -36,6 +36,9 @@
 #include "planning/metadata_io/manifest/iceberg_manifest_reader.hpp"
 #include "planning/metadata_io/manifest_list/iceberg_manifest_list_reader.hpp"
 #include "planning/metadata_io/manifest_list/bound_iceberg_manifest_list_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/iceberg_catalog.hpp"
+#include "catalog/rest/storage/iceberg_authorization.hpp"
 
 namespace duckdb {
 
@@ -992,6 +995,16 @@ OpenFileInfo IcebergMultiFileList::GetFileInternal(idx_t file_id, lock_guard<mut
 		auto &fs = FileSystem::GetFileSystem(context);
 		file_path = IcebergUtils::GetFullPath(iceberg_path, path, fs);
 	}
+
+#ifndef EMSCRIPTEN
+	if (table && table->table_info.catalog.attach_options.access_mode == IRCAccessDelegationMode::LF_FILTERED &&
+	    !data_file.partition_info.empty()) {
+		// Table-level LF credentials may not cover every partition's S3 prefix; refresh
+		// secrets lazily as we discover files in each partition during manifest walks.
+		table->table_info.EnsureLakeFormationPartitionCredentials(context, data_file.partition_info, file_path);
+	}
+#endif
+
 	OpenFileInfo res(file_path);
 	auto extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
 	extended_info->options["file_size"] = Value::UBIGINT(data_file.file_size_in_bytes);

--- a/src/planning/iceberg_optimizer.cpp
+++ b/src/planning/iceberg_optimizer.cpp
@@ -12,6 +12,7 @@
 #include "planning/iceberg_multi_file_list.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 
 namespace duckdb {
 
@@ -134,12 +135,63 @@ void GuaranteeEqualityDeleteColumnsOptimizer::VisitOperator(unique_ptr<LogicalOp
 	}
 }
 
+LakeFormationRowFilterOptimizer::LakeFormationRowFilterOptimizer(ClientContext &context) : context(context) {
+}
+
+static unique_ptr<Expression> RemapFilterBindings(Expression &expr, const vector<ColumnBinding> &bindings) {
+	auto copy = expr.Copy();
+	ExpressionIterator::EnumerateExpression(copy, [&](unique_ptr<Expression> &child) {
+		if (child->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+			auto &colref = child->Cast<BoundColumnRefExpression>();
+			if (colref.Binding().column_index < bindings.size()) {
+				colref.BindingMutable() = bindings[colref.Binding().column_index];
+			}
+		}
+	});
+	return copy;
+}
+
+void LakeFormationRowFilterOptimizer::VisitOperator(unique_ptr<LogicalOperator> &op) {
+	for (idx_t child_index = 0; child_index < op->children.size(); child_index++) {
+		auto &child = op->children[child_index];
+		if (child->type != LogicalOperatorType::LOGICAL_GET) {
+			VisitOperator(child);
+			continue;
+		}
+		auto &get = child->Cast<LogicalGet>();
+		if (get.function.name != "iceberg_scan" || !get.bind_data) {
+			VisitOperator(child);
+			continue;
+		}
+		auto &mfbd = get.bind_data->Cast<MultiFileBindData>();
+		if (!mfbd.file_list) {
+			continue;
+		}
+		auto &iceberg_list = mfbd.file_list->Cast<IcebergMultiFileList>();
+		if (!iceberg_list.scan_info || !iceberg_list.scan_info->mandatory_lf_filter_bound) {
+			continue;
+		}
+
+		// Safety net: re-apply the LF row filter above the scan even if bind-time
+		// table_filters were elided or the user added predicates that try to bypass it.
+		auto bindings = get.GetColumnBindings();
+		auto remapped =
+		    RemapFilterBindings(*iceberg_list.scan_info->mandatory_lf_filter_bound, bindings);
+		auto filter = make_uniq<LogicalFilter>();
+		filter->expressions.push_back(std::move(remapped));
+		filter->children.push_back(std::move(op->children[child_index]));
+		op->children[child_index] = std::move(filter);
+	}
+}
+
 void IcebergOptimizer::PreOptimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
 	GuaranteeEqualityDeleteColumnsOptimizer guarantee_equality_delete_columns_optimizer(input.context);
+	LakeFormationRowFilterOptimizer lake_formation_row_filter_optimizer(input.context);
 	if (plan->children.size() == 0) {
 		return;
 	}
 	guarantee_equality_delete_columns_optimizer.VisitOperator(plan);
+	lake_formation_row_filter_optimizer.VisitOperator(plan);
 }
 
 OptimizerExtension IcebergOptimizer::Create() {

--- a/src/planning/iceberg_optimizer.cpp
+++ b/src/planning/iceberg_optimizer.cpp
@@ -176,8 +176,7 @@ void LakeFormationRowFilterOptimizer::VisitOperator(unique_ptr<LogicalOperator> 
 		// Safety net: re-apply the LF row filter above the scan even if bind-time
 		// table_filters were elided or the user added predicates that try to bypass it.
 		auto bindings = get.GetColumnBindings();
-		auto remapped =
-		    RemapFilterBindings(*scan_info->mandatory_lf_filter_bound, bindings);
+		auto remapped = RemapFilterBindings(*scan_info->mandatory_lf_filter_bound, bindings);
 		auto filter = make_uniq<LogicalFilter>();
 		filter->expressions.push_back(std::move(remapped));
 		filter->children.push_back(std::move(op->children[child_index]));

--- a/src/planning/iceberg_optimizer.cpp
+++ b/src/planning/iceberg_optimizer.cpp
@@ -168,7 +168,8 @@ void LakeFormationRowFilterOptimizer::VisitOperator(unique_ptr<LogicalOperator> 
 			continue;
 		}
 		auto &iceberg_list = mfbd.file_list->Cast<IcebergMultiFileList>();
-		if (!iceberg_list.scan_info || !iceberg_list.scan_info->mandatory_lf_filter_bound) {
+		auto &scan_info = iceberg_list.GetScanInfo();
+		if (!scan_info || !scan_info->mandatory_lf_filter_bound) {
 			continue;
 		}
 
@@ -176,7 +177,7 @@ void LakeFormationRowFilterOptimizer::VisitOperator(unique_ptr<LogicalOperator> 
 		// table_filters were elided or the user added predicates that try to bypass it.
 		auto bindings = get.GetColumnBindings();
 		auto remapped =
-		    RemapFilterBindings(*iceberg_list.scan_info->mandatory_lf_filter_bound, bindings);
+		    RemapFilterBindings(*scan_info->mandatory_lf_filter_bound, bindings);
 		auto filter = make_uniq<LogicalFilter>();
 		filter->expressions.push_back(std::move(remapped));
 		filter->children.push_back(std::move(op->children[child_index]));

--- a/test/configs/lakeformation.json
+++ b/test/configs/lakeformation.json
@@ -1,0 +1,11 @@
+{
+  "description": "Lake Formation filtered Glue catalog for cloud LF integration tests.",
+  "statically_loaded_extensions": [
+    "core_functions",
+    "parquet",
+    "avro",
+    "iceberg",
+    "httpfs",
+    "aws"
+  ]
+}

--- a/test/sql/cloud/lakeformation/lf_cloud_setup.inc
+++ b/test/sql/cloud/lakeformation/lf_cloud_setup.inc
@@ -1,0 +1,16 @@
+statement ok
+CREATE SECRET glue_lf_secret (
+    TYPE S3,
+    REGION '{ICEBERG_LF_REGION}',
+    PROVIDER credential_chain,
+    CHAIN 'sts',
+    ASSUME_ROLE_ARN '{ICEBERG_LF_TEST_ROLE_ARN}'
+);
+
+statement ok
+attach '{ICEBERG_LF_CATALOG_ID}' as lf_datalake (
+    TYPE ICEBERG,
+    ENDPOINT_TYPE 'GLUE',
+    LAKE_FORMATION_DATA_FILTERS true,
+    LF_SESSION_TAG '{ICEBERG_LF_SESSION_TAG}'
+);

--- a/test/sql/cloud/lakeformation/test_lf_bypass_attempt.test
+++ b/test/sql/cloud/lakeformation/test_lf_bypass_attempt.test
@@ -1,0 +1,41 @@
+# name: test/sql/cloud/lakeformation/test_lf_bypass_attempt.test
+# description: User WHERE cannot bypass mandatory Lake Formation row filter
+# group: [lakeformation]
+
+require-env ICEBERG_LF_REMOTE_AVAILABLE
+
+require-env LAKEFORMATION_TEST_CONFIG_SETUP
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env ICEBERG_LF_REGION
+
+require-env ICEBERG_LF_CATALOG_ID
+
+require-env ICEBERG_LF_TEST_ROLE_ARN
+
+require-env ICEBERG_LF_SESSION_TAG
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require aws
+
+include test/sql/cloud/lakeformation/lf_cloud_setup.inc
+
+query I
+SELECT count(*) FROM lf_datalake.test_inserts.basic_insert_test WHERE id = 999;
+----
+0
+
+query II
+SELECT count(*) FROM lf_datalake.test_inserts.basic_insert_test;
+----
+3

--- a/test/sql/cloud/lakeformation/test_lf_column_filter_rejected.test
+++ b/test/sql/cloud/lakeformation/test_lf_column_filter_rejected.test
@@ -1,0 +1,36 @@
+# name: test/sql/cloud/lakeformation/test_lf_column_filter_rejected.test
+# description: Column-restricted Lake Formation grant returns v1 not-implemented error
+# group: [lakeformation]
+
+require-env ICEBERG_LF_REMOTE_AVAILABLE
+
+require-env LAKEFORMATION_TEST_CONFIG_SETUP
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env ICEBERG_LF_REGION
+
+require-env ICEBERG_LF_CATALOG_ID
+
+require-env ICEBERG_LF_TEST_ROLE_ARN
+
+require-env ICEBERG_LF_SESSION_TAG
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require aws
+
+include test/sql/cloud/lakeformation/lf_cloud_setup.inc
+
+statement error
+SELECT * FROM lf_datalake.test_inserts.basic_insert_test;
+----
+<REGEX>:.*(column-level permissions are not supported|cell-level data filters are not supported).*

--- a/test/sql/cloud/lakeformation/test_lf_no_filter_grant.test
+++ b/test/sql/cloud/lakeformation/test_lf_no_filter_grant.test
@@ -1,0 +1,36 @@
+# name: test/sql/cloud/lakeformation/test_lf_no_filter_grant.test
+# description: Access denied without Lake Formation data filter grant
+# group: [lakeformation]
+
+require-env ICEBERG_LF_REMOTE_AVAILABLE
+
+require-env LAKEFORMATION_TEST_CONFIG_SETUP
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env ICEBERG_LF_REGION
+
+require-env ICEBERG_LF_CATALOG_ID
+
+require-env ICEBERG_LF_TEST_ROLE_ARN
+
+require-env ICEBERG_LF_SESSION_TAG
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require aws
+
+include test/sql/cloud/lakeformation/lf_cloud_setup.inc
+
+statement error
+SELECT * FROM lf_datalake.test_inserts.no_lf_grant_test;
+----
+<REGEX>:.*(AccessDenied|Forbidden|not authorized|GetTemporaryGlueTableCredentials failed).*

--- a/test/sql/cloud/lakeformation/test_lf_row_filter_partitioned.test
+++ b/test/sql/cloud/lakeformation/test_lf_row_filter_partitioned.test
@@ -1,0 +1,36 @@
+# name: test/sql/cloud/lakeformation/test_lf_row_filter_partitioned.test
+# description: Lake Formation row filter on partitioned table with per-partition credentials
+# group: [lakeformation]
+
+require-env ICEBERG_LF_REMOTE_AVAILABLE
+
+require-env LAKEFORMATION_TEST_CONFIG_SETUP
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env ICEBERG_LF_REGION
+
+require-env ICEBERG_LF_CATALOG_ID
+
+require-env ICEBERG_LF_TEST_ROLE_ARN
+
+require-env ICEBERG_LF_SESSION_TAG
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require aws
+
+include test/sql/cloud/lakeformation/lf_cloud_setup.inc
+
+query I
+SELECT count(*) FROM lf_datalake.test_inserts.basic_insert_test_partitioned;
+----
+3

--- a/test/sql/cloud/lakeformation/test_lf_row_filter_unpartitioned.test
+++ b/test/sql/cloud/lakeformation/test_lf_row_filter_unpartitioned.test
@@ -1,0 +1,36 @@
+# name: test/sql/cloud/lakeformation/test_lf_row_filter_unpartitioned.test
+# description: Lake Formation row filter on unpartitioned table
+# group: [lakeformation]
+
+require-env ICEBERG_LF_REMOTE_AVAILABLE
+
+require-env LAKEFORMATION_TEST_CONFIG_SETUP
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env ICEBERG_LF_REGION
+
+require-env ICEBERG_LF_CATALOG_ID
+
+require-env ICEBERG_LF_TEST_ROLE_ARN
+
+require-env ICEBERG_LF_SESSION_TAG
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require aws
+
+include test/sql/cloud/lakeformation/lf_cloud_setup.inc
+
+query I
+SELECT count(*) FROM lf_datalake.test_inserts.basic_insert_test;
+----
+3

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,6 +8,8 @@
 		{
 			"name": "aws-sdk-cpp",
 			"features": [
+				"glue",
+				"lakeformation",
 				"sso",
 				"sts",
 				"identity-management",


### PR DESCRIPTION
## Summary

Adds Lake Formation (LF from now on ) data filter support for AWS Glue Iceberg catalogs. When enabled, DuckDB participates in Lake Formation’s [application integration / external data filtering](https://docs.aws.amazon.com/lake-formation/latest/dg/permitting-third-party-call.html) flow: it discovers the caller’s effective row filter via Glue, vends scoped S3 credentials via Lake Formation, and enforces the filter at scan time so user predicates cannot widen the grant.

## Use Case

AWS admins want to filter S3 Tables by, say, `account_id`, for simple row-level security.  This is support OOTB in AWS, but requires a separate credential path and APIs that `duckdb-iceberg` does not use.

## Out of Scope

Column filters (will be a separate PR).  This is just for row filters.

## Motivation

Glue Iceberg REST catalogs expose table metadata, but **row-level access control** for Lake Formation–registered tables is enforced through a separate integration path:

1. Glue returns the caller’s effective filter policy ([`GetUnfilteredTableMetadata`](https://docs.aws.amazon.com/glue/latest/webapi/API_GetUnfilteredTableMetadata.html), and [`GetUnfilteredPartitionsMetadata`](https://docs.aws.amazon.com/glue/latest/webapi/API_GetUnfilteredPartitionsMetadata.html) for partitioned tables).
2. Lake Formation returns **temporary, scope-down S3 credentials** ([`GetTemporaryGlueTableCredentials`](https://docs.aws.amazon.com/lake-formation/latest/APIReference/API_GetTemporaryGlueTableCredentials.html) / [`GetTemporaryGluePartitionCredentials`](https://docs.aws.amazon.com/lake-formation/latest/APIReference/API_GetTemporaryGluePartitionCredentials.html)).

Without this, a client attached to Glue with normal credentials could read more data than Lake Formation grants allow, resulting in runtime errors.

## How it works

```mermaid
sequenceDiagram
    participant User
    participant DuckDB
    participant GlueIRC as Glue Iceberg REST
    participant GlueAPI as Glue Data Catalog API
    participant LF as Lake Formation
    participant S3

    User->>DuckDB: ATTACH ... LAKE_FORMATION_DATA_FILTERS true
    User->>DuckDB: SELECT ... FROM catalog.schema.table
    DuckDB->>GlueIRC: GetTable (metadata, no vended-credentials header)
    DuckDB->>GlueAPI: GetUnfilteredTableMetadata (CELL_FILTER_PERMISSION)
    GlueAPI-->>DuckDB: row_filter SQL, queryAuthorizationId, ...
    DuckDB->>LF: GetTemporaryGlueTableCredentials (scoped S3 keys)
    LF-->>DuckDB: temporary credentials
    DuckDB->>DuckDB: Apply mandatory row filter (bind + optimizer)
    DuckDB->>S3: Read Parquet with LF-scoped credentials
```

* Credential path: IRC `access_delegation_mode` stays `none` (no `X-Iceberg-Access-Delegation: vended-credentials`). S3 access uses LF temporary credentials instead of catalog-vended credentials.

* Policy discovery: Per-table LF policy is fetched from Glue and cached on `IcebergTableInformation`. For partitioned tables, partition-scoped credentials are refreshed lazily during manifest enumeration.

* Enforcement: LF row-filter SQL is parsed and bound as mandatory scan filters at bind time, with a `LakeFormationRowFilterOptimizer` safety net so predicates like `WHERE id = 999` cannot bypass the grant.

* Auth: Requires `SIGV4` catalog authentication. If the catalog secret uses `assume_role_arn`, the extension assumes that role with an STS session tag `LakeFormationAuthorizedCaller=<LF_SESSION_TAG>` (see [application integration settings](https://docs.aws.amazon.com/lake-formation/latest/dg/permitting-third-party-call.html)).

## Usage

```sql
CREATE SECRET glue_lf_secret (
    TYPE S3,
    REGION 'us-east-1',
    PROVIDER credential_chain,
    CHAIN 'sts',
    ASSUME_ROLE_ARN 'arn:aws:iam::<account>:role/<lf-role>'
);

ATTACH '<catalog-id>' AS lf_datalake (
    TYPE ICEBERG,
    ENDPOINT_TYPE 'GLUE',
    SECRET glue_lf_secret,
    LAKE_FORMATION_DATA_FILTERS true,
    LF_SESSION_TAG 'duckdb'
);

SELECT * FROM lf_datalake.test_inserts.basic_insert_test;
```

### Attach options

| Option | Required | Description |
|--------|----------|-------------|
| `LAKE_FORMATION_DATA_FILTERS` | Yes | Enables Lake Formation mode |
| `LF_SESSION_TAG` | Yes | Must match a value in the account’s [authorized session tag list](https://docs.aws.amazon.com/lake-formation/latest/dg/permitting-third-party-call.html) |
| `ENDPOINT_TYPE 'GLUE'` | Yes | LF integration is Glue-only |
| `access_delegation_mode` | No | Must be `none` (default) or omitted; **not** `vended_credentials` |
| `ENDPOINT_TYPE 'GLUE'` | Yes | LF integration requires the Glue Iceberg REST endpoint (even when the catalog is an S3 Tables catalog) |
| `ENDPOINT_TYPE 'S3TABLES'` | — | **Not supported** with `LAKE_FORMATION_DATA_FILTERS` |
`access_delegation_mode 'lf_filtered'` is rejected; use `LAKE_FORMATION_DATA_FILTERS true` instead.

## v1 limitations

Fails closed on grant shapes we do not enforce yet:

- **Row-level filters only** — rejects [cell-level / data cell filters](https://docs.aws.amazon.com/lake-formation/latest/dg/data-filtering.html)
- **No column-level permissions** — tables must grant all columns (or use row filters only)
- **Not available in WASM builds** (`EMSCRIPTEN`)


## Testing

- **Cloud tests:** `test/sql/cloud/lakeformation/*` — row filters (partitioned/unpartitioned), bypass attempt, no grant, unsupported column filter
  - requires set up on the AWS side; not sure if the AWS permissions are set up correctly to allow creation of necessary resources
- **CI setup:** `scripts/setup_lf_data_filters.py` provisions [data cell filters](https://docs.aws.amazon.com/lake-formation/latest/APIReference/API_CreateDataCellsFilter.html) and grants; enables external data filtering on the test account
- **Table fixtures:** `scripts/create_s3_insert_table.py` extended for LF test tables on Glue
   - again, not sure if the AWS account the CI environment uses can make these resources

## AWS documentation

- [Lake Formation data filtering overview](https://docs.aws.amazon.com/lake-formation/latest/dg/data-filtering.html)
- [Application integration / external data filtering](https://docs.aws.amazon.com/lake-formation/latest/dg/permitting-third-party-call.html)
- [Integrate custom applications with Lake Formation (AWS blog)](https://aws.amazon.com/blogs/big-data/integrate-custom-applications-with-aws-lake-formation-part-1/)
- [Glue: GetUnfilteredTableMetadata](https://docs.aws.amazon.com/glue/latest/webapi/API_GetUnfilteredTableMetadata.html)
- [Glue: GetUnfilteredPartitionsMetadata](https://docs.aws.amazon.com/glue/latest/webapi/API_GetUnfilteredPartitionsMetadata.html)
- [Lake Formation: GetTemporaryGlueTableCredentials](https://docs.aws.amazon.com/lake-formation/latest/APIReference/API_GetTemporaryGlueTableCredentials.html)
- [Lake Formation: GetTemporaryGluePartitionCredentials](https://docs.aws.amazon.com/lake-formation/latest/APIReference/API_GetTemporaryGluePartitionCredentials.html)
- [Glue Iceberg REST endpoint](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-iceberg.html)
- [Amazon S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html) — for the storage/catalog side



### Glue vs S3 Tables

This integration uses the **Glue Iceberg REST catalog** (`ENDPOINT_TYPE 'GLUE'`), which is the entry point Lake Formation’s application integration expects. It does **not** support attaching with `ENDPOINT_TYPE 'S3TABLES'`.

Cloud tests use this pattern: Iceberg metadata comes from Glue REST; physical table data lives in S3 Tables; LF row filters and temporary credentials are applied on top.