### PR TITLE
[Retry] Add retrying mechanism for INSERT operations

### DIFF
--- a/src/catalog/rest/api/catalog_api.cpp
+++ b/src/catalog/rest/api/catalog_api.cpp
@@ -24,6 +24,22 @@
 using namespace duckdb_yyjson;
 namespace duckdb {
 
+void CommitResult::Throw(const string &url) const {
+	if (success) {
+		return;
+	}
+	if (error_) {
+		auto error_copy = error_->Copy();
+		error_copy._error.stack = vector<string>();
+		throw InvalidConfigurationException(
+		    "Request to '%s' returned a non-200 status code (%s). \n message: %s\n type: %s\n reason: %s\n", url,
+		    EnumUtil::ToString(status), error_copy._error.message, error_copy._error.type, reason);
+	}
+	throw InvalidConfigurationException(
+	    "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s", url,
+	    EnumUtil::ToString(status), reason, body);
+}
+
 vector<string> IRCAPI::ParseSchemaName(const string &namespace_name) {
 	idx_t start = 0;
 	idx_t end = namespace_name.find(".", start);
@@ -367,7 +383,32 @@ vector<IRCAPISchema> IRCAPI::GetSchemas(ClientContext &context, IcebergCatalog &
 	return result;
 }
 
-void IRCAPI::CommitMultiTableUpdate(ClientContext &context, IcebergCatalog &catalog, const string &body) {
+static CommitResult BuildCommitResult(ClientContext &context, const unique_ptr<HTTPResponse> &response) {
+	CommitResult result;
+	result.status = response->status;
+	result.reason = response->reason;
+	result.body = response->body;
+	result.success = response->status == HTTPStatusCode::OK_200 || response->status == HTTPStatusCode::NoContent_204;
+	if (result.success) {
+		return result;
+	}
+
+	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> out_doc;
+	yyjson_val *error_obj = ICUtils::GetErrorMessage(response->body, out_doc);
+	if (error_obj != nullptr) {
+		result.error_ = rest_api_objects::IcebergErrorResponse::FromJSON(error_obj);
+		if (result.error_->_error.stack) {
+			string stack_trace;
+			for (const auto &str : *result.error_->_error.stack) {
+				stack_trace.append(str + "\n");
+			}
+			DUCKDB_LOG(context, IcebergLogType, stack_trace);
+		}
+	}
+	return result;
+}
+
+CommitResult IRCAPI::CommitMultiTableUpdate(ClientContext &context, IcebergCatalog &catalog, const string &body) {
 	auto url_builder = catalog.GetBaseUrl();
 	url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("transactions"));
@@ -376,32 +417,11 @@ void IRCAPI::CommitMultiTableUpdate(ClientContext &context, IcebergCatalog &cata
 	headers.Insert("Content-Type", "application/json");
 	LogPostBody(context, url_builder, body);
 	auto response = catalog.auth_handler->Request(RequestType::POST_REQUEST, context, url_builder, headers, body);
-	if (response->status != HTTPStatusCode::OK_200 && response->status != HTTPStatusCode::NoContent_204) {
-		std::unique_ptr<yyjson_doc, YyjsonDocDeleter> out_doc;
-		yyjson_val *error_obj = ICUtils::GetErrorMessage(response->body, out_doc);
-		if (error_obj == nullptr) {
-			throw InvalidConfigurationException(response->body);
-		}
-		auto error = rest_api_objects::IcebergErrorResponse::FromJSON(error_obj);
-		string stack_trace;
-		if (error._error.stack) {
-			for (const auto &str : *error._error.stack) {
-				stack_trace.append(str + "\n");
-			}
-		}
-		DUCKDB_LOG(context, IcebergLogType, stack_trace);
-
-		// Omit stack from error output
-		error._error.stack = vector<string>();
-		throw InvalidConfigurationException(
-		    "Request to '%s' returned a non-200 status code (%s). \n message: %s\n type: %s\n reason: %s\n",
-		    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), error._error.message, error._error.type,
-		    response->reason);
-	}
+	return BuildCommitResult(context, response);
 }
 
-void IRCAPI::CommitTableUpdate(ClientContext &context, IcebergCatalog &catalog, const vector<string> &schema,
-                               const string &table, const string &body) {
+CommitResult IRCAPI::CommitTableUpdate(ClientContext &context, IcebergCatalog &catalog, const vector<string> &schema,
+                                       const string &table, const string &body) {
 	auto url_builder = catalog.GetBaseUrl();
 	url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
@@ -412,11 +432,7 @@ void IRCAPI::CommitTableUpdate(ClientContext &context, IcebergCatalog &catalog, 
 	headers.Insert("Content-Type", "application/json");
 	LogPostBody(context, url_builder, body);
 	auto response = catalog.auth_handler->Request(RequestType::POST_REQUEST, context, url_builder, headers, body);
-	if (response->status != HTTPStatusCode::OK_200 && response->status != HTTPStatusCode::NoContent_204) {
-		throw InvalidConfigurationException(
-		    "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
-		    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), response->reason, response->body);
-	}
+	return BuildCommitResult(context, response);
 }
 
 void IRCAPI::CommitTableDelete(ClientContext &context, IcebergCatalog &catalog, const vector<string> &schema,

--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -24,6 +24,10 @@ IcebergAddSnapshot::IcebergAddSnapshot(const IcebergTableInformation &table_info
 	schema_id = table_info.table_metadata.GetCurrentSchemaId();
 }
 
+bool IcebergAddSnapshot::IsRetryable() const {
+	return altered_manifests.IsEmpty();
+}
+
 static rest_api_objects::TableUpdate CreateAddSnapshotUpdate(const IcebergTableInformation &table_info,
                                                              const IcebergSnapshot &snapshot) {
 	rest_api_objects::TableUpdate table_update;
@@ -159,6 +163,23 @@ static IcebergManifestListEntry WriteManifestListEntry(const IcebergTableInforma
 	return new_entry;
 }
 
+static vector<IcebergManifestListEntry>
+CreateCommitManifestFiles(const vector<IcebergManifestListEntry> &manifest_files,
+                          const IcebergTableInformation &table_info, IcebergCommitState &commit_state) {
+	vector<IcebergManifestListEntry> result;
+	result.reserve(manifest_files.size());
+	auto &fs = FileSystem::GetFileSystem(commit_state.context);
+	auto next_row_id = commit_state.next_row_id;
+	for (const auto &manifest_entry : manifest_files) {
+		auto copied_entries = manifest_entry.manifest_entries;
+		auto copied_manifest = IcebergManifestListEntry::CreateFromEntries(
+		    fs, IcebergSnapshot::NewSnapshotId(), commit_state.next_sequence_number, table_info.table_metadata,
+		    manifest_entry.file.content, std::move(copied_entries), next_row_id);
+		result.push_back(std::move(copied_manifest));
+	}
+	return result;
+}
+
 void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &context,
                                       IcebergCommitState &commit_state) const {
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
@@ -168,7 +189,7 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 	D_ASSERT(avro_copy_p);
 	auto &avro_copy = avro_copy_p->Cast<CopyFunctionCatalogEntry>().function;
 
-	const auto &uncommitted_manifest_files = manifest_files;
+	auto uncommitted_manifest_files = CreateCommitManifestFiles(manifest_files, table_info, commit_state);
 	D_ASSERT(!uncommitted_manifest_files.empty());
 
 	auto &table_metadata = commit_state.table_info.table_metadata;
@@ -213,6 +234,7 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 		new_snapshot.metrics.AddManifestFile(manifest_file);
 
 		auto new_manifest_list_entry = WriteManifestListEntry(table_info, manifest_list_entry, avro_copy, db, context);
+		commit_state.created_metadata_files.push_back(new_manifest_list_entry.file.manifest_path);
 		new_manifest_list.AddNewManifestFile(std::move(new_manifest_list_entry));
 
 		if (table_metadata.iceberg_version >= 3) {
@@ -225,6 +247,7 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 	}
 
 	manifest_list::WriteToFile(table_metadata, new_manifest_list, avro_copy, db, context);
+	commit_state.created_metadata_files.push_back(manifest_list_path);
 	commit_state.manifests = new_manifest_list.GetManifestListEntries();
 
 	commit_state.created_snapshots.push_back(new_snapshot);

--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -25,7 +25,8 @@ IcebergAddSnapshot::IcebergAddSnapshot(const IcebergTableInformation &table_info
 }
 
 bool IcebergAddSnapshot::IsRetryable() const {
-	return altered_manifests.IsEmpty();
+	//! Only retry INSERT for now
+	return operation == IcebergSnapshotOperationType::APPEND;
 }
 
 static rest_api_objects::TableUpdate CreateAddSnapshotUpdate(const IcebergTableInformation &table_info,

--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -165,7 +165,8 @@ static IcebergManifestListEntry WriteManifestListEntry(const IcebergTableInforma
 
 static vector<IcebergManifestListEntry>
 CreateCommitManifestFiles(const vector<IcebergManifestListEntry> &manifest_files,
-                          const IcebergTableInformation &table_info, IcebergCommitState &commit_state) {
+                          const IcebergTableInformation &table_info, IcebergCommitState &commit_state,
+                          int64_t snapshot_id, int64_t sequence_number) {
 	vector<IcebergManifestListEntry> result;
 	result.reserve(manifest_files.size());
 	auto &fs = FileSystem::GetFileSystem(commit_state.context);
@@ -173,8 +174,8 @@ CreateCommitManifestFiles(const vector<IcebergManifestListEntry> &manifest_files
 	for (const auto &manifest_entry : manifest_files) {
 		auto copied_entries = manifest_entry.manifest_entries;
 		auto copied_manifest = IcebergManifestListEntry::CreateFromEntries(
-		    fs, IcebergSnapshot::NewSnapshotId(), commit_state.next_sequence_number, table_info.table_metadata,
-		    manifest_entry.file.content, std::move(copied_entries), next_row_id);
+		    fs, snapshot_id, sequence_number, table_info.table_metadata, manifest_entry.file.content,
+		    std::move(copied_entries), next_row_id);
 		result.push_back(std::move(copied_manifest));
 	}
 	return result;
@@ -189,13 +190,12 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 	D_ASSERT(avro_copy_p);
 	auto &avro_copy = avro_copy_p->Cast<CopyFunctionCatalogEntry>().function;
 
-	auto uncommitted_manifest_files = CreateCommitManifestFiles(manifest_files, table_info, commit_state);
-	D_ASSERT(!uncommitted_manifest_files.empty());
-
 	auto &table_metadata = commit_state.table_info.table_metadata;
-
 	const auto snapshot_id = IcebergSnapshot::NewSnapshotId();
 	const auto sequence_number = commit_state.next_sequence_number++;
+	auto uncommitted_manifest_files =
+	    CreateCommitManifestFiles(manifest_files, table_info, commit_state, snapshot_id, sequence_number);
+	D_ASSERT(!uncommitted_manifest_files.empty());
 
 	auto &fs = FileSystem::GetFileSystem(context);
 	auto manifest_list_uuid = UUID::ToString(UUID::GenerateRandomUUID());

--- a/src/catalog/rest/api/iceberg_table_update.cpp
+++ b/src/catalog/rest/api/iceberg_table_update.cpp
@@ -6,7 +6,12 @@ namespace duckdb {
 
 IcebergCommitState::IcebergCommitState(const IcebergTableInformation &table_info, ClientContext &context)
     : table_info(table_info), context(context) {
+	RefreshFromTable();
+}
+
+void IcebergCommitState::RefreshFromTable() {
 	next_sequence_number = table_info.table_metadata.last_sequence_number + 1;
+	next_row_id = 0;
 	if (table_info.table_metadata.has_next_row_id) {
 		next_row_id = table_info.table_metadata.next_row_id;
 	}

--- a/src/catalog/rest/api/iceberg_table_update.cpp
+++ b/src/catalog/rest/api/iceberg_table_update.cpp
@@ -1,8 +1,37 @@
 #include "catalog/rest/api/iceberg_table_update.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "planning/metadata_io/avro/avro_scan.hpp"
+#include "planning/metadata_io/manifest_list/iceberg_manifest_list_reader.hpp"
 
 namespace duckdb {
+
+static void AssignManifestFirstRowIds(const IcebergTableMetadata &metadata,
+                                      optional_ptr<const IcebergSnapshot> current_snapshot,
+                                      vector<IcebergManifestListEntry> &existing_manifest_list, int64_t &next_row_id) {
+	if (metadata.iceberg_version < 3) {
+		return;
+	}
+	for (auto &manifest_list_entry : existing_manifest_list) {
+		auto &manifest_file = manifest_list_entry.file;
+		if (manifest_file.content != IcebergManifestContentType::DATA) {
+			continue;
+		}
+		if (manifest_file.has_first_row_id) {
+			next_row_id = MaxValue<int64_t>(next_row_id, manifest_file.first_row_id + manifest_file.added_rows_count +
+			                                                 manifest_file.existing_rows_count);
+			continue;
+		}
+		if (current_snapshot && current_snapshot->has_first_row_id) {
+			throw InternalException("Table is corrupted, snapshot has 'first-row-id' but not all 'manifest_file' "
+			                        "entries have a 'first_row_id'");
+		}
+		manifest_file.has_first_row_id = true;
+		manifest_file.first_row_id = next_row_id;
+		next_row_id += manifest_file.added_rows_count;
+		next_row_id += manifest_file.existing_rows_count;
+	}
+}
 
 IcebergCommitState::IcebergCommitState(const IcebergTableInformation &table_info, ClientContext &context)
     : table_info(table_info), context(context) {
@@ -15,6 +44,29 @@ void IcebergCommitState::RefreshFromTable() {
 	if (table_info.table_metadata.has_next_row_id) {
 		next_row_id = table_info.table_metadata.next_row_id;
 	}
+}
+
+void IcebergCommitState::LoadExistingManifests(vector<IcebergManifestListEntry> &&existing_manifests) {
+	manifests = std::move(existing_manifests);
+	auto current_snapshot = table_info.table_metadata.GetLatestSnapshot();
+	if (manifests.empty() && current_snapshot) {
+		IcebergSnapshotScanInfo snapshot_info;
+		snapshot_info.snapshot = current_snapshot;
+		snapshot_info.schema_id = table_info.table_metadata.GetCurrentSchemaId();
+
+		auto scan = AvroScan::ScanManifestList(snapshot_info, table_info.table_metadata, context,
+		                                       current_snapshot->manifest_list, manifests);
+		auto manifest_list_reader = make_uniq<manifest_list::ManifestListReader>(*scan);
+		while (!manifest_list_reader->Finished()) {
+			manifest_list_reader->Read();
+		}
+	}
+
+	next_row_id = 0;
+	if (table_info.table_metadata.has_next_row_id) {
+		next_row_id = table_info.table_metadata.next_row_id;
+	}
+	AssignManifestFirstRowIds(table_info.table_metadata, current_snapshot, manifests, next_row_id);
 }
 
 IcebergTableUpdate::IcebergTableUpdate(IcebergTableUpdateType type, const IcebergTableInformation &table_info)

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/exception/http_exception.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/common/exception/transaction_exception.hpp"
@@ -588,6 +589,27 @@ bool IcebergTableInformation::HasTransactionUpdates() const {
 		return true;
 	}
 	return false;
+}
+
+void IcebergTableInformation::RefreshFromCatalog(ClientContext &context) {
+	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
+	auto table_key = GetTableKey();
+	auto get_table_result = IRCAPI::GetTable(context, ic_catalog, schema, name);
+	if (get_table_result.error_) {
+		throw HTTPException(
+		    StringUtil::Format("GetTableInformation endpoint returned response code %s with message \"%s\"",
+		                       EnumUtil::ToString(get_table_result.status_), get_table_result.error_->_error.message));
+	}
+	ic_catalog.table_request_cache.SetOrOverwrite(context, table_key, std::move(get_table_result.result_));
+	schema_versions.clear();
+	dummy_entry.reset();
+	{
+		lock_guard<std::mutex> cache_lock(ic_catalog.table_request_cache.Lock());
+		auto cached_table_result = ic_catalog.table_request_cache.Get(context, table_key, cache_lock, false);
+		D_ASSERT(cached_table_result);
+		auto &load_table_result = *cached_table_result->load_table_result;
+		InitializeFromLoadTableResult(load_table_result);
+	}
 }
 
 IcebergTableInformation IcebergTableInformation::Copy(ClientContext &context) const {

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -610,6 +610,9 @@ void IcebergTableInformation::RefreshFromCatalog(ClientContext &context) {
 		auto &load_table_result = *cached_table_result->load_table_result;
 		InitializeFromLoadTableResult(load_table_result);
 	}
+	if (transaction_data) {
+		transaction_data->RefreshExistingManifestList(context, table_metadata);
+	}
 }
 
 IcebergTableInformation IcebergTableInformation::Copy(ClientContext &context) const {

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -610,9 +610,6 @@ void IcebergTableInformation::RefreshFromCatalog(ClientContext &context) {
 		auto &load_table_result = *cached_table_result->load_table_result;
 		InitializeFromLoadTableResult(load_table_result);
 	}
-	if (transaction_data) {
-		transaction_data->RefreshExistingManifestList(context, table_metadata);
-	}
 }
 
 IcebergTableInformation IcebergTableInformation::Copy(ClientContext &context) const {

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -213,6 +213,23 @@ static void CreateTableRequirements(DatabaseInstance &db, ClientContext &context
 	}
 }
 
+static int64_t GetCommitStartRowId(const IcebergTransactionData &transaction_data,
+                                   const IcebergTableMetadata &metadata) {
+	int64_t next_row_id = 0;
+	if (metadata.has_next_row_id) {
+		next_row_id = metadata.next_row_id;
+	}
+	for (const auto &manifest_list_entry : transaction_data.existing_manifest_list) {
+		const auto &manifest_file = manifest_list_entry.file;
+		if (manifest_file.content != IcebergManifestContentType::DATA || !manifest_file.has_first_row_id) {
+			continue;
+		}
+		next_row_id = MaxValue<int64_t>(next_row_id, manifest_file.first_row_id + manifest_file.added_rows_count +
+		                                                 manifest_file.existing_rows_count);
+	}
+	return next_row_id;
+}
+
 static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, IcebergTableInformation &table_info,
                                                       ClientContext &context) {
 	SingleTableStagedCommit info;
@@ -230,7 +247,7 @@ static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, Iceb
 	if (!transaction_data.alters.empty()) {
 		commit_state.manifests = transaction_data.existing_manifest_list;
 	}
-	commit_state.next_row_id = transaction_data.next_row_id;
+	commit_state.next_row_id = GetCommitStartRowId(transaction_data, metadata);
 	commit_state.latest_snapshot = current_snapshot;
 
 	for (auto &update : transaction_data.updates) {

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -156,86 +156,129 @@ static bool NeedsAssertSchemaId(const IcebergTransactionData &transaction_data,
 	return transaction_data.assert_schema_id;
 }
 
+namespace {
+
+struct SingleTableTransactionInfo {
+	rest_api_objects::CommitTableRequest request;
+	vector<string> created_metadata_files;
+	idx_t max_retries = 0;
+	bool retryable = false;
+};
+
+static void InitializeRetryInfo(const IcebergTransactionData &transaction_data, SingleTableTransactionInfo &info) {
+	info.retryable = transaction_data.SupportsAppendRetry();
+	if (!info.retryable) {
+		info.max_retries = 0;
+		return;
+	}
+	info.max_retries = NumericCast<idx_t>(transaction_data.GetCommitRetryCount());
+}
+
+static void CreateTableRequirements(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state,
+                                    const IcebergTransactionData &transaction_data,
+                                    const optional_ptr<const IcebergSnapshot> &current_snapshot) {
+	const bool has_assert_create = transaction_data.has_assert_create;
+	for (auto &requirement : transaction_data.requirements) {
+		requirement->CreateRequirement(db, context, commit_state);
+	}
+	if (!has_assert_create && NeedsAssertSchemaId(transaction_data, commit_state.table_info)) {
+		AssertCurrentSchemaIdRequirement requirement(commit_state.table_info);
+		requirement.current_schema_id = transaction_data.initial_schema_id;
+		requirement.CreateRequirement(db, context, commit_state);
+	}
+	if (!has_assert_create && commit_state.table_info.HasTransactionUpdates()) {
+		auto uuid_requirement = AssertTableUUIDRequirement(commit_state.table_info);
+		uuid_requirement.CreateRequirement(db, context, commit_state);
+	}
+	if (current_snapshot && !transaction_data.alters.empty()) {
+		commit_state.table_change.requirements.push_back(CreateAssertRefSnapshotIdRequirement(*current_snapshot));
+	} else if (!current_snapshot && !transaction_data.alters.empty() && !has_assert_create) {
+		commit_state.table_change.requirements.push_back(CreateAssertNoSnapshotRequirement());
+	}
+}
+
+static SingleTableTransactionInfo
+GetSingleTableTransactionInfo(DatabaseInstance &db, IcebergTableInformation &table_info, ClientContext &context) {
+	SingleTableTransactionInfo info;
+	IcebergCommitState commit_state(table_info, context);
+	auto &table_change = commit_state.table_change;
+	auto &schema = table_info.schema.Cast<IcebergSchemaEntry>();
+	table_change.identifier = rest_api_objects::TableIdentifier();
+	table_change.identifier->_namespace.value = schema.namespace_items;
+	table_change.identifier->name = table_info.name;
+
+	auto &metadata = commit_state.table_info.table_metadata;
+	auto current_snapshot = metadata.GetLatestSnapshot();
+	auto &transaction_data = *commit_state.table_info.transaction_data;
+	InitializeRetryInfo(transaction_data, info);
+	if (!transaction_data.alters.empty()) {
+		commit_state.manifests = transaction_data.existing_manifest_list;
+	}
+	commit_state.next_row_id = transaction_data.next_row_id;
+	commit_state.latest_snapshot = current_snapshot;
+
+	for (auto &update : transaction_data.updates) {
+		if (update->type == IcebergTableUpdateType::ADD_SNAPSHOT) {
+			auto &ic_table_entry = table_info.GetLatestSchema(context)->Cast<IcebergTableEntry>();
+			ic_table_entry.PrepareIcebergScanFromEntry(context);
+		}
+		update->CreateUpdate(db, context, commit_state);
+	}
+
+	CreateTableRequirements(db, context, commit_state, transaction_data, current_snapshot);
+
+	if (!transaction_data.alters.empty()) {
+		auto &snapshot = *commit_state.latest_snapshot;
+		auto set_snapshot_ref_update = CreateSetSnapshotRefUpdate(snapshot.snapshot_id);
+		commit_state.table_change.updates.push_back(std::move(set_snapshot_ref_update));
+	}
+
+	if (transaction_data.set_schema_id) {
+		SetCurrentSchema update(table_info);
+		update.CreateUpdate(db, context, commit_state);
+	}
+
+	info.created_metadata_files = std::move(commit_state.created_metadata_files);
+	info.request = std::move(table_change);
+	return info;
+}
+
+} // namespace
+
 TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactionAlterUpdate &alter_update,
                                                                ClientContext &context) {
 	TableTransactionInfo info;
 	auto &transaction = info.request;
+	bool all_retryable = true;
+	bool saw_table = false;
 	for (auto &updated_table : alter_update.updated_tables) {
 		auto &table_key = updated_table.first;
-
 		if (alter_update.committed_tables.count(table_key)) {
-			//! Table is already committed
+			//! Already committed
 			continue;
 		}
 		auto &table_info = updated_table.second;
 		if (!table_info.HasTransactionUpdates()) {
+			//! No changes to commit
 			continue;
 		}
-		IcebergCommitState commit_state(table_info, context);
-		auto &table_change = commit_state.table_change;
-		auto &schema = table_info.schema.Cast<IcebergSchemaEntry>();
-		table_change.identifier = rest_api_objects::TableIdentifier();
-		table_change.identifier->_namespace.value = schema.namespace_items;
-		table_change.identifier->name = table_info.name;
 
-		auto &metadata = commit_state.table_info.table_metadata;
-		auto current_snapshot = metadata.GetLatestSnapshot();
-		auto &transaction_data = *commit_state.table_info.transaction_data;
-		const bool has_assert_create = transaction_data.has_assert_create;
-		if (!transaction_data.alters.empty()) {
-			commit_state.manifests = transaction_data.existing_manifest_list;
-		}
-		commit_state.latest_snapshot = current_snapshot;
-
-		for (auto &update : transaction_data.updates) {
-			if (update->type == IcebergTableUpdateType::ADD_SNAPSHOT) {
-				// we need to recreate the keys in the current context.
-				auto &ic_table_entry = table_info.GetLatestSchema(context)->Cast<IcebergTableEntry>();
-				ic_table_entry.PrepareIcebergScanFromEntry(context);
-			}
-			update->CreateUpdate(db, context, commit_state);
-		}
-		for (auto &requirement : transaction_data.requirements) {
-			requirement->CreateRequirement(db, context, commit_state);
-		}
-		if (!has_assert_create && NeedsAssertSchemaId(transaction_data, table_info)) {
-			// Ensure schema is the same as current
-			AssertCurrentSchemaIdRequirement requirement(table_info);
-			requirement.current_schema_id = transaction_data.initial_schema_id;
-			requirement.CreateRequirement(db, context, commit_state);
-		}
-
-		if (!transaction_data.alters.empty()) {
-			auto &snapshot = *commit_state.latest_snapshot;
-			auto snapshot_id = snapshot.snapshot_id;
-			auto set_snapshot_ref_update = CreateSetSnapshotRefUpdate(snapshot_id);
-			commit_state.table_change.updates.push_back(std::move(set_snapshot_ref_update));
-		}
-
-		if (!has_assert_create && commit_state.table_info.HasTransactionUpdates()) {
-			// ensure table hasn't been swapped by another one with the same name
-			auto uuid_requirement = AssertTableUUIDRequirement(table_info);
-			uuid_requirement.CreateRequirement(db, context, commit_state);
-		}
-
-		if (current_snapshot && !transaction_data.alters.empty()) {
-			//! If any changes were made to the state of the table, we should assert that our parent snapshot has
-			//! not changed. We don't want to change the table location if someone has added a snapshot
-			commit_state.table_change.requirements.push_back(CreateAssertRefSnapshotIdRequirement(*current_snapshot));
-		} else if (!current_snapshot && !transaction_data.alters.empty() && !has_assert_create) {
-			//! If the table had no snapshots, is not created in this transaction, and has some kind of update
-			//! we should ensure no snapshots have been added in the meantime
-			commit_state.table_change.requirements.push_back(CreateAssertNoSnapshotRequirement());
-		}
-
-		if (transaction_data.set_schema_id) {
-			SetCurrentSchema update(table_info);
-			update.CreateUpdate(db, context, commit_state);
-		}
-
-		info.created_metadata_files.emplace(table_key, std::move(commit_state.created_metadata_files));
+		auto table_transaction_info = GetSingleTableTransactionInfo(db, table_info, context);
+		info.created_metadata_files.emplace(table_key, std::move(table_transaction_info.created_metadata_files));
 		info.table_requests.emplace(table_key, transaction.table_changes.size());
-		transaction.table_changes.push_back(std::move(table_change));
+		transaction.table_changes.push_back(std::move(table_transaction_info.request));
+
+		if (!saw_table) {
+			info.max_retries = table_transaction_info.max_retries;
+			saw_table = true;
+		} else {
+			info.max_retries = MinValue<idx_t>(info.max_retries, table_transaction_info.max_retries);
+		}
+		all_retryable = all_retryable && table_transaction_info.retryable;
+	}
+	info.retryable = saw_table && all_retryable;
+	if (!info.retryable) {
+		info.max_retries = 0;
 	}
 	return info;
 }
@@ -255,35 +298,6 @@ bool IcebergTransaction::CanUseMultiTableCommit(const IcebergTransactionAlterUpd
 		}
 	}
 	return true;
-}
-
-RetryCommitState IcebergTransaction::GetRetryCommitState(const IcebergTransactionAlterUpdate &alter_update) const {
-	RetryCommitState result;
-	bool saw_retryable_table = false;
-	for (const auto &entry : alter_update.updated_tables) {
-		if (alter_update.committed_tables.count(entry.first)) {
-			continue;
-		}
-		const auto &table_info = entry.second;
-		if (!table_info.transaction_data || !table_info.HasTransactionUpdates()) {
-			continue;
-		}
-		auto &transaction_data = *table_info.transaction_data;
-		if (!transaction_data.SupportsAppendRetry()) {
-			result.retryable = false;
-			result.max_retries = 0;
-			return result;
-		}
-		auto retry_count = transaction_data.GetCommitRetryCount();
-		if (!saw_retryable_table) {
-			result.max_retries = retry_count;
-			saw_retryable_table = true;
-		} else {
-			result.max_retries = MinValue<idx_t>(result.max_retries, NumericCast<idx_t>(retry_count));
-		}
-	}
-	result.retryable = saw_retryable_table;
-	return result;
 }
 
 void IcebergTransaction::CleanupMetadataFiles(ClientContext &context, const vector<string> &paths) {
@@ -327,12 +341,12 @@ void IcebergTransaction::RefreshRetryTables(IcebergTransactionAlterUpdate &alter
 	}
 }
 
-static bool CommitIsRetryable(const RetryCommitState &retry_state, const CommitResult &result, idx_t attempt) {
-	if (attempt >= retry_state.max_retries) {
+static bool CommitIsRetryable(bool retryable, idx_t max_retries, const CommitResult &result, idx_t attempt) {
+	if (attempt >= max_retries) {
 		//! We've reached the max amount of retries
 		return false;
 	}
-	if (!retry_state.retryable) {
+	if (!retryable) {
 		//! The operation isn't retryable in general
 		return false;
 	}
@@ -357,18 +371,6 @@ static case_insensitive_set_t GetRetryTableKeys(const TableTransactionInfo &tran
 		table_keys.insert(entry.first);
 	}
 	return table_keys;
-}
-
-static RetryCommitState GetSingleTableRetryCommitState(const IcebergTransactionAlterUpdate &alter_update,
-                                                       const string &table_key) {
-	RetryCommitState retry_state;
-	auto updated_table = alter_update.updated_tables.find(table_key);
-	if (updated_table == alter_update.updated_tables.end() || !updated_table->second.transaction_data) {
-		return retry_state;
-	}
-	retry_state.retryable = updated_table->second.transaction_data->SupportsAppendRetry();
-	retry_state.max_retries = NumericCast<idx_t>(updated_table->second.transaction_data->GetCommitRetryCount());
-	return retry_state;
 }
 
 void IcebergTransaction::Commit() {
@@ -480,7 +482,6 @@ void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate
 			return;
 		}
 
-		auto retry_state = GetRetryCommitState(alter_update);
 		std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
 		auto doc = doc_p.get();
 		auto root_object = CommitTransactionToJSON(doc, transaction_info.request);
@@ -495,7 +496,7 @@ void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate
 			return;
 		}
 		auto created_metadata_files = GetCreatedMetadataFiles(transaction_info);
-		if (!CommitIsRetryable(retry_state, result, attempt)) {
+		if (!CommitIsRetryable(transaction_info.retryable, transaction_info.max_retries, result, attempt)) {
 			result.Throw(catalog.GetBaseUrl().GetURLEncoded());
 		}
 		CleanupMetadataFiles(context, created_metadata_files);
@@ -507,32 +508,19 @@ void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate
 void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update,
                                                     ClientContext &context) {
 	D_ASSERT(catalog.supported_urls.count("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}"));
-	auto transaction_info = GetTransactionRequest(alter_update, context);
-	if (transaction_info.request.table_changes.empty()) {
-		alter_update.updated_tables.clear();
-		return;
-	}
-
-	vector<string> table_keys;
-	table_keys.reserve(transaction_info.table_requests.size());
-	for (const auto &entry : transaction_info.table_requests) {
-		table_keys.push_back(entry.first);
-	}
-
-	for (const auto &table_key : table_keys) {
+	for (auto &entry : alter_update.updated_tables) {
+		auto &table_key = entry.first;
 		for (idx_t attempt = 0;; attempt++) {
-			auto current_info = GetTransactionRequest(alter_update, context);
-			if (current_info.request.table_changes.empty()) {
-				alter_update.updated_tables.clear();
-				return;
+			if (alter_update.committed_tables.count(table_key)) {
+				break;
 			}
-
-			auto table_request_it = current_info.table_requests.find(table_key);
-			if (table_request_it == current_info.table_requests.end()) {
+			auto &table_info = entry.second;
+			if (!table_info.HasTransactionUpdates()) {
 				break;
 			}
 
-			auto &table_change = current_info.request.table_changes[table_request_it->second];
+			auto table_transaction_info = GetSingleTableTransactionInfo(db, table_info, context);
+			auto &table_change = table_transaction_info.request;
 			D_ASSERT(table_change.identifier);
 			auto &identifier = *table_change.identifier;
 			auto transaction_json = ConstructTableUpdateJSON(table_change);
@@ -543,12 +531,11 @@ void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdat
 				break;
 			}
 
-			auto retry_state = GetSingleTableRetryCommitState(alter_update, table_key);
-			auto created_metadata_files = GetCreatedMetadataFiles(current_info);
-			if (!CommitIsRetryable(retry_state, result, attempt)) {
+			if (!CommitIsRetryable(table_transaction_info.retryable, table_transaction_info.max_retries, result,
+			                       attempt)) {
 				result.Throw(catalog.GetBaseUrl().GetURLEncoded());
 			}
-			CleanupMetadataFiles(context, created_metadata_files);
+			CleanupMetadataFiles(context, table_transaction_info.created_metadata_files);
 			case_insensitive_set_t retry_tables;
 			retry_tables.insert(table_key);
 			RefreshRetryTables(alter_update, retry_tables, context);

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -299,7 +299,12 @@ void IcebergTransaction::CleanupMetadataFiles(ClientContext &context, const vect
 		if (!deleted.insert(path).second) {
 			continue;
 		}
-		(void)fs.TryRemoveFile(path);
+		if (fs.TryRemoveFile(path)) {
+			DUCKDB_LOG(context, IcebergLogType, "Iceberg Transaction Cleanup, deleted retry metadata file: '%s'", path);
+		} else {
+			DUCKDB_LOG(context, IcebergLogType,
+			           "Iceberg Transaction Cleanup, failed to delete retry metadata file: '%s'", path);
+		}
 	}
 }
 

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -158,20 +158,36 @@ static bool NeedsAssertSchemaId(const IcebergTransactionData &transaction_data,
 
 namespace {
 
-struct SingleTableTransactionInfo {
+struct SingleTableStagedCommit {
 	rest_api_objects::CommitTableRequest request;
 	vector<string> created_metadata_files;
-	idx_t max_retries = 0;
 	bool retryable = false;
 };
 
-static void InitializeRetryInfo(const IcebergTransactionData &transaction_data, SingleTableTransactionInfo &info) {
-	info.retryable = transaction_data.SupportsAppendRetry();
-	if (!info.retryable) {
-		info.max_retries = 0;
-		return;
+static idx_t GetMaxRetries(const IcebergTransactionData &transaction_data) {
+	return NumericCast<idx_t>(transaction_data.GetCommitRetryCount());
+}
+
+static idx_t GetMaxRetries(const IcebergTransactionAlterUpdate &alter_update) {
+	idx_t max_retries = 0;
+	bool saw_table = false;
+	for (const auto &entry : alter_update.updated_tables) {
+		if (alter_update.committed_tables.count(entry.first)) {
+			continue;
+		}
+		const auto &table_info = entry.second;
+		if (!table_info.transaction_data || !table_info.HasTransactionUpdates()) {
+			continue;
+		}
+		auto table_max_retries = GetMaxRetries(*table_info.transaction_data);
+		if (!saw_table) {
+			max_retries = table_max_retries;
+			saw_table = true;
+		} else {
+			max_retries = MinValue<idx_t>(max_retries, table_max_retries);
+		}
 	}
-	info.max_retries = NumericCast<idx_t>(transaction_data.GetCommitRetryCount());
+	return max_retries;
 }
 
 static void CreateTableRequirements(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state,
@@ -197,9 +213,9 @@ static void CreateTableRequirements(DatabaseInstance &db, ClientContext &context
 	}
 }
 
-static SingleTableTransactionInfo
-GetSingleTableTransactionInfo(DatabaseInstance &db, IcebergTableInformation &table_info, ClientContext &context) {
-	SingleTableTransactionInfo info;
+static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, IcebergTableInformation &table_info,
+                                                      ClientContext &context) {
+	SingleTableStagedCommit info;
 	IcebergCommitState commit_state(table_info, context);
 	auto &table_change = commit_state.table_change;
 	auto &schema = table_info.schema.Cast<IcebergSchemaEntry>();
@@ -210,7 +226,7 @@ GetSingleTableTransactionInfo(DatabaseInstance &db, IcebergTableInformation &tab
 	auto &metadata = commit_state.table_info.table_metadata;
 	auto current_snapshot = metadata.GetLatestSnapshot();
 	auto &transaction_data = *commit_state.table_info.transaction_data;
-	InitializeRetryInfo(transaction_data, info);
+	info.retryable = transaction_data.SupportsAppendRetry();
 	if (!transaction_data.alters.empty()) {
 		commit_state.manifests = transaction_data.existing_manifest_list;
 	}
@@ -263,23 +279,14 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 			continue;
 		}
 
-		auto table_transaction_info = GetSingleTableTransactionInfo(db, table_info, context);
+		auto table_transaction_info = StageSingleTableCommit(db, table_info, context);
 		info.created_metadata_files.emplace(table_key, std::move(table_transaction_info.created_metadata_files));
 		info.table_requests.emplace(table_key, transaction.table_changes.size());
 		transaction.table_changes.push_back(std::move(table_transaction_info.request));
-
-		if (!saw_table) {
-			info.max_retries = table_transaction_info.max_retries;
-			saw_table = true;
-		} else {
-			info.max_retries = MinValue<idx_t>(info.max_retries, table_transaction_info.max_retries);
-		}
+		saw_table = true;
 		all_retryable = all_retryable && table_transaction_info.retryable;
 	}
 	info.retryable = saw_table && all_retryable;
-	if (!info.retryable) {
-		info.max_retries = 0;
-	}
 	return info;
 }
 
@@ -475,6 +482,7 @@ void IcebergTransaction::DoTableRename(IcebergTransactionRenameUpdate &rename_up
 
 void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update,
                                                    ClientContext &context) {
+	const auto max_retries = GetMaxRetries(alter_update);
 	for (idx_t attempt = 0;; attempt++) {
 		auto transaction_info = GetTransactionRequest(alter_update, context);
 		if (transaction_info.request.table_changes.empty()) {
@@ -496,7 +504,7 @@ void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate
 			return;
 		}
 		auto created_metadata_files = GetCreatedMetadataFiles(transaction_info);
-		if (!CommitIsRetryable(transaction_info.retryable, transaction_info.max_retries, result, attempt)) {
+		if (!CommitIsRetryable(transaction_info.retryable, max_retries, result, attempt)) {
 			result.Throw(catalog.GetBaseUrl().GetURLEncoded());
 		}
 		CleanupMetadataFiles(context, created_metadata_files);
@@ -510,6 +518,8 @@ void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdat
 	D_ASSERT(catalog.supported_urls.count("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}"));
 	for (auto &entry : alter_update.updated_tables) {
 		auto &table_key = entry.first;
+		const auto max_retries =
+		    entry.second.transaction_data ? GetMaxRetries(*entry.second.transaction_data) : idx_t(0);
 		for (idx_t attempt = 0;; attempt++) {
 			if (alter_update.committed_tables.count(table_key)) {
 				break;
@@ -519,7 +529,7 @@ void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdat
 				break;
 			}
 
-			auto table_transaction_info = GetSingleTableTransactionInfo(db, table_info, context);
+			auto table_transaction_info = StageSingleTableCommit(db, table_info, context);
 			auto &table_change = table_transaction_info.request;
 			D_ASSERT(table_change.identifier);
 			auto &identifier = *table_change.identifier;
@@ -531,8 +541,7 @@ void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdat
 				break;
 			}
 
-			if (!CommitIsRetryable(table_transaction_info.retryable, table_transaction_info.max_retries, result,
-			                       attempt)) {
+			if (!CommitIsRetryable(table_transaction_info.retryable, max_retries, result, attempt)) {
 				result.Throw(catalog.GetBaseUrl().GetURLEncoded());
 			}
 			CleanupMetadataFiles(context, table_transaction_info.created_metadata_files);

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -213,23 +213,6 @@ static void CreateTableRequirements(DatabaseInstance &db, ClientContext &context
 	}
 }
 
-static int64_t GetCommitStartRowId(const IcebergTransactionData &transaction_data,
-                                   const IcebergTableMetadata &metadata) {
-	int64_t next_row_id = 0;
-	if (metadata.has_next_row_id) {
-		next_row_id = metadata.next_row_id;
-	}
-	for (const auto &manifest_list_entry : transaction_data.existing_manifest_list) {
-		const auto &manifest_file = manifest_list_entry.file;
-		if (manifest_file.content != IcebergManifestContentType::DATA || !manifest_file.has_first_row_id) {
-			continue;
-		}
-		next_row_id = MaxValue<int64_t>(next_row_id, manifest_file.first_row_id + manifest_file.added_rows_count +
-		                                                 manifest_file.existing_rows_count);
-	}
-	return next_row_id;
-}
-
 static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, IcebergTableInformation &table_info,
                                                       ClientContext &context) {
 	SingleTableStagedCommit info;
@@ -245,9 +228,8 @@ static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, Iceb
 	auto &transaction_data = *commit_state.table_info.transaction_data;
 	info.retryable = transaction_data.SupportsAppendRetry();
 	if (!transaction_data.alters.empty()) {
-		commit_state.manifests = transaction_data.existing_manifest_list;
+		commit_state.LoadExistingManifests(std::move(transaction_data.existing_manifest_list));
 	}
-	commit_state.next_row_id = GetCommitStartRowId(transaction_data, metadata);
 	commit_state.latest_snapshot = current_snapshot;
 
 	for (auto &update : transaction_data.updates) {

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -161,7 +161,9 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 	TableTransactionInfo info;
 	auto &transaction = info.request;
 	for (auto &updated_table : alter_update.updated_tables) {
-		if (alter_update.committed_tables.count(updated_table.first)) {
+		auto &table_key = updated_table.first;
+
+		if (alter_update.committed_tables.count(table_key)) {
 			//! Table is already committed
 			continue;
 		}
@@ -231,8 +233,8 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 			update.CreateUpdate(db, context, commit_state);
 		}
 
-		info.created_metadata_files.emplace(updated_table.first, std::move(commit_state.created_metadata_files));
-		info.table_requests.emplace(updated_table.first, transaction.table_changes.size());
+		info.created_metadata_files.emplace(table_key, std::move(commit_state.created_metadata_files));
+		info.table_requests.emplace(table_key, transaction.table_changes.size());
 		transaction.table_changes.push_back(std::move(table_change));
 	}
 	return info;
@@ -303,17 +305,19 @@ void IcebergTransaction::RefreshRetryTables(IcebergTransactionAlterUpdate &alter
 	}
 }
 
-bool IcebergTransaction::RetryCommittedTable(IcebergTransactionAlterUpdate &alter_update, const string &table_key,
-                                             idx_t attempt, const RetryCommitState &retry_state,
-                                             const CommitResult &result, const vector<string> &created_metadata_files,
-                                             ClientContext &context) {
-	if (!retry_state.retryable || !result.IsConflict() || attempt >= retry_state.max_retries) {
+static bool CommitIsRetryable(const RetryCommitState &retry_state, const CommitResult &result, idx_t attempt) {
+	if (attempt >= retry_state.max_retries) {
+		//! We've reached the max amount of retries
 		return false;
 	}
-	CleanupMetadataFiles(context, created_metadata_files);
-	case_insensitive_set_t retry_tables;
-	retry_tables.insert(table_key);
-	RefreshRetryTables(alter_update, retry_tables, context);
+	if (!retry_state.retryable) {
+		//! The operation isn't retryable in general
+		return false;
+	}
+	if (!result.IsConflict()) {
+		//! Only conflicts (409) are retryable
+		return false;
+	}
 	return true;
 }
 
@@ -407,19 +411,21 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 				}
 				break;
 			}
-			if (!retry_state.retryable || !result.IsConflict() || multi_attempt >= retry_state.max_retries) {
-				result.Throw(catalog.GetBaseUrl().GetURLEncoded());
-			}
 			vector<string> created_metadata_files;
 			for (const auto &entry : transaction_info.created_metadata_files) {
 				created_metadata_files.insert(created_metadata_files.end(), entry.second.begin(), entry.second.end());
 			}
-			CleanupMetadataFiles(context, created_metadata_files);
-			case_insensitive_set_t retry_tables;
-			for (const auto &entry : transaction_info.table_requests) {
-				retry_tables.insert(entry.first);
+			if (!CommitIsRetryable(retry_state, result, multi_attempt)) {
+				result.Throw(catalog.GetBaseUrl().GetURLEncoded());
 			}
-			RefreshRetryTables(alter_update, retry_tables, context);
+
+			CleanupMetadataFiles(context, created_metadata_files);
+			case_insensitive_set_t table_keys;
+			for (const auto &entry : transaction_info.table_requests) {
+				auto &table_key = entry.first;
+				table_keys.insert(table_key);
+			}
+			RefreshRetryTables(alter_update, table_keys, context);
 			multi_attempt++;
 			continue;
 		}
@@ -427,6 +433,7 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 		D_ASSERT(catalog.supported_urls.count("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}"));
 		bool rebuilt_requests = false;
 		for (auto &it : transaction_info.table_requests) {
+			auto &table_key = it.first;
 			auto &table_change = transaction.table_changes[it.second];
 			D_ASSERT(table_change.identifier);
 			auto &identifier = *table_change.identifier;
@@ -435,28 +442,32 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 			                                        transaction_json);
 			if (!result.Success()) {
 				RetryCommitState retry_state;
-				auto updated_table = alter_update.updated_tables.find(it.first);
+				auto updated_table = alter_update.updated_tables.find(table_key);
 				if (updated_table != alter_update.updated_tables.end() && updated_table->second.transaction_data) {
 					retry_state.retryable = updated_table->second.transaction_data->SupportsAppendRetry();
 					retry_state.max_retries =
 					    NumericCast<idx_t>(updated_table->second.transaction_data->GetCommitRetryCount());
 				}
-				auto attempt_it = single_table_attempts.find(it.first);
+				auto attempt_it = single_table_attempts.find(table_key);
 				idx_t attempt = attempt_it == single_table_attempts.end() ? 0 : attempt_it->second;
 				vector<string> created_metadata_files;
 				for (const auto &entry : transaction_info.created_metadata_files) {
 					created_metadata_files.insert(created_metadata_files.end(), entry.second.begin(),
 					                              entry.second.end());
 				}
-				if (!RetryCommittedTable(alter_update, it.first, attempt, retry_state, result, created_metadata_files,
-				                         context)) {
+				if (!CommitIsRetryable(retry_state, result, attempt)) {
 					result.Throw(catalog.GetBaseUrl().GetURLEncoded());
 				}
-				single_table_attempts[it.first] = attempt + 1;
+				CleanupMetadataFiles(context, created_metadata_files);
+				case_insensitive_set_t retry_tables;
+				retry_tables.insert(table_key);
+				RefreshRetryTables(alter_update, retry_tables, context);
+
+				single_table_attempts[table_key] = attempt + 1;
 				rebuilt_requests = true;
 				break;
 			}
-			alter_update.committed_tables.insert(it.first);
+			alter_update.committed_tables.insert(table_key);
 		}
 		if (!rebuilt_requests) {
 			break;
@@ -607,7 +618,7 @@ void IcebergTransaction::CleanupFiles() {
 		auto &alter_update = transaction_update->Cast<IcebergTransactionAlterUpdate>();
 		for (auto &up_table : alter_update.updated_tables) {
 			if (alter_update.committed_tables.count(up_table.first)) {
-				//! Successively committed, no need to roll back
+				//! Successfully committed, no need to roll back
 				continue;
 			}
 			auto &table = up_table.second;

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -181,7 +181,7 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 		auto &metadata = commit_state.table_info.table_metadata;
 		auto current_snapshot = metadata.GetLatestSnapshot();
 		auto &transaction_data = *commit_state.table_info.transaction_data;
-		bool has_assert_create = false;
+		const bool has_assert_create = transaction_data.has_assert_create;
 		if (!transaction_data.alters.empty()) {
 			commit_state.manifests = transaction_data.existing_manifest_list;
 		}
@@ -197,7 +197,6 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 		}
 		for (auto &requirement : transaction_data.requirements) {
 			requirement->CreateRequirement(db, context, commit_state);
-			has_assert_create |= requirement->type == IcebergTableRequirementType::ASSERT_CREATE;
 		}
 		if (!has_assert_create && NeedsAssertSchemaId(transaction_data, table_info)) {
 			// Ensure schema is the same as current
@@ -251,10 +250,8 @@ bool IcebergTransaction::CanUseMultiTableCommit(const IcebergTransactionAlterUpd
 		if (!table_info.transaction_data) {
 			continue;
 		}
-		for (const auto &requirement : table_info.transaction_data->requirements) {
-			if (requirement->type == IcebergTableRequirementType::ASSERT_CREATE) {
-				return false;
-			}
+		if (table_info.transaction_data->has_assert_create) {
+			return false;
 		}
 	}
 	return true;

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -505,18 +505,32 @@ void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate
 void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update,
                                                     ClientContext &context) {
 	D_ASSERT(catalog.supported_urls.count("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}"));
-	case_insensitive_map_t<idx_t> single_table_attempts;
-	while (true) {
-		auto transaction_info = GetTransactionRequest(alter_update, context);
-		if (transaction_info.request.table_changes.empty()) {
-			alter_update.updated_tables.clear();
-			return;
-		}
-		auto &transaction = transaction_info.request;
-		bool should_retry = false;
-		for (auto &it : transaction_info.table_requests) {
-			auto &table_key = it.first;
-			auto &table_change = transaction.table_changes[it.second];
+	auto transaction_info = GetTransactionRequest(alter_update, context);
+	if (transaction_info.request.table_changes.empty()) {
+		alter_update.updated_tables.clear();
+		return;
+	}
+
+	vector<string> table_keys;
+	table_keys.reserve(transaction_info.table_requests.size());
+	for (const auto &entry : transaction_info.table_requests) {
+		table_keys.push_back(entry.first);
+	}
+
+	for (const auto &table_key : table_keys) {
+		for (idx_t attempt = 0;; attempt++) {
+			auto current_info = GetTransactionRequest(alter_update, context);
+			if (current_info.request.table_changes.empty()) {
+				alter_update.updated_tables.clear();
+				return;
+			}
+
+			auto table_request_it = current_info.table_requests.find(table_key);
+			if (table_request_it == current_info.table_requests.end()) {
+				break;
+			}
+
+			auto &table_change = current_info.request.table_changes[table_request_it->second];
 			D_ASSERT(table_change.identifier);
 			auto &identifier = *table_change.identifier;
 			auto transaction_json = ConstructTableUpdateJSON(table_change);
@@ -524,13 +538,11 @@ void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdat
 			                                        transaction_json);
 			if (result.Success()) {
 				alter_update.committed_tables.insert(table_key);
-				continue;
+				break;
 			}
 
 			auto retry_state = GetSingleTableRetryCommitState(alter_update, table_key);
-			auto attempt_it = single_table_attempts.find(table_key);
-			idx_t attempt = attempt_it == single_table_attempts.end() ? 0 : attempt_it->second;
-			auto created_metadata_files = GetCreatedMetadataFiles(transaction_info);
+			auto created_metadata_files = GetCreatedMetadataFiles(current_info);
 			if (!CommitIsRetryable(retry_state, result, attempt)) {
 				result.Throw(catalog.GetBaseUrl().GetURLEncoded());
 			}
@@ -538,12 +550,6 @@ void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdat
 			case_insensitive_set_t retry_tables;
 			retry_tables.insert(table_key);
 			RefreshRetryTables(alter_update, retry_tables, context);
-			single_table_attempts[table_key] = attempt + 1;
-			should_retry = true;
-			break;
-		}
-		if (!should_retry) {
-			return;
 		}
 	}
 }

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -152,11 +152,8 @@ static rest_api_objects::TableUpdate CreateSetSnapshotRefUpdate(int64_t snapshot
 
 static bool NeedsAssertSchemaId(const IcebergTransactionData &transaction_data,
                                 const IcebergTableInformation &table_info) {
-	if (!transaction_data.assert_schema_id) {
-		return false;
-	}
-	auto &initial_schema_id = transaction_data.initial_schema_id;
-	return initial_schema_id != table_info.table_metadata.GetCurrentSchemaId();
+	(void)table_info;
+	return transaction_data.assert_schema_id;
 }
 
 TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactionAlterUpdate &alter_update,
@@ -234,10 +231,90 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 			update.CreateUpdate(db, context, commit_state);
 		}
 
+		info.created_metadata_files.emplace(updated_table.first, std::move(commit_state.created_metadata_files));
 		info.table_requests.emplace(updated_table.first, transaction.table_changes.size());
 		transaction.table_changes.push_back(std::move(table_change));
 	}
 	return info;
+}
+
+RetryCommitState IcebergTransaction::GetRetryCommitState(const IcebergTransactionAlterUpdate &alter_update) const {
+	RetryCommitState result;
+	bool saw_retryable_table = false;
+	for (const auto &entry : alter_update.updated_tables) {
+		if (alter_update.committed_tables.count(entry.first)) {
+			continue;
+		}
+		const auto &table_info = entry.second;
+		if (!table_info.transaction_data || !table_info.HasTransactionUpdates()) {
+			continue;
+		}
+		auto &transaction_data = *table_info.transaction_data;
+		if (!transaction_data.SupportsAppendRetry()) {
+			result.retryable = false;
+			result.max_retries = 0;
+			return result;
+		}
+		auto retry_count = transaction_data.GetCommitRetryCount();
+		if (!saw_retryable_table) {
+			result.max_retries = retry_count;
+			saw_retryable_table = true;
+		} else {
+			result.max_retries = MinValue<idx_t>(result.max_retries, NumericCast<idx_t>(retry_count));
+		}
+	}
+	result.retryable = saw_retryable_table;
+	return result;
+}
+
+void IcebergTransaction::CleanupMetadataFiles(ClientContext &context, const vector<string> &paths) {
+	if (!catalog.attach_options.remove_files_on_delete || paths.empty()) {
+		return;
+	}
+	auto &fs = FileSystem::GetFileSystem(context);
+	unordered_set<string> deleted;
+	for (const auto &path : paths) {
+		if (!deleted.insert(path).second) {
+			continue;
+		}
+		(void)fs.TryRemoveFile(path);
+	}
+}
+
+void IcebergTransaction::RefreshRetryTables(IcebergTransactionAlterUpdate &alter_update,
+                                            const case_insensitive_set_t &table_keys, ClientContext &context) {
+	for (const auto &table_key : table_keys) {
+		auto it = alter_update.updated_tables.find(table_key);
+		if (it == alter_update.updated_tables.end()) {
+			continue;
+		}
+		auto &table_info = it->second;
+		if (!table_info.transaction_data) {
+			continue;
+		}
+		if (!table_info.transaction_data->RetryStateMatches(table_info)) {
+			throw TransactionException("Table %s changed incompatibly while retrying commit", table_key);
+		}
+		table_info.RefreshFromCatalog(context);
+		if (!table_info.transaction_data->RetryStateMatches(table_info)) {
+			throw TransactionException("Table %s changed incompatibly while retrying commit", table_key);
+		}
+		SetLatestTableState(table_info, IcebergTableStatus::ALIVE);
+	}
+}
+
+bool IcebergTransaction::RetryCommittedTable(IcebergTransactionAlterUpdate &alter_update, const string &table_key,
+                                             idx_t attempt, const RetryCommitState &retry_state,
+                                             const CommitResult &result, const vector<string> &created_metadata_files,
+                                             ClientContext &context) {
+	if (!retry_state.retryable || !result.IsConflict() || attempt >= retry_state.max_retries) {
+		return false;
+	}
+	CleanupMetadataFiles(context, created_metadata_files);
+	case_insensitive_set_t retry_tables;
+	retry_tables.insert(table_key);
+	RefreshRetryTables(alter_update, retry_tables, context);
+	return true;
 }
 
 void IcebergTransaction::Commit() {
@@ -297,44 +374,95 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 	if (!alter_update.HasUpdates()) {
 		return;
 	}
-	auto transaction_info = GetTransactionRequest(alter_update, context);
-	auto &transaction = transaction_info.request;
+	idx_t multi_attempt = 0;
+	case_insensitive_map_t<idx_t> single_table_attempts;
+	while (true) {
+		auto transaction_info = GetTransactionRequest(alter_update, context);
+		auto &transaction = transaction_info.request;
 
-	// if there are no new tables, we can post to the transactions/commit endpoint
-	// otherwise we fall back to posting a commit for each table.
-	if (transaction.table_changes.empty()) {
-		alter_update.updated_tables.clear();
-		DropSecrets(context);
-		return;
-	}
-
-	const bool can_use_multi_table_commit = !transaction_info.has_assert_create &&
-	                                        !catalog.attach_options.disable_multi_table_commit &&
-	                                        catalog.supported_urls.count("POST /v1/{prefix}/transactions/commit");
-	if (can_use_multi_table_commit) {
-		// commit all transactions at once
-		std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
-		auto doc = doc_p.get();
-		auto root_object = CommitTransactionToJSON(doc, transaction);
-		yyjson_mut_doc_set_root(doc, root_object);
-
-		auto transaction_json = JsonDocToString(std::move(doc_p));
-		IRCAPI::CommitMultiTableUpdate(context, catalog, transaction_json);
-		for (auto &it : alter_update.updated_tables) {
-			alter_update.committed_tables.insert(it.first);
+		// if there are no new tables, we can post to the transactions/commit endpoint
+		// otherwise we fall back to posting a commit for each table.
+		if (transaction.table_changes.empty()) {
+			alter_update.updated_tables.clear();
+			DropSecrets(context);
+			return;
 		}
-	} else {
+
+		const bool can_use_multi_table_commit = !transaction_info.has_assert_create &&
+		                                        !catalog.attach_options.disable_multi_table_commit &&
+		                                        catalog.supported_urls.count("POST /v1/{prefix}/transactions/commit");
+		if (can_use_multi_table_commit) {
+			auto retry_state = GetRetryCommitState(alter_update);
+
+			std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
+			auto doc = doc_p.get();
+			auto root_object = CommitTransactionToJSON(doc, transaction);
+			yyjson_mut_doc_set_root(doc, root_object);
+
+			auto transaction_json = JsonDocToString(std::move(doc_p));
+			auto result = IRCAPI::CommitMultiTableUpdate(context, catalog, transaction_json);
+			if (result.Success()) {
+				for (auto &it : alter_update.updated_tables) {
+					alter_update.committed_tables.insert(it.first);
+				}
+				break;
+			}
+			if (!retry_state.retryable || !result.IsConflict() || multi_attempt >= retry_state.max_retries) {
+				result.Throw(catalog.GetBaseUrl().GetURLEncoded());
+			}
+			vector<string> created_metadata_files;
+			for (const auto &entry : transaction_info.created_metadata_files) {
+				created_metadata_files.insert(created_metadata_files.end(), entry.second.begin(), entry.second.end());
+			}
+			CleanupMetadataFiles(context, created_metadata_files);
+			case_insensitive_set_t retry_tables;
+			for (const auto &entry : transaction_info.table_requests) {
+				retry_tables.insert(entry.first);
+			}
+			RefreshRetryTables(alter_update, retry_tables, context);
+			multi_attempt++;
+			continue;
+		}
+
 		D_ASSERT(catalog.supported_urls.count("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}"));
-		// each table change will make a separate request
+		bool rebuilt_requests = false;
 		for (auto &it : transaction_info.table_requests) {
 			auto &table_change = transaction.table_changes[it.second];
 			D_ASSERT(table_change.identifier);
 			auto &identifier = *table_change.identifier;
 			auto transaction_json = ConstructTableUpdateJSON(table_change);
-			IRCAPI::CommitTableUpdate(context, catalog, identifier._namespace.value, identifier.name, transaction_json);
+			auto result = IRCAPI::CommitTableUpdate(context, catalog, identifier._namespace.value, identifier.name,
+			                                        transaction_json);
+			if (!result.Success()) {
+				RetryCommitState retry_state;
+				auto updated_table = alter_update.updated_tables.find(it.first);
+				if (updated_table != alter_update.updated_tables.end() && updated_table->second.transaction_data) {
+					retry_state.retryable = updated_table->second.transaction_data->SupportsAppendRetry();
+					retry_state.max_retries =
+					    NumericCast<idx_t>(updated_table->second.transaction_data->GetCommitRetryCount());
+				}
+				auto attempt_it = single_table_attempts.find(it.first);
+				idx_t attempt = attempt_it == single_table_attempts.end() ? 0 : attempt_it->second;
+				vector<string> created_metadata_files;
+				for (const auto &entry : transaction_info.created_metadata_files) {
+					created_metadata_files.insert(created_metadata_files.end(), entry.second.begin(),
+					                              entry.second.end());
+				}
+				if (!RetryCommittedTable(alter_update, it.first, attempt, retry_state, result, created_metadata_files,
+				                         context)) {
+					result.Throw(catalog.GetBaseUrl().GetURLEncoded());
+				}
+				single_table_attempts[it.first] = attempt + 1;
+				rebuilt_requests = true;
+				break;
+			}
 			alter_update.committed_tables.insert(it.first);
 		}
+		if (!rebuilt_requests) {
+			break;
+		}
 	}
+
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	if (ic_catalog.attach_options.max_table_staleness_micros.IsValid()) {
 		for (auto &it : alter_update.committed_tables) {

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -181,6 +181,7 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 		auto &metadata = commit_state.table_info.table_metadata;
 		auto current_snapshot = metadata.GetLatestSnapshot();
 		auto &transaction_data = *commit_state.table_info.transaction_data;
+		bool has_assert_create = false;
 		if (!transaction_data.alters.empty()) {
 			commit_state.manifests = transaction_data.existing_manifest_list;
 		}
@@ -196,9 +197,9 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 		}
 		for (auto &requirement : transaction_data.requirements) {
 			requirement->CreateRequirement(db, context, commit_state);
-			info.has_assert_create = requirement->type == IcebergTableRequirementType::ASSERT_CREATE;
+			has_assert_create |= requirement->type == IcebergTableRequirementType::ASSERT_CREATE;
 		}
-		if (!info.has_assert_create && NeedsAssertSchemaId(transaction_data, table_info)) {
+		if (!has_assert_create && NeedsAssertSchemaId(transaction_data, table_info)) {
 			// Ensure schema is the same as current
 			AssertCurrentSchemaIdRequirement requirement(table_info);
 			requirement.current_schema_id = transaction_data.initial_schema_id;
@@ -212,7 +213,7 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 			commit_state.table_change.updates.push_back(std::move(set_snapshot_ref_update));
 		}
 
-		if (!info.has_assert_create && commit_state.table_info.HasTransactionUpdates()) {
+		if (!has_assert_create && commit_state.table_info.HasTransactionUpdates()) {
 			// ensure table hasn't been swapped by another one with the same name
 			auto uuid_requirement = AssertTableUUIDRequirement(table_info);
 			uuid_requirement.CreateRequirement(db, context, commit_state);
@@ -222,7 +223,7 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 			//! If any changes were made to the state of the table, we should assert that our parent snapshot has
 			//! not changed. We don't want to change the table location if someone has added a snapshot
 			commit_state.table_change.requirements.push_back(CreateAssertRefSnapshotIdRequirement(*current_snapshot));
-		} else if (!current_snapshot && !transaction_data.alters.empty() && !info.has_assert_create) {
+		} else if (!current_snapshot && !transaction_data.alters.empty() && !has_assert_create) {
 			//! If the table had no snapshots, is not created in this transaction, and has some kind of update
 			//! we should ensure no snapshots have been added in the meantime
 			commit_state.table_change.requirements.push_back(CreateAssertNoSnapshotRequirement());
@@ -238,6 +239,25 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 		transaction.table_changes.push_back(std::move(table_change));
 	}
 	return info;
+}
+
+bool IcebergTransaction::CanUseMultiTableCommit(const IcebergTransactionAlterUpdate &alter_update) const {
+	if (catalog.attach_options.disable_multi_table_commit ||
+	    !catalog.supported_urls.count("POST /v1/{prefix}/transactions/commit")) {
+		return false;
+	}
+	for (const auto &entry : alter_update.updated_tables) {
+		const auto &table_info = entry.second;
+		if (!table_info.transaction_data) {
+			continue;
+		}
+		for (const auto &requirement : table_info.transaction_data->requirements) {
+			if (requirement->type == IcebergTableRequirementType::ASSERT_CREATE) {
+				return false;
+			}
+		}
+	}
+	return true;
 }
 
 RetryCommitState IcebergTransaction::GetRetryCommitState(const IcebergTransactionAlterUpdate &alter_update) const {
@@ -321,6 +341,34 @@ static bool CommitIsRetryable(const RetryCommitState &retry_state, const CommitR
 	return true;
 }
 
+static vector<string> GetCreatedMetadataFiles(const TableTransactionInfo &transaction_info) {
+	vector<string> created_metadata_files;
+	for (const auto &entry : transaction_info.created_metadata_files) {
+		created_metadata_files.insert(created_metadata_files.end(), entry.second.begin(), entry.second.end());
+	}
+	return created_metadata_files;
+}
+
+static case_insensitive_set_t GetRetryTableKeys(const TableTransactionInfo &transaction_info) {
+	case_insensitive_set_t table_keys;
+	for (const auto &entry : transaction_info.table_requests) {
+		table_keys.insert(entry.first);
+	}
+	return table_keys;
+}
+
+static RetryCommitState GetSingleTableRetryCommitState(const IcebergTransactionAlterUpdate &alter_update,
+                                                       const string &table_key) {
+	RetryCommitState retry_state;
+	auto updated_table = alter_update.updated_tables.find(table_key);
+	if (updated_table == alter_update.updated_tables.end() || !updated_table->second.transaction_data) {
+		return retry_state;
+	}
+	retry_state.retryable = updated_table->second.transaction_data->SupportsAppendRetry();
+	retry_state.max_retries = NumericCast<idx_t>(updated_table->second.transaction_data->GetCommitRetryCount());
+	return retry_state;
+}
+
 void IcebergTransaction::Commit() {
 	if (transaction_updates.empty() && created_schemas.empty() && deleted_schemas.empty() &&
 	    schema_property_updates.empty()) {
@@ -378,100 +426,10 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 	if (!alter_update.HasUpdates()) {
 		return;
 	}
-	idx_t multi_attempt = 0;
-	case_insensitive_map_t<idx_t> single_table_attempts;
-	while (true) {
-		auto transaction_info = GetTransactionRequest(alter_update, context);
-		auto &transaction = transaction_info.request;
-
-		// if there are no new tables, we can post to the transactions/commit endpoint
-		// otherwise we fall back to posting a commit for each table.
-		if (transaction.table_changes.empty()) {
-			alter_update.updated_tables.clear();
-			DropSecrets(context);
-			return;
-		}
-
-		const bool can_use_multi_table_commit = !transaction_info.has_assert_create &&
-		                                        !catalog.attach_options.disable_multi_table_commit &&
-		                                        catalog.supported_urls.count("POST /v1/{prefix}/transactions/commit");
-		if (can_use_multi_table_commit) {
-			auto retry_state = GetRetryCommitState(alter_update);
-
-			std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
-			auto doc = doc_p.get();
-			auto root_object = CommitTransactionToJSON(doc, transaction);
-			yyjson_mut_doc_set_root(doc, root_object);
-
-			auto transaction_json = JsonDocToString(std::move(doc_p));
-			auto result = IRCAPI::CommitMultiTableUpdate(context, catalog, transaction_json);
-			if (result.Success()) {
-				for (auto &it : alter_update.updated_tables) {
-					alter_update.committed_tables.insert(it.first);
-				}
-				break;
-			}
-			vector<string> created_metadata_files;
-			for (const auto &entry : transaction_info.created_metadata_files) {
-				created_metadata_files.insert(created_metadata_files.end(), entry.second.begin(), entry.second.end());
-			}
-			if (!CommitIsRetryable(retry_state, result, multi_attempt)) {
-				result.Throw(catalog.GetBaseUrl().GetURLEncoded());
-			}
-
-			CleanupMetadataFiles(context, created_metadata_files);
-			case_insensitive_set_t table_keys;
-			for (const auto &entry : transaction_info.table_requests) {
-				auto &table_key = entry.first;
-				table_keys.insert(table_key);
-			}
-			RefreshRetryTables(alter_update, table_keys, context);
-			multi_attempt++;
-			continue;
-		}
-
-		D_ASSERT(catalog.supported_urls.count("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}"));
-		bool rebuilt_requests = false;
-		for (auto &it : transaction_info.table_requests) {
-			auto &table_key = it.first;
-			auto &table_change = transaction.table_changes[it.second];
-			D_ASSERT(table_change.identifier);
-			auto &identifier = *table_change.identifier;
-			auto transaction_json = ConstructTableUpdateJSON(table_change);
-			auto result = IRCAPI::CommitTableUpdate(context, catalog, identifier._namespace.value, identifier.name,
-			                                        transaction_json);
-			if (!result.Success()) {
-				RetryCommitState retry_state;
-				auto updated_table = alter_update.updated_tables.find(table_key);
-				if (updated_table != alter_update.updated_tables.end() && updated_table->second.transaction_data) {
-					retry_state.retryable = updated_table->second.transaction_data->SupportsAppendRetry();
-					retry_state.max_retries =
-					    NumericCast<idx_t>(updated_table->second.transaction_data->GetCommitRetryCount());
-				}
-				auto attempt_it = single_table_attempts.find(table_key);
-				idx_t attempt = attempt_it == single_table_attempts.end() ? 0 : attempt_it->second;
-				vector<string> created_metadata_files;
-				for (const auto &entry : transaction_info.created_metadata_files) {
-					created_metadata_files.insert(created_metadata_files.end(), entry.second.begin(),
-					                              entry.second.end());
-				}
-				if (!CommitIsRetryable(retry_state, result, attempt)) {
-					result.Throw(catalog.GetBaseUrl().GetURLEncoded());
-				}
-				CleanupMetadataFiles(context, created_metadata_files);
-				case_insensitive_set_t retry_tables;
-				retry_tables.insert(table_key);
-				RefreshRetryTables(alter_update, retry_tables, context);
-
-				single_table_attempts[table_key] = attempt + 1;
-				rebuilt_requests = true;
-				break;
-			}
-			alter_update.committed_tables.insert(table_key);
-		}
-		if (!rebuilt_requests) {
-			break;
-		}
+	if (CanUseMultiTableCommit(alter_update)) {
+		DoMultiTableCommitUpdates(alter_update, context);
+	} else {
+		DoSingleTableCommitUpdates(alter_update, context);
 	}
 
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
@@ -508,6 +466,85 @@ void IcebergTransaction::DoTableRename(IcebergTransactionRenameUpdate &rename_up
 	schema.tables.CreateEntryInternal(guard, new_name, std::move(rename_update.new_table), old_version);
 	if (old_version) {
 		throw TransactionException("Table %s was already created by a different transaction!", new_name);
+	}
+}
+
+void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update,
+                                                   ClientContext &context) {
+	for (idx_t attempt = 0;; attempt++) {
+		auto transaction_info = GetTransactionRequest(alter_update, context);
+		if (transaction_info.request.table_changes.empty()) {
+			alter_update.updated_tables.clear();
+			return;
+		}
+
+		auto retry_state = GetRetryCommitState(alter_update);
+		std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
+		auto doc = doc_p.get();
+		auto root_object = CommitTransactionToJSON(doc, transaction_info.request);
+		yyjson_mut_doc_set_root(doc, root_object);
+
+		auto transaction_json = JsonDocToString(std::move(doc_p));
+		auto result = IRCAPI::CommitMultiTableUpdate(context, catalog, transaction_json);
+		if (result.Success()) {
+			for (auto &it : alter_update.updated_tables) {
+				alter_update.committed_tables.insert(it.first);
+			}
+			return;
+		}
+		auto created_metadata_files = GetCreatedMetadataFiles(transaction_info);
+		if (!CommitIsRetryable(retry_state, result, attempt)) {
+			result.Throw(catalog.GetBaseUrl().GetURLEncoded());
+		}
+		CleanupMetadataFiles(context, created_metadata_files);
+		auto table_keys = GetRetryTableKeys(transaction_info);
+		RefreshRetryTables(alter_update, table_keys, context);
+	}
+}
+
+void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update,
+                                                    ClientContext &context) {
+	D_ASSERT(catalog.supported_urls.count("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}"));
+	case_insensitive_map_t<idx_t> single_table_attempts;
+	while (true) {
+		auto transaction_info = GetTransactionRequest(alter_update, context);
+		if (transaction_info.request.table_changes.empty()) {
+			alter_update.updated_tables.clear();
+			return;
+		}
+		auto &transaction = transaction_info.request;
+		bool should_retry = false;
+		for (auto &it : transaction_info.table_requests) {
+			auto &table_key = it.first;
+			auto &table_change = transaction.table_changes[it.second];
+			D_ASSERT(table_change.identifier);
+			auto &identifier = *table_change.identifier;
+			auto transaction_json = ConstructTableUpdateJSON(table_change);
+			auto result = IRCAPI::CommitTableUpdate(context, catalog, identifier._namespace.value, identifier.name,
+			                                        transaction_json);
+			if (result.Success()) {
+				alter_update.committed_tables.insert(table_key);
+				continue;
+			}
+
+			auto retry_state = GetSingleTableRetryCommitState(alter_update, table_key);
+			auto attempt_it = single_table_attempts.find(table_key);
+			idx_t attempt = attempt_it == single_table_attempts.end() ? 0 : attempt_it->second;
+			auto created_metadata_files = GetCreatedMetadataFiles(transaction_info);
+			if (!CommitIsRetryable(retry_state, result, attempt)) {
+				result.Throw(catalog.GetBaseUrl().GetURLEncoded());
+			}
+			CleanupMetadataFiles(context, created_metadata_files);
+			case_insensitive_set_t retry_tables;
+			retry_tables.insert(table_key);
+			RefreshRetryTables(alter_update, retry_tables, context);
+			single_table_attempts[table_key] = attempt + 1;
+			should_retry = true;
+			break;
+		}
+		if (!should_retry) {
+			return;
+		}
 	}
 }
 

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -138,7 +138,12 @@ void IcebergTransactionData::CacheExistingManifestList(lock_guard<mutex> &guard,
 	if (!alters.empty()) {
 		return;
 	}
-	LoadExistingManifestList(context, metadata, existing_manifest_list, next_row_id);
+	int64_t loaded_next_row_id = 0;
+	if (metadata.has_next_row_id) {
+		loaded_next_row_id = metadata.next_row_id;
+	}
+	LoadExistingManifestList(context, metadata, existing_manifest_list, loaded_next_row_id);
+	next_row_id = loaded_next_row_id;
 }
 
 void IcebergTransactionData::RefreshExistingManifestList(ClientContext &context, const IcebergTableMetadata &metadata) {
@@ -152,7 +157,6 @@ void IcebergTransactionData::RefreshExistingManifestList(ClientContext &context,
 		refreshed_next_row_id = metadata.next_row_id;
 	}
 	LoadExistingManifestList(context, metadata, existing_manifest_list, refreshed_next_row_id);
-	next_row_id = refreshed_next_row_id;
 }
 
 void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -7,7 +7,6 @@
 #include "core/metadata/manifest/iceberg_manifest.hpp"
 #include "core/metadata/snapshot/iceberg_snapshot.hpp"
 #include "catalog/rest/iceberg_table_set.hpp"
-#include "catalog/rest/api/iceberg_add_snapshot.hpp"
 #include "catalog/rest/api/table_update.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
 #include "planning/metadata_io/avro/avro_scan.hpp"
@@ -18,10 +17,76 @@ namespace duckdb {
 
 IcebergTransactionData::IcebergTransactionData(ClientContext &context, const IcebergTableInformation &table_info)
     : context(context), table_info(table_info) {
+	initial_table_uuid = table_info.table_metadata.table_uuid;
 	if (table_info.table_metadata.has_next_row_id) {
 		next_row_id = table_info.table_metadata.next_row_id;
 	}
 	initial_schema_id = table_info.table_metadata.GetCurrentSchemaId();
+	initial_default_spec_id = table_info.table_metadata.default_spec_id;
+	if (table_info.table_metadata.HasSortOrder()) {
+		initial_default_sort_order_id = table_info.table_metadata.default_sort_order_id;
+	}
+}
+
+int64_t IcebergTransactionData::GetCommitRetryCount() const {
+	static constexpr const int64_t DEFAULT_RETRY_COUNT = 4;
+	auto it = table_info.table_metadata.table_properties.find("commit.retry.num-retries");
+	if (it == table_info.table_metadata.table_properties.end()) {
+		return DEFAULT_RETRY_COUNT;
+	}
+	int64_t result;
+	try {
+		size_t processed = 0;
+		result = std::stoll(it->second, &processed);
+		if (processed != it->second.size()) {
+			throw InvalidInputException(
+			    "Invalid value '%s' for table property 'commit.retry.num-retries': expected an integer", it->second);
+		}
+	} catch (std::exception &) {
+		throw InvalidInputException(
+		    "Invalid value '%s' for table property 'commit.retry.num-retries': expected an integer", it->second);
+	}
+	if (result < 0) {
+		throw InvalidInputException(
+		    "Invalid value '%s' for table property 'commit.retry.num-retries': expected a non-negative integer",
+		    it->second);
+	}
+	return result;
+}
+
+bool IcebergTransactionData::SupportsAppendRetry() const {
+	if (!requirements.empty() || set_schema_id) {
+		return false;
+	}
+	if (updates.empty()) {
+		return false;
+	}
+	for (auto &update : updates) {
+		if (!update->IsRetryable()) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool IcebergTransactionData::RetryStateMatches(const IcebergTableInformation &table) const {
+	if (table.table_metadata.table_uuid != initial_table_uuid) {
+		return false;
+	}
+	if (table.table_metadata.GetCurrentSchemaId() != initial_schema_id) {
+		return false;
+	}
+	if (table.table_metadata.default_spec_id != initial_default_spec_id) {
+		return false;
+	}
+	if (table.table_metadata.HasSortOrder() != initial_default_sort_order_id.IsValid()) {
+		return false;
+	}
+	if (table.table_metadata.HasSortOrder() &&
+	    table.table_metadata.default_sort_order_id.GetIndex() != initial_default_sort_order_id.GetIndex()) {
+		return false;
+	}
+	return true;
 }
 
 void IcebergTransactionData::CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata) {

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -146,19 +146,6 @@ void IcebergTransactionData::CacheExistingManifestList(lock_guard<mutex> &guard,
 	next_row_id = loaded_next_row_id;
 }
 
-void IcebergTransactionData::RefreshExistingManifestList(ClientContext &context, const IcebergTableMetadata &metadata) {
-	lock_guard<mutex> guard(lock);
-	if (alters.empty()) {
-		existing_manifest_list.clear();
-		return;
-	}
-	int64_t refreshed_next_row_id = 0;
-	if (metadata.has_next_row_id) {
-		refreshed_next_row_id = metadata.next_row_id;
-	}
-	LoadExistingManifestList(context, metadata, existing_manifest_list, refreshed_next_row_id);
-}
-
 void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
                                          vector<IcebergManifestEntry> &&data_files,
                                          IcebergManifestDeletes &&altered_manifests) {

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -245,6 +245,7 @@ void IcebergTransactionData::TableAssignUUID() {
 }
 
 void IcebergTransactionData::TableAddAssertCreate() {
+	has_assert_create = true;
 	requirements.push_back(make_uniq<AssertCreateRequirement>(table_info));
 }
 

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -152,6 +152,7 @@ void IcebergTransactionData::RefreshExistingManifestList(ClientContext &context,
 		refreshed_next_row_id = metadata.next_row_id;
 	}
 	LoadExistingManifestList(context, metadata, existing_manifest_list, refreshed_next_row_id);
+	next_row_id = refreshed_next_row_id;
 }
 
 void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -40,6 +40,7 @@ static void LoadExistingManifestList(ClientContext &context, const IcebergTableM
 		return;
 	}
 
+	//! Deal with upgraded tables, if the snapshot originated from V2
 	for (auto &manifest_list_entry : existing_manifest_list) {
 		auto &manifest_file = manifest_list_entry.file;
 		if (manifest_file.content != IcebergManifestContentType::DATA) {

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -15,6 +15,50 @@
 
 namespace duckdb {
 
+static void LoadExistingManifestList(ClientContext &context, const IcebergTableMetadata &metadata,
+                                     vector<IcebergManifestListEntry> &existing_manifest_list, int64_t &next_row_id) {
+	existing_manifest_list.clear();
+
+	auto current_snapshot = metadata.GetLatestSnapshot();
+	if (!current_snapshot) {
+		return;
+	}
+
+	IcebergSnapshotScanInfo snapshot_info;
+	snapshot_info.snapshot = current_snapshot;
+	snapshot_info.schema_id = metadata.GetCurrentSchemaId();
+
+	auto &manifest_list_path = current_snapshot->manifest_list;
+	auto scan =
+	    AvroScan::ScanManifestList(snapshot_info, metadata, context, manifest_list_path, existing_manifest_list);
+	auto manifest_list_reader = make_uniq<manifest_list::ManifestListReader>(*scan);
+	while (!manifest_list_reader->Finished()) {
+		manifest_list_reader->Read();
+	}
+
+	if (metadata.iceberg_version < 3) {
+		return;
+	}
+
+	for (auto &manifest_list_entry : existing_manifest_list) {
+		auto &manifest_file = manifest_list_entry.file;
+		if (manifest_file.content != IcebergManifestContentType::DATA) {
+			continue;
+		}
+		if (manifest_file.has_first_row_id) {
+			continue;
+		}
+		if (current_snapshot->has_first_row_id) {
+			throw InternalException("Table is corrupted, snapshot has 'first-row-id' but not all 'manifest_file' "
+			                        "entries have a 'first_row_id'");
+		}
+		manifest_file.has_first_row_id = true;
+		manifest_file.first_row_id = next_row_id;
+		next_row_id += manifest_file.added_rows_count;
+		next_row_id += manifest_file.existing_rows_count;
+	}
+}
+
 IcebergTransactionData::IcebergTransactionData(ClientContext &context, const IcebergTableInformation &table_info)
     : context(context), table_info(table_info) {
 	initial_table_uuid = table_info.table_metadata.table_uuid;
@@ -93,47 +137,20 @@ void IcebergTransactionData::CacheExistingManifestList(lock_guard<mutex> &guard,
 	if (!alters.empty()) {
 		return;
 	}
+	LoadExistingManifestList(context, metadata, existing_manifest_list, next_row_id);
+}
 
-	auto current_snapshot = metadata.GetLatestSnapshot();
-	if (!current_snapshot) {
+void IcebergTransactionData::RefreshExistingManifestList(ClientContext &context, const IcebergTableMetadata &metadata) {
+	lock_guard<mutex> guard(lock);
+	if (alters.empty()) {
+		existing_manifest_list.clear();
 		return;
 	}
-
-	IcebergSnapshotScanInfo snapshot_info;
-	snapshot_info.snapshot = current_snapshot;
-	snapshot_info.schema_id = metadata.GetCurrentSchemaId();
-
-	auto &manifest_list_path = current_snapshot->manifest_list;
-	//! Read the manifest list
-	auto scan =
-	    AvroScan::ScanManifestList(snapshot_info, metadata, context, manifest_list_path, existing_manifest_list);
-	auto manifest_list_reader = make_uniq<manifest_list::ManifestListReader>(*scan);
-	while (!manifest_list_reader->Finished()) {
-		manifest_list_reader->Read();
+	int64_t refreshed_next_row_id = 0;
+	if (metadata.has_next_row_id) {
+		refreshed_next_row_id = metadata.next_row_id;
 	}
-
-	if (metadata.iceberg_version < 3) {
-		return;
-	}
-
-	//! Deal with upgraded tables, if the snapshot originated from V2
-	for (auto &manifest_list_entry : existing_manifest_list) {
-		auto &manifest_file = manifest_list_entry.file;
-		if (manifest_file.content != IcebergManifestContentType::DATA) {
-			continue;
-		}
-		if (manifest_file.has_first_row_id) {
-			continue;
-		}
-		if (current_snapshot->has_first_row_id) {
-			throw InternalException("Table is corrupted, snapshot has 'first-row-id' but not all 'manifest_file' "
-			                        "entries have a 'first_row_id'");
-		}
-		manifest_file.has_first_row_id = true;
-		manifest_file.first_row_id = next_row_id;
-		next_row_id += manifest_file.added_rows_count;
-		next_row_id += manifest_file.existing_rows_count;
-	}
+	LoadExistingManifestList(context, metadata, existing_manifest_list, refreshed_next_row_id);
 }
 
 void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,

--- a/src/core/metadata/manifest/iceberg_manifest_list.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest_list.cpp
@@ -41,7 +41,7 @@ IcebergManifestListEntry IcebergManifestListEntry::CreateFromEntries(FileSystem 
 	auto manifest_file_uuid = UUID::ToString(UUID::GenerateRandomUUID());
 	auto manifest_file_path = fs.JoinPath(table_metadata.GetMetadataPath(fs), manifest_file_uuid + "-m0.avro");
 
-	// Add a manifest list entry for the delete files
+	// Add a manifest list entry for the entries
 	IcebergManifestListEntry manifest_list_entry(manifest_file_path);
 	auto &manifest_file = manifest_list_entry.file;
 	manifest_file.manifest_path = manifest_file_path;

--- a/src/include/catalog/rest/api/catalog_api.hpp
+++ b/src/include/catalog/rest/api/catalog_api.hpp
@@ -3,6 +3,7 @@
 
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/optional.hpp"
+#include "duckdb/common/enums/http_status_code.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/parser/parsed_data/create_secret_info.hpp"
 
@@ -37,6 +38,28 @@ public:
 	optional<rest_api_objects::IcebergErrorResponse> error_;
 };
 
+class CommitResult {
+public:
+	CommitResult() {
+	}
+
+public:
+	bool Success() const {
+		return success;
+	}
+	bool IsConflict() const {
+		return status == HTTPStatusCode::Conflict_409;
+	}
+	void Throw(const string &url) const;
+
+public:
+	bool success = false;
+	HTTPStatusCode status = HTTPStatusCode::OK_200;
+	string reason;
+	string body;
+	optional<rest_api_objects::IcebergErrorResponse> error_;
+};
+
 class IRCAPI {
 public:
 	static const string API_VERSION_1;
@@ -56,12 +79,12 @@ public:
 	GetNamespace(ClientContext &context, IcebergCatalog &catalog, const IcebergSchemaEntry &schema);
 	static vector<IRCAPISchema> GetSchemas(ClientContext &context, IcebergCatalog &catalog,
 	                                       const vector<string> &parent);
-	static void CommitTableUpdate(ClientContext &context, IcebergCatalog &catalog, const vector<string> &schema,
-	                              const string &table_name, const string &body);
+	static CommitResult CommitTableUpdate(ClientContext &context, IcebergCatalog &catalog, const vector<string> &schema,
+	                                      const string &table_name, const string &body);
 	static void CommitTableDelete(ClientContext &context, IcebergCatalog &catalog, const vector<string> &schema,
 	                              const string &table_name);
 	static void CommitTableRename(ClientContext &context, IcebergCatalog &catalog, const string &body);
-	static void CommitMultiTableUpdate(ClientContext &context, IcebergCatalog &catalog, const string &body);
+	static CommitResult CommitMultiTableUpdate(ClientContext &context, IcebergCatalog &catalog, const string &body);
 	static void CommitNamespaceCreate(ClientContext &context, IcebergCatalog &catalog, string body);
 	static void CommitNamespaceDrop(ClientContext &context, IcebergCatalog &catalog,
 	                                const vector<string> &namespace_items);

--- a/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
+++ b/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
@@ -24,6 +24,7 @@ public:
 	                   IcebergSnapshotOperationType operation = IcebergSnapshotOperationType::OVERWRITE);
 
 public:
+	bool IsRetryable() const override;
 	void ConstructManifestList(IcebergManifestList &manifest_list, CopyFunction &avro_copy, DatabaseInstance &db,
 	                           IcebergCommitState &commit_state) const;
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;

--- a/src/include/catalog/rest/api/iceberg_table_update.hpp
+++ b/src/include/catalog/rest/api/iceberg_table_update.hpp
@@ -46,6 +46,7 @@ public:
 	int64_t next_row_id = 0;
 
 	ClientContext &context;
+	vector<string> created_metadata_files;
 
 	//! All the 'manifest_file' entries we will write to the new manifest list
 	vector<IcebergManifestListEntry> manifests;
@@ -60,6 +61,9 @@ public:
 
 public:
 	virtual void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const = 0;
+	virtual bool IsRetryable() const {
+		return false;
+	}
 
 public:
 	template <class TARGET>

--- a/src/include/catalog/rest/api/iceberg_table_update.hpp
+++ b/src/include/catalog/rest/api/iceberg_table_update.hpp
@@ -36,6 +36,7 @@ enum class IcebergTableUpdateType : uint8_t {
 struct IcebergCommitState {
 public:
 	IcebergCommitState(const IcebergTableInformation &table_info, ClientContext &context);
+	void RefreshFromTable();
 
 public:
 	const IcebergTableInformation &table_info;

--- a/src/include/catalog/rest/api/iceberg_table_update.hpp
+++ b/src/include/catalog/rest/api/iceberg_table_update.hpp
@@ -37,6 +37,7 @@ struct IcebergCommitState {
 public:
 	IcebergCommitState(const IcebergTableInformation &table_info, ClientContext &context);
 	void RefreshFromTable();
+	void LoadExistingManifests(vector<IcebergManifestListEntry> &&existing_manifests);
 
 public:
 	const IcebergTableInformation &table_info;

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -74,6 +74,7 @@ public:
 	bool HasTransactionUpdates() const;
 	void InitializeFromLoadTableResult(const rest_api_objects::LoadTableResult &load_table_result,
 	                                   bool initialize_schemas = true);
+	void RefreshFromCatalog(ClientContext &context);
 
 public:
 	IcebergCatalog &catalog;

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -113,9 +113,6 @@ private:
 	void CleanupMetadataFiles(ClientContext &context, const vector<string> &paths);
 	void RefreshRetryTables(IcebergTransactionAlterUpdate &alter_update, const case_insensitive_set_t &table_keys,
 	                        ClientContext &context);
-	bool RetryCommittedTable(IcebergTransactionAlterUpdate &alter_update, const string &table_key, idx_t attempt,
-	                         const RetryCommitState &retry_state, const CommitResult &result,
-	                         const vector<string> &created_metadata_files, ClientContext &context);
 	void CleanupFiles();
 
 private:

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -18,11 +18,22 @@ struct TableTransactionInfo {
 
 	rest_api_objects::CommitTransactionRequest request;
 	case_insensitive_map_t<idx_t> table_requests;
+	case_insensitive_map_t<vector<string>> created_metadata_files;
 
 	// if a table is created with assert create, we cannot use the
 	// transactions/commit endpoint. Instead we iterate through each table
 	// update and update each table individually
 	bool has_assert_create = false;
+};
+
+struct RetryCommitState {
+public:
+	RetryCommitState() {
+	}
+
+public:
+	idx_t max_retries = 0;
+	bool retryable = false;
 };
 
 enum class IcebergTableStatus : uint8_t { ALIVE, DROPPED, RENAMED, MISSING };
@@ -89,6 +100,7 @@ public:
 	IcebergCatalog &GetCatalog();
 	void DropSecrets(ClientContext &context);
 	TableTransactionInfo GetTransactionRequest(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
+	RetryCommitState GetRetryCommitState(const IcebergTransactionAlterUpdate &alter_update) const;
 	optional_ptr<IcebergTransactionTableState> GetLatestTableState(const string &table_key);
 	IcebergTransactionTableState &SetLatestTableState(IcebergTableInformation &table, IcebergTableStatus status);
 	IcebergTransactionTableState &SetLatestTableState(const string &table_key, IcebergTableStatus status);
@@ -98,6 +110,12 @@ public:
 	IcebergTableInformation &RenameTable(IcebergTableInformation &table, const string &new_name);
 
 private:
+	void CleanupMetadataFiles(ClientContext &context, const vector<string> &paths);
+	void RefreshRetryTables(IcebergTransactionAlterUpdate &alter_update, const case_insensitive_set_t &table_keys,
+	                        ClientContext &context);
+	bool RetryCommittedTable(IcebergTransactionAlterUpdate &alter_update, const string &table_key, idx_t attempt,
+	                         const RetryCommitState &retry_state, const CommitResult &result,
+	                         const vector<string> &created_metadata_files, ClientContext &context);
 	void CleanupFiles();
 
 private:

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -19,14 +19,6 @@ struct TableTransactionInfo {
 	rest_api_objects::CommitTransactionRequest request;
 	case_insensitive_map_t<idx_t> table_requests;
 	case_insensitive_map_t<vector<string>> created_metadata_files;
-};
-
-struct RetryCommitState {
-public:
-	RetryCommitState() {
-	}
-
-public:
 	idx_t max_retries = 0;
 	bool retryable = false;
 };
@@ -95,7 +87,6 @@ public:
 	IcebergCatalog &GetCatalog();
 	void DropSecrets(ClientContext &context);
 	TableTransactionInfo GetTransactionRequest(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
-	RetryCommitState GetRetryCommitState(const IcebergTransactionAlterUpdate &alter_update) const;
 	void DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
 	void DoSingleTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
 	optional_ptr<IcebergTransactionTableState> GetLatestTableState(const string &table_key);

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -19,11 +19,6 @@ struct TableTransactionInfo {
 	rest_api_objects::CommitTransactionRequest request;
 	case_insensitive_map_t<idx_t> table_requests;
 	case_insensitive_map_t<vector<string>> created_metadata_files;
-
-	// if a table is created with assert create, we cannot use the
-	// transactions/commit endpoint. Instead we iterate through each table
-	// update and update each table individually
-	bool has_assert_create = false;
 };
 
 struct RetryCommitState {
@@ -101,6 +96,8 @@ public:
 	void DropSecrets(ClientContext &context);
 	TableTransactionInfo GetTransactionRequest(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
 	RetryCommitState GetRetryCommitState(const IcebergTransactionAlterUpdate &alter_update) const;
+	void DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
+	void DoSingleTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
 	optional_ptr<IcebergTransactionTableState> GetLatestTableState(const string &table_key);
 	IcebergTransactionTableState &SetLatestTableState(IcebergTableInformation &table, IcebergTableStatus status);
 	IcebergTransactionTableState &SetLatestTableState(const string &table_key, IcebergTableStatus status);
@@ -110,6 +107,7 @@ public:
 	IcebergTableInformation &RenameTable(IcebergTableInformation &table, const string &new_name);
 
 private:
+	bool CanUseMultiTableCommit(const IcebergTransactionAlterUpdate &alter_update) const;
 	void CleanupMetadataFiles(ClientContext &context, const vector<string> &paths);
 	void RefreshRetryTables(IcebergTransactionAlterUpdate &alter_update, const case_insensitive_set_t &table_keys,
 	                        ClientContext &context);

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -19,7 +19,6 @@ struct TableTransactionInfo {
 	rest_api_objects::CommitTransactionRequest request;
 	case_insensitive_map_t<idx_t> table_requests;
 	case_insensitive_map_t<vector<string>> created_metadata_files;
-	idx_t max_retries = 0;
 	bool retryable = false;
 };
 

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -24,6 +24,10 @@ public:
 	IcebergTransactionData(ClientContext &context, const IcebergTableInformation &table_info);
 
 public:
+	int64_t GetCommitRetryCount() const;
+	bool SupportsAppendRetry() const;
+	bool RetryStateMatches(const IcebergTableInformation &table_info) const;
+
 	void AddSnapshot(IcebergSnapshotOperationType operation, vector<IcebergManifestEntry> &&data_files,
 	                 IcebergManifestDeletes &&altered_manifests);
 	void AddUpdateSnapshot(vector<IcebergManifestEntry> &&delete_files, vector<IcebergManifestEntry> &&data_files,
@@ -51,7 +55,10 @@ private:
 	void CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata);
 
 public:
+	string initial_table_uuid;
 	int32_t initial_schema_id;
+	int32_t initial_default_spec_id = 0;
+	optional_idx initial_default_sort_order_id;
 
 	ClientContext &context;
 	const IcebergTableInformation &table_info;

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -27,7 +27,6 @@ public:
 	int64_t GetCommitRetryCount() const;
 	bool SupportsAppendRetry() const;
 	bool RetryStateMatches(const IcebergTableInformation &table_info) const;
-	void RefreshExistingManifestList(ClientContext &context, const IcebergTableMetadata &metadata);
 
 	void AddSnapshot(IcebergSnapshotOperationType operation, vector<IcebergManifestEntry> &&data_files,
 	                 IcebergManifestDeletes &&altered_manifests);

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -27,6 +27,7 @@ public:
 	int64_t GetCommitRetryCount() const;
 	bool SupportsAppendRetry() const;
 	bool RetryStateMatches(const IcebergTableInformation &table_info) const;
+	void RefreshExistingManifestList(ClientContext &context, const IcebergTableMetadata &metadata);
 
 	void AddSnapshot(IcebergSnapshotOperationType operation, vector<IcebergManifestEntry> &&data_files,
 	                 IcebergManifestDeletes &&altered_manifests);

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -78,6 +78,8 @@ public:
 
 	//! If we perform an update that relies on the current schema id staying unchanged
 	bool assert_schema_id = false;
+	//! Whether this transaction explicitly requires the table to be newly created.
+	bool has_assert_create = false;
 	//! Whether the current schema of the table should be updated
 	bool set_schema_id = false;
 	mutex lock;

--- a/test/configs/nessie.json
+++ b/test/configs/nessie.json
@@ -104,6 +104,7 @@
       "paths": [
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_get_transaction_snapshot.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_one_update_one_snapshot.test",
+        "test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_transactional_deletes_not_retried.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_transaction_get_from_transaction_start.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_transactional_updates.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_transactional_updates_error_omits_stacktrace.test",

--- a/test/configs/nessie.json
+++ b/test/configs/nessie.json
@@ -32,6 +32,7 @@
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_deletion_vector_consolidation_commit.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/test_row_lineage_read_from_upgraded.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/test_row_lineage_write_after_upgrade.test",
+        "test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_append_retry_v3_row_lineage.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/test_basic_variant.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/update/partitions/update_v3_row_lineage.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/create/default/test_create_default_varchar.test",

--- a/test/python/test_insert_end_to_end.py
+++ b/test/python/test_insert_end_to_end.py
@@ -21,7 +21,8 @@ INSERT_TEST_SEED = SparkSeedTable(
     )
     TBLPROPERTIES (
         'format-version'='2',
-        'write.update.mode'='merge-on-read'
+        'write.update.mode'='merge-on-read',
+        'commit.retry.num-retries'='0'
     );
     """,
 )

--- a/test/sql/cloud/glue/test_insert_glue.test
+++ b/test/sql/cloud/glue/test_insert_glue.test
@@ -116,20 +116,18 @@ select * from my_datalake.test_inserts.basic_insert_test order by id;
 statement ok con2
 commit
 
-# The second commit failed because both transactions tried to add sequence number: 2
-# Invalid Configuration Error: Request to 'http://127.0.0.1:8181/v1/transactions/commit' returned a non-200 status code
-statement error con1
+# The second commit refreshes and retries against con2's snapshot
+statement ok con1
 commit
-----
-<REGEX>:.*TransactionContext Error.*
 
-# we see the con2 update
+# we see both updates
 query IIII
 select * from my_datalake.test_inserts.basic_insert_test order by id;
 ----
 1	Alice	Smith	1990-01-01
 2	Bob	Jones	1985-06-15
 3	Charlie	Brown	2000-12-31
+8	mr.scroog	bitlane	2010-06-11
 10	duckman	byteway	2010-06-11
 
 # Insert multiple times into the same table in the same transaction
@@ -170,4 +168,3 @@ select * from my_datalake.test_inserts.basic_insert_test order by id;
 15	mr.scroog	bitlane	2010-06-11
 16	mr.Goose	ponder	2010-06-11
 17	ms.Swan	lakeway	2010-06-11
-

--- a/test/sql/cloud/r2_catalog/test_r2_inserts.test
+++ b/test/sql/cloud/r2_catalog/test_r2_inserts.test
@@ -113,20 +113,18 @@ select * from my_datalake.test_inserts.basic_insert_test order by id;
 statement ok con2
 commit
 
-# The second commit failed because both transactions tried to add sequence number: 2
-# Invalid Configuration Error: Request to 'http://127.0.0.1:8181/v1/transactions/commit' returned a non-200 status code
-statement error con1
+# The second commit refreshes and retries against con2's snapshot
+statement ok con1
 commit
-----
-<REGEX>:.*TransactionContext Error.*Branch.*main.*has changed.*
 
-# we see the con2 update
+# we see both updates
 query IIII
 select * from my_datalake.test_inserts.basic_insert_test order by id;
 ----
 1	Alice	Smith	1990-01-01
 2	Bob	Jones	1985-06-15
 3	Charlie	Brown	2000-12-31
+8	mr.scroog	bitlane	2010-06-11
 10	duckman	byteway	2010-06-11
 
 # Insert multiple times into the same table in the same transaction

--- a/test/sql/cloud/s3tables/test_insert_into_s3table.test
+++ b/test/sql/cloud/s3tables/test_insert_into_s3table.test
@@ -115,12 +115,9 @@ select * from s3_catalog.test_inserts.basic_insert_test order by id;
 statement ok con2
 commit
 
-# The second commit failed because both transactions tried to add sequence number: 2
-# Invalid Configuration Error: Request to 'http://127.0.0.1:8181/v1/transactions/commit' returned a non-200 status code
-statement error con1
+# The second commit refreshes and retries against con2's snapshot
+statement ok con1
 commit
-----
-<REGEX>:.*TransactionContext Error.*Conflict_409.*
 
 statement ok
 select 1;
@@ -134,13 +131,14 @@ select * from s3_catalog.test_inserts.basic_insert_test;
 statement ok
 select 1;
 
-# we see the con2 update
+# we see both updates
 query IIII
 select * from s3_catalog.test_inserts.basic_insert_test order by id;
 ----
 1	Alice	Smith	1990-01-01
 2	Bob	Jones	1985-06-15
 3	Charlie	Brown	2000-12-31
+8	mr.scroog	bitlane	2010-06-11
 10	duckman	byteway	2010-06-11
 
 # # wait a little bit

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/add_column/alter_add_column_warn_schema_mismatch.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/add_column/alter_add_column_warn_schema_mismatch.test
@@ -119,5 +119,8 @@ FROM my_datalake.default.alter_add_column_explicit_txn ORDER BY a;
 42
 43
 
-statement ok con2
+# COMMIT failed because the schema id is different from when the transaction started
+statement error con2
 commit;
+----
+<REGEX>:TransactionContext Error.*changed incompatibly while retrying commit.*

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/table_properties/test_upgrade_format_version_2_to_3.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/table_properties/test_upgrade_format_version_2_to_3.test
@@ -18,6 +18,9 @@ require core_functions
 set ignore_error_messages
 
 statement ok
+CREATE SCHEMA IF NOT EXISTS my_datalake.default;
+
+statement ok
 DROP TABLE IF EXISTS my_datalake.default.v2_to_v3_upgrade;
 
 # Create table explicitly as V2

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_append_retry_v3_row_lineage.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_append_retry_v3_row_lineage.test
@@ -1,0 +1,61 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_append_retry_v3_row_lineage.test
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+create schema if not exists my_datalake.default;
+
+statement ok
+drop table if exists my_datalake.default.append_retry_v3_row_lineage;
+
+statement ok
+create table my_datalake.default.append_retry_v3_row_lineage (
+	id int,
+	payload varchar
+) WITH (
+	'format-version' = 3
+);
+
+statement ok
+insert into my_datalake.default.append_retry_v3_row_lineage values
+	(0, 'base');
+
+statement ok con1
+begin
+
+statement ok con2
+begin
+
+statement ok con1
+insert into my_datalake.default.append_retry_v3_row_lineage values
+	(1, 'one');
+
+statement ok con2
+insert into my_datalake.default.append_retry_v3_row_lineage values
+	(2, 'two');
+
+statement ok con1
+commit
+
+statement ok con2
+commit
+
+query IIII
+select _last_updated_sequence_number, _row_id, id, payload
+from my_datalake.default.append_retry_v3_row_lineage
+order by _row_id;
+----
+1	0	0	base
+2	1	1	one
+3	2	2	two

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_concurrent_insert_new_table.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_concurrent_insert_new_table.test
@@ -40,16 +40,15 @@ INSERT INTO my_datalake.default.concurrent_new_table_test VALUES (2, 'con2');
 statement ok con2
 commit
 
-# con1 should fail because con2 already added a snapshot
-statement error con1
+# con1 refreshes and retries against the snapshot con2 created
+statement ok con1
 commit
-----
-<REGEX>:.*TransactionContext Error.*Conflict_409.*
 
-# only con2's data is in the table
+# both rows are committed
 query II
 SELECT * FROM my_datalake.default.concurrent_new_table_test ORDER BY id;
 ----
+1	con1
 2	con2
 
 statement ok

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_multiple_transactions.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_multiple_transactions.test
@@ -28,11 +28,15 @@ statement ok
 drop table if exists my_datalake.default.multi_transaction_insert;
 
 statement ok
-create table my_datalake.default.multi_transaction_insert (a int, b int);
+create table my_datalake.default.multi_transaction_insert (
+	a int,
+	b int
+);
 
 # make sure the table has a snapshot id to start
 statement ok
-insert into my_datalake.default.multi_transaction_insert select 0, 0;
+insert into my_datalake.default.multi_transaction_insert VALUES
+	(0, 0);
 
 # Perform an insert into the same table from two separate transactions
 
@@ -43,10 +47,12 @@ statement ok con2
 begin
 
 statement ok con1
-insert into my_datalake.default.multi_transaction_insert select 1, 1;
+insert into my_datalake.default.multi_transaction_insert VALUES
+	(1, 1);
 
 statement ok con2
-insert into my_datalake.default.multi_transaction_insert select 2, 2;
+insert into my_datalake.default.multi_transaction_insert VALUES
+	(2, 2);
 
 statement ok con1
 commit

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_multiple_transactions.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_multiple_transactions.test
@@ -58,14 +58,13 @@ select * from my_datalake.default.multi_transaction_insert order by all;
 0	0
 2	2
 
-# The second commit failed because both transactions tried to add sequence number: 2
-statement error con2
+# The second commit refreshes and retries against the newer snapshot
+statement ok con2
 commit
-----
-<REGEX>:.*TransactionContext Error.*Conflict_409.*
 
 query II
-select * from my_datalake.default.multi_transaction_insert;
+select * from my_datalake.default.multi_transaction_insert order by all;
 ----
 0	0
 1	1
+2	2

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_multiple_transactions_retry_disabled.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_multiple_transactions_retry_disabled.test
@@ -1,0 +1,56 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_multiple_transactions_retry_disabled.test
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.multi_transaction_insert_retry_disabled;
+
+statement ok
+create table my_datalake.default.multi_transaction_insert_retry_disabled (a int, b int);
+
+statement ok
+insert into my_datalake.default.multi_transaction_insert_retry_disabled values (0, 0);
+
+statement ok
+CALL set_iceberg_table_properties(my_datalake.default.multi_transaction_insert_retry_disabled,
+    {
+    'commit.retry.num-retries' : '0'
+    }
+);
+
+statement ok con1
+begin
+
+statement ok con2
+begin
+
+statement ok con1
+insert into my_datalake.default.multi_transaction_insert_retry_disabled values (1, 1);
+
+statement ok con2
+insert into my_datalake.default.multi_transaction_insert_retry_disabled values (2, 2);
+
+statement ok con1
+commit
+
+statement error con2
+commit
+----
+<REGEX>:.*TransactionContext Error.*Conflict_409.*
+
+query II
+select * from my_datalake.default.multi_transaction_insert_retry_disabled order by all;
+----
+0	0
+1	1

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_append_retry_schema_conflict.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_append_retry_schema_conflict.test
@@ -1,0 +1,48 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_append_retry_schema_conflict.test
+# group: [transactions]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.append_retry_schema_conflict;
+
+statement ok
+create table my_datalake.default.append_retry_schema_conflict (a int);
+
+statement ok
+insert into my_datalake.default.append_retry_schema_conflict values (0);
+
+statement ok con1
+begin
+
+statement ok con2
+begin
+
+statement ok con1
+insert into my_datalake.default.append_retry_schema_conflict values (1);
+
+statement ok con2
+alter table my_datalake.default.append_retry_schema_conflict add column b int;
+
+statement ok con2
+commit
+
+statement error con1
+commit
+----
+<REGEX>:.*TransactionContext Error.*changed incompatibly while retrying commit.*
+
+query II
+select a, b from my_datalake.default.append_retry_schema_conflict order by a;
+----
+0	NULL

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_multi_table_commit_integrity.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_multi_table_commit_integrity.test
@@ -26,10 +26,16 @@ statement ok
 drop table if exists my_datalake.default.cleanup_tbl_{i};
 
 statement ok
-create table my_datalake.default.cleanup_tbl_{i} (id int, val varchar);
+create table my_datalake.default.cleanup_tbl_{i} (
+	id int,
+	val varchar
+) WITH (
+	'commit.retry.num-retries' = '0'
+);
 
 statement ok
-insert into my_datalake.default.cleanup_tbl_{i} values (0, 'seed');
+insert into my_datalake.default.cleanup_tbl_{i} values
+	(0, 'seed');
 
 endloop
 
@@ -47,22 +53,28 @@ begin
 loop i 0 20
 
 statement ok con1
-insert into my_datalake.default.cleanup_tbl_{i} values (1, 'from_con1');
+insert into my_datalake.default.cleanup_tbl_{i} values
+	(1, 'from_con1');
 
 endloop
 
 statement ok con1
-create table my_datalake.default.cleanup_new_tbl (id int, val varchar);
+create table my_datalake.default.cleanup_new_tbl (
+	id int,
+	val varchar
+);
 
 statement ok con1
-insert into my_datalake.default.cleanup_new_tbl values (1, 'from_con1');
+insert into my_datalake.default.cleanup_new_tbl values
+	(1, 'from_con1');
 
 # ---------------------------------------------------------------------------
 # con2: INSERT into tbl_10 to create a 409 conflict for con1
 # ---------------------------------------------------------------------------
 
 statement ok con2
-insert into my_datalake.default.cleanup_tbl_10 values (2, 'from_con2');
+insert into my_datalake.default.cleanup_tbl_10 values
+	(2, 'from_con2');
 
 # ---------------------------------------------------------------------------
 # con1: commit — per-table fallback loop.

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_transactional_deletes_not_retried.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_transactional_deletes_not_retried.test
@@ -1,0 +1,66 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_transactional_deletes_not_retried.test
+# group: [transactions]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.multi_transaction_delete;
+
+statement ok
+create table my_datalake.default.multi_transaction_delete (a int, b int);
+
+# Insert 0,0
+statement ok
+insert into my_datalake.default.multi_transaction_delete select 0, 0;
+
+statement ok con1
+begin
+
+statement ok con2
+begin
+
+# Insert 2,2
+statement ok con2
+insert into my_datalake.default.multi_transaction_delete select 2, 2;
+
+statement ok con2
+commit
+
+# con1 doesn't see 2,2 yet
+query II con1
+select * from my_datalake.default.multi_transaction_delete;
+----
+0	0
+
+# con1 deletes 0,0 from the old snapshot
+statement ok con1
+delete from my_datalake.default.multi_transaction_delete where a = 0;
+
+query I con1
+select count(*) from my_datalake.default.multi_transaction_delete;
+----
+0
+
+# NOTE: Delete isn't retried yet
+statement error con1
+commit;
+----
+<REGEX>:.*TransactionContext Error: Failed to commit:.*
+
+# con1 DELETE didn't go through
+query II
+select * from my_datalake.default.multi_transaction_delete order by all
+----
+0	0
+2	2

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_transactional_deletes_not_retried.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_transactional_deletes_not_retried.test
@@ -15,14 +15,21 @@ require httpfs
 set ignore_error_messages
 
 statement ok
+create schema if not exists my_datalake.default;
+
+statement ok
 drop table if exists my_datalake.default.multi_transaction_delete;
 
 statement ok
-create table my_datalake.default.multi_transaction_delete (a int, b int);
+create table my_datalake.default.multi_transaction_delete (
+	a int,
+	b int
+);
 
 # Insert 0,0
 statement ok
-insert into my_datalake.default.multi_transaction_delete select 0, 0;
+insert into my_datalake.default.multi_transaction_delete VALUES
+	(0, 0);
 
 statement ok con1
 begin
@@ -32,7 +39,8 @@ begin
 
 # Insert 2,2
 statement ok con2
-insert into my_datalake.default.multi_transaction_delete select 2, 2;
+insert into my_datalake.default.multi_transaction_delete VALUES
+	(2, 2);
 
 statement ok con2
 commit

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/test_polaris_concurrent_insert.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/test_polaris_concurrent_insert.test
@@ -21,7 +21,12 @@ statement ok
 DROP TABLE IF EXISTS my_datalake.default.concurrent_new_table_test;
 
 statement ok
-CREATE TABLE my_datalake.default.concurrent_new_table_test (id INTEGER, name VARCHAR);
+CREATE TABLE my_datalake.default.concurrent_new_table_test (
+	id INTEGER,
+	name VARCHAR
+) WITH (
+	'commit.retry.num-retries' = '0'
+);
 
 # con1 starts a transaction and inserts
 statement ok con1
@@ -73,7 +78,12 @@ statement ok
 DROP TABLE IF EXISTS my_datalake.default.concurrent_new_table_test;
 
 statement ok
-CREATE TABLE my_datalake.default.concurrent_new_table_test (id INTEGER, name VARCHAR);
+CREATE TABLE my_datalake.default.concurrent_new_table_test (
+	id INTEGER,
+	name VARCHAR
+) WITH (
+	'commit.retry.num-retries' = '0'
+)
 
 # con1 starts a transaction and inserts
 statement ok con1


### PR DESCRIPTION
This PR takes the first step towards implementing retries on COMMIT

This first step only enables INSERT operations to be retried.
Following the spec: https://iceberg.apache.org/spec/#commit-conflict-resolution-and-retry

> Append operations have no requirements and can always be applied.

### Summary of changes
- Changed failed commit API requests to not immediately throw, instead they now produce a `CommitResult` object
- Added virtual `IsRetryable` method to `IcebergTableUpdate`, defaulting to false, only implemented for `IcebergAddSnapshot` for now
- Separated `DoTableUpdates` logic into `DoSingleTableCommitUpdates` and `DoMultiTableCommitUpdates`, both apply retry logic now
- Added refreshing of metadata and saved initial properties in `IcebergTransactionData` to be able to identify unresolvable conflicts in the uuid, schema, partition spec id and sort order