### PR TITLE
Support write.manifest.compression-codec via native Avro CODEC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(EXTENSION_SOURCES
 	src/core/metadata/iceberg_table_metadata.cpp
 	src/core/metadata/manifest/iceberg_manifest_list.cpp
 	src/core/metadata/manifest/iceberg_manifest.cpp
+	src/core/metadata/manifest/iceberg_avro_codec.cpp
 	src/core/metadata/partition/iceberg_partition_spec.cpp
 	src/core/metadata/schema/iceberg_column_definition.cpp
 	src/core/metadata/schema/iceberg_field_mapping.cpp

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@ if (NOT EMSCRIPTEN)
   duckdb_extension_load(avro
   LOAD_TESTS
   GIT_URL https://github.com/duckdb/duckdb-avro
-  GIT_TAG 1e1055ffc25dde1e3be2ca3ff2ef6218f4a4467d
+  GIT_TAG 5f5f481d103497ac1907d7343a2ba2432fb4874e
   SUBMODULES "third_party/avro-c"
 )
 endif()

--- a/src/core/metadata/manifest/iceberg_avro_codec.cpp
+++ b/src/core/metadata/manifest/iceberg_avro_codec.cpp
@@ -1,0 +1,29 @@
+#include "core/metadata/manifest/iceberg_avro_codec.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+
+namespace duckdb {
+
+namespace iceberg_avro_codec {
+
+string ResolveAvroCodec(const string &property_value) {
+	if (property_value.empty()) {
+		return "deflate";
+	}
+	if (StringUtil::CIEquals(property_value, "gzip") || StringUtil::CIEquals(property_value, "deflate")) {
+		return "deflate";
+	}
+	if (StringUtil::CIEquals(property_value, "none") || StringUtil::CIEquals(property_value, "null") ||
+	    StringUtil::CIEquals(property_value, "uncompressed")) {
+		return "null";
+	}
+	throw NotImplementedException(
+	    "Unsupported value '%s' for 'write.manifest.compression-codec'; supported: 'gzip'/'deflate' and "
+	    "'none'/'uncompressed'",
+	    property_value);
+}
+
+} // namespace iceberg_avro_codec
+
+} // namespace duckdb

--- a/src/core/metadata/manifest/iceberg_manifest.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest.cpp
@@ -1,5 +1,6 @@
 #include "core/metadata/manifest/iceberg_manifest.hpp"
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
+#include "core/metadata/manifest/iceberg_avro_codec.hpp"
 
 #include "duckdb/storage/external_file_cache/caching_file_system.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
@@ -683,6 +684,14 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	copy_info.options["root_name"].push_back(Value("manifest_entry"));
 	copy_info.options["field_ids"].push_back(Value::STRUCT(field_ids));
 	copy_info.options["metadata"].push_back(metadata_map);
+
+	//! write.manifest.compression-codec: let the Avro COPY writer emit the codec natively.
+	//! "null" is the COPY default (uncompressed), so only set the option for a compressing codec.
+	auto avro_codec =
+	    iceberg_avro_codec::ResolveAvroCodec(table_metadata.GetTableProperty("write.manifest.compression-codec"));
+	if (!StringUtil::CIEquals(avro_codec, "null")) {
+		copy_info.options["codec"].push_back(Value(avro_codec));
+	}
 
 	CopyFunctionBindInput input(copy_info);
 	input.file_extension = "avro";

--- a/src/core/metadata/manifest/iceberg_manifest_list.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest_list.cpp
@@ -1,5 +1,7 @@
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
 
+#include "core/metadata/manifest/iceberg_avro_codec.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/exception/conversion_exception.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
@@ -455,6 +457,14 @@ void WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManife
 	copy_info.is_from = false;
 	copy_info.options["root_name"].push_back(Value("manifest_file"));
 	copy_info.options["field_ids"].push_back(Value::STRUCT(metadata.field_ids));
+
+	//! write.manifest.compression-codec: let the Avro COPY writer emit the codec natively.
+	//! "null" is the COPY default (uncompressed), so only set the option for a compressing codec.
+	auto avro_codec =
+	    iceberg_avro_codec::ResolveAvroCodec(table_metadata.GetTableProperty("write.manifest.compression-codec"));
+	if (!StringUtil::CIEquals(avro_codec, "null")) {
+		copy_info.options["codec"].push_back(Value(avro_codec));
+	}
 
 	CopyFunctionBindInput input(copy_info);
 	input.file_extension = "avro";

--- a/src/include/core/metadata/manifest/iceberg_avro_codec.hpp
+++ b/src/include/core/metadata/manifest/iceberg_avro_codec.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "duckdb/common/string.hpp"
+
+namespace duckdb {
+
+namespace iceberg_avro_codec {
+
+//! Map the `write.manifest.compression-codec` property to the Avro codec name to emit:
+//! ""/"gzip"/"deflate" -> "deflate" (Java default), "none"/"null"/"uncompressed" -> "null".
+//! Throws on any other value. The codec is validated again by the avro extension at write time.
+string ResolveAvroCodec(const string &property_value);
+
+} // namespace iceberg_avro_codec
+
+} // namespace duckdb

--- a/test/configs/nessie.json
+++ b/test/configs/nessie.json
@@ -22,6 +22,7 @@
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_deletion_vector_is_valid_puffin.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_to_v3_tables.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_transactional_insert_v3.test",
+        "test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression_v3.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/table_properties/test_many_table_properties.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/test_row_lineage_read.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/test_row_lineage_write.test",

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression.test
@@ -1,7 +1,8 @@
 # name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression.test
 # description: write.manifest.compression-codec - manifests are written with the configured Avro
-#              codec (default deflate, matching Java), applied natively by the Avro COPY writer.
 # group: [insert]
+
+#              codec (default deflate, matching Java), applied natively by the Avro COPY writer.
 
 require-env CATALOG_TEST_CONFIG_SETUP
 

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression.test
@@ -183,32 +183,3 @@ SELECT record_count FROM (SELECT unnest(data_file) FROM read_avro(getvariable('m
 
 statement ok
 drop table my_datalake.default.compress_bounds;
-
-# --- v3 table with compression ----------------------------------------------------------------
-statement ok
-drop table if exists my_datalake.default.compress_v3;
-
-statement ok
-create table my_datalake.default.compress_v3 (id INTEGER, data VARCHAR) WITH ('format-version' = 3, 'write.manifest.compression-codec' = 'deflate');
-
-statement ok
-insert into my_datalake.default.compress_v3 select i, 'v' from range(300) t(i);
-
-query I
-select count(*) from my_datalake.default.compress_v3;
-----
-300
-
-statement ok
-SET VARIABLE manifest_v3 = (
-	SELECT manifest_path FROM iceberg_metadata(my_datalake.default.compress_v3)
-	ORDER BY manifest_sequence_number DESC LIMIT 1
-);
-
-query I
-SELECT position('deflate' IN (content[1:60]::VARCHAR)) > 0 FROM read_blob(getvariable('manifest_v3'));
-----
-true
-
-statement ok
-drop table my_datalake.default.compress_v3;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression.test
@@ -1,0 +1,213 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression.test
+# description: write.manifest.compression-codec - manifests are written with the configured Avro
+#              codec (default deflate, matching Java), applied natively by the Avro COPY writer.
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+# --- Default codec (deflate): data round-trips correctly --------------------------------------
+statement ok
+drop table if exists my_datalake.default.compress_default;
+
+statement ok
+create table my_datalake.default.compress_default (id INTEGER, data VARCHAR);
+
+statement ok
+insert into my_datalake.default.compress_default select i, 'row_' || (i % 8)::VARCHAR from range(500) t(i);
+
+query II
+select count(*), sum(id) from my_datalake.default.compress_default;
+----
+500	124750
+
+# More inserts (more manifests) still read back correctly under the default compressing codec.
+statement ok
+insert into my_datalake.default.compress_default select i, 'x' from range(500, 1000) t(i);
+
+query II
+select count(*), sum(id) from my_datalake.default.compress_default;
+----
+1000	499500
+
+# Prove the manifest is actually deflate-compressed AND valid:
+#  - the Avro object-container header records avro.codec -> deflate (in the first bytes; the
+#    compressed data blocks that follow are not valid UTF-8, so we slice the header first), and
+#  - read_avro can decompress and read it back (it would fail if the codec were written wrong).
+statement ok
+SET VARIABLE manifest_default = (
+	SELECT manifest_path FROM iceberg_metadata(my_datalake.default.compress_default)
+	ORDER BY manifest_sequence_number DESC LIMIT 1
+);
+
+query II
+SELECT position('deflate' IN (content[1:60]::VARCHAR)) > 0, position('null' IN (content[1:60]::VARCHAR)) = 0
+FROM read_blob(getvariable('manifest_default'));
+----
+true	true
+
+query I
+SELECT count(*) > 0 FROM read_avro(getvariable('manifest_default'));
+----
+true
+
+statement ok
+drop table my_datalake.default.compress_default;
+
+# --- Explicit deflate -------------------------------------------------------------------------
+statement ok
+drop table if exists my_datalake.default.compress_deflate;
+
+statement ok
+create table my_datalake.default.compress_deflate (id INTEGER, data VARCHAR) WITH ('write.manifest.compression-codec' = 'deflate');
+
+statement ok
+insert into my_datalake.default.compress_deflate select i, 'v' from range(300) t(i);
+
+query I
+select count(*) from my_datalake.default.compress_deflate;
+----
+300
+
+statement ok
+drop table my_datalake.default.compress_deflate;
+
+# --- Uncompressed (none) ----------------------------------------------------------------------
+statement ok
+drop table if exists my_datalake.default.compress_none;
+
+statement ok
+create table my_datalake.default.compress_none (id INTEGER, data VARCHAR) WITH ('write.manifest.compression-codec' = 'none');
+
+statement ok
+insert into my_datalake.default.compress_none select i, 'v' from range(300) t(i);
+
+query I
+select count(*) from my_datalake.default.compress_none;
+----
+300
+
+# With 'none', the manifest is written uncompressed: the Avro header records avro.codec -> null and
+# there is no 'deflate' marker.
+statement ok
+SET VARIABLE manifest_none = (
+	SELECT manifest_path FROM iceberg_metadata(my_datalake.default.compress_none)
+	ORDER BY manifest_sequence_number DESC LIMIT 1
+);
+
+query II
+SELECT position('deflate' IN (content[1:60]::VARCHAR)) = 0, position('null' IN (content[1:60]::VARCHAR)) > 0
+FROM read_blob(getvariable('manifest_none'));
+----
+true	true
+
+statement ok
+drop table my_datalake.default.compress_none;
+
+# --- gzip alias resolves to the deflate Avro codec --------------------------------------------
+statement ok
+drop table if exists my_datalake.default.compress_gzip;
+
+statement ok
+create table my_datalake.default.compress_gzip (id INTEGER) WITH ('write.manifest.compression-codec' = 'gzip');
+
+statement ok
+insert into my_datalake.default.compress_gzip select i from range(300) t(i);
+
+query I
+select count(*) from my_datalake.default.compress_gzip;
+----
+300
+
+statement ok
+drop table my_datalake.default.compress_gzip;
+
+# --- Unsupported codec errors out -------------------------------------------------------------
+statement ok
+drop table if exists my_datalake.default.compress_bad;
+
+statement ok
+create table my_datalake.default.compress_bad (id INTEGER) WITH ('write.manifest.compression-codec' = 'bogus');
+
+statement error
+insert into my_datalake.default.compress_bad select i from range(10) t(i);
+----
+Unsupported value 'bogus' for 'write.manifest.compression-codec'
+
+statement ok
+drop table my_datalake.default.compress_bad;
+
+# --- Compression does not corrupt manifest statistics -----------------------------------------
+# The per-data-file statistics (lower/upper bounds, value/null counts) live inside the manifest.
+# Reading them back from a deflate-compressed manifest must yield the same complete, correct
+# values; i.e. decompression is transparent to the statistics readers.
+statement ok
+drop table if exists my_datalake.default.compress_bounds;
+
+statement ok
+create table my_datalake.default.compress_bounds (id INTEGER, val INTEGER) WITH ('write.manifest.compression-codec' = 'deflate');
+
+statement ok
+insert into my_datalake.default.compress_bounds select i, i * 10 from range(200) t(i);
+
+statement ok
+SET VARIABLE manifest_bounds = (
+	SELECT manifest_path FROM iceberg_metadata(my_datalake.default.compress_bounds)
+	ORDER BY manifest_sequence_number DESC LIMIT 1
+);
+
+# Both columns have lower- and upper-bound statistics recorded and readable from the compressed
+# manifest (two columns -> two bound entries each).
+query II
+SELECT
+  (SELECT count(*) FROM (SELECT unnest(map_keys(lower_bounds)) FROM (SELECT unnest(data_file) FROM read_avro(getvariable('manifest_bounds'))))),
+  (SELECT count(*) FROM (SELECT unnest(map_keys(upper_bounds)) FROM (SELECT unnest(data_file) FROM read_avro(getvariable('manifest_bounds')))));
+----
+2	2
+
+# Record counts survive too.
+query I
+SELECT record_count FROM (SELECT unnest(data_file) FROM read_avro(getvariable('manifest_bounds')));
+----
+200
+
+statement ok
+drop table my_datalake.default.compress_bounds;
+
+# --- v3 table with compression ----------------------------------------------------------------
+statement ok
+drop table if exists my_datalake.default.compress_v3;
+
+statement ok
+create table my_datalake.default.compress_v3 (id INTEGER, data VARCHAR) WITH ('format-version' = 3, 'write.manifest.compression-codec' = 'deflate');
+
+statement ok
+insert into my_datalake.default.compress_v3 select i, 'v' from range(300) t(i);
+
+query I
+select count(*) from my_datalake.default.compress_v3;
+----
+300
+
+statement ok
+SET VARIABLE manifest_v3 = (
+	SELECT manifest_path FROM iceberg_metadata(my_datalake.default.compress_v3)
+	ORDER BY manifest_sequence_number DESC LIMIT 1
+);
+
+query I
+SELECT position('deflate' IN (content[1:60]::VARCHAR)) > 0 FROM read_blob(getvariable('manifest_v3'));
+----
+true
+
+statement ok
+drop table my_datalake.default.compress_v3;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression_v3.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression_v3.test
@@ -1,6 +1,5 @@
 # name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression_v3.test
-# description: write.manifest.compression-codec on a format-version 3 table. Split from
-#              test_manifest_compression.test because not every catalog supports v3 (skipped there).
+# description: write.manifest.compression-codec on a format-version 3 table (split out; not every catalog supports v3)
 # group: [insert]
 
 require-env CATALOG_TEST_CONFIG_SETUP

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression_v3.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression_v3.test
@@ -1,0 +1,51 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_compression_v3.test
+# description: write.manifest.compression-codec on a format-version 3 table. Split from
+#              test_manifest_compression.test because not every catalog supports v3 (skipped there).
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.compress_v3;
+
+statement ok
+create table my_datalake.default.compress_v3 (id INTEGER, data VARCHAR) WITH ('format-version' = 3, 'write.manifest.compression-codec' = 'deflate');
+
+statement ok
+insert into my_datalake.default.compress_v3 select i, 'v' from range(300) t(i);
+
+query I
+select count(*) from my_datalake.default.compress_v3;
+----
+300
+
+# The v3 manifest is deflate-compressed: its Avro header records avro.codec -> deflate.
+statement ok
+SET VARIABLE manifest_v3 = (
+	SELECT manifest_path FROM iceberg_metadata(my_datalake.default.compress_v3)
+	ORDER BY manifest_sequence_number DESC LIMIT 1
+);
+
+query I
+SELECT position('deflate' IN (content[1:60]::VARCHAR)) > 0 FROM read_blob(getvariable('manifest_v3'));
+----
+true
+
+# And read_avro can decompress and read the v3 manifest back.
+query I
+SELECT count(*) > 0 FROM read_avro(getvariable('manifest_v3'));
+----
+true
+
+statement ok
+drop table my_datalake.default.compress_v3;


### PR DESCRIPTION
Rewrite of #1059, targeting `main` as suggested by @Tishj — now much smaller.

## What

Manifest and manifest-list files honor the `write.manifest.compression-codec` table property (default `deflate`, matching Java's `TableProperties` default).

## How

Instead of post-processing the written file, the codec is handed to the Avro COPY writer's `CODEC` option (duckdb/duckdb-avro#106), so the object container is compressed **natively in a single write** — no temp file, no recompression pass. This is the approach @Tishj asked for (do it in the Avro layer, communicate the codec through COPY).

- `ResolveAvroCodec` maps the property (`gzip`/`deflate` → `deflate`, `none`/`null`/`uncompressed` → `null`) and rejects unsupported values.
- `WriteToFile` (manifest + manifest-list) resolves the codec from the table metadata and sets the COPY `codec` option for a compressing codec; `null` is the COPY default so it is left unset. No call-site signature changes.
- Bumps `duckdb-avro` in `extension_config.cmake` to include the `CODEC` option (duckdb/duckdb-avro#106, merged).

## Testing

`test_manifest_compression.test` against the fixture REST catalog:
- default / explicit `deflate`, `none`, `gzip` alias, and an unsupported-codec error
- byte-level proof the manifest header records `avro.codec` (`deflate` vs `null`)
- `read_avro` round-trip of the compressed manifest
- per-data-file statistics (lower/upper bounds, record_count) read back intact from a compressed manifest

Verified locally that self-contained insert tests (big insert, counts, supplied columns, snapshot ops, transactional v3) all still pass with compression on, i.e. no regression in the write path. (The Spark-data-dependent tests need `make fixture-data`, which can't run here due to an unrelated local Python 3.14 / pydantic-core build issue.)

Supersedes #1059.