### PR TITLE
Fix stale in-memory catalog state after an Iceberg ALTER

### DIFF
--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -387,6 +387,31 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 	return info;
 }
 
+static shared_ptr<IcebergTableInformation> CreateCommittedTableInfo(IcebergTableInformation &table) {
+	auto published = make_shared_ptr<IcebergTableInformation>(table.catalog, table.schema, table.name);
+	published->table_id = std::move(table.table_id);
+	published->table_metadata = std::move(table.table_metadata);
+	published->config = std::move(table.config);
+	published->storage_credentials = std::move(table.storage_credentials);
+	published->latest_metadata_json = std::move(table.latest_metadata_json);
+	published->InitSchemaVersions();
+	return published;
+}
+
+static void PublishCommittedAlter(IcebergTransactionAlterUpdate &alter_update) {
+	for (auto &table_key : alter_update.committed_tables) {
+		auto table = alter_update.updated_tables.find(table_key);
+		if (table == alter_update.updated_tables.end()) {
+			continue;
+		}
+		auto &table_info = table->second;
+		auto &schema = table_info.schema.Cast<IcebergSchemaEntry>();
+		auto published = CreateCommittedTableInfo(table_info);
+		lock_guard<mutex> guard(schema.tables.GetEntryLock());
+		schema.tables.GetEntriesMutable()[published->name] = std::move(published);
+	}
+}
+
 void IcebergTransaction::Commit() {
 	if (transaction_updates.empty() && created_schemas.empty() && deleted_schemas.empty() &&
 	    schema_property_updates.empty()) {
@@ -438,6 +463,12 @@ void IcebergTransaction::Commit() {
 	}
 
 	temp_con.Rollback();
+
+	for (auto &transaction_update : transaction_updates) {
+		if (transaction_update->type == IcebergTransactionUpdateType::ALTER) {
+			PublishCommittedAlter(transaction_update->Cast<IcebergTransactionAlterUpdate>());
+		}
+	}
 }
 
 void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context) {
@@ -538,12 +569,13 @@ void IcebergTransaction::DoTableRename(IcebergTransactionRenameUpdate &rename_up
 	drop_info.if_not_found = OnEntryNotFound::THROW_EXCEPTION;
 	schema.DropEntry(context, drop_info, true);
 
+	auto published = CreateCommittedTableInfo(rename_update.new_table);
 	lock_guard<mutex> guard(schema.tables.GetEntryLock());
-	shared_ptr<IcebergTableInformation> old_version;
-	schema.tables.CreateEntryInternal(guard, new_name, std::move(rename_update.new_table), old_version);
-	if (old_version) {
+	auto &entries = schema.tables.GetEntriesMutable();
+	if (entries.find(new_name) != entries.end()) {
 		throw TransactionException("Table %s was already created by a different transaction!", new_name);
 	}
+	entries[new_name] = std::move(published);
 }
 
 void IcebergTransaction::DoTableDeletes(IcebergTransactionDeleteUpdate &delete_update, ClientContext &context) {

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/add_column/alter_add_column_catalog_scan_after_commit.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/add_column/alter_add_column_catalog_scan_after_commit.test
@@ -1,0 +1,78 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/add_column/alter_add_column_catalog_scan_after_commit.test
+# group: [add_column]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+CALL enable_logging(level='warning');
+
+statement ok
+SET warnings_as_errors = True;
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS my_datalake.default;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.alter_add_column_scan_after_commit_table;
+
+statement ok
+CREATE TABLE my_datalake.default.alter_add_column_scan_after_commit_table WITH ('format-version' = 3) AS (SELECT range a FROM range(3));
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE my_datalake.default.alter_add_column_scan_after_commit_table ADD COLUMN b int;
+
+statement ok
+ALTER TABLE my_datalake.default.alter_add_column_scan_after_commit_table ADD COLUMN c int;
+
+query III
+FROM my_datalake.default.alter_add_column_scan_after_commit_table;
+----
+0	NULL	NULL
+1	NULL	NULL
+2	NULL	NULL
+
+statement ok
+COMMIT;
+
+query T
+SELECT column_name FROM information_schema.columns
+WHERE table_catalog = 'my_datalake'
+  AND table_schema = 'default'
+  AND table_name = 'alter_add_column_scan_after_commit_table'
+ORDER BY ordinal_position;
+----
+a
+b
+c
+
+query III
+FROM my_datalake.default.alter_add_column_scan_after_commit_table;
+----
+0	NULL	NULL
+1	NULL	NULL
+2	NULL	NULL
+
+query T
+SELECT column_name FROM duckdb_columns()
+WHERE database_name = 'my_datalake'
+  AND schema_name = 'default'
+  AND table_name = 'alter_add_column_scan_after_commit_table'
+ORDER BY column_index;
+----
+a
+b
+c


### PR DESCRIPTION
After an Iceberg `ALTER` (e.g. `ADD COLUMN`) or table rename is committed, the catalog left the old `IcebergTableInformation` in `schema.tables`. A scan in the same connection then read the pre-ALTER schema.

This refreshes the published table info on commit and swaps it into the schema under the entry lock, for both ALTER and rename, so subsequent reads see the committed schema.