### PR TITLE
[Dev] Clean up relation between `IcebergTransactionData` and `IcebergTableInformation`

### DIFF
--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -17,7 +17,7 @@ namespace duckdb {
 
 IcebergAddSnapshot::IcebergAddSnapshot(const IcebergTableInformation &table_info,
                                        IcebergSnapshotOperationType operation)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SNAPSHOT, table_info), operation(operation) {
+    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SNAPSHOT), operation(operation) {
 	//! FIXME: Do we also need to capture the current partition spec and sort order?
 	//! This is a bit of a code smell, the `IcebergTableInformation` should instead be const
 	//! and all transactional changes should live in the IcebergTransactionData
@@ -165,8 +165,7 @@ static IcebergManifestListEntry WriteManifestListEntry(const IcebergTableInforma
 }
 
 static vector<IcebergManifestListEntry>
-CreateCommitManifestFiles(const vector<IcebergManifestListEntry> &manifest_files,
-                          const IcebergTableInformation &table_info, IcebergCommitState &commit_state,
+CreateCommitManifestFiles(const vector<IcebergManifestListEntry> &manifest_files, IcebergCommitState &commit_state,
                           int64_t snapshot_id, int64_t sequence_number) {
 	vector<IcebergManifestListEntry> result;
 	result.reserve(manifest_files.size());
@@ -175,7 +174,7 @@ CreateCommitManifestFiles(const vector<IcebergManifestListEntry> &manifest_files
 	for (const auto &manifest_entry : manifest_files) {
 		auto copied_entries = manifest_entry.manifest_entries;
 		auto copied_manifest = IcebergManifestListEntry::CreateFromEntries(
-		    fs, snapshot_id, sequence_number, table_info.table_metadata, manifest_entry.file.content,
+		    fs, snapshot_id, sequence_number, commit_state.table_info.table_metadata, manifest_entry.file.content,
 		    std::move(copied_entries), next_row_id);
 		result.push_back(std::move(copied_manifest));
 	}
@@ -195,7 +194,7 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 	const auto snapshot_id = IcebergSnapshot::NewSnapshotId();
 	const auto sequence_number = commit_state.next_sequence_number++;
 	auto uncommitted_manifest_files =
-	    CreateCommitManifestFiles(manifest_files, table_info, commit_state, snapshot_id, sequence_number);
+	    CreateCommitManifestFiles(manifest_files, commit_state, snapshot_id, sequence_number);
 	D_ASSERT(!uncommitted_manifest_files.empty());
 
 	auto &fs = FileSystem::GetFileSystem(context);
@@ -234,7 +233,8 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 		auto &manifest_file = manifest_list_entry.file;
 		new_snapshot.metrics.AddManifestFile(manifest_file);
 
-		auto new_manifest_list_entry = WriteManifestListEntry(table_info, manifest_list_entry, avro_copy, db, context);
+		auto new_manifest_list_entry =
+		    WriteManifestListEntry(commit_state.table_info, manifest_list_entry, avro_copy, db, context);
 		commit_state.created_metadata_files.push_back(new_manifest_list_entry.file.manifest_path);
 		new_manifest_list.AddNewManifestFile(std::move(new_manifest_list_entry));
 
@@ -255,7 +255,8 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 	commit_state.latest_snapshot = commit_state.created_snapshots.back();
 
 	//! Finally add a Iceberg REST Catalog 'TableUpdate' to commit
-	commit_state.table_change.updates.push_back(CreateAddSnapshotUpdate(table_info, *commit_state.latest_snapshot));
+	commit_state.table_change.updates.push_back(
+	    CreateAddSnapshotUpdate(commit_state.table_info, *commit_state.latest_snapshot));
 }
 
 void IcebergAddSnapshot::AddManifestFile(IcebergManifestListEntry &&manifest_file) {

--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -15,13 +15,10 @@
 
 namespace duckdb {
 
-IcebergAddSnapshot::IcebergAddSnapshot(const IcebergTableInformation &table_info,
+IcebergAddSnapshot::IcebergAddSnapshot(const IcebergTableMetadata &table_metadata,
                                        IcebergSnapshotOperationType operation)
     : IcebergTableUpdate(IcebergTableUpdateType::ADD_SNAPSHOT), operation(operation) {
-	//! FIXME: Do we also need to capture the current partition spec and sort order?
-	//! This is a bit of a code smell, the `IcebergTableInformation` should instead be const
-	//! and all transactional changes should live in the IcebergTransactionData
-	schema_id = table_info.table_metadata.GetCurrentSchemaId();
+	schema_id = table_metadata.GetCurrentSchemaId();
 }
 
 bool IcebergAddSnapshot::IsRetryable() const {

--- a/src/catalog/rest/api/iceberg_table_update.cpp
+++ b/src/catalog/rest/api/iceberg_table_update.cpp
@@ -69,8 +69,7 @@ void IcebergCommitState::LoadExistingManifests(vector<IcebergManifestListEntry> 
 	AssignManifestFirstRowIds(table_info.table_metadata, current_snapshot, manifests, next_row_id);
 }
 
-IcebergTableUpdate::IcebergTableUpdate(IcebergTableUpdateType type, const IcebergTableInformation &table_info)
-    : type(type), table_info(table_info) {
+IcebergTableUpdate::IcebergTableUpdate(IcebergTableUpdateType type) : type(type) {
 }
 
 } // namespace duckdb

--- a/src/catalog/rest/api/table_update.cpp
+++ b/src/catalog/rest/api/table_update.cpp
@@ -4,28 +4,24 @@
 
 namespace duckdb {
 
-static rest_api_objects::Schema CopySchema(const IcebergTableSchema &schema) {
-	// the rest api objects are currently not copyable. Without having to modify generated code
-	//  the easiest way to copy for now is to write the schema to string, then parse it again
+AddSchemaUpdate::AddSchemaUpdate(const IcebergTableInformation &table_info, const IcebergTableMetadata &table_metadata,
+                                 int32_t schema_id)
+    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA), schema_id(schema_id) {
+	if (table_metadata.HasLastColumnId()) {
+		last_column_id = table_metadata.GetLastColumnId();
+	}
+
+	auto &schemas = table_metadata.GetSchemas();
+	auto it = schemas.find(schema_id);
+	if (it == schemas.end()) {
+		throw InternalException("(AddSchemaUpdate) Couldn't find schema with id: %d", schema_id);
+	}
 	std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
 	yyjson_mut_doc *doc = doc_p.get();
 	auto root_object = yyjson_mut_obj(doc);
 	yyjson_mut_doc_set_root(doc, root_object);
-	IcebergCreateTableRequest::PopulateSchema(doc, root_object, schema);
-	auto schema_str = ICUtils::JsonToString(std::move(doc_p));
-
-	// Parse it back as immutable
-	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> new_doc(
-	    yyjson_read(schema_str.c_str(), strlen(schema_str.c_str()), 0));
-	yyjson_val *val = yyjson_doc_get_root(new_doc.get());
-	return rest_api_objects::Schema::FromJSON(val);
-}
-
-AddSchemaUpdate::AddSchemaUpdate(const IcebergTableInformation &table_info, int32_t schema_id)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA), schema_id(schema_id) {
-	if (table_info.table_metadata.HasLastColumnId()) {
-		last_column_id = table_info.table_metadata.GetLastColumnId();
-	}
+	IcebergCreateTableRequest::PopulateSchema(doc, root_object, *it->second);
+	schema_json = ICUtils::JsonToString(std::move(doc_p));
 }
 
 void AddSchemaUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -35,13 +31,9 @@ void AddSchemaUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 	update.add_schema_update = rest_api_objects::AddSchemaUpdate();
 	update.add_schema_update->base_update.action = "add-schema";
 
-	auto &schemas = commit_state.table_info.table_metadata.GetSchemas();
-	auto it = schemas.find(schema_id);
-	if (it == schemas.end()) {
-		throw InternalException("(AddSchemaUpdate) Couldn't find schema with id: %d", schema_id);
-	}
-	auto &schema = it->second;
-	update.add_schema_update->schema = CopySchema(*schema.get());
+	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> new_doc(yyjson_read(schema_json.c_str(), schema_json.size(), 0));
+	yyjson_val *val = yyjson_doc_get_root(new_doc.get());
+	update.add_schema_update->schema = rest_api_objects::Schema::FromJSON(val);
 	// last-column-id is technically deprecated in AddSchemaUpdate, but some catalogs still use it (nessie).
 	if (last_column_id.IsValid()) {
 		update.add_schema_update->last_column_id = last_column_id.GetIndex();

--- a/src/catalog/rest/api/table_update.cpp
+++ b/src/catalog/rest/api/table_update.cpp
@@ -4,18 +4,12 @@
 
 namespace duckdb {
 
-AddSchemaUpdate::AddSchemaUpdate(const IcebergTableMetadata &table_metadata, int32_t schema_id)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA), schema_id(schema_id) {
-	if (table_metadata.HasLastColumnId()) {
-		last_column_id = table_metadata.GetLastColumnId();
+AddSchemaUpdate::AddSchemaUpdate(shared_ptr<IcebergTableSchema> schema_p, optional_idx last_column_id_p)
+    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA), last_column_id(last_column_id_p),
+      schema(std::move(schema_p)) {
+	if (!schema) {
+		throw InternalException("(AddSchemaUpdate) Missing schema payload");
 	}
-
-	auto &schemas = table_metadata.GetSchemas();
-	auto it = schemas.find(schema_id);
-	if (it == schemas.end()) {
-		throw InternalException("(AddSchemaUpdate) Couldn't find schema with id: %d", schema_id);
-	}
-	schema = it->second;
 	std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
 	yyjson_mut_doc *doc = doc_p.get();
 	auto root_object = yyjson_mut_obj(doc);

--- a/src/catalog/rest/api/table_update.cpp
+++ b/src/catalog/rest/api/table_update.cpp
@@ -236,7 +236,7 @@ void SetProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context, I
 }
 
 RemoveProperties::RemoveProperties(const vector<string> &properties)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES), properties(properties) {
+    : IcebergTableUpdate(IcebergTableUpdateType::REMOVE_PROPERTIES), properties(properties) {
 }
 
 void RemoveProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context,

--- a/src/catalog/rest/api/table_update.cpp
+++ b/src/catalog/rest/api/table_update.cpp
@@ -22,7 +22,7 @@ static rest_api_objects::Schema CopySchema(const IcebergTableSchema &schema) {
 }
 
 AddSchemaUpdate::AddSchemaUpdate(const IcebergTableInformation &table_info, int32_t schema_id)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA, table_info), schema_id(schema_id) {
+    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA), schema_id(schema_id) {
 	if (table_info.table_metadata.HasLastColumnId()) {
 		last_column_id = table_info.table_metadata.GetLastColumnId();
 	}
@@ -35,7 +35,7 @@ void AddSchemaUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 	update.add_schema_update = rest_api_objects::AddSchemaUpdate();
 	update.add_schema_update->base_update.action = "add-schema";
 
-	auto &schemas = table_info.table_metadata.GetSchemas();
+	auto &schemas = commit_state.table_info.table_metadata.GetSchemas();
 	auto it = schemas.find(schema_id);
 	if (it == schemas.end()) {
 		throw InternalException("(AddSchemaUpdate) Couldn't find schema with id: %d", schema_id);
@@ -49,7 +49,7 @@ void AddSchemaUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 }
 
 AssignUUIDUpdate::AssignUUIDUpdate(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA, table_info) {
+    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA) {
 }
 
 void AssignUUIDUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -59,11 +59,11 @@ void AssignUUIDUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	update.assign_uuidupdate = rest_api_objects::AssignUUIDUpdate();
 	update.assign_uuidupdate->base_update.action = "assign-uuid";
 	// uuid most likely created by the rest catalog?
-	update.assign_uuidupdate->uuid = table_info.table_metadata.table_uuid;
+	update.assign_uuidupdate->uuid = commit_state.table_info.table_metadata.table_uuid;
 }
 
 AssertCreateRequirement::AssertCreateRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_CREATE, table_info) {
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_CREATE) {
 }
 
 void AssertCreateRequirement::CreateRequirement(DatabaseInstance &db, ClientContext &context,
@@ -75,7 +75,7 @@ void AssertCreateRequirement::CreateRequirement(DatabaseInstance &db, ClientCont
 }
 
 AssertTableUUIDRequirement::AssertTableUUIDRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_TABLE_UUID, table_info) {
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_TABLE_UUID) {
 }
 
 void AssertTableUUIDRequirement::CreateRequirement(DatabaseInstance &db, ClientContext &context,
@@ -88,7 +88,7 @@ void AssertTableUUIDRequirement::CreateRequirement(DatabaseInstance &db, ClientC
 }
 
 AssertCurrentSchemaIdRequirement::AssertCurrentSchemaIdRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_CURRENT_SCHEMA_ID, table_info) {
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_CURRENT_SCHEMA_ID) {
 	current_schema_id = table_info.table_metadata.GetCurrentSchemaId();
 }
 
@@ -102,7 +102,7 @@ void AssertCurrentSchemaIdRequirement::CreateRequirement(DatabaseInstance &db, C
 }
 
 AssertLastAssignedFieldIdRequirement::AssertLastAssignedFieldIdRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_FIELD_ID, table_info) {
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_FIELD_ID) {
 	D_ASSERT(table_info.table_metadata.HasLastColumnId());
 	last_assigned_field_id = static_cast<int32_t>(table_info.table_metadata.GetLastColumnId());
 }
@@ -118,7 +118,7 @@ void AssertLastAssignedFieldIdRequirement::CreateRequirement(DatabaseInstance &d
 
 AssertLastAssignedPartitionIdRequirement::AssertLastAssignedPartitionIdRequirement(
     const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_PARTITION_ID, table_info) {
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_PARTITION_ID) {
 	if (table_info.table_metadata.HasLastPartitionId()) {
 		last_assigned_partition_id = table_info.table_metadata.GetLastPartitionFieldId();
 	} else {
@@ -138,7 +138,7 @@ void AssertLastAssignedPartitionIdRequirement::CreateRequirement(DatabaseInstanc
 }
 
 AssertDefaultSpecIdRequirement::AssertDefaultSpecIdRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_DEFAULT_SPEC_ID, table_info) {
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_DEFAULT_SPEC_ID) {
 	default_spec_id = table_info.table_metadata.default_spec_id;
 }
 
@@ -152,7 +152,7 @@ void AssertDefaultSpecIdRequirement::CreateRequirement(DatabaseInstance &db, Cli
 }
 
 UpgradeFormatVersion::UpgradeFormatVersion(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::UPGRADE_FORMAT_VERSION, table_info) {
+    : IcebergTableUpdate(IcebergTableUpdateType::UPGRADE_FORMAT_VERSION) {
 }
 
 void UpgradeFormatVersion::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -161,11 +161,11 @@ void UpgradeFormatVersion::CreateUpdate(DatabaseInstance &db, ClientContext &con
 	auto &req = commit_state.table_change.updates.back();
 	req.upgrade_format_version_update = rest_api_objects::UpgradeFormatVersionUpdate();
 	req.upgrade_format_version_update->base_update.action = "upgrade-format-version";
-	req.upgrade_format_version_update->format_version = table_info.table_metadata.iceberg_version;
+	req.upgrade_format_version_update->format_version = commit_state.table_info.table_metadata.iceberg_version;
 }
 
 SetCurrentSchema::SetCurrentSchema(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_CURRENT_SCHEMA, table_info) {
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_CURRENT_SCHEMA) {
 }
 
 void SetCurrentSchema::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -175,11 +175,11 @@ void SetCurrentSchema::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	req.set_current_schema_update = rest_api_objects::SetCurrentSchemaUpdate();
 	req.set_current_schema_update->base_update.action = "set-current-schema";
 	// TODO: should this be a different value? or is the rest catalog setting this again?
-	req.set_current_schema_update->schema_id = table_info.table_metadata.GetCurrentSchemaId();
+	req.set_current_schema_update->schema_id = commit_state.table_info.table_metadata.GetCurrentSchemaId();
 }
 
 AddPartitionSpec::AddPartitionSpec(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_PARTITION_SPEC, table_info) {
+    : IcebergTableUpdate(IcebergTableUpdateType::ADD_PARTITION_SPEC) {
 }
 
 void AddPartitionSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -189,9 +189,9 @@ void AddPartitionSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	req.add_partition_spec_update = rest_api_objects::AddPartitionSpecUpdate();
 	req.add_partition_spec_update->base_update.action = "add-spec";
 	// need to get the spec id from table_info() so we can also check updated tables.
-	req.add_partition_spec_update->spec.spec_id = table_info.table_metadata.default_spec_id;
-	if (table_info.table_metadata.HasPartitionSpec()) {
-		auto &current_partition_spec = table_info.table_metadata.GetLatestPartitionSpec();
+	req.add_partition_spec_update->spec.spec_id = commit_state.table_info.table_metadata.default_spec_id;
+	if (commit_state.table_info.table_metadata.HasPartitionSpec()) {
+		auto &current_partition_spec = commit_state.table_info.table_metadata.GetLatestPartitionSpec();
 		for (auto &field : current_partition_spec.fields) {
 			req.add_partition_spec_update->spec.fields.push_back(rest_api_objects::PartitionField());
 			auto &updated_field = req.add_partition_spec_update->spec.fields.back();
@@ -204,7 +204,7 @@ void AddPartitionSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context
 }
 
 AddSortOrder::AddSortOrder(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SORT_ORDER, table_info) {
+    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SORT_ORDER) {
 }
 
 void AddSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const {
@@ -212,13 +212,14 @@ void AddSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context, Ic
 	auto &req = commit_state.table_change.updates.back();
 	req.add_sort_order_update = rest_api_objects::AddSortOrderUpdate();
 	req.add_sort_order_update->base_update.action = "add-sort-order";
-	if (table_info.table_metadata.HasSortOrder()) {
-		req.add_sort_order_update->sort_order.order_id = table_info.table_metadata.default_sort_order_id.GetIndex();
+	if (commit_state.table_info.table_metadata.HasSortOrder()) {
+		req.add_sort_order_update->sort_order.order_id =
+		    commit_state.table_info.table_metadata.default_sort_order_id.GetIndex();
 	}
 
-	if (table_info.table_metadata.HasSortOrder()) {
+	if (commit_state.table_info.table_metadata.HasSortOrder()) {
 		// FIXME: is it correct to just get the latest sort order?
-		auto &current_sort_order = table_info.table_metadata.GetLatestSortOrder();
+		auto &current_sort_order = commit_state.table_info.table_metadata.GetLatestSortOrder();
 		for (auto &field : current_sort_order.fields) {
 			req.add_sort_order_update->sort_order.fields.push_back(rest_api_objects::SortField());
 			auto &updated_field = req.add_sort_order_update->sort_order.fields.back();
@@ -231,7 +232,7 @@ void AddSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context, Ic
 }
 
 SetDefaultSortOrder::SetDefaultSortOrder(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SORT_ORDER, table_info) {
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SORT_ORDER) {
 }
 
 void SetDefaultSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -240,12 +241,13 @@ void SetDefaultSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &cont
 	auto &req = commit_state.table_change.updates.back();
 	req.set_default_sort_order_update = rest_api_objects::SetDefaultSortOrderUpdate();
 	req.set_default_sort_order_update->base_update.action = "set-default-sort-order";
-	D_ASSERT(table_info.table_metadata.HasSortOrder());
-	req.set_default_sort_order_update->sort_order_id = table_info.table_metadata.GetLatestSortOrder().sort_order_id;
+	D_ASSERT(commit_state.table_info.table_metadata.HasSortOrder());
+	req.set_default_sort_order_update->sort_order_id =
+	    commit_state.table_info.table_metadata.GetLatestSortOrder().sort_order_id;
 }
 
 SetDefaultSpec::SetDefaultSpec(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SPEC, table_info) {
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SPEC) {
 }
 
 void SetDefaultSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -254,12 +256,12 @@ void SetDefaultSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 	auto &req = commit_state.table_change.updates.back();
 	req.set_default_spec_update = rest_api_objects::SetDefaultSpecUpdate();
 	req.set_default_spec_update->base_update.action = "set-default-spec";
-	req.set_default_spec_update->spec_id = table_info.table_metadata.default_spec_id;
+	req.set_default_spec_update->spec_id = commit_state.table_info.table_metadata.default_spec_id;
 }
 
 SetProperties::SetProperties(const IcebergTableInformation &table_info,
                              const case_insensitive_map_t<string> &properties)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES, table_info), properties(properties) {
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES), properties(properties) {
 }
 
 void SetProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const {
@@ -271,7 +273,7 @@ void SetProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context, I
 }
 
 RemoveProperties::RemoveProperties(const IcebergTableInformation &table_info, const vector<string> &properties)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES, table_info), properties(properties) {
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES), properties(properties) {
 }
 
 void RemoveProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -284,7 +286,7 @@ void RemoveProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context
 }
 
 SetLocation::SetLocation(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_LOCATION, table_info) {
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_LOCATION) {
 }
 
 void SetLocation::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const {
@@ -292,7 +294,7 @@ void SetLocation::CreateUpdate(DatabaseInstance &db, ClientContext &context, Ice
 	auto &req = commit_state.table_change.updates.back();
 	req.set_location_update = rest_api_objects::SetLocationUpdate();
 	req.set_location_update->base_update.action = "set-location";
-	req.set_location_update->location = table_info.table_metadata.location;
+	req.set_location_update->location = commit_state.table_info.table_metadata.location;
 }
 
 } // namespace duckdb

--- a/src/catalog/rest/api/table_update.cpp
+++ b/src/catalog/rest/api/table_update.cpp
@@ -4,8 +4,7 @@
 
 namespace duckdb {
 
-AddSchemaUpdate::AddSchemaUpdate(const IcebergTableInformation &table_info, const IcebergTableMetadata &table_metadata,
-                                 int32_t schema_id)
+AddSchemaUpdate::AddSchemaUpdate(const IcebergTableMetadata &table_metadata, int32_t schema_id)
     : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA), schema_id(schema_id) {
 	if (table_metadata.HasLastColumnId()) {
 		last_column_id = table_metadata.GetLastColumnId();
@@ -16,11 +15,12 @@ AddSchemaUpdate::AddSchemaUpdate(const IcebergTableInformation &table_info, cons
 	if (it == schemas.end()) {
 		throw InternalException("(AddSchemaUpdate) Couldn't find schema with id: %d", schema_id);
 	}
+	schema = it->second;
 	std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
 	yyjson_mut_doc *doc = doc_p.get();
 	auto root_object = yyjson_mut_obj(doc);
 	yyjson_mut_doc_set_root(doc, root_object);
-	IcebergCreateTableRequest::PopulateSchema(doc, root_object, *it->second);
+	IcebergCreateTableRequest::PopulateSchema(doc, root_object, *schema);
 	schema_json = ICUtils::JsonToString(std::move(doc_p));
 }
 
@@ -66,9 +66,8 @@ void AssertCreateRequirement::CreateRequirement(DatabaseInstance &db, ClientCont
 	req.assert_create->type.value = "assert-create";
 }
 
-AssertTableUUIDRequirement::AssertTableUUIDRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_TABLE_UUID),
-      uuid(table_info.table_metadata.table_uuid) {
+AssertTableUUIDRequirement::AssertTableUUIDRequirement(string uuid)
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_TABLE_UUID), uuid(std::move(uuid)) {
 }
 
 void AssertTableUUIDRequirement::CreateRequirement(DatabaseInstance &db, ClientContext &context,
@@ -80,9 +79,9 @@ void AssertTableUUIDRequirement::CreateRequirement(DatabaseInstance &db, ClientC
 	req.assert_table_uuid->uuid = uuid;
 }
 
-AssertCurrentSchemaIdRequirement::AssertCurrentSchemaIdRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_CURRENT_SCHEMA_ID) {
-	current_schema_id = table_info.table_metadata.GetCurrentSchemaId();
+AssertCurrentSchemaIdRequirement::AssertCurrentSchemaIdRequirement(int32_t current_schema_id)
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_CURRENT_SCHEMA_ID),
+      current_schema_id(current_schema_id) {
 }
 
 void AssertCurrentSchemaIdRequirement::CreateRequirement(DatabaseInstance &db, ClientContext &context,
@@ -94,10 +93,9 @@ void AssertCurrentSchemaIdRequirement::CreateRequirement(DatabaseInstance &db, C
 	req.assert_current_schema_id->current_schema_id = current_schema_id;
 }
 
-AssertLastAssignedFieldIdRequirement::AssertLastAssignedFieldIdRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_FIELD_ID) {
-	D_ASSERT(table_info.table_metadata.HasLastColumnId());
-	last_assigned_field_id = static_cast<int32_t>(table_info.table_metadata.GetLastColumnId());
+AssertLastAssignedFieldIdRequirement::AssertLastAssignedFieldIdRequirement(int32_t last_assigned_field_id)
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_FIELD_ID),
+      last_assigned_field_id(last_assigned_field_id) {
 }
 
 void AssertLastAssignedFieldIdRequirement::CreateRequirement(DatabaseInstance &db, ClientContext &context,
@@ -109,16 +107,9 @@ void AssertLastAssignedFieldIdRequirement::CreateRequirement(DatabaseInstance &d
 	req.assert_last_assigned_field_id->last_assigned_field_id = last_assigned_field_id;
 }
 
-AssertLastAssignedPartitionIdRequirement::AssertLastAssignedPartitionIdRequirement(
-    const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_PARTITION_ID) {
-	if (table_info.table_metadata.HasLastPartitionId()) {
-		last_assigned_partition_id = table_info.table_metadata.GetLastPartitionFieldId();
-	} else {
-		// If no partition field IDs have been assigned, use 999 as the last assigned so 1000 becomes the
-		// next partition id. Based on assignments in v1 in https://iceberg.apache.org/spec/#partition-evolution
-		last_assigned_partition_id = 999;
-	}
+AssertLastAssignedPartitionIdRequirement::AssertLastAssignedPartitionIdRequirement(int32_t last_assigned_partition_id)
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_PARTITION_ID),
+      last_assigned_partition_id(last_assigned_partition_id) {
 }
 
 void AssertLastAssignedPartitionIdRequirement::CreateRequirement(DatabaseInstance &db, ClientContext &context,
@@ -130,9 +121,8 @@ void AssertLastAssignedPartitionIdRequirement::CreateRequirement(DatabaseInstanc
 	req.assert_last_assigned_partition_id->last_assigned_partition_id = last_assigned_partition_id;
 }
 
-AssertDefaultSpecIdRequirement::AssertDefaultSpecIdRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_DEFAULT_SPEC_ID) {
-	default_spec_id = table_info.table_metadata.default_spec_id;
+AssertDefaultSpecIdRequirement::AssertDefaultSpecIdRequirement(int32_t default_spec_id)
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_DEFAULT_SPEC_ID), default_spec_id(default_spec_id) {
 }
 
 void AssertDefaultSpecIdRequirement::CreateRequirement(DatabaseInstance &db, ClientContext &context,
@@ -239,8 +229,7 @@ void SetDefaultSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 	req.set_default_spec_update->spec_id = spec_id;
 }
 
-SetProperties::SetProperties(const IcebergTableInformation &table_info,
-                             const case_insensitive_map_t<string> &properties)
+SetProperties::SetProperties(const case_insensitive_map_t<string> &properties)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES), properties(properties) {
 }
 
@@ -252,7 +241,7 @@ void SetProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context, I
 	req.set_properties_update->updates = properties;
 }
 
-RemoveProperties::RemoveProperties(const IcebergTableInformation &table_info, const vector<string> &properties)
+RemoveProperties::RemoveProperties(const vector<string> &properties)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES), properties(properties) {
 }
 

--- a/src/catalog/rest/api/table_update.cpp
+++ b/src/catalog/rest/api/table_update.cpp
@@ -40,8 +40,8 @@ void AddSchemaUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 	}
 }
 
-AssignUUIDUpdate::AssignUUIDUpdate(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA) {
+AssignUUIDUpdate::AssignUUIDUpdate(string uuid)
+    : IcebergTableUpdate(IcebergTableUpdateType::ASSIGN_UUID), uuid(std::move(uuid)) {
 }
 
 void AssignUUIDUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -51,7 +51,7 @@ void AssignUUIDUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	update.assign_uuidupdate = rest_api_objects::AssignUUIDUpdate();
 	update.assign_uuidupdate->base_update.action = "assign-uuid";
 	// uuid most likely created by the rest catalog?
-	update.assign_uuidupdate->uuid = commit_state.table_info.table_metadata.table_uuid;
+	update.assign_uuidupdate->uuid = uuid;
 }
 
 AssertCreateRequirement::AssertCreateRequirement(const IcebergTableInformation &table_info)
@@ -67,7 +67,8 @@ void AssertCreateRequirement::CreateRequirement(DatabaseInstance &db, ClientCont
 }
 
 AssertTableUUIDRequirement::AssertTableUUIDRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_TABLE_UUID) {
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_TABLE_UUID),
+      uuid(table_info.table_metadata.table_uuid) {
 }
 
 void AssertTableUUIDRequirement::CreateRequirement(DatabaseInstance &db, ClientContext &context,
@@ -76,7 +77,7 @@ void AssertTableUUIDRequirement::CreateRequirement(DatabaseInstance &db, ClientC
 	auto &req = commit_state.table_change.requirements.back();
 	req.assert_table_uuid = rest_api_objects::AssertTableUUID();
 	req.assert_table_uuid->type.value = "assert-table-uuid";
-	req.assert_table_uuid->uuid = commit_state.table_info.table_metadata.table_uuid;
+	req.assert_table_uuid->uuid = uuid;
 }
 
 AssertCurrentSchemaIdRequirement::AssertCurrentSchemaIdRequirement(const IcebergTableInformation &table_info)
@@ -143,8 +144,8 @@ void AssertDefaultSpecIdRequirement::CreateRequirement(DatabaseInstance &db, Cli
 	req.assert_default_spec_id->default_spec_id = default_spec_id;
 }
 
-UpgradeFormatVersion::UpgradeFormatVersion(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::UPGRADE_FORMAT_VERSION) {
+UpgradeFormatVersion::UpgradeFormatVersion(int32_t format_version)
+    : IcebergTableUpdate(IcebergTableUpdateType::UPGRADE_FORMAT_VERSION), format_version(format_version) {
 }
 
 void UpgradeFormatVersion::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -153,11 +154,11 @@ void UpgradeFormatVersion::CreateUpdate(DatabaseInstance &db, ClientContext &con
 	auto &req = commit_state.table_change.updates.back();
 	req.upgrade_format_version_update = rest_api_objects::UpgradeFormatVersionUpdate();
 	req.upgrade_format_version_update->base_update.action = "upgrade-format-version";
-	req.upgrade_format_version_update->format_version = commit_state.table_info.table_metadata.iceberg_version;
+	req.upgrade_format_version_update->format_version = format_version;
 }
 
-SetCurrentSchema::SetCurrentSchema(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_CURRENT_SCHEMA) {
+SetCurrentSchema::SetCurrentSchema(int32_t schema_id)
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_CURRENT_SCHEMA), schema_id(schema_id) {
 }
 
 void SetCurrentSchema::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -167,11 +168,11 @@ void SetCurrentSchema::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	req.set_current_schema_update = rest_api_objects::SetCurrentSchemaUpdate();
 	req.set_current_schema_update->base_update.action = "set-current-schema";
 	// TODO: should this be a different value? or is the rest catalog setting this again?
-	req.set_current_schema_update->schema_id = commit_state.table_info.table_metadata.GetCurrentSchemaId();
+	req.set_current_schema_update->schema_id = schema_id;
 }
 
-AddPartitionSpec::AddPartitionSpec(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_PARTITION_SPEC) {
+AddPartitionSpec::AddPartitionSpec(const IcebergPartitionSpec &partition_spec)
+    : IcebergTableUpdate(IcebergTableUpdateType::ADD_PARTITION_SPEC), partition_spec(partition_spec) {
 }
 
 void AddPartitionSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -181,22 +182,19 @@ void AddPartitionSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	req.add_partition_spec_update = rest_api_objects::AddPartitionSpecUpdate();
 	req.add_partition_spec_update->base_update.action = "add-spec";
 	// need to get the spec id from table_info() so we can also check updated tables.
-	req.add_partition_spec_update->spec.spec_id = commit_state.table_info.table_metadata.default_spec_id;
-	if (commit_state.table_info.table_metadata.HasPartitionSpec()) {
-		auto &current_partition_spec = commit_state.table_info.table_metadata.GetLatestPartitionSpec();
-		for (auto &field : current_partition_spec.fields) {
-			req.add_partition_spec_update->spec.fields.push_back(rest_api_objects::PartitionField());
-			auto &updated_field = req.add_partition_spec_update->spec.fields.back();
-			updated_field.name = field.GetPartitionSpecFieldName();
-			updated_field.transform.value = field.transform.RawType();
-			updated_field.field_id = field.partition_field_id;
-			updated_field.source_id = field.source_id;
-		}
+	req.add_partition_spec_update->spec.spec_id = partition_spec.spec_id;
+	for (auto &field : partition_spec.fields) {
+		req.add_partition_spec_update->spec.fields.push_back(rest_api_objects::PartitionField());
+		auto &updated_field = req.add_partition_spec_update->spec.fields.back();
+		updated_field.name = field.GetPartitionSpecFieldName();
+		updated_field.transform.value = field.transform.RawType();
+		updated_field.field_id = field.partition_field_id;
+		updated_field.source_id = field.source_id;
 	}
 }
 
-AddSortOrder::AddSortOrder(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SORT_ORDER) {
+AddSortOrder::AddSortOrder(const IcebergSortOrder &sort_order)
+    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SORT_ORDER), sort_order(sort_order) {
 }
 
 void AddSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const {
@@ -204,27 +202,19 @@ void AddSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context, Ic
 	auto &req = commit_state.table_change.updates.back();
 	req.add_sort_order_update = rest_api_objects::AddSortOrderUpdate();
 	req.add_sort_order_update->base_update.action = "add-sort-order";
-	if (commit_state.table_info.table_metadata.HasSortOrder()) {
-		req.add_sort_order_update->sort_order.order_id =
-		    commit_state.table_info.table_metadata.default_sort_order_id.GetIndex();
-	}
-
-	if (commit_state.table_info.table_metadata.HasSortOrder()) {
-		// FIXME: is it correct to just get the latest sort order?
-		auto &current_sort_order = commit_state.table_info.table_metadata.GetLatestSortOrder();
-		for (auto &field : current_sort_order.fields) {
-			req.add_sort_order_update->sort_order.fields.push_back(rest_api_objects::SortField());
-			auto &updated_field = req.add_sort_order_update->sort_order.fields.back();
-			updated_field.direction.value = field.direction;
-			updated_field.transform.value = field.transform.RawType();
-			updated_field.null_order.value = field.null_order;
-			updated_field.source_id = field.source_id;
-		}
+	req.add_sort_order_update->sort_order.order_id = sort_order.sort_order_id;
+	for (auto &field : sort_order.fields) {
+		req.add_sort_order_update->sort_order.fields.push_back(rest_api_objects::SortField());
+		auto &updated_field = req.add_sort_order_update->sort_order.fields.back();
+		updated_field.direction.value = field.direction;
+		updated_field.transform.value = field.transform.RawType();
+		updated_field.null_order.value = field.null_order;
+		updated_field.source_id = field.source_id;
 	}
 }
 
-SetDefaultSortOrder::SetDefaultSortOrder(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SORT_ORDER) {
+SetDefaultSortOrder::SetDefaultSortOrder(int32_t sort_order_id)
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SORT_ORDER), sort_order_id(sort_order_id) {
 }
 
 void SetDefaultSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -233,13 +223,11 @@ void SetDefaultSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &cont
 	auto &req = commit_state.table_change.updates.back();
 	req.set_default_sort_order_update = rest_api_objects::SetDefaultSortOrderUpdate();
 	req.set_default_sort_order_update->base_update.action = "set-default-sort-order";
-	D_ASSERT(commit_state.table_info.table_metadata.HasSortOrder());
-	req.set_default_sort_order_update->sort_order_id =
-	    commit_state.table_info.table_metadata.GetLatestSortOrder().sort_order_id;
+	req.set_default_sort_order_update->sort_order_id = sort_order_id;
 }
 
-SetDefaultSpec::SetDefaultSpec(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SPEC) {
+SetDefaultSpec::SetDefaultSpec(int32_t spec_id)
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SPEC), spec_id(spec_id) {
 }
 
 void SetDefaultSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -248,7 +236,7 @@ void SetDefaultSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 	auto &req = commit_state.table_change.updates.back();
 	req.set_default_spec_update = rest_api_objects::SetDefaultSpecUpdate();
 	req.set_default_spec_update->base_update.action = "set-default-spec";
-	req.set_default_spec_update->spec_id = commit_state.table_info.table_metadata.default_spec_id;
+	req.set_default_spec_update->spec_id = spec_id;
 }
 
 SetProperties::SetProperties(const IcebergTableInformation &table_info,
@@ -277,8 +265,8 @@ void RemoveProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	req.remove_properties_update->removals = properties;
 }
 
-SetLocation::SetLocation(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_LOCATION) {
+SetLocation::SetLocation(string location)
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_LOCATION), location(std::move(location)) {
 }
 
 void SetLocation::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const {
@@ -286,7 +274,7 @@ void SetLocation::CreateUpdate(DatabaseInstance &db, ClientContext &context, Ice
 	auto &req = commit_state.table_change.updates.back();
 	req.set_location_update = rest_api_objects::SetLocationUpdate();
 	req.set_location_update->base_update.action = "set-location";
-	req.set_location_update->location = commit_state.table_info.table_metadata.location;
+	req.set_location_update->location = location;
 }
 
 } // namespace duckdb

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -262,19 +262,19 @@ static void VerifySchemaEvolution(const IcebergTableMetadata &table_metadata, co
 	throw CatalogException(error);
 }
 
-void IntroduceNewSchema(IcebergTableInformation &updated_table, IcebergTransactionData &transaction_data,
+void IntroduceNewSchema(IcebergTransactionTableState &updated_table, IcebergTransactionData &transaction_data,
                         shared_ptr<IcebergTableSchema> new_schema) {
 	auto new_schema_id = new_schema->schema_id;
 
-	auto &result_schema = updated_table.table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
+	auto &table_metadata = updated_table.GetMetadata();
+	auto &result_schema = table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
 	if (result_schema.schema_id == new_schema_id) {
-		// Update the Table Metadata to have our new schema
-		updated_table.CreateSchemaVersion(result_schema);
+		updated_table.GetOrCreateSchemaEntry(result_schema);
 		transaction_data.TableAddSchema(new_schema_id);
 	} else {
 		transaction_data.TableSetCurrentSchema();
 	}
-	updated_table.table_metadata.SetCurrentSchemaId(result_schema.schema_id);
+	table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 }
 
 template <typename T>
@@ -309,7 +309,8 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 	auto &alter = irc_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(catalog_table_info);
 	auto &transaction_data = alter.GetOrCreateTransactionData(updated_table);
-	auto &current_schema = updated_table.table_metadata.GetLatestSchema();
+	auto &table_metadata = updated_table.GetMetadata();
+	auto &current_schema = table_metadata.GetLatestSchema();
 
 	switch (alter_table_info.alter_table_type) {
 	case AlterTableType::SET_PARTITIONED_BY: {
@@ -320,7 +321,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		// Ensure last assigned partition field id is up to date
 		transaction_data.TableAddAssertLastAssignedPartitionId();
 
-		updated_table.SetPartitionedBy(transaction_data, partition_info.partition_keys, current_schema);
+		table_metadata.SetPartitionedBy(transaction_data, partition_info.partition_keys, current_schema);
 		return;
 	}
 	case AlterTableType::ADD_COLUMN: {
@@ -338,7 +339,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			}
 		}
 
-		auto &last_column_id = updated_table.table_metadata.last_column_id;
+		auto &last_column_id = table_metadata.last_column_id;
 		if (!last_column_id.IsValid()) {
 			throw InternalException("No last_column_id when trying to ADD COLUMN %s", add_column_info.name);
 		}
@@ -349,7 +350,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 
 		IcebergDefaultBinder binder(context);
 		auto new_iceberg_column = IcebergCreateTableRequest::CreateIcebergColumn(
-		    column_definition, binder, false, next_field_id, updated_table.table_metadata.iceberg_version);
+		    column_definition, binder, false, next_field_id, table_metadata.iceberg_version);
 		last_column_id = field_id - 1;
 
 		auto new_schema = current_schema.Copy();
@@ -382,7 +383,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			return;
 		}
 
-		auto &partition_spec = updated_table.table_metadata.GetLatestPartitionSpec();
+		auto &partition_spec = table_metadata.GetLatestPartitionSpec();
 		auto partition_field = partition_spec.TryGetFieldBySourceId(column_id.GetIndex());
 		if (partition_field) {
 			throw CatalogException(
@@ -409,7 +410,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		if (change_type_info.expression->GetExpressionType() != ExpressionType::OPERATOR_CAST) {
 			throw NotImplementedException("ALTER TYPE with a USING expression is not supported for Iceberg tables");
 		}
-		VerifySchemaEvolution(updated_table.table_metadata, column, change_type_info.target_type);
+		VerifySchemaEvolution(table_metadata, column, change_type_info.target_type);
 		column.type = change_type_info.target_type;
 
 		IntroduceNewSchema(updated_table, transaction_data, new_schema);
@@ -450,7 +451,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			//! The table is dropped or renamed by this transaction, so it's not a conflict anymore
 			D_ASSERT(state && state->IsDroppedOrRenamed());
 		}
-		irc_transaction.RenameTable(updated_table, new_name.GetIdentifierName());
+		irc_transaction.RenameTable(updated_table.GetInfo(), new_name.GetIdentifierName());
 		break;
 	}
 	case AlterTableType::RENAME_COLUMN: {
@@ -477,15 +478,14 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 
 		auto new_schema_id = new_schema->schema_id;
 
-		auto &result_schema = updated_table.table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
+		auto &result_schema = table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
 		if (result_schema.schema_id == new_schema_id) {
-			// Update the Table Metadata to have our new schema
-			updated_table.CreateSchemaVersion(result_schema);
+			updated_table.GetOrCreateSchemaEntry(result_schema);
 			transaction_data.TableAddSchema(new_schema_id);
 		} else {
 			transaction_data.TableSetCurrentSchema();
 		}
-		updated_table.table_metadata.SetCurrentSchemaId(result_schema.schema_id);
+		table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 		return;
 	}
 	case AlterTableType::SET_TABLE_OPTIONS: {
@@ -523,19 +523,19 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		}
 
 		if (new_format_version.IsValid()) {
-			auto current_version = updated_table.table_metadata.iceberg_version;
+			auto current_version = table_metadata.iceberg_version;
 			if ((int32_t)new_format_version.GetIndex() < current_version) {
 				throw InvalidInputException("Cannot downgrade format-version from %d to %d", current_version,
 				                            new_format_version.GetIndex());
 			}
-			updated_table.table_metadata.iceberg_version = (int32_t)new_format_version.GetIndex();
+			table_metadata.iceberg_version = (int32_t)new_format_version.GetIndex();
 			transaction_data.TableAddUpradeFormatVersion();
 		}
 
 		if (!new_properties.empty()) {
 			transaction_data.TableSetProperties(new_properties);
 			for (auto &prop : new_properties) {
-				updated_table.table_metadata.table_properties[prop.first] = prop.second;
+				table_metadata.table_properties[prop.first] = prop.second;
 			}
 		}
 
@@ -549,7 +549,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		if (!properties_to_remove.empty()) {
 			transaction_data.TableRemoveProperties(properties_to_remove);
 			for (auto &key : properties_to_remove) {
-				updated_table.table_metadata.table_properties.erase(key);
+				table_metadata.table_properties.erase(key);
 			}
 		}
 		return;
@@ -568,7 +568,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			                       column_name, table_entry.name);
 		}
 		auto &column = *column_p;
-		if (updated_table.table_metadata.iceberg_version < 3) {
+		if (table_metadata.iceberg_version < 3) {
 			throw NotImplementedException("SET DEFAULT is not supported on tables < V3");
 		}
 
@@ -578,15 +578,14 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 
 		auto new_schema_id = new_schema->schema_id;
 
-		auto &result_schema = updated_table.table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
+		auto &result_schema = table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
 		if (result_schema.schema_id == new_schema_id) {
-			// Update the Table Metadata to have our new schema
-			updated_table.CreateSchemaVersion(result_schema);
+			updated_table.GetOrCreateSchemaEntry(result_schema);
 			transaction_data.TableAddSchema(new_schema_id);
 		} else {
 			transaction_data.TableSetCurrentSchema();
 		}
-		updated_table.table_metadata.SetCurrentSchemaId(result_schema.schema_id);
+		table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 		return;
 	}
 	case AlterTableType::ADD_FIELD: {
@@ -625,7 +624,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			                       parent.type.ToString());
 		}
 
-		auto &last_column_id = updated_table.table_metadata.last_column_id;
+		auto &last_column_id = table_metadata.last_column_id;
 		if (!last_column_id.IsValid()) {
 			throw InternalException("No last_column_id when trying to ADD COLUMN %s",
 			                        StringUtil::Join(IdentifiersToStrings(column_path), "."));
@@ -637,7 +636,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 
 		IcebergDefaultBinder binder(context);
 		auto new_iceberg_column = IcebergCreateTableRequest::CreateIcebergColumn(
-		    new_field, binder, false, next_field_id, updated_table.table_metadata.iceberg_version);
+		    new_field, binder, false, next_field_id, table_metadata.iceberg_version);
 		last_column_id = field_id - 1;
 
 		parent.AddChild(std::move(new_iceberg_column));

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -94,7 +94,7 @@ optional_ptr<CatalogEntry> IcebergSchemaEntry::CreateTable(CatalogTransaction &t
 	}
 
 	auto &table_info = IcebergTableSet::CreateNewEntry(context, ir_catalog, *this, base_info);
-	return table_info.schema_versions[0].get();
+	return table_info.GetLatestSchema(context);
 }
 
 optional_ptr<CatalogEntry> IcebergSchemaEntry::CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) {

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -270,7 +270,7 @@ void IntroduceNewSchema(IcebergTransactionTableState &updated_table, IcebergTran
 	auto &result_schema = table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
 	if (result_schema.schema_id == new_schema_id) {
 		updated_table.GetOrCreateSchemaEntry(result_schema);
-		transaction_data.TableAddSchema(new_schema_id);
+		transaction_data.TableAddSchema(table_metadata, new_schema_id);
 	} else {
 		transaction_data.TableSetCurrentSchema();
 	}
@@ -481,7 +481,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		auto &result_schema = table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
 		if (result_schema.schema_id == new_schema_id) {
 			updated_table.GetOrCreateSchemaEntry(result_schema);
-			transaction_data.TableAddSchema(new_schema_id);
+			transaction_data.TableAddSchema(table_metadata, new_schema_id);
 		} else {
 			transaction_data.TableSetCurrentSchema();
 		}
@@ -581,7 +581,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		auto &result_schema = table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
 		if (result_schema.schema_id == new_schema_id) {
 			updated_table.GetOrCreateSchemaEntry(result_schema);
-			transaction_data.TableAddSchema(new_schema_id);
+			transaction_data.TableAddSchema(table_metadata, new_schema_id);
 		} else {
 			transaction_data.TableSetCurrentSchema();
 		}

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -263,10 +263,9 @@ static void VerifySchemaEvolution(const IcebergTableMetadata &table_metadata, co
 }
 
 void IntroduceNewSchema(IcebergTransactionTableState &updated_table, IcebergTransactionData &transaction_data,
-                        shared_ptr<IcebergTableSchema> new_schema) {
+                        IcebergTableMetadata &table_metadata, shared_ptr<IcebergTableSchema> new_schema) {
 	auto new_schema_id = new_schema->schema_id;
 
-	auto &table_metadata = updated_table.GetMetadata();
 	auto &result_schema = table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
 	if (result_schema.schema_id == new_schema_id) {
 		updated_table.GetOrCreateSchemaEntry(result_schema);
@@ -309,7 +308,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 	auto &alter = irc_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(catalog_table_info);
 	auto &transaction_data = alter.GetOrCreateTransactionData(updated_table);
-	auto &table_metadata = updated_table.GetMetadata();
+	auto table_metadata = updated_table.GetTransactionMetadata();
 	auto &current_schema = table_metadata.GetLatestSchema();
 
 	switch (alter_table_info.alter_table_type) {
@@ -319,7 +318,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		// Ensure schema is the same as current
 		transaction_data.TableAddAssertCurrentSchemaId();
 		// Ensure last assigned partition field id is up to date
-		transaction_data.TableAddAssertLastAssignedPartitionId();
+		transaction_data.TableAddAssertLastAssignedPartitionId(table_metadata);
 
 		table_metadata.SetPartitionedBy(transaction_data, partition_info.partition_keys, current_schema);
 		return;
@@ -357,7 +356,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		new_schema->schema_id++;
 		new_schema->columns.push_back(std::move(new_iceberg_column));
 
-		IntroduceNewSchema(updated_table, transaction_data, new_schema);
+		IntroduceNewSchema(updated_table, transaction_data, table_metadata, new_schema);
 
 		return;
 	}
@@ -395,7 +394,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			throw CatalogException("Cannot drop column: table '%s' only has one column remaining!", table_entry.name);
 		}
 
-		IntroduceNewSchema(updated_table, transaction_data, new_schema);
+		IntroduceNewSchema(updated_table, transaction_data, table_metadata, new_schema);
 
 		return;
 	}
@@ -413,7 +412,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		VerifySchemaEvolution(table_metadata, column, change_type_info.target_type);
 		column.type = change_type_info.target_type;
 
-		IntroduceNewSchema(updated_table, transaction_data, new_schema);
+		IntroduceNewSchema(updated_table, transaction_data, table_metadata, new_schema);
 		return;
 	}
 	case AlterTableType::SET_NOT_NULL: {
@@ -430,7 +429,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 
 		column.required = false;
 
-		IntroduceNewSchema(updated_table, transaction_data, new_schema);
+		IntroduceNewSchema(updated_table, transaction_data, table_metadata, new_schema);
 		return;
 	}
 	case AlterTableType::RENAME_TABLE: {
@@ -640,7 +639,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		last_column_id = field_id - 1;
 
 		parent.AddChild(std::move(new_iceberg_column));
-		IntroduceNewSchema(updated_table, transaction_data, new_schema);
+		IntroduceNewSchema(updated_table, transaction_data, table_metadata, new_schema);
 		return;
 	}
 	case AlterTableType::RENAME_FIELD: {
@@ -669,7 +668,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		}
 		column_p->name = new_name.GetIdentifierName();
 		column_p->RewriteType();
-		IntroduceNewSchema(updated_table, transaction_data, new_schema);
+		IntroduceNewSchema(updated_table, transaction_data, table_metadata, new_schema);
 		return;
 	}
 	case AlterTableType::REMOVE_FIELD: {
@@ -713,7 +712,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			                       StringUtil::Join(IdentifiersToStrings(column_path), "."));
 		}
 		parent.RemoveChild(child->name);
-		IntroduceNewSchema(updated_table, transaction_data, new_schema);
+		IntroduceNewSchema(updated_table, transaction_data, table_metadata, new_schema);
 		return;
 	}
 	default: {

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -308,7 +308,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 
 	auto &alter = irc_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(catalog_table_info);
-	auto &transaction_data = updated_table.GetOrCreateTransactionData(irc_transaction);
+	auto &transaction_data = alter.GetOrCreateTransactionData(updated_table);
 	auto &current_schema = updated_table.table_metadata.GetLatestSchema();
 
 	switch (alter_table_info.alter_table_type) {
@@ -320,7 +320,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		// Ensure last assigned partition field id is up to date
 		transaction_data.TableAddAssertLastAssignedPartitionId();
 
-		updated_table.SetPartitionedBy(irc_transaction, partition_info.partition_keys, current_schema);
+		updated_table.SetPartitionedBy(transaction_data, partition_info.partition_keys, current_schema);
 		return;
 	}
 	case AlterTableType::ADD_COLUMN: {

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -535,8 +535,11 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 	case AlterTableType::RESET_TABLE_OPTIONS: {
 		auto &reset_options_info = alter_table_info.Cast<ResetTableOptionsInfo>();
 
-		vector<string> properties_to_remove(reset_options_info.table_options.begin(),
-		                                    reset_options_info.table_options.end());
+		vector<string> properties_to_remove;
+		properties_to_remove.reserve(reset_options_info.table_options.size());
+		for (auto &option : reset_options_info.table_options) {
+			properties_to_remove.push_back(option.GetIdentifierName());
+		}
 		if (!properties_to_remove.empty()) {
 			transaction_data.TableRemoveProperties(properties_to_remove);
 			for (auto &key : properties_to_remove) {

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -303,6 +303,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 	}
 	auto &table_entry = catalog_entry->Cast<IcebergTableEntry>();
 	auto &catalog_table_info = table_entry.table_info;
+	auto table_name = catalog_table_info.name;
 
 	auto &alter = irc_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(catalog_table_info);
@@ -376,7 +377,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 				throw CatalogException(
 				    "Attempted to drop column '%s' from table '%s', but no column by this name exists "
 				    "in the current schema (id: %d)",
-				    to_remove_column, table_entry.name, current_schema->schema_id);
+				    to_remove_column, table_name, current_schema->schema_id);
 			}
 			//! Column doesn't exist, just return
 			return;
@@ -391,7 +392,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		}
 
 		if (new_schema->columns.empty()) {
-			throw CatalogException("Cannot drop column: table '%s' only has one column remaining!", table_entry.name);
+			throw CatalogException("Cannot drop column: table '%s' only has one column remaining!", table_name);
 		}
 
 		IntroduceNewSchema(updated_table, transaction_data, table_metadata, new_schema);
@@ -464,12 +465,12 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		auto column_p = new_schema->GetMutableFromPath({column_name}, nullptr);
 		if (!column_p) {
 			throw CatalogException("Column with name '%s' does not exist on the table '%s', RENAME COLUMN failed",
-			                       column_name, table_entry.name);
+			                       column_name, table_name);
 		}
 		auto collision_column_p = new_schema->GetMutableFromPath({new_name}, nullptr);
 		if (collision_column_p) {
 			throw CatalogException("Column with name '%s' already exists on the table '%s', RENAME COLUMN failed",
-			                       new_name, table_entry.name);
+			                       new_name, table_name);
 		}
 		auto &column = *column_p;
 		column.name = new_name.GetIdentifierName();
@@ -555,7 +556,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		auto column_p = new_schema->GetMutableFromPath({column_name}, nullptr);
 		if (!column_p) {
 			throw CatalogException("Column with name '%s' does not exist on the table '%s', SET DEFAULT failed",
-			                       column_name, table_entry.name);
+			                       column_name, table_name);
 		}
 		auto &column = *column_p;
 		if (table_metadata.iceberg_version < 3) {
@@ -585,7 +586,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		if (!parent_p) {
 			throw CatalogException(
 			    "The parent column ('%s') does not exist on the table '%s', ADD COLUMN failed to add a new field",
-			    StringUtil::Join(IdentifiersToStrings(parent_path), "."), table_entry.name);
+			    StringUtil::Join(IdentifiersToStrings(parent_path), "."), table_name);
 		}
 		auto &parent = *parent_p;
 
@@ -596,7 +597,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			}
 			throw CatalogException(
 			    "The column ('%s') already exists on the table '%s', ADD COLUMN failed to add a new field",
-			    StringUtil::Join(IdentifiersToStrings(column_path), "."), table_entry.name);
+			    StringUtil::Join(IdentifiersToStrings(column_path), "."), table_name);
 		}
 
 		if (parent.type.id() != LogicalTypeId::STRUCT) {
@@ -635,7 +636,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		auto column_p = new_schema->GetMutableFromPath(column_path, nullptr);
 		if (!column_p) {
 			throw CatalogException("The column ('%s') doesn't exist on the table '%s', RENAME COLUMN failed",
-			                       StringUtil::Join(IdentifiersToStrings(column_path), "."), table_entry.name);
+			                       StringUtil::Join(IdentifiersToStrings(column_path), "."), table_name);
 		}
 
 		auto new_path = column_path;
@@ -646,7 +647,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		if (existing_column) {
 			throw CatalogException(
 			    "The column ('%s') already exists on the table '%s', RENAME COLUMN failed to rename the field",
-			    StringUtil::Join(IdentifiersToStrings(new_path), "."), table_entry.name);
+			    StringUtil::Join(IdentifiersToStrings(new_path), "."), table_name);
 		}
 		column_p->name = new_name.GetIdentifierName();
 		column_p->RewriteType();
@@ -677,7 +678,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			}
 			throw CatalogException(
 			    "The column ('%s') doesnt exist on the table '%s', DROP COLUMN failed to remove the field",
-			    StringUtil::Join(IdentifiersToStrings(column_path), "."), table_entry.name);
+			    StringUtil::Join(IdentifiersToStrings(column_path), "."), table_name);
 		}
 		auto &parent = *parent_p;
 		auto child = parent.GetChild(column_path.back().GetIdentifierName());
@@ -687,7 +688,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			}
 			throw CatalogException(
 			    "The column ('%s') doesnt exist on the table '%s', DROP COLUMN failed to remove the field",
-			    StringUtil::Join(IdentifiersToStrings(column_path), "."), table_entry.name);
+			    StringUtil::Join(IdentifiersToStrings(column_path), "."), table_name);
 		}
 		if (parent.GetChildCount() == 1) {
 			throw CatalogException("Can't drop field '%s' because it's the last field of the STRUCT!",

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -308,7 +308,8 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 	auto &updated_table = alter.GetOrInitializeTable(catalog_table_info);
 	auto &transaction_data = alter.GetOrCreateTransactionData(updated_table);
 	auto table_metadata = updated_table.GetTransactionMetadata();
-	auto &current_schema = table_metadata.GetLatestSchema();
+	auto current_schema = table_metadata.GetSchemaFromId(table_metadata.GetCurrentSchemaId());
+	D_ASSERT(current_schema);
 
 	switch (alter_table_info.alter_table_type) {
 	case AlterTableType::SET_PARTITIONED_BY: {
@@ -319,7 +320,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		// Ensure last assigned partition field id is up to date
 		transaction_data.TableAddAssertLastAssignedPartitionId(table_metadata);
 
-		table_metadata.SetPartitionedBy(transaction_data, partition_info.partition_keys, current_schema);
+		table_metadata.SetPartitionedBy(transaction_data, partition_info.partition_keys, *current_schema);
 		return;
 	}
 	case AlterTableType::ADD_COLUMN: {
@@ -330,7 +331,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		}
 
 		if (add_column_info.if_column_not_exists) {
-			for (auto &col : current_schema.columns) {
+			for (auto &col : current_schema->columns) {
 				if (col->name == column_definition.GetName()) {
 					return;
 				}
@@ -351,7 +352,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		    column_definition, binder, false, next_field_id, table_metadata.iceberg_version);
 		last_column_id = field_id - 1;
 
-		auto new_schema = current_schema.Copy();
+		auto new_schema = current_schema->Copy();
 		new_schema->schema_id++;
 		new_schema->columns.push_back(std::move(new_iceberg_column));
 
@@ -368,14 +369,14 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		}
 
 		optional_idx column_id;
-		auto new_schema = current_schema.RemoveColumn(to_remove_column.GetIdentifierName(), column_id);
+		auto new_schema = current_schema->RemoveColumn(to_remove_column.GetIdentifierName(), column_id);
 		const bool column_exists = column_id.IsValid();
 		if (!column_exists) {
 			if (!remove_column_info.if_column_exists) {
 				throw CatalogException(
 				    "Attempted to drop column '%s' from table '%s', but no column by this name exists "
 				    "in the current schema (id: %d)",
-				    to_remove_column, table_entry.name, current_schema.schema_id);
+				    to_remove_column, table_entry.name, current_schema->schema_id);
 			}
 			//! Column doesn't exist, just return
 			return;
@@ -400,7 +401,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 	case AlterTableType::ALTER_COLUMN_TYPE: {
 		auto &change_type_info = alter_table_info.Cast<ChangeColumnTypeInfo>();
 
-		auto new_schema = current_schema.Copy();
+		auto new_schema = current_schema->Copy();
 		new_schema->schema_id++;
 
 		auto &column = ResolveColumn<ChangeColumnTypeInfo>(change_type_info, new_schema);
@@ -421,7 +422,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 	case AlterTableType::DROP_NOT_NULL: {
 		auto &drop_not_null_info = alter_table_info.Cast<DropNotNullInfo>();
 
-		auto new_schema = current_schema.Copy();
+		auto new_schema = current_schema->Copy();
 		new_schema->schema_id++;
 
 		auto &column = ResolveColumn<DropNotNullInfo>(drop_not_null_info, new_schema);
@@ -457,7 +458,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		auto &column_name = rename_info.old_name;
 		auto &new_name = rename_info.new_name;
 
-		auto new_schema = current_schema.Copy();
+		auto new_schema = current_schema->Copy();
 		new_schema->schema_id++;
 
 		auto column_p = new_schema->GetMutableFromPath({column_name}, nullptr);
@@ -548,7 +549,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		auto &column_name = set_default_info.column_name;
 		auto &expression = set_default_info.expression;
 
-		auto new_schema = current_schema.Copy();
+		auto new_schema = current_schema->Copy();
 		new_schema->schema_id++;
 
 		auto column_p = new_schema->GetMutableFromPath({column_name}, nullptr);
@@ -574,7 +575,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		auto &new_field = add_field_info.new_field;
 		auto &if_field_not_exists = add_field_info.if_field_not_exists;
 
-		auto new_schema = current_schema.Copy();
+		auto new_schema = current_schema->Copy();
 		new_schema->schema_id++;
 
 		auto parent_path = column_path;
@@ -628,7 +629,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		auto &column_path = rename_field_info.column_path;
 		auto &new_name = rename_field_info.new_name;
 
-		auto new_schema = current_schema.Copy();
+		auto new_schema = current_schema->Copy();
 		new_schema->schema_id++;
 
 		auto column_p = new_schema->GetMutableFromPath(column_path, nullptr);
@@ -658,7 +659,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		auto &cascade = remove_field_info.cascade;
 		auto &if_column_exists = remove_field_info.if_column_exists;
 
-		auto new_schema = current_schema.Copy();
+		auto new_schema = current_schema->Copy();
 		new_schema->schema_id++;
 
 		D_ASSERT(column_path.size() > 1);

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -264,16 +264,15 @@ static void VerifySchemaEvolution(const IcebergTableMetadata &table_metadata, co
 
 void IntroduceNewSchema(IcebergTransactionTableState &updated_table, IcebergTransactionData &transaction_data,
                         IcebergTableMetadata &table_metadata, shared_ptr<IcebergTableSchema> new_schema) {
-	auto new_schema_id = new_schema->schema_id;
-
-	auto &result_schema = table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
-	if (result_schema.schema_id == new_schema_id) {
-		updated_table.GetOrCreateSchemaEntry(result_schema);
-		transaction_data.TableAddSchema(table_metadata, new_schema_id);
+	bool created = false;
+	auto result_schema =
+	    transaction_data.AddSchemaOrGetExisting(updated_table.GetBaseMetadata(), std::move(new_schema), created);
+	if (created) {
+		updated_table.GetOrCreateSchemaEntry(*result_schema);
+		transaction_data.TableAddSchema(result_schema, table_metadata.last_column_id);
 	} else {
-		transaction_data.TableSetCurrentSchema(table_metadata);
+		transaction_data.TableSetCurrentSchema(result_schema->schema_id);
 	}
-	table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 }
 
 template <typename T>
@@ -475,16 +474,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		column.name = new_name.GetIdentifierName();
 		column.RewriteType();
 
-		auto new_schema_id = new_schema->schema_id;
-
-		auto &result_schema = table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
-		if (result_schema.schema_id == new_schema_id) {
-			updated_table.GetOrCreateSchemaEntry(result_schema);
-			transaction_data.TableAddSchema(table_metadata, new_schema_id);
-		} else {
-			transaction_data.TableSetCurrentSchema(table_metadata);
-		}
-		table_metadata.SetCurrentSchemaId(result_schema.schema_id);
+		IntroduceNewSchema(updated_table, transaction_data, table_metadata, new_schema);
 		return;
 	}
 	case AlterTableType::SET_TABLE_OPTIONS: {
@@ -575,16 +565,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 		auto default_constant_value = binder.Evaluate(expression.get(), column.type);
 		column.write_default = make_uniq<Value>(default_constant_value);
 
-		auto new_schema_id = new_schema->schema_id;
-
-		auto &result_schema = table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
-		if (result_schema.schema_id == new_schema_id) {
-			updated_table.GetOrCreateSchemaEntry(result_schema);
-			transaction_data.TableAddSchema(table_metadata, new_schema_id);
-		} else {
-			transaction_data.TableSetCurrentSchema(table_metadata);
-		}
-		table_metadata.SetCurrentSchemaId(result_schema.schema_id);
+		IntroduceNewSchema(updated_table, transaction_data, table_metadata, new_schema);
 		return;
 	}
 	case AlterTableType::ADD_FIELD: {

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -272,7 +272,7 @@ void IntroduceNewSchema(IcebergTransactionTableState &updated_table, IcebergTran
 		updated_table.GetOrCreateSchemaEntry(result_schema);
 		transaction_data.TableAddSchema(table_metadata, new_schema_id);
 	} else {
-		transaction_data.TableSetCurrentSchema();
+		transaction_data.TableSetCurrentSchema(table_metadata);
 	}
 	table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 }
@@ -483,7 +483,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			updated_table.GetOrCreateSchemaEntry(result_schema);
 			transaction_data.TableAddSchema(table_metadata, new_schema_id);
 		} else {
-			transaction_data.TableSetCurrentSchema();
+			transaction_data.TableSetCurrentSchema(table_metadata);
 		}
 		table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 		return;
@@ -529,7 +529,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 				                            new_format_version.GetIndex());
 			}
 			table_metadata.iceberg_version = (int32_t)new_format_version.GetIndex();
-			transaction_data.TableAddUpradeFormatVersion();
+			transaction_data.TableAddUpradeFormatVersion(table_metadata);
 		}
 
 		if (!new_properties.empty()) {
@@ -583,7 +583,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			updated_table.GetOrCreateSchemaEntry(result_schema);
 			transaction_data.TableAddSchema(table_metadata, new_schema_id);
 		} else {
-			transaction_data.TableSetCurrentSchema();
+			transaction_data.TableSetCurrentSchema(table_metadata);
 		}
 		table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 		return;

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
@@ -16,6 +16,8 @@
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
 #include "catalog/rest/api/catalog_api.hpp"
+#include "catalog/rest/transaction/iceberg_transaction.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "planning/iceberg_multi_file_reader.hpp"
 #include "planning/iceberg_multi_file_reader.hpp"
 #include "catalog/rest/storage/authorization/sigv4.hpp"
@@ -192,7 +194,10 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 	// lookup should be asof start of the transaction if the lookup info is empty and there are no transaction updates
 	bool using_transaction_timestamp = false;
 	IcebergSnapshotLookup snapshot_lookup;
-	if (!lookup.GetAtClause() && !table_info.HasTransactionUpdates()) {
+	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
+	auto transaction_data = iceberg_transaction.GetTransactionData(table_info.GetTableKey());
+	const bool has_transaction_updates = transaction_data && transaction_data->HasUpdates();
+	if (!lookup.GetAtClause() && !has_transaction_updates) {
 		// if there is no user supplied AT () clause, and the table does not have transaction updates
 		// use transaction start time
 		snapshot_lookup = table_info.GetSnapshotLookup(context);
@@ -219,8 +224,8 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 	auto &fs = FileSystem::GetFileSystem(context);
 	auto scan_info =
 	    make_shared_ptr<IcebergScanInfo>(metadata.GetMetadataPath(fs), metadata, snapshot_info, iceberg_schema);
-	if (table_info.transaction_data && snapshot_lookup.IsLatest()) {
-		scan_info->transaction_data = table_info.transaction_data.get();
+	if (transaction_data && snapshot_lookup.IsLatest()) {
+		scan_info->transaction_data = transaction_data;
 	}
 
 	iceberg_scan_function.function_info = scan_info;

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
@@ -82,8 +82,8 @@ void IcebergTableEntry::PrepareIcebergScanFromEntry(ClientContext &context) cons
 	}
 	// Get Credentials from IRC API
 	auto &fs = FileSystem::GetFileSystem(context);
-	auto table_credentials = table_info.GetVendedCredentials(context);
 	auto table_metadata = GetTransactionTableMetadata();
+	auto table_credentials = table_info.GetVendedCredentials(context, table_metadata);
 	auto metadata_path = table_metadata.GetMetadataPath(fs);
 
 	unique_ptr<SecretEntry> http_secret_entry;

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
@@ -37,11 +37,18 @@ IcebergTableEntry::IcebergTableEntry(IcebergTableInformation &table_info, Catalo
 	this->internal = false;
 }
 
-const IcebergTableMetadata &IcebergTableEntry::GetTableMetadata() const {
+const IcebergTableMetadata &IcebergTableEntry::GetBaseTableMetadata() const {
 	if (transaction_state) {
-		return transaction_state->GetMetadata();
+		return transaction_state->GetBaseMetadata();
 	}
 	return table_info.table_metadata;
+}
+
+IcebergTableMetadata IcebergTableEntry::GetTransactionTableMetadata() const {
+	if (transaction_state) {
+		return transaction_state->GetTransactionMetadata();
+	}
+	return table_info.table_metadata.Copy();
 }
 
 optional_ptr<IcebergTransactionData> IcebergTableEntry::GetTransactionData() const {
@@ -76,7 +83,7 @@ void IcebergTableEntry::PrepareIcebergScanFromEntry(ClientContext &context) cons
 	// Get Credentials from IRC API
 	auto &fs = FileSystem::GetFileSystem(context);
 	auto table_credentials = table_info.GetVendedCredentials(context);
-	auto &table_metadata = GetTableMetadata();
+	auto table_metadata = GetTransactionTableMetadata();
 	auto metadata_path = table_metadata.GetMetadataPath(fs);
 
 	unique_ptr<SecretEntry> http_secret_entry;
@@ -205,18 +212,20 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 		throw InternalException("GetScanFunction was called with a dummy IcebergTableEntry, this should never happen");
 	}
 	const auto schema_id = this->schema_id.GetIndex();
-	const auto &metadata = GetTableMetadata();
-	const auto &iceberg_schema = *metadata.GetSchemaFromId(schema_id);
-
-	// lookup should be asof start of the transaction if the lookup info is empty and there are no transaction updates
-	bool using_transaction_timestamp = false;
-	IcebergSnapshotLookup snapshot_lookup;
 	auto transaction_data = GetTransactionData();
 	if (!transaction_data) {
 		auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
 		transaction_data = iceberg_transaction.GetTransactionData(table_info.GetTableKey());
 	}
 	const bool has_transaction_updates = transaction_data && transaction_data->HasUpdates();
+	auto metadata = GetBaseTableMetadata().Copy();
+	if (has_transaction_updates && !lookup.GetAtClause()) {
+		metadata = GetTransactionTableMetadata();
+	}
+
+	// lookup should be asof start of the transaction if the lookup info is empty and there are no transaction updates
+	bool using_transaction_timestamp = false;
+	IcebergSnapshotLookup snapshot_lookup;
 	if (!lookup.GetAtClause() && !has_transaction_updates) {
 		// if there is no user supplied AT () clause, and the table does not have transaction updates
 		// use transaction start time
@@ -242,8 +251,12 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 	}
 
 	auto &fs = FileSystem::GetFileSystem(context);
-	auto scan_info =
-	    make_shared_ptr<IcebergScanInfo>(metadata.GetMetadataPath(fs), metadata, snapshot_info, iceberg_schema);
+	auto temp_data = make_uniq<IcebergScanTemporaryData>();
+	temp_data->metadata = std::move(metadata);
+	auto &scan_metadata = temp_data->metadata;
+	const auto &iceberg_schema = *scan_metadata.GetSchemaFromId(schema_id);
+	auto scan_info = make_shared_ptr<IcebergScanInfo>(scan_metadata.GetMetadataPath(fs), std::move(temp_data),
+	                                                  snapshot_info, iceberg_schema);
 	if (transaction_data && snapshot_lookup.IsLatest()) {
 		scan_info->transaction_data = transaction_data;
 	}
@@ -292,7 +305,7 @@ virtual_column_map_t IcebergTableEntry::VirtualColumns() {
 
 vector<column_t> IcebergTableEntry::GetRowIdColumns() const {
 	vector<column_t> result;
-	auto &table_metadata = GetTableMetadata();
+	auto table_metadata = GetTransactionTableMetadata();
 	if (table_metadata.iceberg_version >= 3) {
 		//! Project the _row_id column as part of the row-id-columns
 		result.push_back(COLUMN_IDENTIFIER_ROW_ID);

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
@@ -30,9 +30,25 @@ class OAuth2Authorization;
 constexpr column_t IcebergMultiFileReader::COLUMN_IDENTIFIER_LAST_SEQUENCE_NUMBER;
 
 IcebergTableEntry::IcebergTableEntry(IcebergTableInformation &table_info, Catalog &catalog, SchemaCatalogEntry &schema,
-                                     CreateTableInfo &info, optional_idx schema_id)
-    : TableCatalogEntry(catalog, schema, info), table_info(table_info), schema_id(schema_id) {
+                                     CreateTableInfo &info, optional_idx schema_id,
+                                     optional_ptr<IcebergTransactionTableState> transaction_state)
+    : TableCatalogEntry(catalog, schema, info), table_info(table_info), schema_id(schema_id),
+      transaction_state(transaction_state) {
 	this->internal = false;
+}
+
+const IcebergTableMetadata &IcebergTableEntry::GetTableMetadata() const {
+	if (transaction_state) {
+		return transaction_state->GetMetadata();
+	}
+	return table_info.table_metadata;
+}
+
+optional_ptr<IcebergTransactionData> IcebergTableEntry::GetTransactionData() const {
+	if (transaction_state) {
+		return transaction_state->GetTransactionData();
+	}
+	return nullptr;
 }
 
 unique_ptr<BaseStatistics> IcebergTableEntry::GetStatistics(ClientContext &context, column_t column_id) {
@@ -60,7 +76,8 @@ void IcebergTableEntry::PrepareIcebergScanFromEntry(ClientContext &context) cons
 	// Get Credentials from IRC API
 	auto &fs = FileSystem::GetFileSystem(context);
 	auto table_credentials = table_info.GetVendedCredentials(context);
-	auto metadata_path = table_info.table_metadata.GetMetadataPath(fs);
+	auto &table_metadata = GetTableMetadata();
+	auto metadata_path = table_metadata.GetMetadataPath(fs);
 
 	unique_ptr<SecretEntry> http_secret_entry;
 
@@ -90,11 +107,11 @@ void IcebergTableEntry::PrepareIcebergScanFromEntry(ClientContext &context) cons
 		auto &info = *table_credentials.config;
 		D_ASSERT(info.scope.empty());
 		string storage_scope;
-		auto data_path = table_info.table_metadata.table_properties.find("write.data.path");
-		if (data_path != table_info.table_metadata.table_properties.end()) {
+		auto data_path = table_metadata.table_properties.find("write.data.path");
+		if (data_path != table_metadata.table_properties.end()) {
 			storage_scope = data_path->second;
 		} else {
-			storage_scope = table_info.table_metadata.GetLocation();
+			storage_scope = table_metadata.GetLocation();
 		}
 		if (!storage_scope.empty()) {
 			if (!StringUtil::EndsWith(storage_scope, "/")) {
@@ -188,14 +205,17 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 		throw InternalException("GetScanFunction was called with a dummy IcebergTableEntry, this should never happen");
 	}
 	const auto schema_id = this->schema_id.GetIndex();
-	const auto &metadata = table_info.table_metadata;
+	const auto &metadata = GetTableMetadata();
 	const auto &iceberg_schema = *metadata.GetSchemaFromId(schema_id);
 
 	// lookup should be asof start of the transaction if the lookup info is empty and there are no transaction updates
 	bool using_transaction_timestamp = false;
 	IcebergSnapshotLookup snapshot_lookup;
-	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
-	auto transaction_data = iceberg_transaction.GetTransactionData(table_info.GetTableKey());
+	auto transaction_data = GetTransactionData();
+	if (!transaction_data) {
+		auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
+		transaction_data = iceberg_transaction.GetTransactionData(table_info.GetTableKey());
+	}
 	const bool has_transaction_updates = transaction_data && transaction_data->HasUpdates();
 	if (!lookup.GetAtClause() && !has_transaction_updates) {
 		// if there is no user supplied AT () clause, and the table does not have transaction updates
@@ -272,7 +292,7 @@ virtual_column_map_t IcebergTableEntry::VirtualColumns() {
 
 vector<column_t> IcebergTableEntry::GetRowIdColumns() const {
 	vector<column_t> result;
-	auto &table_metadata = table_info.table_metadata;
+	auto &table_metadata = GetTableMetadata();
 	if (table_metadata.iceberg_version >= 3) {
 		//! Project the _row_id column as part of the row-id-columns
 		result.push_back(COLUMN_IDENTIFIER_ROW_ID);

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -163,7 +163,8 @@ static void ParseConfigOptions(const case_insensitive_map_t<string> &config, cas
 	endpoint_it->second = endpoint;
 }
 
-IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(ClientContext &context) {
+IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(ClientContext &context,
+                                                                     const IcebergTableMetadata &metadata) {
 	IRCAPITableCredentials result;
 	auto transaction_id = MetaTransaction::Get(context).global_transaction_id;
 	auto &transaction = IcebergTransaction::Get(context, catalog);
@@ -199,7 +200,7 @@ IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(ClientConte
 	}
 
 	// Detect storage type from metadata location
-	const auto &table_location = table_metadata.GetLocation();
+	const auto &table_location = metadata.GetLocation();
 	string storage_type = DetectStorageType(table_location);
 
 	// Mapping from config key to a duckdb secret option

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -529,17 +529,27 @@ void IcebergTableInformation::RefreshFromCatalog(ClientContext &context) {
 	}
 }
 
-IcebergTableInformation IcebergTableInformation::Copy(ClientContext &context) const {
+std::optional<IcebergTableInformation> IcebergTableInformation::TryCopy(ClientContext &context) const {
 	auto ret = IcebergTableInformation(catalog, schema, name);
 	auto table_key = ret.GetTableKey();
 	{
 		lock_guard<std::mutex> cache_lock(catalog.table_request_cache.Lock());
 		auto cached_result = catalog.table_request_cache.Get(context, table_key, cache_lock, false);
-		D_ASSERT(cached_result);
+		if (!cached_result) {
+			return std::nullopt;
+		}
 		auto &cached_table_result = *cached_result->load_table_result;
 		ret.InitializeFromLoadTableResult(cached_table_result, false);
 	}
 	return ret;
+}
+
+IcebergTableInformation IcebergTableInformation::Copy(ClientContext &context) const {
+	auto res = TryCopy(context);
+	if (!res) {
+		throw InvalidInputException("Table '%s' can't be reached anymore, likely deleted from the catalog", name);
+	}
+	return std::move(*res);
 }
 
 IcebergTableMetadata IcebergTableInformation::CreateMetadataFromLog(ClientContext &context,

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -438,7 +438,7 @@ IcebergTableInformation::BuildPartitionSpec(const vector<unique_ptr<ParsedExpres
 	return new_spec;
 }
 
-void IcebergTableInformation::SetPartitionedBy(IcebergTransaction &transaction,
+void IcebergTableInformation::SetPartitionedBy(IcebergTransactionData &transaction_data,
                                                const vector<unique_ptr<ParsedExpression>> &partition_keys,
                                                const IcebergTableSchema &schema, bool first_partition_spec) {
 	idx_t base_partition_field_id = 1000;
@@ -450,8 +450,6 @@ void IcebergTableInformation::SetPartitionedBy(IcebergTransaction &transaction,
 	if (!first_partition_spec) {
 		new_spec_id = GetNextPartitionSpecId();
 	}
-	auto &transaction_data = GetOrCreateTransactionData(transaction);
-
 	auto new_spec =
 	    BuildPartitionSpec(partition_keys, schema, static_cast<int32_t>(new_spec_id), base_partition_field_id);
 
@@ -545,7 +543,7 @@ IcebergSnapshotLookup IcebergTableInformation::GetSnapshotLookup(IcebergTransact
 
 IcebergSnapshotLookup IcebergTableInformation::GetSnapshotLookup(ClientContext &context,
                                                                  optional_ptr<BoundAtClause> at) const {
-	if (!at && !HasTransactionUpdates()) {
+	if (!at) {
 		// if there is no user supplied AT () clause, and the table does not have transaction updates
 		// use transaction start time
 		return GetSnapshotLookup(context);
@@ -566,26 +564,6 @@ IcebergSnapshotLookup IcebergTableInformation::GetSnapshotLookup(ClientContext &
 bool IcebergTableInformation::TableIsEmpty(const IcebergSnapshotLookup &snapshot_lookup) const {
 	(void)snapshot_lookup;
 	if (!table_metadata.GetLatestSnapshot()) {
-		return true;
-	}
-	return false;
-}
-
-bool IcebergTableInformation::HasTransactionUpdates() const {
-	if (!transaction_data) {
-		return false;
-	}
-	auto &data = *transaction_data;
-	if (!data.updates.empty()) {
-		return true;
-	}
-	if (!data.requirements.empty()) {
-		return true;
-	}
-	if (data.set_schema_id) {
-		return true;
-	}
-	if (data.assert_schema_id) {
 		return true;
 	}
 	return false;
@@ -706,15 +684,6 @@ IcebergTableInformation::IcebergTableInformation(IcebergCatalog &catalog, Iceber
                                                  const string &name)
     : catalog(catalog), schema(schema), name(name) {
 	table_id = "uuid-" + schema.name + "-" + name;
-}
-
-IcebergTransactionData &IcebergTableInformation::GetOrCreateTransactionData(IcebergTransaction &transaction) {
-	lock_guard<mutex> guard(transaction.lock);
-	if (!transaction_data) {
-		auto context = transaction.context.lock();
-		transaction_data = make_uniq<IcebergTransactionData>(*context, *this);
-	}
-	return *transaction_data;
 }
 
 void IcebergTableInformation::InitializeFromLoadTableResult(const rest_api_objects::LoadTableResult &load_table_result,

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -303,46 +303,11 @@ idx_t IcebergTableInformation::GetMaxSchemaId() {
 }
 
 idx_t IcebergTableInformation::GetNextPartitionSpecId() {
-	idx_t max_partition_spec_id = table_metadata.default_spec_id;
-	for (auto &schema : table_metadata.GetPartitionSpecs()) {
-		if (schema.first > max_partition_spec_id) {
-			max_partition_spec_id = schema.first;
-		}
-	}
-	return max_partition_spec_id + 1;
+	return table_metadata.GetNextPartitionSpecId();
 }
 
 int64_t IcebergTableInformation::GetExistingSpecId(IcebergPartitionSpec &spec) {
-	int64_t existing_spec_id = -1;
-	for (auto &existing_spec : table_metadata.GetPartitionSpecs()) {
-		bool fields_match = true;
-		if (existing_spec.second.fields.size() != spec.fields.size()) {
-			continue;
-		}
-		for (idx_t field_index = 0; field_index < existing_spec.second.fields.size(); field_index++) {
-			auto existing_partition_col_source_id = existing_spec.second.fields[field_index].source_id;
-			// if the number of partition columns don't match, the specs are not the same
-			auto new_spec_col_source_id = spec.fields[field_index].source_id;
-			if (existing_partition_col_source_id != new_spec_col_source_id) {
-				fields_match = false;
-				break;
-			}
-			auto existing_partition_col_transform = existing_spec.second.fields[field_index].transform.RawType();
-			auto new_spec_col_transform = spec.fields[field_index].transform.RawType();
-			if (existing_partition_col_transform != new_spec_col_transform) {
-				fields_match = false;
-				break;
-			}
-		}
-		if (!fields_match) {
-			continue;
-		}
-		// source ids are the same, transforms are the same, and partition amount is the same
-		// so we just use the existing spec.
-		existing_spec_id = existing_spec.second.spec_id;
-		break;
-	}
-	return existing_spec_id;
+	return table_metadata.GetExistingSpecId(spec);
 }
 
 IcebergPartitionSpec
@@ -441,33 +406,7 @@ IcebergTableInformation::BuildPartitionSpec(const vector<unique_ptr<ParsedExpres
 void IcebergTableInformation::SetPartitionedBy(IcebergTransactionData &transaction_data,
                                                const vector<unique_ptr<ParsedExpression>> &partition_keys,
                                                const IcebergTableSchema &schema, bool first_partition_spec) {
-	idx_t base_partition_field_id = 1000;
-	if (!first_partition_spec && table_metadata.HasLastPartitionId()) {
-		base_partition_field_id = table_metadata.GetLastPartitionFieldId() + 1;
-	}
-
-	idx_t new_spec_id = 0;
-	if (!first_partition_spec) {
-		new_spec_id = GetNextPartitionSpecId();
-	}
-	auto new_spec =
-	    BuildPartitionSpec(partition_keys, schema, static_cast<int32_t>(new_spec_id), base_partition_field_id);
-
-	// if spec definition already exists in a previous spec definition, set it to that spec id
-	// (some catalog may allow duplicate definitions, others not)
-	int64_t existing_spec_id = GetExistingSpecId(new_spec);
-	if (existing_spec_id >= 0) {
-		table_metadata.default_spec_id = existing_spec_id;
-		transaction_data.TableSetDefaultSpec();
-		return;
-	}
-
-	table_metadata.partition_specs.emplace(new_spec_id, std::move(new_spec));
-	table_metadata.default_spec_id = new_spec_id;
-	if (!first_partition_spec) {
-		transaction_data.TableAddPartitionSpec();
-		transaction_data.TableSetDefaultSpec();
-	}
+	table_metadata.SetPartitionedBy(transaction_data, partition_keys, schema, first_partition_spec);
 }
 
 optional_ptr<CatalogEntry> IcebergTableInformation::GetSchemaVersion(ClientContext &context,
@@ -536,9 +475,7 @@ string IcebergTableInformation::GetTableKey() const {
 }
 
 IcebergSnapshotLookup IcebergTableInformation::GetSnapshotLookup(IcebergTransaction &iceberg_transaction) const {
-	auto locked_context = iceberg_transaction.context.lock();
-	auto &context = *locked_context;
-	return GetSnapshotLookup(context);
+	return GetSnapshotLookup(iceberg_transaction.GetTransactionStartTimestamp());
 }
 
 IcebergSnapshotLookup IcebergTableInformation::GetSnapshotLookup(ClientContext &context,
@@ -553,8 +490,10 @@ IcebergSnapshotLookup IcebergTableInformation::GetSnapshotLookup(ClientContext &
 
 IcebergSnapshotLookup IcebergTableInformation::GetSnapshotLookup(ClientContext &context) const {
 	auto &meta_transaction = MetaTransaction::Get(context);
-	auto transaction_start = meta_transaction.GetCurrentTransactionStartTimestamp();
+	return GetSnapshotLookup(meta_transaction.GetCurrentTransactionStartTimestamp());
+}
 
+IcebergSnapshotLookup IcebergTableInformation::GetSnapshotLookup(timestamp_t transaction_start) const {
 	IcebergSnapshotLookup res;
 	res.snapshot_timestamp = transaction_start;
 	res.SetSource(SnapshotSource::FROM_TIMESTAMP);
@@ -635,8 +574,15 @@ IcebergTableInformation IcebergTableInformation::Copy(IcebergTransaction &iceber
 	auto &context = *locked_context;
 
 	auto ret = Copy(context);
-	auto &meta_transaction = MetaTransaction::Get(context);
-	auto transaction_start = meta_transaction.GetCurrentTransactionStartTimestamp();
+	ret.table_metadata = GetTransactionStartMetadata(context, iceberg_transaction);
+	return ret;
+}
+
+IcebergTableMetadata
+IcebergTableInformation::GetTransactionStartMetadata(ClientContext &context,
+                                                     IcebergTransaction &iceberg_transaction) const {
+	auto ret = Copy(context);
+	auto transaction_start = iceberg_transaction.GetTransactionStartTimestamp();
 	auto transaction_start_millis = Timestamp::GetEpochMs(transaction_start);
 
 	if (table_metadata.last_updated_ms.value > transaction_start_millis) {
@@ -652,7 +598,7 @@ IcebergTableInformation IcebergTableInformation::Copy(IcebergTransaction &iceber
 		if (!can_use_metadata_log) {
 			auto snapshot_lookup = GetSnapshotLookup(iceberg_transaction);
 			if (ret.TableIsEmpty(snapshot_lookup)) {
-				return ret;
+				return std::move(ret.table_metadata);
 			}
 			IcebergSnapshotScanInfo snapshot_info;
 			snapshot_info = ret.table_metadata.GetSnapshot(snapshot_lookup);
@@ -666,12 +612,11 @@ IcebergTableInformation IcebergTableInformation::Copy(IcebergTransaction &iceber
 			ret.table_metadata.SetCurrentSchemaId(table_metadata.GetCurrentSchemaId());
 			ret.table_metadata.last_sequence_number = snapshot->sequence_number;
 			ret.table_metadata.current_snapshot_id = snapshot->snapshot_id;
-			return ret;
+			return std::move(ret.table_metadata);
 		}
-		ret.table_metadata = ret.CreateMetadataFromLog(context, transaction_start_millis, ret.latest_metadata_json);
-		return ret;
+		return ret.CreateMetadataFromLog(context, transaction_start_millis, ret.latest_metadata_json);
 	}
-	return ret;
+	return std::move(ret.table_metadata);
 }
 
 void IcebergTableInformation::InitSchemaVersions() {

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -288,7 +288,7 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 	// other required updates to the table
 	transaction_data.TableAssignUUID();
 	transaction_data.TableAddUpradeFormatVersion();
-	transaction_data.TableAddSchema(0);
+	transaction_data.TableAddSchema(table_metadata, 0);
 	transaction_data.TableAddPartitionSpec();
 	transaction_data.TableSetDefaultSpec();
 	transaction_data.TableAddSortOrder();

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -223,30 +223,28 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 
 	auto key = IcebergTableInformation::GetTableKey(schema.namespace_items, info.table.GetIdentifierName());
 	auto &alter_update = iceberg_transaction.GetOrCreateAlter();
-	auto &table_info =
-	    alter_update.CreateTable(key, IcebergTableInformation(catalog, schema, info.table.GetIdentifierName()));
-	// auto &table_info = emplace_res.first->second;
-	auto &table_metadata = table_info.table_metadata;
-	auto table_entry = make_uniq<IcebergTableEntry>(table_info, catalog, schema, info, 0);
+	auto request_table_info = IcebergTableInformation(catalog, schema, info.table.GetIdentifierName());
+	auto &request_metadata = request_table_info.table_metadata;
+	auto table_entry = make_uniq<IcebergTableEntry>(request_table_info, catalog, schema, info, 0);
 	auto table_ptr = table_entry.get();
-	table_info.schema_versions[0] = std::move(table_entry);
-	table_metadata.iceberg_version = iceberg_version.GetIndex();
+	request_table_info.schema_versions[0] = std::move(table_entry);
+	request_metadata.iceberg_version = iceberg_version.GetIndex();
 	int32_t last_column_id;
 
-	auto new_schema = IcebergCreateTableRequest::CreateIcebergSchema(context, table_metadata, table_ptr->GetColumns(),
+	auto new_schema = IcebergCreateTableRequest::CreateIcebergSchema(context, request_metadata, table_ptr->GetColumns(),
 	                                                                 table_ptr->GetConstraints(), last_column_id);
 	new_schema->schema_id = 0;
-	auto &result_schema = table_metadata.AddSchema(std::move(new_schema));
+	auto &result_schema = request_metadata.AddSchema(std::move(new_schema));
 	if (result_schema.schema_id != 0) {
 		throw InternalException("Adding initial schema didn't result in schema id 0? (actual: %d)",
 		                        result_schema.schema_id);
 	}
-	table_metadata.SetCurrentSchemaId(0);
-	table_metadata.last_column_id = last_column_id;
+	request_metadata.SetCurrentSchemaId(0);
+	request_metadata.last_column_id = last_column_id;
 
 	// Get Location
 	if (!location.empty()) {
-		table_metadata.location = location;
+		request_metadata.location = location;
 	}
 	for (auto &option : info.options) {
 		if (option.first == "format-version" || option.first == "location") {
@@ -255,22 +253,24 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 		auto option_val =
 		    ParseTableProperty(property_binder, context, *option.second, option.first, LogicalType::VARCHAR)
 		        .GetValue<string>();
-		table_metadata.table_properties.emplace(option.first, option_val);
+		request_metadata.table_properties.emplace(option.first, option_val);
 	}
 
-	auto request_schema = table_info.table_metadata.GetSchemaFromId(table_info.table_metadata.GetCurrentSchemaId());
+	auto request_schema =
+	    request_table_info.table_metadata.GetSchemaFromId(request_table_info.table_metadata.GetCurrentSchemaId());
 	D_ASSERT(request_schema);
 	auto request_partition_spec =
 	    IcebergTableInformation::BuildPartitionSpec(info.partition_keys, *request_schema, 0, 1000);
 	table_ptr->table_info.table_metadata.partition_specs.emplace(0, std::move(request_partition_spec));
 	table_ptr->table_info.table_metadata.default_spec_id = 0;
-	auto &created_table = alter_update.GetOrInitializeTable(table_info);
 
 	// Immediately create the table with stage_create = true to get metadata & data location(s)
 	// transaction commit will either commit with data (OR) create the table with stage_create = false
 	auto load_table_result =
 	    make_uniq<const rest_api_objects::LoadTableResult>(IRCAPI::CommitNewTable(context, catalog, *table_ptr));
 
+	auto &table_info =
+	    alter_update.CreateTable(key, IcebergTableInformation(catalog, schema, info.table.GetIdentifierName()));
 	catalog.table_request_cache.SetOrOverwrite(context, key, std::move(load_table_result));
 	{
 		lock_guard<mutex> cache_lock(catalog.table_request_cache.Lock());
@@ -279,9 +279,11 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 		auto &load_table_result = cached_table_result->load_table_result;
 		table_info.InitializeFromLoadTableResult(*load_table_result, false);
 	}
+	auto &created_table = alter_update.GetOrInitializeTable(table_info);
 	created_table.SetBaseMetadata(table_info.table_metadata.Copy());
 	auto current_schema = table_info.table_metadata.GetSchemaFromId(table_info.table_metadata.GetCurrentSchemaId());
 	D_ASSERT(current_schema);
+	table_info.CreateSchemaVersion(*current_schema);
 	auto &transaction_data = alter_update.GetOrCreateTransactionData(created_table);
 
 	// if we stage created the table, we add an assert create
@@ -292,15 +294,15 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 		return table_info;
 	}
 	// other required updates to the table
-	transaction_data.TableAssignUUID(table_metadata);
-	transaction_data.TableAddUpradeFormatVersion(table_metadata);
-	transaction_data.TableAddSchema(current_schema->Copy(), table_metadata.last_column_id);
-	transaction_data.TableAddPartitionSpec(table_metadata);
-	transaction_data.TableSetDefaultSpec(table_metadata);
-	transaction_data.TableAddSortOrder(table_metadata);
-	transaction_data.TableSetDefaultSortOrder(table_metadata);
-	transaction_data.TableSetLocation(table_metadata);
-	transaction_data.TableSetProperties(table_metadata.table_properties);
+	transaction_data.TableAssignUUID(table_info.table_metadata);
+	transaction_data.TableAddUpradeFormatVersion(table_info.table_metadata);
+	transaction_data.TableAddSchema(current_schema->Copy(), table_info.table_metadata.last_column_id);
+	transaction_data.TableAddPartitionSpec(table_info.table_metadata);
+	transaction_data.TableSetDefaultSpec(table_info.table_metadata);
+	transaction_data.TableAddSortOrder(table_info.table_metadata);
+	transaction_data.TableSetDefaultSortOrder(table_info.table_metadata);
+	transaction_data.TableSetLocation(table_info.table_metadata);
+	transaction_data.TableSetProperties(table_info.table_metadata.table_properties);
 	transaction_data.MarkCreateSeeded();
 
 	iceberg_transaction.SetLatestTableState(table_info, IcebergTableStatus::ALIVE);

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -318,8 +318,7 @@ optional_ptr<CatalogEntry> IcebergTableSet::GetEntry(ClientContext &context, con
 			// If table has been deleted or is missing within the transaction, return null
 			return nullptr;
 		}
-		auto &table_info = latest_state->GetInfo();
-		return table_info.GetSchemaVersion(context, at);
+		return latest_state->GetSchemaVersion(context, at);
 	}
 
 	//! Preserve the old version in case our replacement fails

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -277,6 +277,7 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 		auto &load_table_result = cached_table_result->load_table_result;
 		table_info.InitializeFromLoadTableResult(*load_table_result, false);
 	}
+	created_table.SetBaseMetadata(table_info.table_metadata.Copy());
 
 	// if we stage created the table, we add an assert create
 	if (catalog.attach_options.stage_create_tables) {
@@ -295,6 +296,7 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 	transaction_data.TableSetDefaultSortOrder(table_metadata);
 	transaction_data.TableSetLocation(table_metadata);
 	transaction_data.TableSetProperties(table_metadata.table_properties);
+	transaction_data.MarkCreateSeeded();
 
 	iceberg_transaction.SetLatestTableState(table_info, IcebergTableStatus::ALIVE);
 	return table_info;

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -286,14 +286,14 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 		return table_info;
 	}
 	// other required updates to the table
-	transaction_data.TableAssignUUID();
-	transaction_data.TableAddUpradeFormatVersion();
+	transaction_data.TableAssignUUID(table_metadata);
+	transaction_data.TableAddUpradeFormatVersion(table_metadata);
 	transaction_data.TableAddSchema(table_metadata, 0);
-	transaction_data.TableAddPartitionSpec();
-	transaction_data.TableSetDefaultSpec();
-	transaction_data.TableAddSortOrder();
-	transaction_data.TableSetDefaultSortOrder();
-	transaction_data.TableSetLocation();
+	transaction_data.TableAddPartitionSpec(table_metadata);
+	transaction_data.TableSetDefaultSpec(table_metadata);
+	transaction_data.TableAddSortOrder(table_metadata);
+	transaction_data.TableSetDefaultSortOrder(table_metadata);
+	transaction_data.TableSetLocation(table_metadata);
 	transaction_data.TableSetProperties(table_metadata.table_properties);
 
 	iceberg_transaction.SetLatestTableState(table_info, IcebergTableStatus::ALIVE);

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -260,7 +260,8 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 
 	auto &current_schema = table_info.table_metadata.GetLatestSchema();
 	table_ptr->table_info.table_metadata.default_spec_id = 0;
-	table_ptr->table_info.SetPartitionedBy(iceberg_transaction, info.partition_keys, current_schema, true);
+	auto &transaction_data = alter_update.GetOrCreateTransactionData(table_info);
+	table_ptr->table_info.SetPartitionedBy(transaction_data, info.partition_keys, current_schema, true);
 
 	// Immediately create the table with stage_create = true to get metadata & data location(s)
 	// transaction commit will either commit with data (OR) create the table with stage_create = false
@@ -277,7 +278,6 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 	}
 
 	// if we stage created the table, we add an assert create
-	auto &transaction_data = table_info.GetOrCreateTransactionData(iceberg_transaction);
 	if (catalog.attach_options.stage_create_tables) {
 		transaction_data.TableAddAssertCreate();
 	}

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -258,12 +258,12 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 		table_metadata.table_properties.emplace(option.first, option_val);
 	}
 
-	auto current_schema = table_info.table_metadata.GetSchemaFromId(table_info.table_metadata.GetCurrentSchemaId());
-	D_ASSERT(current_schema);
+	auto request_schema = table_info.table_metadata.GetSchemaFromId(table_info.table_metadata.GetCurrentSchemaId());
+	D_ASSERT(request_schema);
 	table_ptr->table_info.table_metadata.default_spec_id = 0;
 	auto &created_table = alter_update.GetOrInitializeTable(table_info);
 	auto &transaction_data = alter_update.GetOrCreateTransactionData(created_table);
-	table_ptr->table_info.SetPartitionedBy(transaction_data, info.partition_keys, *current_schema, true);
+	table_ptr->table_info.SetPartitionedBy(transaction_data, info.partition_keys, *request_schema, true);
 
 	// Immediately create the table with stage_create = true to get metadata & data location(s)
 	// transaction commit will either commit with data (OR) create the table with stage_create = false
@@ -279,6 +279,8 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 		table_info.InitializeFromLoadTableResult(*load_table_result, false);
 	}
 	created_table.SetBaseMetadata(table_info.table_metadata.Copy());
+	auto current_schema = table_info.table_metadata.GetSchemaFromId(table_info.table_metadata.GetCurrentSchemaId());
+	D_ASSERT(current_schema);
 
 	// if we stage created the table, we add an assert create
 	if (catalog.attach_options.stage_create_tables) {

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -236,7 +236,7 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 	auto new_schema = IcebergCreateTableRequest::CreateIcebergSchema(context, table_metadata, table_ptr->GetColumns(),
 	                                                                 table_ptr->GetConstraints(), last_column_id);
 	new_schema->schema_id = 0;
-	auto &result_schema = table_metadata.AddSchemaOrGetExisting(std::move(new_schema));
+	auto &result_schema = table_metadata.AddSchema(std::move(new_schema));
 	if (result_schema.schema_id != 0) {
 		throw InternalException("Adding initial schema didn't result in schema id 0? (actual: %d)",
 		                        result_schema.schema_id);
@@ -289,7 +289,7 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 	// other required updates to the table
 	transaction_data.TableAssignUUID(table_metadata);
 	transaction_data.TableAddUpradeFormatVersion(table_metadata);
-	transaction_data.TableAddSchema(table_metadata, 0);
+	transaction_data.TableAddSchema(current_schema.Copy(), table_metadata.last_column_id);
 	transaction_data.TableAddPartitionSpec(table_metadata);
 	transaction_data.TableSetDefaultSpec(table_metadata);
 	transaction_data.TableAddSortOrder(table_metadata);

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -260,7 +260,8 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 
 	auto &current_schema = table_info.table_metadata.GetLatestSchema();
 	table_ptr->table_info.table_metadata.default_spec_id = 0;
-	auto &transaction_data = alter_update.GetOrCreateTransactionData(table_info);
+	auto &created_table = alter_update.GetOrInitializeTable(table_info);
+	auto &transaction_data = alter_update.GetOrCreateTransactionData(created_table);
 	table_ptr->table_info.SetPartitionedBy(transaction_data, info.partition_keys, current_schema, true);
 
 	// Immediately create the table with stage_create = true to get metadata & data location(s)

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -280,7 +280,6 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 		table_info.InitializeFromLoadTableResult(*load_table_result, false);
 	}
 	auto &created_table = alter_update.GetOrInitializeTable(table_info);
-	created_table.SetBaseMetadata(table_info.table_metadata.Copy());
 	auto current_schema = table_info.table_metadata.GetSchemaFromId(table_info.table_metadata.GetCurrentSchemaId());
 	D_ASSERT(current_schema);
 	table_info.CreateSchemaVersion(*current_schema);

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -258,11 +258,12 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 		table_metadata.table_properties.emplace(option.first, option_val);
 	}
 
-	auto &current_schema = table_info.table_metadata.GetLatestSchema();
+	auto current_schema = table_info.table_metadata.GetSchemaFromId(table_info.table_metadata.GetCurrentSchemaId());
+	D_ASSERT(current_schema);
 	table_ptr->table_info.table_metadata.default_spec_id = 0;
 	auto &created_table = alter_update.GetOrInitializeTable(table_info);
 	auto &transaction_data = alter_update.GetOrCreateTransactionData(created_table);
-	table_ptr->table_info.SetPartitionedBy(transaction_data, info.partition_keys, current_schema, true);
+	table_ptr->table_info.SetPartitionedBy(transaction_data, info.partition_keys, *current_schema, true);
 
 	// Immediately create the table with stage_create = true to get metadata & data location(s)
 	// transaction commit will either commit with data (OR) create the table with stage_create = false
@@ -289,7 +290,7 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 	// other required updates to the table
 	transaction_data.TableAssignUUID(table_metadata);
 	transaction_data.TableAddUpradeFormatVersion(table_metadata);
-	transaction_data.TableAddSchema(current_schema.Copy(), table_metadata.last_column_id);
+	transaction_data.TableAddSchema(current_schema->Copy(), table_metadata.last_column_id);
 	transaction_data.TableAddPartitionSpec(table_metadata);
 	transaction_data.TableSetDefaultSpec(table_metadata);
 	transaction_data.TableAddSortOrder(table_metadata);

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -260,10 +260,11 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 
 	auto request_schema = table_info.table_metadata.GetSchemaFromId(table_info.table_metadata.GetCurrentSchemaId());
 	D_ASSERT(request_schema);
+	auto request_partition_spec =
+	    IcebergTableInformation::BuildPartitionSpec(info.partition_keys, *request_schema, 0, 1000);
+	table_ptr->table_info.table_metadata.partition_specs.emplace(0, std::move(request_partition_spec));
 	table_ptr->table_info.table_metadata.default_spec_id = 0;
 	auto &created_table = alter_update.GetOrInitializeTable(table_info);
-	auto &transaction_data = alter_update.GetOrCreateTransactionData(created_table);
-	table_ptr->table_info.SetPartitionedBy(transaction_data, info.partition_keys, *request_schema, true);
 
 	// Immediately create the table with stage_create = true to get metadata & data location(s)
 	// transaction commit will either commit with data (OR) create the table with stage_create = false
@@ -281,6 +282,7 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 	created_table.SetBaseMetadata(table_info.table_metadata.Copy());
 	auto current_schema = table_info.table_metadata.GetSchemaFromId(table_info.table_metadata.GetCurrentSchemaId());
 	D_ASSERT(current_schema);
+	auto &transaction_data = alter_update.GetOrCreateTransactionData(created_table);
 
 	// if we stage created the table, we add an assert create
 	if (catalog.attach_options.stage_create_tables) {

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -21,6 +21,7 @@
 #include "core/metadata/snapshot/iceberg_snapshot.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
 #include "planning/metadata_io/avro/avro_scan.hpp"
 #include "iceberg_logging.hpp"
 #include "catalog/rest/api/table_update.hpp"
@@ -33,13 +34,116 @@ IcebergTransactionTableState::IcebergTransactionTableState(optional_ptr<IcebergT
     : table(table), status(table ? IcebergTableStatus::ALIVE : IcebergTableStatus::MISSING) {
 }
 
+IcebergTransactionData &IcebergTransactionTableState::GetOrCreateTransactionData(IcebergTransaction &transaction) {
+	if (!transaction_data) {
+		auto context = transaction.context.lock();
+		transaction_data = make_uniq<IcebergTransactionData>(*context, GetInfo());
+	}
+	return *transaction_data;
+}
+
+IcebergTableEntry &IcebergTransactionTableState::GetOrCreateSchemaEntry(const IcebergTableSchema &table_schema) {
+	auto it = schema_versions.find(table_schema.schema_id);
+	if (it != schema_versions.end()) {
+		return *it->second;
+	}
+
+	CreateTableInfo info;
+	info.table = Identifier(GetInfo().name);
+	for (auto &col : table_schema.columns) {
+		info.columns.AddColumn(col->GetColumnDefinition());
+	}
+
+	auto table_entry = make_uniq<IcebergTableEntry>(GetInfo(), GetInfo().catalog, GetInfo().schema, info,
+	                                                table_schema.schema_id, *this);
+	if (!table_entry->internal) {
+		table_entry->internal = GetInfo().schema.internal;
+	}
+	auto &result = *table_entry;
+	schema_versions.emplace(table_schema.schema_id, std::move(table_entry));
+	return result;
+}
+
+IcebergTableEntry &IcebergTransactionTableState::GetOrCreateDummyEntry() {
+	if (dummy_entry) {
+		return *dummy_entry;
+	}
+	CreateTableInfo info(GetInfo().schema, Identifier(GetInfo().name));
+	vector<ColumnDefinition> columns;
+	columns.emplace_back(Identifier("__"), LogicalType::UNKNOWN);
+	info.columns = ColumnList(std::move(columns));
+	dummy_entry =
+	    make_uniq<IcebergTableEntry>(GetInfo(), GetInfo().catalog, GetInfo().schema, info, optional_idx(), *this);
+	if (!dummy_entry->internal) {
+		dummy_entry->internal = GetInfo().schema.internal;
+	}
+	return *dummy_entry;
+}
+
+optional_ptr<CatalogEntry> IcebergTransactionTableState::GetLatestSchema(ClientContext &context) {
+	return GetSchemaVersion(context, nullptr);
+}
+
+optional_ptr<CatalogEntry> IcebergTransactionTableState::GetSchemaVersion(ClientContext &context,
+                                                                          optional_ptr<BoundAtClause> at) {
+	auto &metadata = GetMetadata();
+	if (metadata.snapshots.empty()) {
+		auto schema = metadata.GetSchemaFromId(metadata.GetCurrentSchemaId());
+		D_ASSERT(schema);
+		return GetOrCreateSchemaEntry(*schema);
+	}
+
+	auto &meta_transaction = MetaTransaction::Get(context);
+	auto transaction_start = meta_transaction.GetCurrentTransactionStartTimestamp();
+	auto transaction_start_millis = Timestamp::GetEpochMs(transaction_start);
+
+	auto snapshot_lookup = IcebergSnapshotLookup::FromAtClause(at);
+	auto snapshot_info = metadata.GetSnapshot(snapshot_lookup);
+
+	int32_t schema_id;
+	if (!snapshot_lookup.IsLatest() && snapshot_info.snapshot) {
+		auto &snapshot = *snapshot_info.snapshot;
+		if (snapshot.timestamp_ms.value > transaction_start.value) {
+			return nullptr;
+		}
+		schema_id = snapshot.GetSchemaId();
+	} else {
+		bool use_metadata_log = true;
+		Value val;
+		if (context.TryGetCurrentSetting("iceberg_use_metadata_log", val)) {
+			if (!val.IsNull() && val.type().id() == LogicalTypeId::BOOLEAN) {
+				use_metadata_log = val.GetValue<bool>();
+			}
+		}
+
+		const bool latest_metadata_is_too_fresh = metadata.last_updated_ms.value > transaction_start_millis;
+		const bool can_use_metadata_log = use_metadata_log && !metadata.metadata_log.empty();
+		if (latest_metadata_is_too_fresh && can_use_metadata_log) {
+			string metadata_path;
+			auto relevant_metadata = GetInfo().CreateMetadataFromLog(context, transaction_start_millis, metadata_path);
+			schema_id = relevant_metadata.GetCurrentSchemaId();
+		} else {
+			schema_id = metadata.GetCurrentSchemaId();
+		}
+	}
+	auto schema = metadata.GetSchemaFromId(schema_id);
+	if (!schema) {
+		return nullptr;
+	}
+	return GetOrCreateSchemaEntry(*schema);
+}
+
 IcebergTransaction::IcebergTransaction(IcebergCatalog &ic_catalog, TransactionManager &manager, ClientContext &context)
-    : Transaction(manager, context), db(*context.db), catalog(ic_catalog), access_mode(ic_catalog.access_mode) {
+    : Transaction(manager, context), db(*context.db), catalog(ic_catalog), access_mode(ic_catalog.access_mode),
+      transaction_start_timestamp(timestamp_t(0)) {
 }
 
 IcebergTransaction::~IcebergTransaction() = default;
 
 void IcebergTransaction::Start() {
+	auto ctx = context.lock();
+	auto &meta_transaction = MetaTransaction::Get(*ctx);
+	transaction_start_timestamp = meta_transaction.GetCurrentTransactionStartTimestamp();
 }
 
 IcebergCatalog &IcebergTransaction::GetCatalog() {
@@ -213,11 +317,16 @@ static void CreateTableRequirements(DatabaseInstance &db, ClientContext &context
 	}
 }
 
-static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, IcebergTableInformation &table_info,
+static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, IcebergTransactionTableState &table_state,
                                                       IcebergTransactionData &transaction_data,
                                                       ClientContext &context) {
 	SingleTableStagedCommit info;
-	IcebergCommitState commit_state(table_info, context);
+	auto &table_info = table_state.GetInfo();
+	auto commit_table = table_info.Copy(context);
+	if (!transaction_data.SupportsAppendRetry()) {
+		commit_table.table_metadata = table_state.GetMetadata().Copy();
+	}
+	IcebergCommitState commit_state(commit_table, context);
 	auto &table_change = commit_state.table_change;
 	auto &schema = table_info.schema.Cast<IcebergSchemaEntry>();
 	table_change.identifier = rest_api_objects::TableIdentifier();
@@ -234,7 +343,7 @@ static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, Iceb
 
 	for (auto &update : transaction_data.updates) {
 		if (update->type == IcebergTableUpdateType::ADD_SNAPSHOT) {
-			auto &ic_table_entry = table_info.GetLatestSchema(context)->Cast<IcebergTableEntry>();
+			auto &ic_table_entry = table_state.GetLatestSchema(context)->Cast<IcebergTableEntry>();
 			ic_table_entry.PrepareIcebergScanFromEntry(context);
 		}
 		update->CreateUpdate(db, context, commit_state);
@@ -272,14 +381,14 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 			//! Already committed
 			continue;
 		}
-		auto &table_info = updated_table.second;
+		auto &table_state = updated_table.second;
 		auto transaction_data = alter_update.GetTransactionData(table_key);
 		if (!transaction_data || !transaction_data->HasUpdates()) {
 			//! No changes to commit
 			continue;
 		}
 
-		auto table_transaction_info = StageSingleTableCommit(db, table_info, *transaction_data, context);
+		auto table_transaction_info = StageSingleTableCommit(db, table_state, *transaction_data, context);
 		info.created_metadata_files.emplace(table_key, std::move(table_transaction_info.created_metadata_files));
 		info.table_requests.emplace(table_key, transaction.table_changes.size());
 		transaction.table_changes.push_back(std::move(table_transaction_info.request));
@@ -333,19 +442,20 @@ void IcebergTransaction::RefreshRetryTables(IcebergTransactionAlterUpdate &alter
 		if (it == alter_update.updated_tables.end()) {
 			continue;
 		}
-		auto &table_info = it->second;
+		auto &table_state = it->second;
 		auto transaction_data = alter_update.GetTransactionData(table_key);
 		if (!transaction_data) {
 			continue;
 		}
-		if (!transaction_data->RetryStateMatches(table_info)) {
+		auto &base_table = table_state.GetInfo();
+		if (!transaction_data->RetryStateMatches(base_table)) {
 			throw TransactionException("Table %s changed incompatibly while retrying commit", table_key);
 		}
-		table_info.RefreshFromCatalog(context);
-		if (!transaction_data->RetryStateMatches(table_info)) {
+		base_table.RefreshFromCatalog(context);
+		if (!transaction_data->RetryStateMatches(base_table)) {
 			throw TransactionException("Table %s changed incompatibly while retrying commit", table_key);
 		}
-		SetLatestTableState(table_info, IcebergTableStatus::ALIVE);
+		SetLatestTableState(base_table, IcebergTableStatus::ALIVE);
 	}
 }
 
@@ -525,13 +635,13 @@ void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdat
 			if (alter_update.committed_tables.count(table_key)) {
 				break;
 			}
-			auto &table_info = entry.second;
+			auto &table_state = entry.second;
 			transaction_data = alter_update.GetTransactionData(table_key);
 			if (!transaction_data || !transaction_data->HasUpdates()) {
 				break;
 			}
 
-			auto table_transaction_info = StageSingleTableCommit(db, table_info, *transaction_data, context);
+			auto table_transaction_info = StageSingleTableCommit(db, table_state, *transaction_data, context);
 			auto &table_change = table_transaction_info.request;
 			D_ASSERT(table_change.identifier);
 			auto &identifier = *table_change.identifier;
@@ -706,10 +816,7 @@ IcebergTransaction &IcebergTransaction::Get(ClientContext &context, Catalog &cat
 }
 
 bool IcebergTransaction::StartedBefore(timestamp_t timestamp_ms) const {
-	auto ctx = context.lock();
-	auto &meta_transaction = MetaTransaction::Get(*ctx);
-	auto meta_transaction_start = meta_transaction.GetCurrentTransactionStartTimestamp();
-	auto start = Timestamp::GetEpochMs(meta_transaction_start);
+	auto start = Timestamp::GetEpochMs(transaction_start_timestamp);
 	return start < timestamp_ms.value;
 }
 
@@ -823,7 +930,7 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 }
 
 void ApplyTableUpdate(IcebergTableInformation &table_info, IcebergTransaction &iceberg_transaction,
-                      const std::function<void(IcebergTableInformation &, IcebergTransactionData &)> &callback) {
+                      const std::function<void(IcebergTransactionTableState &, IcebergTransactionData &)> &callback) {
 	auto &alter = iceberg_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(table_info);
 	auto &transaction_data = alter.GetOrCreateTransactionData(updated_table);

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -580,6 +580,7 @@ void IcebergTransaction::DoTableRename(IcebergTransactionRenameUpdate &rename_up
 	    IcebergTableInformation::GetTableKey(rename_update.source_namespace_items, rename_update.source_name);
 	auto &table_name = rename_update.source_name;
 	auto new_name = rename_update.new_name;
+	auto new_table_key = new_table.GetTableKey();
 
 	rest_api_objects::RenameTableRequest request;
 	request.source._namespace.value = rename_update.source_namespace_items;
@@ -588,6 +589,20 @@ void IcebergTransaction::DoTableRename(IcebergTransactionRenameUpdate &rename_up
 	request.destination.name = new_name;
 	auto transaction_json = RESTObjectToJSONString(request);
 	IRCAPI::CommitTableRename(context, catalog, transaction_json);
+
+	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
+	auto &table_request_cache = ic_catalog.table_request_cache;
+	{
+		lock_guard<mutex> cache_guard(table_request_cache.Lock());
+		auto cache = table_request_cache.Get(context, table_key, cache_guard, false);
+		if (cache) {
+			table_request_cache.SetOrOverwriteInternal(cache_guard, context, new_table_key, cache->expire_timestamp,
+			                                           std::move(cache->load_table_result));
+		} else {
+			table_request_cache.ExpireInternal(cache_guard, context, new_table_key);
+		}
+		table_request_cache.ExpireInternal(cache_guard, context, table_key);
+	}
 
 	DropInfo drop_info;
 	drop_info.name = Identifier(table_name);
@@ -740,6 +755,16 @@ void IcebergTransaction::DoSchemaPropertyUpdates(ClientContext &context) {
 }
 
 namespace {
+
+static IcebergTableInformation CopyTransactionTableInfo(const IcebergTableInformation &source) {
+	auto result = IcebergTableInformation(source.catalog, source.schema, source.name);
+	result.table_id = source.table_id;
+	result.table_metadata = source.table_metadata.Copy();
+	result.config = source.config;
+	result.storage_credentials = source.storage_credentials;
+	result.latest_metadata_json = source.latest_metadata_json;
+	return result;
+}
 
 struct ScopedTransaction {
 public:
@@ -908,7 +933,11 @@ IcebergTableInformation &IcebergTransaction::DeleteTable(IcebergTableInformation
 	unique_ptr<IcebergTransactionDeleteUpdate> delete_update;
 	if (state) {
 		auto &table_info = state->GetInfo();
-		delete_update = make_uniq<IcebergTransactionDeleteUpdate>(*this, table_info);
+		if (state->HasOwnedTable()) {
+			delete_update = make_uniq<IcebergTransactionDeleteUpdate>(*this, CopyTransactionTableInfo(table_info));
+		} else {
+			delete_update = make_uniq<IcebergTransactionDeleteUpdate>(*this, table_info);
+		}
 	} else {
 		delete_update = make_uniq<IcebergTransactionDeleteUpdate>(*this, table);
 	}
@@ -921,6 +950,7 @@ IcebergTableInformation &IcebergTransaction::DeleteTable(IcebergTableInformation
 IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation &table, const string &new_name) {
 	auto table_key = table.GetTableKey();
 	auto state = GetLatestTableState(table_key);
+	const bool source_is_transaction_local = state && state->HasOwnedTable();
 	if (state) {
 		auto &original_table = state->GetInfo();
 		if (HasTransactionUpdates(original_table.GetTableKey())) {
@@ -931,7 +961,12 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 	state = SetLatestTableState(table, IcebergTableStatus::RENAMED);
 
 	//! Create the rename update, creating the new IcebergTableInformation in the process
-	auto rename = make_uniq<IcebergTransactionRenameUpdate>(*this, state->GetInfo(), new_name);
+	unique_ptr<IcebergTransactionRenameUpdate> rename;
+	if (source_is_transaction_local) {
+		rename = make_uniq<IcebergTransactionRenameUpdate>(*this, CopyTransactionTableInfo(state->GetInfo()), new_name);
+	} else {
+		rename = make_uniq<IcebergTransactionRenameUpdate>(*this, state->GetInfo(), new_name);
+	}
 	auto &rename_update = *rename;
 	transaction_updates.push_back(std::move(rename));
 
@@ -940,22 +975,8 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 	auto &new_state = SetLatestTableState(new_table, IcebergTableStatus::ALIVE);
 	new_table.InitSchemaVersions();
 
-	auto locked_context = context.lock();
-	auto &client_context = *locked_context;
-	//! FIXME: just like the other place, this can easily go wrong
-	//! Migrate the MetadataCache
-	auto new_table_key = new_table.GetTableKey();
-	auto &table_request_cache = catalog.table_request_cache;
-	{
-		lock_guard<mutex> cache_guard(table_request_cache.Lock());
-		auto cache = table_request_cache.Get(client_context, table_key, cache_guard, false);
-		table_request_cache.SetOrOverwriteInternal(cache_guard, client_context, new_table_key, cache->expire_timestamp,
-		                                           std::move(cache->load_table_result));
-		table_request_cache.ExpireInternal(cache_guard, client_context, table_key);
-	}
-
 	//! Decouple subsequent transaction-local operations on the renamed table from the rename update's storage.
-	new_state.SetOwnedTable(new_table.Copy(client_context));
+	new_state.SetOwnedTable(CopyTransactionTableInfo(new_table));
 	new_state.GetInfo().InitSchemaVersions();
 	return state->GetInfo();
 }

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -175,11 +175,11 @@ static idx_t GetMaxRetries(const IcebergTransactionAlterUpdate &alter_update) {
 		if (alter_update.committed_tables.count(entry.first)) {
 			continue;
 		}
-		const auto &table_info = entry.second;
-		if (!table_info.transaction_data || !table_info.HasTransactionUpdates()) {
+		auto transaction_data = alter_update.GetTransactionData(entry.first);
+		if (!transaction_data || !transaction_data->HasUpdates()) {
 			continue;
 		}
-		auto table_max_retries = GetMaxRetries(*table_info.transaction_data);
+		auto table_max_retries = GetMaxRetries(*transaction_data);
 		if (!saw_table) {
 			max_retries = table_max_retries;
 			saw_table = true;
@@ -202,7 +202,7 @@ static void CreateTableRequirements(DatabaseInstance &db, ClientContext &context
 		requirement.current_schema_id = transaction_data.initial_schema_id;
 		requirement.CreateRequirement(db, context, commit_state);
 	}
-	if (!has_assert_create && commit_state.table_info.HasTransactionUpdates()) {
+	if (!has_assert_create && transaction_data.HasUpdates()) {
 		auto uuid_requirement = AssertTableUUIDRequirement(commit_state.table_info);
 		uuid_requirement.CreateRequirement(db, context, commit_state);
 	}
@@ -214,6 +214,7 @@ static void CreateTableRequirements(DatabaseInstance &db, ClientContext &context
 }
 
 static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, IcebergTableInformation &table_info,
+                                                      IcebergTransactionData &transaction_data,
                                                       ClientContext &context) {
 	SingleTableStagedCommit info;
 	IcebergCommitState commit_state(table_info, context);
@@ -225,7 +226,6 @@ static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, Iceb
 
 	auto &metadata = commit_state.table_info.table_metadata;
 	auto current_snapshot = metadata.GetLatestSnapshot();
-	auto &transaction_data = *commit_state.table_info.transaction_data;
 	info.retryable = transaction_data.SupportsAppendRetry();
 	if (!transaction_data.alters.empty()) {
 		commit_state.LoadExistingManifests(std::move(transaction_data.existing_manifest_list));
@@ -273,12 +273,13 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 			continue;
 		}
 		auto &table_info = updated_table.second;
-		if (!table_info.HasTransactionUpdates()) {
+		auto transaction_data = alter_update.GetTransactionData(table_key);
+		if (!transaction_data || !transaction_data->HasUpdates()) {
 			//! No changes to commit
 			continue;
 		}
 
-		auto table_transaction_info = StageSingleTableCommit(db, table_info, context);
+		auto table_transaction_info = StageSingleTableCommit(db, table_info, *transaction_data, context);
 		info.created_metadata_files.emplace(table_key, std::move(table_transaction_info.created_metadata_files));
 		info.table_requests.emplace(table_key, transaction.table_changes.size());
 		transaction.table_changes.push_back(std::move(table_transaction_info.request));
@@ -295,11 +296,11 @@ bool IcebergTransaction::CanUseMultiTableCommit(const IcebergTransactionAlterUpd
 		return false;
 	}
 	for (const auto &entry : alter_update.updated_tables) {
-		const auto &table_info = entry.second;
-		if (!table_info.transaction_data) {
+		auto transaction_data = alter_update.GetTransactionData(entry.first);
+		if (!transaction_data) {
 			continue;
 		}
-		if (table_info.transaction_data->has_assert_create) {
+		if (transaction_data->has_assert_create) {
 			return false;
 		}
 	}
@@ -333,14 +334,15 @@ void IcebergTransaction::RefreshRetryTables(IcebergTransactionAlterUpdate &alter
 			continue;
 		}
 		auto &table_info = it->second;
-		if (!table_info.transaction_data) {
+		auto transaction_data = alter_update.GetTransactionData(table_key);
+		if (!transaction_data) {
 			continue;
 		}
-		if (!table_info.transaction_data->RetryStateMatches(table_info)) {
+		if (!transaction_data->RetryStateMatches(table_info)) {
 			throw TransactionException("Table %s changed incompatibly while retrying commit", table_key);
 		}
 		table_info.RefreshFromCatalog(context);
-		if (!table_info.transaction_data->RetryStateMatches(table_info)) {
+		if (!transaction_data->RetryStateMatches(table_info)) {
 			throw TransactionException("Table %s changed incompatibly while retrying commit", table_key);
 		}
 		SetLatestTableState(table_info, IcebergTableStatus::ALIVE);
@@ -517,18 +519,19 @@ void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdat
 	D_ASSERT(catalog.supported_urls.count("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}"));
 	for (auto &entry : alter_update.updated_tables) {
 		auto &table_key = entry.first;
-		const auto max_retries =
-		    entry.second.transaction_data ? GetMaxRetries(*entry.second.transaction_data) : idx_t(0);
+		auto transaction_data = alter_update.GetTransactionData(table_key);
+		const auto max_retries = transaction_data ? GetMaxRetries(*transaction_data) : idx_t(0);
 		for (idx_t attempt = 0;; attempt++) {
 			if (alter_update.committed_tables.count(table_key)) {
 				break;
 			}
 			auto &table_info = entry.second;
-			if (!table_info.HasTransactionUpdates()) {
+			transaction_data = alter_update.GetTransactionData(table_key);
+			if (!transaction_data || !transaction_data->HasUpdates()) {
 				break;
 			}
 
-			auto table_transaction_info = StageSingleTableCommit(db, table_info, context);
+			auto table_transaction_info = StageSingleTableCommit(db, table_info, *transaction_data, context);
 			auto &table_change = table_transaction_info.request;
 			D_ASSERT(table_change.identifier);
 			auto &identifier = *table_change.identifier;
@@ -662,13 +665,13 @@ void IcebergTransaction::CleanupFiles() {
 				continue;
 			}
 			auto &table = up_table.second;
-			if (!table.transaction_data) {
+			auto transaction_data = alter_update.GetTransactionData(up_table.first);
+			if (!transaction_data) {
 				// error occurred before transaction data was initialized
 				// this can happen during table creation with table schema that cannot convert to
 				// an iceberg table schema due to type incompatabilities
 				continue;
 			}
-			auto &transaction_data = table.transaction_data;
 			for (auto &update : transaction_data->updates) {
 				if (update->type != IcebergTableUpdateType::ADD_SNAPSHOT) {
 					continue;
@@ -746,6 +749,26 @@ IcebergTransactionAlterUpdate &IcebergTransaction::GetOrCreateAlter() {
 	return transaction_updates.back()->Cast<IcebergTransactionAlterUpdate>();
 }
 
+optional_ptr<IcebergTransactionData> IcebergTransaction::GetTransactionData(const string &table_key) const {
+	for (idx_t i = transaction_updates.size(); i-- > 0;) {
+		auto &transaction_update = transaction_updates[i];
+		if (transaction_update->type != IcebergTransactionUpdateType::ALTER) {
+			continue;
+		}
+		auto &alter_update = transaction_update->Cast<IcebergTransactionAlterUpdate>();
+		auto transaction_data = alter_update.GetTransactionData(table_key);
+		if (transaction_data) {
+			return transaction_data;
+		}
+	}
+	return nullptr;
+}
+
+bool IcebergTransaction::HasTransactionUpdates(const string &table_key) const {
+	auto transaction_data = GetTransactionData(table_key);
+	return transaction_data && transaction_data->HasUpdates();
+}
+
 IcebergTableInformation &IcebergTransaction::DeleteTable(IcebergTableInformation &table) {
 	auto table_key = table.GetTableKey();
 	auto state = GetLatestTableState(table_key);
@@ -768,7 +791,7 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 	auto state = GetLatestTableState(table_key);
 	if (state) {
 		auto &original_table = state->GetInfo();
-		if (original_table.HasTransactionUpdates()) {
+		if (HasTransactionUpdates(original_table.GetTableKey())) {
 			throw CatalogException("This table (%s) was modified already, can't be renamed!", table.name);
 		}
 	}
@@ -800,10 +823,11 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 }
 
 void ApplyTableUpdate(IcebergTableInformation &table_info, IcebergTransaction &iceberg_transaction,
-                      const std::function<void(IcebergTableInformation &)> &callback) {
+                      const std::function<void(IcebergTableInformation &, IcebergTransactionData &)> &callback) {
 	auto &alter = iceberg_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(table_info);
-	callback(updated_table);
+	auto &transaction_data = alter.GetOrCreateTransactionData(updated_table);
+	callback(updated_table, transaction_data);
 }
 
 } // namespace duckdb

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -42,6 +42,14 @@ IcebergTransactionData &IcebergTransactionTableState::GetOrCreateTransactionData
 	return *transaction_data;
 }
 
+IcebergTableMetadata IcebergTransactionTableState::GetTransactionMetadata() const {
+	auto metadata = GetBaseMetadata().Copy();
+	if (!transaction_data || !transaction_data->HasUpdates()) {
+		return metadata;
+	}
+	return transaction_data->GetTransactionMetadata(metadata);
+}
+
 IcebergTableEntry &IcebergTransactionTableState::GetOrCreateSchemaEntry(const IcebergTableSchema &table_schema) {
 	auto it = schema_versions.find(table_schema.schema_id);
 	if (it != schema_versions.end()) {
@@ -86,7 +94,7 @@ optional_ptr<CatalogEntry> IcebergTransactionTableState::GetLatestSchema(ClientC
 
 optional_ptr<CatalogEntry> IcebergTransactionTableState::GetSchemaVersion(ClientContext &context,
                                                                           optional_ptr<BoundAtClause> at) {
-	auto &metadata = GetMetadata();
+	auto metadata = GetTransactionMetadata();
 	if (metadata.snapshots.empty()) {
 		auto schema = metadata.GetSchemaFromId(metadata.GetCurrentSchemaId());
 		D_ASSERT(schema);
@@ -302,12 +310,11 @@ static void CreateTableRequirements(DatabaseInstance &db, ClientContext &context
 		requirement->CreateRequirement(db, context, commit_state);
 	}
 	if (!has_assert_create && NeedsAssertSchemaId(transaction_data, commit_state.table_info)) {
-		AssertCurrentSchemaIdRequirement requirement(commit_state.table_info);
-		requirement.current_schema_id = transaction_data.initial_schema_id;
+		AssertCurrentSchemaIdRequirement requirement(transaction_data.initial_schema_id);
 		requirement.CreateRequirement(db, context, commit_state);
 	}
 	if (!has_assert_create && transaction_data.HasUpdates()) {
-		auto uuid_requirement = AssertTableUUIDRequirement(commit_state.table_info);
+		auto uuid_requirement = AssertTableUUIDRequirement(transaction_data.initial_table_uuid);
 		uuid_requirement.CreateRequirement(db, context, commit_state);
 	}
 	if (current_snapshot && !transaction_data.alters.empty()) {
@@ -324,7 +331,7 @@ static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, Iceb
 	auto &table_info = table_state.GetInfo();
 	auto commit_table = table_info.Copy(context);
 	if (!transaction_data.SupportsAppendRetry()) {
-		commit_table.table_metadata = table_state.GetMetadata().Copy();
+		commit_table.table_metadata = table_state.GetTransactionMetadata();
 	}
 	IcebergCommitState commit_state(commit_table, context);
 	auto &table_change = commit_state.table_change;

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -334,11 +334,14 @@ static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, Iceb
                                                       ClientContext &context) {
 	SingleTableStagedCommit info;
 	auto &table_info = table_state.GetInfo();
-	auto commit_table = table_info.Copy(context);
-	if (!transaction_data.SupportsAppendRetry()) {
-		commit_table.table_metadata = table_state.GetTransactionMetadata();
+	auto commit_table = table_info.TryCopy(context);
+	if (!commit_table) {
+		throw CatalogException("Table '%s' no longer exists, failed to commit", table_info.name);
 	}
-	IcebergCommitState commit_state(commit_table, context);
+	if (!transaction_data.SupportsAppendRetry()) {
+		commit_table->table_metadata = table_state.GetTransactionMetadata();
+	}
+	IcebergCommitState commit_state(*commit_table, context);
 	auto &table_change = commit_state.table_change;
 	auto &schema = table_info.schema.Cast<IcebergSchemaEntry>();
 	table_change.identifier = rest_api_objects::TableIdentifier();

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -37,7 +37,7 @@ IcebergTransactionTableState::IcebergTransactionTableState(optional_ptr<IcebergT
 IcebergTransactionData &IcebergTransactionTableState::GetOrCreateTransactionData(IcebergTransaction &transaction) {
 	if (!transaction_data) {
 		auto context = transaction.context.lock();
-		transaction_data = make_uniq<IcebergTransactionData>(*context, GetInfo());
+		transaction_data = make_uniq<IcebergTransactionData>(*context, GetInfo(), GetBaseMetadata());
 	}
 	return *transaction_data;
 }
@@ -116,22 +116,27 @@ optional_ptr<CatalogEntry> IcebergTransactionTableState::GetSchemaVersion(Client
 		}
 		schema_id = snapshot.GetSchemaId();
 	} else {
-		bool use_metadata_log = true;
-		Value val;
-		if (context.TryGetCurrentSetting("iceberg_use_metadata_log", val)) {
-			if (!val.IsNull() && val.type().id() == LogicalTypeId::BOOLEAN) {
-				use_metadata_log = val.GetValue<bool>();
-			}
-		}
-
-		const bool latest_metadata_is_too_fresh = metadata.last_updated_ms.value > transaction_start_millis;
-		const bool can_use_metadata_log = use_metadata_log && !metadata.metadata_log.empty();
-		if (latest_metadata_is_too_fresh && can_use_metadata_log) {
-			string metadata_path;
-			auto relevant_metadata = GetInfo().CreateMetadataFromLog(context, transaction_start_millis, metadata_path);
-			schema_id = relevant_metadata.GetCurrentSchemaId();
-		} else {
+		if (transaction_data && transaction_data->HasUpdates()) {
 			schema_id = metadata.GetCurrentSchemaId();
+		} else {
+			bool use_metadata_log = true;
+			Value val;
+			if (context.TryGetCurrentSetting("iceberg_use_metadata_log", val)) {
+				if (!val.IsNull() && val.type().id() == LogicalTypeId::BOOLEAN) {
+					use_metadata_log = val.GetValue<bool>();
+				}
+			}
+
+			const bool latest_metadata_is_too_fresh = metadata.last_updated_ms.value > transaction_start_millis;
+			const bool can_use_metadata_log = use_metadata_log && !metadata.metadata_log.empty();
+			if (latest_metadata_is_too_fresh && can_use_metadata_log) {
+				string metadata_path;
+				auto relevant_metadata =
+				    GetInfo().CreateMetadataFromLog(context, transaction_start_millis, metadata_path);
+				schema_id = relevant_metadata.GetCurrentSchemaId();
+			} else {
+				schema_id = metadata.GetCurrentSchemaId();
+			}
 		}
 	}
 	auto schema = metadata.GetSchemaFromId(schema_id);
@@ -823,11 +828,25 @@ bool IcebergTransaction::StartedBefore(timestamp_t timestamp_ms) const {
 }
 
 optional_ptr<IcebergTransactionTableState> IcebergTransaction::GetLatestTableState(const string &table_key) {
-	auto it = current_table_data.find(table_key);
-	if (it == current_table_data.end()) {
+	auto current_it = current_table_data.find(table_key);
+	if (current_it != current_table_data.end() && !current_it->second.IsAlive()) {
+		return current_it->second;
+	}
+	for (idx_t i = transaction_updates.size(); i-- > 0;) {
+		auto &transaction_update = transaction_updates[i];
+		if (transaction_update->type != IcebergTransactionUpdateType::ALTER) {
+			continue;
+		}
+		auto &alter_update = transaction_update->Cast<IcebergTransactionAlterUpdate>();
+		auto alter_it = alter_update.updated_tables.find(table_key);
+		if (alter_it != alter_update.updated_tables.end()) {
+			return alter_it->second;
+		}
+	}
+	if (current_it == current_table_data.end()) {
 		return nullptr;
 	}
-	return it->second;
+	return current_it->second;
 }
 
 IcebergTransactionTableState &IcebergTransaction::SetLatestTableState(const string &table_key,

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -275,10 +275,16 @@ static bool NeedsAssertSchemaId(const IcebergTransactionData &transaction_data,
 
 namespace {
 
+static IcebergTableInformation CopyTransactionTableInfo(const IcebergTableInformation &source);
+
 struct SingleTableStagedCommit {
+	IcebergTableInformation table_info;
 	rest_api_objects::CommitTableRequest request;
 	vector<string> created_metadata_files;
 	bool retryable = false;
+
+	SingleTableStagedCommit(IcebergTableInformation &&table_info_p) : table_info(std::move(table_info_p)) {
+	}
 };
 
 static idx_t GetMaxRetries(const IcebergTransactionData &transaction_data) {
@@ -332,21 +338,21 @@ static void CreateTableRequirements(DatabaseInstance &db, ClientContext &context
 static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, IcebergTransactionTableState &table_state,
                                                       IcebergTransactionData &transaction_data,
                                                       ClientContext &context) {
-	SingleTableStagedCommit info;
-	auto &table_info = table_state.GetInfo();
-	auto commit_table = table_info.TryCopy(context);
+	auto &base_table_info = table_state.GetInfo();
+	auto commit_table = base_table_info.TryCopy(context);
 	if (!commit_table) {
-		throw CatalogException("Table '%s' no longer exists, failed to commit", table_info.name);
+		throw CatalogException("Table '%s' no longer exists, failed to commit", base_table_info.name);
 	}
 	if (!transaction_data.SupportsAppendRetry()) {
 		commit_table->table_metadata = table_state.GetTransactionMetadata();
 	}
+	SingleTableStagedCommit info(CopyTransactionTableInfo(*commit_table));
 	IcebergCommitState commit_state(*commit_table, context);
 	auto &table_change = commit_state.table_change;
-	auto &schema = table_info.schema.Cast<IcebergSchemaEntry>();
+	auto &schema = base_table_info.schema.Cast<IcebergSchemaEntry>();
 	table_change.identifier = rest_api_objects::TableIdentifier();
 	table_change.identifier->_namespace.value = schema.namespace_items;
-	table_change.identifier->name = table_info.name;
+	table_change.identifier->name = base_table_info.name;
 
 	auto &metadata = commit_state.table_info.table_metadata;
 	auto current_snapshot = metadata.GetLatestSnapshot();
@@ -379,8 +385,10 @@ static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, Iceb
 
 } // namespace
 
-TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactionAlterUpdate &alter_update,
-                                                               ClientContext &context) {
+TableTransactionInfo
+IcebergTransaction::GetTransactionRequest(IcebergTransactionAlterUpdate &alter_update,
+                                          case_insensitive_map_t<IcebergTableInformation> &staged_tables,
+                                          ClientContext &context) {
 	TableTransactionInfo info;
 	auto &transaction = info.request;
 	bool all_retryable = true;
@@ -399,6 +407,7 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 		}
 
 		auto table_transaction_info = StageSingleTableCommit(db, table_state, *transaction_data, context);
+		staged_tables.emplace(table_key, std::move(table_transaction_info.table_info));
 		info.created_metadata_files.emplace(table_key, std::move(table_transaction_info.created_metadata_files));
 		info.table_requests.emplace(table_key, transaction.table_changes.size());
 		transaction.table_changes.push_back(std::move(table_transaction_info.request));
@@ -446,26 +455,21 @@ void IcebergTransaction::CleanupMetadataFiles(ClientContext &context, const vect
 }
 
 void IcebergTransaction::RefreshRetryTables(IcebergTransactionAlterUpdate &alter_update,
-                                            const case_insensitive_set_t &table_keys, ClientContext &context) {
-	for (const auto &table_key : table_keys) {
-		auto it = alter_update.updated_tables.find(table_key);
-		if (it == alter_update.updated_tables.end()) {
-			continue;
-		}
-		auto &table_state = it->second;
-		auto transaction_data = alter_update.GetTransactionData(table_key);
+                                            case_insensitive_map_t<IcebergTableInformation> &retry_tables,
+                                            ClientContext &context) {
+	for (auto &entry : retry_tables) {
+		auto transaction_data = alter_update.GetTransactionData(entry.first);
 		if (!transaction_data) {
 			continue;
 		}
-		auto &base_table = table_state.GetInfo();
-		if (!transaction_data->RetryStateMatches(base_table)) {
-			throw TransactionException("Table %s changed incompatibly while retrying commit", table_key);
+		auto &commit_table = entry.second;
+		if (!transaction_data->RetryStateMatches(commit_table)) {
+			throw TransactionException("Table %s changed incompatibly while retrying commit", entry.first);
 		}
-		base_table.RefreshFromCatalog(context);
-		if (!transaction_data->RetryStateMatches(base_table)) {
-			throw TransactionException("Table %s changed incompatibly while retrying commit", table_key);
+		commit_table.RefreshFromCatalog(context);
+		if (!transaction_data->RetryStateMatches(commit_table)) {
+			throw TransactionException("Table %s changed incompatibly while retrying commit", entry.first);
 		}
-		SetLatestTableState(base_table, IcebergTableStatus::ALIVE);
 	}
 }
 
@@ -491,14 +495,6 @@ static vector<string> GetCreatedMetadataFiles(const TableTransactionInfo &transa
 		created_metadata_files.insert(created_metadata_files.end(), entry.second.begin(), entry.second.end());
 	}
 	return created_metadata_files;
-}
-
-static case_insensitive_set_t GetRetryTableKeys(const TableTransactionInfo &transaction_info) {
-	case_insensitive_set_t table_keys;
-	for (const auto &entry : transaction_info.table_requests) {
-		table_keys.insert(entry.first);
-	}
-	return table_keys;
 }
 
 void IcebergTransaction::Commit() {
@@ -621,7 +617,8 @@ void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate
                                                    ClientContext &context) {
 	const auto max_retries = GetMaxRetries(alter_update);
 	for (idx_t attempt = 0;; attempt++) {
-		auto transaction_info = GetTransactionRequest(alter_update, context);
+		case_insensitive_map_t<IcebergTableInformation> staged_tables;
+		auto transaction_info = GetTransactionRequest(alter_update, staged_tables, context);
 		if (transaction_info.request.table_changes.empty()) {
 			alter_update.updated_tables.clear();
 			return;
@@ -645,8 +642,7 @@ void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate
 			result.Throw(catalog.GetBaseUrl().GetURLEncoded());
 		}
 		CleanupMetadataFiles(context, created_metadata_files);
-		auto table_keys = GetRetryTableKeys(transaction_info);
-		RefreshRetryTables(alter_update, table_keys, context);
+		RefreshRetryTables(alter_update, staged_tables, context);
 	}
 }
 
@@ -683,8 +679,8 @@ void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdat
 				result.Throw(catalog.GetBaseUrl().GetURLEncoded());
 			}
 			CleanupMetadataFiles(context, table_transaction_info.created_metadata_files);
-			case_insensitive_set_t retry_tables;
-			retry_tables.insert(table_key);
+			case_insensitive_map_t<IcebergTableInformation> retry_tables;
+			retry_tables.emplace(table_key, std::move(table_transaction_info.table_info));
 			RefreshRetryTables(alter_update, retry_tables, context);
 		}
 	}
@@ -950,7 +946,7 @@ IcebergTableInformation &IcebergTransaction::DeleteTable(IcebergTableInformation
 IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation &table, const string &new_name) {
 	auto table_key = table.GetTableKey();
 	auto state = GetLatestTableState(table_key);
-	const bool source_is_transaction_local = state && state->HasOwnedTable();
+	const bool source_is_transaction_local = state && state->IsTransactionLocalTable();
 	if (state) {
 		auto &original_table = state->GetInfo();
 		if (HasTransactionUpdates(original_table.GetTableKey())) {
@@ -976,7 +972,7 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 	new_table.InitSchemaVersions();
 
 	//! Decouple subsequent transaction-local operations on the renamed table from the rename update's storage.
-	new_state.SetOwnedTable(CopyTransactionTableInfo(new_table));
+	new_state.SetOwnedTable(CopyTransactionTableInfo(new_table), true);
 	new_state.GetInfo().InitSchemaVersions();
 	return state->GetInfo();
 }

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -571,14 +571,15 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 }
 
 void IcebergTransaction::DoTableRename(IcebergTransactionRenameUpdate &rename_update, ClientContext &context) {
-	auto &original_table = rename_update.table;
-	auto &schema = original_table.schema;
-	auto table_key = original_table.GetTableKey();
-	auto &table_name = original_table.name;
+	auto &new_table = rename_update.new_table;
+	auto &schema = new_table.schema;
+	auto table_key =
+	    IcebergTableInformation::GetTableKey(rename_update.source_namespace_items, rename_update.source_name);
+	auto &table_name = rename_update.source_name;
 	auto new_name = rename_update.new_name;
 
 	rest_api_objects::RenameTableRequest request;
-	request.source._namespace.value = schema.namespace_items;
+	request.source._namespace.value = rename_update.source_namespace_items;
 	request.source.name = table_name;
 	request.destination._namespace.value = schema.namespace_items;
 	request.destination.name = new_name;
@@ -592,7 +593,7 @@ void IcebergTransaction::DoTableRename(IcebergTransactionRenameUpdate &rename_up
 
 	lock_guard<mutex> guard(schema.tables.GetEntryLock());
 	shared_ptr<IcebergTableInformation> old_version;
-	schema.tables.CreateEntryInternal(guard, new_name, std::move(rename_update.new_table), old_version);
+	schema.tables.CreateEntryInternal(guard, new_name, std::move(new_table), old_version);
 	if (old_version) {
 		throw TransactionException("Table %s was already created by a different transaction!", new_name);
 	}
@@ -933,7 +934,7 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 
 	//! Update the state of the renamed table
 	auto &new_table = rename_update.new_table;
-	SetLatestTableState(new_table, IcebergTableStatus::ALIVE);
+	auto &new_state = SetLatestTableState(new_table, IcebergTableStatus::ALIVE);
 	new_table.InitSchemaVersions();
 
 	auto locked_context = context.lock();
@@ -942,11 +943,17 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 	//! Migrate the MetadataCache
 	auto new_table_key = new_table.GetTableKey();
 	auto &table_request_cache = catalog.table_request_cache;
-	lock_guard<mutex> cache_guard(table_request_cache.Lock());
-	auto cache = table_request_cache.Get(client_context, table_key, cache_guard, false);
-	table_request_cache.SetOrOverwriteInternal(cache_guard, client_context, new_table_key, cache->expire_timestamp,
-	                                           std::move(cache->load_table_result));
-	table_request_cache.ExpireInternal(cache_guard, client_context, table_key);
+	{
+		lock_guard<mutex> cache_guard(table_request_cache.Lock());
+		auto cache = table_request_cache.Get(client_context, table_key, cache_guard, false);
+		table_request_cache.SetOrOverwriteInternal(cache_guard, client_context, new_table_key, cache->expire_timestamp,
+		                                           std::move(cache->load_table_result));
+		table_request_cache.ExpireInternal(cache_guard, client_context, table_key);
+	}
+
+	//! Decouple subsequent transaction-local operations on the renamed table from the rename update's storage.
+	new_state.SetOwnedTable(new_table.Copy(client_context));
+	new_state.GetInfo().InitSchemaVersions();
 	return state->GetInfo();
 }
 

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -357,11 +357,6 @@ static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, Iceb
 		commit_state.table_change.updates.push_back(std::move(set_snapshot_ref_update));
 	}
 
-	if (transaction_data.set_schema_id) {
-		SetCurrentSchema update(table_info);
-		update.CreateUpdate(db, context, commit_state);
-	}
-
 	info.created_metadata_files = std::move(commit_state.created_metadata_files);
 	info.request = std::move(table_change);
 	return info;

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -238,8 +238,8 @@ void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&de
 	updates.push_back(std::move(add_snapshot));
 }
 
-void IcebergTransactionData::TableAddSchema(int32_t schema_id) {
-	auto add_schema_update = make_uniq<AddSchemaUpdate>(table_info, schema_id);
+void IcebergTransactionData::TableAddSchema(const IcebergTableMetadata &table_metadata, int32_t schema_id) {
+	auto add_schema_update = make_uniq<AddSchemaUpdate>(table_info, table_metadata, schema_id);
 	updates.push_back(std::move(add_schema_update));
 	assert_schema_id = true;
 	set_schema_id = true;

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -15,6 +15,8 @@
 
 namespace duckdb {
 
+static constexpr const int64_t DEFAULT_RETRY_COUNT = 4;
+
 static void LoadExistingManifestList(ClientContext &context, const IcebergTableMetadata &metadata,
                                      vector<IcebergManifestListEntry> &existing_manifest_list, int64_t &next_row_id) {
 	existing_manifest_list.clear();
@@ -61,7 +63,7 @@ static void LoadExistingManifestList(ClientContext &context, const IcebergTableM
 }
 
 IcebergTransactionData::IcebergTransactionData(ClientContext &context, const IcebergTableInformation &table_info)
-    : context(context), table_info(table_info) {
+    : commit_retry_count(DEFAULT_RETRY_COUNT), context(context), table_info(table_info) {
 	initial_table_uuid = table_info.table_metadata.table_uuid;
 	if (table_info.table_metadata.has_next_row_id) {
 		next_row_id = table_info.table_metadata.next_row_id;
@@ -71,32 +73,31 @@ IcebergTransactionData::IcebergTransactionData(ClientContext &context, const Ice
 	if (table_info.table_metadata.HasSortOrder()) {
 		initial_default_sort_order_id = table_info.table_metadata.default_sort_order_id;
 	}
-}
 
-int64_t IcebergTransactionData::GetCommitRetryCount() const {
-	static constexpr const int64_t DEFAULT_RETRY_COUNT = 4;
 	auto it = table_info.table_metadata.table_properties.find("commit.retry.num-retries");
-	if (it == table_info.table_metadata.table_properties.end()) {
-		return DEFAULT_RETRY_COUNT;
-	}
-	int64_t result;
-	try {
-		size_t processed = 0;
-		result = std::stoll(it->second, &processed);
-		if (processed != it->second.size()) {
+	if (it != table_info.table_metadata.table_properties.end()) {
+		try {
+			size_t processed = 0;
+			commit_retry_count = std::stoll(it->second, &processed);
+			if (processed != it->second.size()) {
+				throw InvalidInputException(
+				    "Invalid value '%s' for table property 'commit.retry.num-retries': expected an integer",
+				    it->second);
+			}
+		} catch (std::exception &) {
 			throw InvalidInputException(
 			    "Invalid value '%s' for table property 'commit.retry.num-retries': expected an integer", it->second);
 		}
-	} catch (std::exception &) {
-		throw InvalidInputException(
-		    "Invalid value '%s' for table property 'commit.retry.num-retries': expected an integer", it->second);
+		if (commit_retry_count < 0) {
+			throw InvalidInputException(
+			    "Invalid value '%s' for table property 'commit.retry.num-retries': expected a non-negative integer",
+			    it->second);
+		}
 	}
-	if (result < 0) {
-		throw InvalidInputException(
-		    "Invalid value '%s' for table property 'commit.retry.num-retries': expected a non-negative integer",
-		    it->second);
-	}
-	return result;
+}
+
+int64_t IcebergTransactionData::GetCommitRetryCount() const {
+	return commit_retry_count;
 }
 
 bool IcebergTransactionData::HasUpdates() const {
@@ -162,14 +163,14 @@ void IcebergTransactionData::CacheExistingManifestList(lock_guard<mutex> &guard,
 	next_row_id = loaded_next_row_id;
 }
 
-void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
+void IcebergTransactionData::AddSnapshot(const IcebergTableMetadata &table_metadata,
+                                         IcebergSnapshotOperationType operation,
                                          vector<IcebergManifestEntry> &&data_files,
                                          IcebergManifestDeletes &&altered_manifests) {
 	//! NOTE: Lock has to be held to make sure the rows are assigned the correct row ids
 	lock_guard<mutex> guard(lock);
 
 	//! Generate a new snapshot id
-	auto &table_metadata = table_info.table_metadata;
 	CacheExistingManifestList(guard, table_metadata);
 
 	IcebergManifestContentType manifest_content_type;
@@ -192,7 +193,7 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 	    IcebergManifestListEntry::CreateFromEntries(fs, bogus_snapshot_id, temp_sequence_number, table_metadata,
 	                                                manifest_content_type, std::move(data_files), next_row_id);
 
-	auto add_snapshot = make_uniq<IcebergAddSnapshot>(table_info, operation);
+	auto add_snapshot = make_uniq<IcebergAddSnapshot>(table_metadata, operation);
 	add_snapshot->AddManifestFile(std::move(manifest_file));
 	// make sure we are still inserting into the current schema
 	if (table_metadata.has_current_snapshot) {
@@ -204,14 +205,14 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 	updates.push_back(std::move(add_snapshot));
 }
 
-void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&delete_files,
+void IcebergTransactionData::AddUpdateSnapshot(const IcebergTableMetadata &table_metadata,
+                                               vector<IcebergManifestEntry> &&delete_files,
                                                vector<IcebergManifestEntry> &&data_files,
                                                IcebergManifestDeletes &&altered_manifests) {
 	//! NOTE: Lock has to be held to make sure the rows are assigned the correct row ids
 	lock_guard<mutex> guard(lock);
 
 	//! Generate a new snapshot id
-	auto &table_metadata = table_info.table_metadata;
 	auto last_sequence_number = table_metadata.last_sequence_number;
 
 	CacheExistingManifestList(guard, table_metadata);
@@ -229,7 +230,7 @@ void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&de
 	    fs, snapshot_id, sequence_number, table_metadata, IcebergManifestContentType::DATA, std::move(data_files),
 	    next_row_id);
 
-	auto add_snapshot = make_uniq<IcebergAddSnapshot>(table_info);
+	auto add_snapshot = make_uniq<IcebergAddSnapshot>(table_metadata);
 	add_snapshot->AddManifestFile(std::move(delete_manifest_file));
 	add_snapshot->AddManifestFile(std::move(data_manifest_file));
 	add_snapshot->altered_manifests = std::move(altered_manifests);
@@ -241,16 +242,18 @@ void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&de
 void IcebergTransactionData::TableAddSchema(const IcebergTableMetadata &table_metadata, int32_t schema_id) {
 	auto add_schema_update = make_uniq<AddSchemaUpdate>(table_info, table_metadata, schema_id);
 	updates.push_back(std::move(add_schema_update));
+	updates.push_back(make_uniq<SetCurrentSchema>(table_metadata.GetCurrentSchemaId()));
 	assert_schema_id = true;
 	set_schema_id = true;
 }
 
-void IcebergTransactionData::TableSetCurrentSchema() {
+void IcebergTransactionData::TableSetCurrentSchema(const IcebergTableMetadata &table_metadata) {
+	updates.push_back(make_uniq<SetCurrentSchema>(table_metadata.GetCurrentSchemaId()));
 	set_schema_id = true;
 }
 
-void IcebergTransactionData::TableAssignUUID() {
-	updates.push_back(make_uniq<AssignUUIDUpdate>(table_info));
+void IcebergTransactionData::TableAssignUUID(const IcebergTableMetadata &table_metadata) {
+	updates.push_back(make_uniq<AssignUUIDUpdate>(table_metadata.table_uuid));
 }
 
 void IcebergTransactionData::TableAddAssertCreate() {
@@ -278,24 +281,34 @@ void IcebergTransactionData::TableAddAssertDefaultSpecId() {
 	requirements.push_back(make_uniq<AssertDefaultSpecIdRequirement>(table_info));
 }
 
-void IcebergTransactionData::TableAddUpradeFormatVersion() {
-	updates.push_back(make_uniq<UpgradeFormatVersion>(table_info));
+void IcebergTransactionData::TableAddUpradeFormatVersion(const IcebergTableMetadata &table_metadata) {
+	updates.push_back(make_uniq<UpgradeFormatVersion>(table_metadata.iceberg_version));
 }
 
-void IcebergTransactionData::TableAddPartitionSpec() {
-	updates.push_back(make_uniq<AddPartitionSpec>(table_info));
+void IcebergTransactionData::TableAddPartitionSpec(const IcebergTableMetadata &table_metadata) {
+	updates.push_back(make_uniq<AddPartitionSpec>(table_metadata.GetLatestPartitionSpec()));
 }
 
-void IcebergTransactionData::TableAddSortOrder() {
-	updates.push_back(make_uniq<AddSortOrder>(table_info));
+void IcebergTransactionData::TableAddSortOrder(const IcebergTableMetadata &table_metadata) {
+	if (table_metadata.HasSortOrder()) {
+		updates.push_back(make_uniq<AddSortOrder>(table_metadata.GetLatestSortOrder()));
+		return;
+	}
+	IcebergSortOrder empty_sort_order;
+	empty_sort_order.sort_order_id = AddSortOrder::DEFAULT_SORT_ORDER_ID;
+	updates.push_back(make_uniq<AddSortOrder>(empty_sort_order));
 }
 
-void IcebergTransactionData::TableSetDefaultSortOrder() {
-	updates.push_back(make_uniq<SetDefaultSortOrder>(table_info));
+void IcebergTransactionData::TableSetDefaultSortOrder(const IcebergTableMetadata &table_metadata) {
+	if (table_metadata.HasSortOrder()) {
+		updates.push_back(make_uniq<SetDefaultSortOrder>(table_metadata.GetLatestSortOrder().sort_order_id));
+		return;
+	}
+	updates.push_back(make_uniq<SetDefaultSortOrder>(AddSortOrder::DEFAULT_SORT_ORDER_ID));
 }
 
-void IcebergTransactionData::TableSetDefaultSpec() {
-	updates.push_back(make_uniq<SetDefaultSpec>(table_info));
+void IcebergTransactionData::TableSetDefaultSpec(const IcebergTableMetadata &table_metadata) {
+	updates.push_back(make_uniq<SetDefaultSpec>(table_metadata.default_spec_id));
 }
 
 void IcebergTransactionData::TableSetProperties(const case_insensitive_map_t<string> &properties) {
@@ -306,8 +319,8 @@ void IcebergTransactionData::TableRemoveProperties(const vector<string> &propert
 	updates.push_back(make_uniq<RemoveProperties>(table_info, properties));
 }
 
-void IcebergTransactionData::TableSetLocation() {
-	updates.push_back(make_uniq<SetLocation>(table_info));
+void IcebergTransactionData::TableSetLocation(const IcebergTableMetadata &table_metadata) {
+	updates.push_back(make_uniq<SetLocation>(table_metadata.location));
 }
 
 } // namespace duckdb

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -151,6 +151,82 @@ bool IcebergTransactionData::RetryStateMatches(const IcebergTableInformation &ta
 	return true;
 }
 
+void IcebergTransactionData::ApplyMetadataUpdates(IcebergTableMetadata &metadata) const {
+	for (idx_t update_idx = metadata_view_update_offset; update_idx < updates.size(); update_idx++) {
+		auto &update = *updates[update_idx];
+		switch (update.type) {
+		case IcebergTableUpdateType::ASSIGN_UUID:
+			metadata.table_uuid = update.Cast<AssignUUIDUpdate>().uuid;
+			break;
+		case IcebergTableUpdateType::UPGRADE_FORMAT_VERSION:
+			metadata.iceberg_version = update.Cast<UpgradeFormatVersion>().format_version;
+			break;
+		case IcebergTableUpdateType::ADD_SCHEMA: {
+			auto &schema_update = update.Cast<AddSchemaUpdate>();
+			D_ASSERT(schema_update.schema);
+			metadata.AddSchemaOrGetExisting(schema_update.schema);
+			if (schema_update.last_column_id.IsValid()) {
+				metadata.last_column_id = schema_update.last_column_id;
+			}
+			break;
+		}
+		case IcebergTableUpdateType::SET_CURRENT_SCHEMA:
+			metadata.SetCurrentSchemaId(update.Cast<SetCurrentSchema>().schema_id);
+			break;
+		case IcebergTableUpdateType::ADD_PARTITION_SPEC: {
+			auto &partition_update = update.Cast<AddPartitionSpec>();
+			metadata.partition_specs.erase(partition_update.partition_spec.spec_id);
+			metadata.partition_specs.emplace(partition_update.partition_spec.spec_id, partition_update.partition_spec);
+			if (!partition_update.partition_spec.fields.empty()) {
+				metadata.last_partition_field_id = partition_update.partition_spec.fields.back().partition_field_id;
+			}
+			break;
+		}
+		case IcebergTableUpdateType::SET_DEFAULT_SPEC:
+			metadata.default_spec_id = update.Cast<SetDefaultSpec>().spec_id;
+			break;
+		case IcebergTableUpdateType::ADD_SORT_ORDER: {
+			auto &sort_order_update = update.Cast<AddSortOrder>();
+			metadata.sort_specs.erase(sort_order_update.sort_order.sort_order_id);
+			metadata.sort_specs.emplace(sort_order_update.sort_order.sort_order_id, sort_order_update.sort_order);
+			break;
+		}
+		case IcebergTableUpdateType::SET_DEFAULT_SORT_ORDER:
+			metadata.default_sort_order_id = update.Cast<SetDefaultSortOrder>().sort_order_id;
+			break;
+		case IcebergTableUpdateType::SET_LOCATION:
+			metadata.location = update.Cast<SetLocation>().location;
+			break;
+		case IcebergTableUpdateType::SET_PROPERTIES: {
+			auto &set_properties = update.Cast<SetProperties>();
+			for (auto &entry : set_properties.properties) {
+				metadata.table_properties[entry.first] = entry.second;
+			}
+			break;
+		}
+		case IcebergTableUpdateType::REMOVE_PROPERTIES: {
+			auto &remove_properties = update.Cast<RemoveProperties>();
+			for (auto &entry : remove_properties.properties) {
+				metadata.table_properties.erase(entry);
+			}
+			break;
+		}
+		default:
+			break;
+		}
+	}
+}
+
+IcebergTableMetadata IcebergTransactionData::GetTransactionMetadata(const IcebergTableMetadata &base_metadata) const {
+	auto metadata = base_metadata.Copy();
+	ApplyMetadataUpdates(metadata);
+	return metadata;
+}
+
+void IcebergTransactionData::MarkCreateSeeded() {
+	metadata_view_update_offset = updates.size();
+}
+
 void IcebergTransactionData::CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata) {
 	if (!alters.empty()) {
 		return;
@@ -240,7 +316,7 @@ void IcebergTransactionData::AddUpdateSnapshot(const IcebergTableMetadata &table
 }
 
 void IcebergTransactionData::TableAddSchema(const IcebergTableMetadata &table_metadata, int32_t schema_id) {
-	auto add_schema_update = make_uniq<AddSchemaUpdate>(table_info, table_metadata, schema_id);
+	auto add_schema_update = make_uniq<AddSchemaUpdate>(table_metadata, schema_id);
 	updates.push_back(std::move(add_schema_update));
 	updates.push_back(make_uniq<SetCurrentSchema>(table_metadata.GetCurrentSchemaId()));
 	assert_schema_id = true;
@@ -262,23 +338,29 @@ void IcebergTransactionData::TableAddAssertCreate() {
 }
 
 void IcebergTransactionData::TableAddAssertUUID() {
-	requirements.push_back(make_uniq<AssertTableUUIDRequirement>(table_info));
+	requirements.push_back(make_uniq<AssertTableUUIDRequirement>(initial_table_uuid));
 }
 
 void IcebergTransactionData::TableAddAssertCurrentSchemaId() {
 	assert_schema_id = true;
 }
 
-void IcebergTransactionData::TableAddAssertLastAssignedFieldId() {
-	requirements.push_back(make_uniq<AssertLastAssignedFieldIdRequirement>(table_info));
+void IcebergTransactionData::TableAddAssertLastAssignedFieldId(const IcebergTableMetadata &table_metadata) {
+	D_ASSERT(table_metadata.HasLastColumnId());
+	requirements.push_back(
+	    make_uniq<AssertLastAssignedFieldIdRequirement>(static_cast<int32_t>(table_metadata.GetLastColumnId())));
 }
 
-void IcebergTransactionData::TableAddAssertLastAssignedPartitionId() {
-	requirements.push_back(make_uniq<AssertLastAssignedPartitionIdRequirement>(table_info));
+void IcebergTransactionData::TableAddAssertLastAssignedPartitionId(const IcebergTableMetadata &table_metadata) {
+	int32_t last_assigned_partition_id = 999;
+	if (table_metadata.HasLastPartitionId()) {
+		last_assigned_partition_id = table_metadata.GetLastPartitionFieldId();
+	}
+	requirements.push_back(make_uniq<AssertLastAssignedPartitionIdRequirement>(last_assigned_partition_id));
 }
 
-void IcebergTransactionData::TableAddAssertDefaultSpecId() {
-	requirements.push_back(make_uniq<AssertDefaultSpecIdRequirement>(table_info));
+void IcebergTransactionData::TableAddAssertDefaultSpecId(const IcebergTableMetadata &table_metadata) {
+	requirements.push_back(make_uniq<AssertDefaultSpecIdRequirement>(table_metadata.default_spec_id));
 }
 
 void IcebergTransactionData::TableAddUpradeFormatVersion(const IcebergTableMetadata &table_metadata) {
@@ -312,11 +394,11 @@ void IcebergTransactionData::TableSetDefaultSpec(const IcebergTableMetadata &tab
 }
 
 void IcebergTransactionData::TableSetProperties(const case_insensitive_map_t<string> &properties) {
-	updates.push_back(make_uniq<SetProperties>(table_info, properties));
+	updates.push_back(make_uniq<SetProperties>(properties));
 }
 
 void IcebergTransactionData::TableRemoveProperties(const vector<string> &properties) {
-	updates.push_back(make_uniq<RemoveProperties>(table_info, properties));
+	updates.push_back(make_uniq<RemoveProperties>(properties));
 }
 
 void IcebergTransactionData::TableSetLocation(const IcebergTableMetadata &table_metadata) {

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -62,20 +62,21 @@ static void LoadExistingManifestList(ClientContext &context, const IcebergTableM
 	}
 }
 
-IcebergTransactionData::IcebergTransactionData(ClientContext &context, const IcebergTableInformation &table_info)
+IcebergTransactionData::IcebergTransactionData(ClientContext &context, const IcebergTableInformation &table_info,
+                                               const IcebergTableMetadata &base_metadata)
     : commit_retry_count(DEFAULT_RETRY_COUNT), context(context), table_info(table_info) {
-	initial_table_uuid = table_info.table_metadata.table_uuid;
-	if (table_info.table_metadata.has_next_row_id) {
-		next_row_id = table_info.table_metadata.next_row_id;
+	initial_table_uuid = base_metadata.table_uuid;
+	if (base_metadata.has_next_row_id) {
+		next_row_id = base_metadata.next_row_id;
 	}
-	initial_schema_id = table_info.table_metadata.GetCurrentSchemaId();
-	initial_default_spec_id = table_info.table_metadata.default_spec_id;
-	if (table_info.table_metadata.HasSortOrder()) {
-		initial_default_sort_order_id = table_info.table_metadata.default_sort_order_id;
+	initial_schema_id = base_metadata.GetCurrentSchemaId();
+	initial_default_spec_id = base_metadata.default_spec_id;
+	if (base_metadata.HasSortOrder()) {
+		initial_default_sort_order_id = base_metadata.default_sort_order_id;
 	}
 
-	auto it = table_info.table_metadata.table_properties.find("commit.retry.num-retries");
-	if (it != table_info.table_metadata.table_properties.end()) {
+	auto it = base_metadata.table_properties.find("commit.retry.num-retries");
+	if (it != base_metadata.table_properties.end()) {
 		try {
 			size_t processed = 0;
 			commit_retry_count = std::stoll(it->second, &processed);

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -151,6 +151,32 @@ bool IcebergTransactionData::RetryStateMatches(const IcebergTableInformation &ta
 	return true;
 }
 
+shared_ptr<IcebergTableSchema> IcebergTransactionData::AddSchemaOrGetExisting(const IcebergTableMetadata &base_metadata,
+                                                                              shared_ptr<IcebergTableSchema> schema,
+                                                                              bool &created) {
+	for (auto &entry : staged_schemas) {
+		if (schema->Equals(*entry.second)) {
+			created = false;
+			return entry.second;
+		}
+	}
+	for (auto &entry : base_metadata.GetSchemas()) {
+		if (schema->Equals(*entry.second)) {
+			created = false;
+			return entry.second;
+		}
+	}
+
+	auto schema_id = schema->schema_id;
+	auto result = staged_schemas.emplace(schema_id, schema);
+	if (!result.second) {
+		throw InvalidConfigurationException(
+		    "Attempted to stage schema with id %d twice without an equivalent existing schema", schema_id);
+	}
+	created = true;
+	return result.first->second;
+}
+
 void IcebergTransactionData::ApplyMetadataUpdates(IcebergTableMetadata &metadata) const {
 	for (idx_t update_idx = metadata_view_update_offset; update_idx < updates.size(); update_idx++) {
 		auto &update = *updates[update_idx];
@@ -164,7 +190,7 @@ void IcebergTransactionData::ApplyMetadataUpdates(IcebergTableMetadata &metadata
 		case IcebergTableUpdateType::ADD_SCHEMA: {
 			auto &schema_update = update.Cast<AddSchemaUpdate>();
 			D_ASSERT(schema_update.schema);
-			metadata.AddSchemaOrGetExisting(schema_update.schema);
+			metadata.AddSchema(schema_update.schema);
 			if (schema_update.last_column_id.IsValid()) {
 				metadata.last_column_id = schema_update.last_column_id;
 			}
@@ -315,16 +341,17 @@ void IcebergTransactionData::AddUpdateSnapshot(const IcebergTableMetadata &table
 	updates.push_back(std::move(add_snapshot));
 }
 
-void IcebergTransactionData::TableAddSchema(const IcebergTableMetadata &table_metadata, int32_t schema_id) {
-	auto add_schema_update = make_uniq<AddSchemaUpdate>(table_metadata, schema_id);
+void IcebergTransactionData::TableAddSchema(shared_ptr<IcebergTableSchema> schema, optional_idx last_column_id) {
+	auto add_schema_update = make_uniq<AddSchemaUpdate>(std::move(schema), last_column_id);
+	auto schema_id = add_schema_update->schema->schema_id;
 	updates.push_back(std::move(add_schema_update));
-	updates.push_back(make_uniq<SetCurrentSchema>(table_metadata.GetCurrentSchemaId()));
+	updates.push_back(make_uniq<SetCurrentSchema>(schema_id));
 	assert_schema_id = true;
 	set_schema_id = true;
 }
 
-void IcebergTransactionData::TableSetCurrentSchema(const IcebergTableMetadata &table_metadata) {
-	updates.push_back(make_uniq<SetCurrentSchema>(table_metadata.GetCurrentSchemaId()));
+void IcebergTransactionData::TableSetCurrentSchema(int32_t schema_id) {
+	updates.push_back(make_uniq<SetCurrentSchema>(schema_id));
 	set_schema_id = true;
 }
 

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -99,6 +99,22 @@ int64_t IcebergTransactionData::GetCommitRetryCount() const {
 	return result;
 }
 
+bool IcebergTransactionData::HasUpdates() const {
+	if (!updates.empty()) {
+		return true;
+	}
+	if (!requirements.empty()) {
+		return true;
+	}
+	if (set_schema_id) {
+		return true;
+	}
+	if (assert_schema_id) {
+		return true;
+	}
+	return false;
+}
+
 bool IcebergTransactionData::SupportsAppendRetry() const {
 	if (!requirements.empty() || set_schema_id) {
 		return false;

--- a/src/catalog/rest/transaction/iceberg_transaction_update.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_update.cpp
@@ -16,6 +16,16 @@ IcebergTransactionAlterUpdate::IcebergTransactionAlterUpdate(IcebergTransaction 
 IcebergTransactionAlterUpdate::~IcebergTransactionAlterUpdate() {
 }
 
+static IcebergTableInformation CopyTransactionTableInfo(const IcebergTableInformation &source) {
+	auto result = IcebergTableInformation(source.catalog, source.schema, source.name);
+	result.table_id = source.table_id;
+	result.table_metadata = source.table_metadata.Copy();
+	result.config = source.config;
+	result.storage_credentials = source.storage_credentials;
+	result.latest_metadata_json = source.latest_metadata_json;
+	return result;
+}
+
 IcebergTransactionTableState &IcebergTransactionAlterUpdate::GetOrInitializeTable(IcebergTableInformation &table) {
 	auto locked_context = transaction.context.lock();
 	auto &client_context = *locked_context;
@@ -23,12 +33,20 @@ IcebergTransactionTableState &IcebergTransactionAlterUpdate::GetOrInitializeTabl
 	auto table_key = table.GetTableKey();
 	auto it = updated_tables.find(table_key);
 	if (it == updated_tables.end()) {
-		it = updated_tables.emplace(table_key, IcebergTransactionTableState(table)).first;
-		auto metadata = table.GetTransactionStartMetadata(client_context, transaction);
-		if (!table.table_metadata.table_uuid.empty()) {
-			metadata.table_uuid = table.table_metadata.table_uuid;
+		auto latest_state = transaction.GetLatestTableState(table_key);
+		if (latest_state && latest_state->HasOwnedTable()) {
+			it = updated_tables.emplace(table_key, IcebergTransactionTableState(nullptr)).first;
+			it->second.SetOwnedTable(CopyTransactionTableInfo(latest_state->GetInfo()));
+			it->second.SetStatus(IcebergTableStatus::ALIVE);
+			it->second.SetBaseMetadata(latest_state->GetTransactionMetadata());
+		} else {
+			it = updated_tables.emplace(table_key, IcebergTransactionTableState(table)).first;
+			auto metadata = table.GetTransactionStartMetadata(client_context, transaction);
+			if (!table.table_metadata.table_uuid.empty()) {
+				metadata.table_uuid = table.table_metadata.table_uuid;
+			}
+			it->second.SetBaseMetadata(std::move(metadata));
 		}
-		it->second.SetBaseMetadata(std::move(metadata));
 	}
 	transaction.SetLatestTableState(it->second.GetInfo(), IcebergTableStatus::ALIVE);
 	return it->second;
@@ -86,7 +104,12 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::CreateTable(const string
 
 IcebergTransactionDeleteUpdate::IcebergTransactionDeleteUpdate(IcebergTransaction &transaction,
                                                                const IcebergTableInformation &table)
-    : IcebergTransactionUpdate(transaction, TYPE), deleted_table(table.Copy(transaction)) {
+    : IcebergTransactionDeleteUpdate(transaction, table.Copy(transaction)) {
+}
+
+IcebergTransactionDeleteUpdate::IcebergTransactionDeleteUpdate(IcebergTransaction &transaction,
+                                                               IcebergTableInformation &&table)
+    : IcebergTransactionUpdate(transaction, TYPE), deleted_table(std::move(table)) {
 }
 IcebergTransactionDeleteUpdate::~IcebergTransactionDeleteUpdate() {
 }
@@ -94,8 +117,13 @@ IcebergTransactionDeleteUpdate::~IcebergTransactionDeleteUpdate() {
 IcebergTransactionRenameUpdate::IcebergTransactionRenameUpdate(IcebergTransaction &transaction,
                                                                const IcebergTableInformation &table,
                                                                const string &new_name)
+    : IcebergTransactionRenameUpdate(transaction, table.Copy(transaction), new_name) {
+}
+
+IcebergTransactionRenameUpdate::IcebergTransactionRenameUpdate(IcebergTransaction &transaction,
+                                                               IcebergTableInformation &&table, const string &new_name)
     : IcebergTransactionUpdate(transaction, TYPE), source_namespace_items(table.schema.namespace_items),
-      source_name(table.name), new_table(table.Copy(transaction)), new_name(new_name) {
+      source_name(table.name), new_table(std::move(table)), new_name(new_name) {
 	new_table.name = new_name;
 }
 IcebergTransactionRenameUpdate::~IcebergTransactionRenameUpdate() {

--- a/src/catalog/rest/transaction/iceberg_transaction_update.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_update.cpp
@@ -34,18 +34,22 @@ IcebergTransactionTableState &IcebergTransactionAlterUpdate::GetOrInitializeTabl
 	auto it = updated_tables.find(table_key);
 	if (it == updated_tables.end()) {
 		auto latest_state = transaction.GetLatestTableState(table_key);
-		if (latest_state && latest_state->HasOwnedTable()) {
+		if (latest_state && latest_state->IsTransactionLocalTable()) {
+			auto owned_table = CopyTransactionTableInfo(latest_state->GetInfo());
+			owned_table.table_metadata = latest_state->GetTransactionMetadata();
 			it = updated_tables.emplace(table_key, IcebergTransactionTableState(nullptr)).first;
-			it->second.SetOwnedTable(CopyTransactionTableInfo(latest_state->GetInfo()));
+			it->second.SetOwnedTable(std::move(owned_table), true);
 			it->second.SetStatus(IcebergTableStatus::ALIVE);
-			it->second.SetBaseMetadata(latest_state->GetTransactionMetadata());
 		} else {
-			it = updated_tables.emplace(table_key, IcebergTransactionTableState(table)).first;
 			auto metadata = table.GetTransactionStartMetadata(client_context, transaction);
 			if (!table.table_metadata.table_uuid.empty()) {
 				metadata.table_uuid = table.table_metadata.table_uuid;
 			}
-			it->second.SetBaseMetadata(std::move(metadata));
+			auto owned_table = CopyTransactionTableInfo(table);
+			owned_table.table_metadata = std::move(metadata);
+			it = updated_tables.emplace(table_key, IcebergTransactionTableState(nullptr)).first;
+			it->second.SetOwnedTable(std::move(owned_table));
+			it->second.SetStatus(IcebergTableStatus::ALIVE);
 		}
 	}
 	transaction.SetLatestTableState(it->second.GetInfo(), IcebergTableStatus::ALIVE);
@@ -93,9 +97,8 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::CreateTable(const string
 	if (!emplace_res.second) {
 		throw InternalException("Table %s was already created somehow?", table_key);
 	}
-	emplace_res.first->second.SetOwnedTable(std::move(table));
+	emplace_res.first->second.SetOwnedTable(std::move(table), true);
 	emplace_res.first->second.SetStatus(IcebergTableStatus::ALIVE);
-	emplace_res.first->second.SetBaseMetadata(emplace_res.first->second.GetInfo().table_metadata.Copy());
 
 	transaction.current_table_data.emplace(table_key,
 	                                       IcebergTransactionTableState(emplace_res.first->second.GetInfo()));

--- a/src/catalog/rest/transaction/iceberg_transaction_update.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_update.cpp
@@ -76,6 +76,7 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::CreateTable(const string
 		throw InternalException("Table %s was already created somehow?", table_key);
 	}
 	emplace_res.first->second.SetOwnedTable(std::move(table));
+	emplace_res.first->second.SetStatus(IcebergTableStatus::ALIVE);
 	emplace_res.first->second.SetBaseMetadata(emplace_res.first->second.GetInfo().table_metadata.Copy());
 
 	transaction.current_table_data.emplace(table_key,
@@ -93,8 +94,8 @@ IcebergTransactionDeleteUpdate::~IcebergTransactionDeleteUpdate() {
 IcebergTransactionRenameUpdate::IcebergTransactionRenameUpdate(IcebergTransaction &transaction,
                                                                const IcebergTableInformation &table,
                                                                const string &new_name)
-    : IcebergTransactionUpdate(transaction, TYPE), table(table), new_table(table.Copy(transaction)),
-      new_name(new_name) {
+    : IcebergTransactionUpdate(transaction, TYPE), source_namespace_items(table.schema.namespace_items),
+      source_name(table.name), new_table(table.Copy(transaction)), new_name(new_name) {
 	new_table.name = new_name;
 }
 IcebergTransactionRenameUpdate::~IcebergTransactionRenameUpdate() {

--- a/src/catalog/rest/transaction/iceberg_transaction_update.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_update.cpp
@@ -28,7 +28,7 @@ IcebergTransactionTableState &IcebergTransactionAlterUpdate::GetOrInitializeTabl
 		if (!table.table_metadata.table_uuid.empty()) {
 			metadata.table_uuid = table.table_metadata.table_uuid;
 		}
-		it->second.SetMetadata(std::move(metadata));
+		it->second.SetBaseMetadata(std::move(metadata));
 	}
 	transaction.SetLatestTableState(it->second.GetInfo(), IcebergTableStatus::ALIVE);
 	return it->second;
@@ -76,7 +76,7 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::CreateTable(const string
 		throw InternalException("Table %s was already created somehow?", table_key);
 	}
 	emplace_res.first->second.SetOwnedTable(std::move(table));
-	emplace_res.first->second.SetMetadata(emplace_res.first->second.GetInfo().table_metadata.Copy());
+	emplace_res.first->second.SetBaseMetadata(emplace_res.first->second.GetInfo().table_metadata.Copy());
 
 	transaction.current_table_data.emplace(table_key,
 	                                       IcebergTransactionTableState(emplace_res.first->second.GetInfo()));

--- a/src/catalog/rest/transaction/iceberg_transaction_update.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_update.cpp
@@ -1,5 +1,6 @@
 #include "catalog/rest/transaction/iceberg_transaction_update.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 
 namespace duckdb {
 
@@ -33,10 +34,41 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::GetOrInitializeTable(con
 	return it->second;
 }
 
+IcebergTransactionData &IcebergTransactionAlterUpdate::GetOrCreateTransactionData(IcebergTableInformation &table) {
+	auto table_key = table.GetTableKey();
+	auto it = table_transaction_data.find(table_key);
+	if (it == table_transaction_data.end()) {
+		auto context = transaction.context.lock();
+		it = table_transaction_data.emplace(table_key, make_uniq<IcebergTransactionData>(*context, table)).first;
+	}
+	return *it->second;
+}
+
+optional_ptr<IcebergTransactionData> IcebergTransactionAlterUpdate::GetTransactionData(const string &table_key) const {
+	auto it = table_transaction_data.find(table_key);
+	if (it == table_transaction_data.end()) {
+		return nullptr;
+	}
+	return it->second.get();
+}
+
+optional_ptr<IcebergTransactionData>
+IcebergTransactionAlterUpdate::GetTransactionData(const IcebergTableInformation &table) const {
+	return GetTransactionData(table.GetTableKey());
+}
+
+bool IcebergTransactionAlterUpdate::HasTransactionUpdates(const string &table_key) const {
+	auto transaction_data = GetTransactionData(table_key);
+	return transaction_data && transaction_data->HasUpdates();
+}
+
+bool IcebergTransactionAlterUpdate::HasTransactionUpdates(const IcebergTableInformation &table) const {
+	return HasTransactionUpdates(table.GetTableKey());
+}
+
 bool IcebergTransactionAlterUpdate::HasUpdates() const {
 	for (auto &it : updated_tables) {
-		auto &table = it.second;
-		if (table.HasTransactionUpdates()) {
+		if (HasTransactionUpdates(it.first)) {
 			return true;
 		}
 	}

--- a/src/catalog/rest/transaction/iceberg_transaction_update.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_update.cpp
@@ -16,45 +16,39 @@ IcebergTransactionAlterUpdate::IcebergTransactionAlterUpdate(IcebergTransaction 
 IcebergTransactionAlterUpdate::~IcebergTransactionAlterUpdate() {
 }
 
-IcebergTableInformation &IcebergTransactionAlterUpdate::GetOrInitializeTable(const IcebergTableInformation &table) {
+IcebergTransactionTableState &IcebergTransactionAlterUpdate::GetOrInitializeTable(IcebergTableInformation &table) {
+	auto locked_context = transaction.context.lock();
+	auto &client_context = *locked_context;
+
 	auto table_key = table.GetTableKey();
 	auto it = updated_tables.find(table_key);
 	if (it == updated_tables.end()) {
-		it = updated_tables.emplace(table_key, table.Copy(transaction)).first;
-		// Preserve the table_uuid from the original table info (resolved at transaction start).
-		// Copy() reads from the global request cache, which can be contaminated by another
-		// transaction's RENAME overwriting the entry with a different table's metadata.
-		// Only override when the original has a known UUID (skip for newly created tables).
+		it = updated_tables.emplace(table_key, IcebergTransactionTableState(table)).first;
+		auto metadata = table.GetTransactionStartMetadata(client_context, transaction);
 		if (!table.table_metadata.table_uuid.empty()) {
-			it->second.table_metadata.table_uuid = table.table_metadata.table_uuid;
+			metadata.table_uuid = table.table_metadata.table_uuid;
 		}
-		it->second.InitSchemaVersions();
+		it->second.SetMetadata(std::move(metadata));
 	}
-	transaction.SetLatestTableState(it->second, IcebergTableStatus::ALIVE);
+	transaction.SetLatestTableState(it->second.GetInfo(), IcebergTableStatus::ALIVE);
 	return it->second;
 }
 
-IcebergTransactionData &IcebergTransactionAlterUpdate::GetOrCreateTransactionData(IcebergTableInformation &table) {
-	auto table_key = table.GetTableKey();
-	auto it = table_transaction_data.find(table_key);
-	if (it == table_transaction_data.end()) {
-		auto context = transaction.context.lock();
-		it = table_transaction_data.emplace(table_key, make_uniq<IcebergTransactionData>(*context, table)).first;
-	}
-	return *it->second;
+IcebergTransactionData &IcebergTransactionAlterUpdate::GetOrCreateTransactionData(IcebergTransactionTableState &table) {
+	return table.GetOrCreateTransactionData(transaction);
 }
 
 optional_ptr<IcebergTransactionData> IcebergTransactionAlterUpdate::GetTransactionData(const string &table_key) const {
-	auto it = table_transaction_data.find(table_key);
-	if (it == table_transaction_data.end()) {
+	auto it = updated_tables.find(table_key);
+	if (it == updated_tables.end()) {
 		return nullptr;
 	}
-	return it->second.get();
+	return it->second.GetTransactionData();
 }
 
 optional_ptr<IcebergTransactionData>
-IcebergTransactionAlterUpdate::GetTransactionData(const IcebergTableInformation &table) const {
-	return GetTransactionData(table.GetTableKey());
+IcebergTransactionAlterUpdate::GetTransactionData(const IcebergTransactionTableState &table) const {
+	return GetTransactionData(table.GetInfo().GetTableKey());
 }
 
 bool IcebergTransactionAlterUpdate::HasTransactionUpdates(const string &table_key) const {
@@ -62,8 +56,8 @@ bool IcebergTransactionAlterUpdate::HasTransactionUpdates(const string &table_ke
 	return transaction_data && transaction_data->HasUpdates();
 }
 
-bool IcebergTransactionAlterUpdate::HasTransactionUpdates(const IcebergTableInformation &table) const {
-	return HasTransactionUpdates(table.GetTableKey());
+bool IcebergTransactionAlterUpdate::HasTransactionUpdates(const IcebergTransactionTableState &table) const {
+	return HasTransactionUpdates(table.GetInfo().GetTableKey());
 }
 
 bool IcebergTransactionAlterUpdate::HasUpdates() const {
@@ -77,13 +71,16 @@ bool IcebergTransactionAlterUpdate::HasUpdates() const {
 
 IcebergTableInformation &IcebergTransactionAlterUpdate::CreateTable(const string &table_key,
                                                                     IcebergTableInformation &&table) {
-	auto emplace_res = updated_tables.emplace(table_key, std::move(table));
+	auto emplace_res = updated_tables.emplace(table_key, IcebergTransactionTableState(nullptr));
 	if (!emplace_res.second) {
 		throw InternalException("Table %s was already created somehow?", table_key);
 	}
+	emplace_res.first->second.SetOwnedTable(std::move(table));
+	emplace_res.first->second.SetMetadata(emplace_res.first->second.GetInfo().table_metadata.Copy());
 
-	transaction.current_table_data.emplace(table_key, IcebergTransactionTableState(emplace_res.first->second));
-	return emplace_res.first->second;
+	transaction.current_table_data.emplace(table_key,
+	                                       IcebergTransactionTableState(emplace_res.first->second.GetInfo()));
+	return emplace_res.first->second.GetInfo();
 }
 
 IcebergTransactionDeleteUpdate::IcebergTransactionDeleteUpdate(IcebergTransaction &transaction,

--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -299,19 +299,7 @@ int32_t IcebergTableMetadata::GetCurrentSchemaId() const {
 	return current_schema_id;
 }
 
-IcebergTableSchema &IcebergTableMetadata::AddSchemaOrGetExisting(shared_ptr<IcebergTableSchema> schema) {
-	optional_ptr<IcebergTableSchema> existing_schema;
-	for (auto &it : schemas) {
-		auto &item = *it.second;
-
-		if (schema->Equals(item)) {
-			existing_schema = item;
-			break;
-		}
-	}
-	if (existing_schema) {
-		return *existing_schema;
-	}
+IcebergTableSchema &IcebergTableMetadata::AddSchema(shared_ptr<IcebergTableSchema> schema) {
 	auto new_schema_id = schema->schema_id;
 	auto res = schemas.emplace(new_schema_id, std::move(schema));
 	if (!res.second) {

--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -2,6 +2,8 @@
 
 #include "duckdb/common/exception.hpp"
 
+#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "common/iceberg_utils.hpp"
 #include "catalog/rest/api/catalog_utils.hpp"
 #include "core/metadata/snapshot/iceberg_snapshot.hpp"
@@ -344,6 +346,73 @@ int32_t IcebergTableMetadata::GetLastPartitionFieldId() const {
 	return static_cast<int32_t>(last_partition_field_id.GetIndex());
 }
 
+idx_t IcebergTableMetadata::GetNextPartitionSpecId() const {
+	idx_t max_partition_spec_id = default_spec_id;
+	for (auto &spec : GetPartitionSpecs()) {
+		if (spec.first > max_partition_spec_id) {
+			max_partition_spec_id = spec.first;
+		}
+	}
+	return max_partition_spec_id + 1;
+}
+
+int64_t IcebergTableMetadata::GetExistingSpecId(const IcebergPartitionSpec &spec) const {
+	for (auto &existing_spec : GetPartitionSpecs()) {
+		bool fields_match = true;
+		if (existing_spec.second.fields.size() != spec.fields.size()) {
+			continue;
+		}
+		for (idx_t field_index = 0; field_index < existing_spec.second.fields.size(); field_index++) {
+			auto existing_partition_col_source_id = existing_spec.second.fields[field_index].source_id;
+			auto new_spec_col_source_id = spec.fields[field_index].source_id;
+			if (existing_partition_col_source_id != new_spec_col_source_id) {
+				fields_match = false;
+				break;
+			}
+			auto existing_partition_col_transform = existing_spec.second.fields[field_index].transform.RawType();
+			auto new_spec_col_transform = spec.fields[field_index].transform.RawType();
+			if (existing_partition_col_transform != new_spec_col_transform) {
+				fields_match = false;
+				break;
+			}
+		}
+		if (fields_match) {
+			return existing_spec.second.spec_id;
+		}
+	}
+	return -1;
+}
+
+void IcebergTableMetadata::SetPartitionedBy(IcebergTransactionData &transaction_data,
+                                            const vector<unique_ptr<ParsedExpression>> &partition_keys,
+                                            const IcebergTableSchema &schema, bool first_partition_spec) {
+	idx_t base_partition_field_id = 1000;
+	if (!first_partition_spec && HasLastPartitionId()) {
+		base_partition_field_id = GetLastPartitionFieldId() + 1;
+	}
+
+	idx_t new_spec_id = 0;
+	if (!first_partition_spec) {
+		new_spec_id = GetNextPartitionSpecId();
+	}
+	auto new_spec = IcebergTableInformation::BuildPartitionSpec(
+	    partition_keys, schema, static_cast<int32_t>(new_spec_id), base_partition_field_id);
+
+	auto existing_spec_id = GetExistingSpecId(new_spec);
+	if (existing_spec_id >= 0) {
+		default_spec_id = existing_spec_id;
+		transaction_data.TableSetDefaultSpec();
+		return;
+	}
+
+	partition_specs.emplace(new_spec_id, std::move(new_spec));
+	default_spec_id = new_spec_id;
+	if (!first_partition_spec) {
+		transaction_data.TableAddPartitionSpec();
+		transaction_data.TableSetDefaultSpec();
+	}
+}
+
 //! ----------- Parse the Metadata JSON -----------
 
 rest_api_objects::TableMetadata IcebergTableMetadata::Parse(const string &path, FileSystem &fs,
@@ -470,6 +539,35 @@ IcebergTableMetadata IcebergTableMetadata::FromTableMetadata(const rest_api_obje
 		}
 	}
 	return res;
+}
+
+IcebergTableMetadata IcebergTableMetadata::Copy() const {
+	IcebergTableMetadata copy;
+	copy.table_uuid = table_uuid;
+	copy.location = location;
+	copy.iceberg_version = iceberg_version;
+	copy.default_spec_id = default_spec_id;
+	copy.has_next_row_id = has_next_row_id;
+	copy.next_row_id = next_row_id;
+	copy.default_sort_order_id = default_sort_order_id;
+	copy.has_current_snapshot = has_current_snapshot;
+	copy.current_snapshot_id = current_snapshot_id;
+	copy.last_sequence_number = last_sequence_number;
+	copy.last_updated_ms = last_updated_ms;
+	copy.last_column_id = last_column_id;
+	copy.last_partition_field_id = last_partition_field_id;
+	copy.partition_specs = partition_specs;
+	copy.sort_specs = sort_specs;
+	copy.snapshots = snapshots;
+	copy.snapshot_log = snapshot_log;
+	copy.mappings = mappings;
+	copy.write_data_path = write_data_path;
+	copy.write_metadata_path = write_metadata_path;
+	copy.table_properties = table_properties;
+	copy.metadata_log = metadata_log;
+	copy.current_schema_id = current_schema_id;
+	copy.schemas = schemas;
+	return copy;
 }
 
 const case_insensitive_map_t<string> &IcebergTableMetadata::GetTableProperties() const {

--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -401,15 +401,15 @@ void IcebergTableMetadata::SetPartitionedBy(IcebergTransactionData &transaction_
 	auto existing_spec_id = GetExistingSpecId(new_spec);
 	if (existing_spec_id >= 0) {
 		default_spec_id = existing_spec_id;
-		transaction_data.TableSetDefaultSpec();
+		transaction_data.TableSetDefaultSpec(*this);
 		return;
 	}
 
 	partition_specs.emplace(new_spec_id, std::move(new_spec));
 	default_spec_id = new_spec_id;
 	if (!first_partition_spec) {
-		transaction_data.TableAddPartitionSpec();
-		transaction_data.TableSetDefaultSpec();
+		transaction_data.TableAddPartitionSpec(*this);
+		transaction_data.TableSetDefaultSpec(*this);
 	}
 }
 

--- a/src/core/metadata/snapshot/iceberg_snapshot.cpp
+++ b/src/core/metadata/snapshot/iceberg_snapshot.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/types/uuid.hpp"
 
 #include "core/metadata/iceberg_table_metadata.hpp"
+#include "core/metadata/manifest/iceberg_manifest_list.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
 
 namespace duckdb {

--- a/src/execution/helpers/equality_delete_helpers.cpp
+++ b/src/execution/helpers/equality_delete_helpers.cpp
@@ -59,7 +59,7 @@ bool IcebergDelete::TryGetEqualityDeletePredicates(ClientContext &context, Icebe
 	}
 
 	//! Equality-delete writing is only supported for v2, unpartitioned tables.
-	auto &table_metadata = table.table_info.table_metadata;
+	auto table_metadata = table.GetTransactionTableMetadata();
 	if (table_metadata.iceberg_version != 2) {
 		return false;
 	}
@@ -146,7 +146,7 @@ void IcebergDelete::WriteEqualityDeleteFile(ClientContext &context, IcebergDelet
 	D_ASSERT(!equality_predicates.empty());
 
 	auto &fs = FileSystem::GetFileSystem(context);
-	auto data_path = table.table_info.table_metadata.GetDataPath(fs);
+	auto data_path = table.GetTransactionTableMetadata().GetDataPath(fs);
 	string delete_filename = UUID::ToString(UUID::GenerateRandomUUID()) + "-equality-deletes.parquet";
 	string delete_file_path = fs.JoinPath(data_path, delete_filename);
 

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -263,7 +263,8 @@ static void PopulateAlteredManifests(const IcebergMultiFileList &multi_file_list
 
 void IcebergDelete::FlushDeletes(IcebergTransaction &transaction, ClientContext &context,
                                  IcebergDeleteGlobalState &global_state) const {
-	bool write_deletion_vector = table.table_info.table_metadata.iceberg_version >= 3;
+	auto table_metadata = table.GetTransactionTableMetadata();
+	bool write_deletion_vector = table_metadata.iceberg_version >= 3;
 
 	if (!multi_file_list) {
 		throw InternalException("IcebergDelete multi_file_list is NULL");
@@ -415,14 +416,15 @@ SinkFinalizeType IcebergDelete::Finalize(Pipeline &pipeline, Event &event, Clien
 	if (!global_state.written_files.empty()) {
 		ApplyTableUpdate(table_info, iceberg_transaction,
 		                 [&](IcebergTransactionTableState &tbl, IcebergTransactionData &transaction_data) {
-			                 transaction_data.AddSnapshot(tbl.GetMetadata(), IcebergSnapshotOperationType::DELETE,
+			                 auto table_metadata = tbl.GetTransactionMetadata();
+			                 transaction_data.AddSnapshot(table_metadata, IcebergSnapshotOperationType::DELETE,
 			                                              std::move(iceberg_delete_files),
 			                                              std::move(global_state.altered_manifests));
 
 			                 //! Add or overwrite the currently active transaction-local delete files
 			                 for (auto &entry : global_state.written_files) {
 				                 auto &delete_file = entry.second;
-				                 if (tbl.GetMetadata().iceberg_version >= 3) {
+				                 if (table_metadata.iceberg_version >= 3) {
 					                 transaction_data.transactional_delete_files[delete_file.data_file_path] =
 					                     delete_file.file_name;
 				                 }
@@ -515,14 +517,13 @@ PhysicalOperator &IcebergCatalog::PlanDelete(ClientContext &context, PhysicalPla
 	auto &irc_transaction = IcebergTransaction::Get(context, *this);
 	auto &alter = irc_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(table_entry.table_info);
-	auto &table_metadata = updated_table.GetMetadata();
+	auto table_metadata = updated_table.GetTransactionMetadata();
 	auto &schema = table_metadata.GetLatestSchema();
 	auto &updated_table_entry = updated_table.GetOrCreateSchemaEntry(schema);
 
-	auto iceberg_version = updated_table_entry.table_info.table_metadata.iceberg_version;
+	auto iceberg_version = table_metadata.iceberg_version;
 	if (iceberg_version < 2) {
-		throw NotImplementedException("Delete from Iceberg V%d tables",
-		                              updated_table_entry.table_info.table_metadata.iceberg_version);
+		throw NotImplementedException("Delete from Iceberg V%d tables", iceberg_version);
 	}
 
 	vector<idx_t> row_id_indexes;
@@ -537,10 +538,10 @@ PhysicalOperator &IcebergCatalog::PlanDelete(ClientContext &context, PhysicalPla
 		row_id_indexes.push_back(bound_ref.Index());
 	}
 
-	auto allows_positional_deletes = updated_table_entry.table_info.table_metadata.PropertiesAllowPositionalDeletes(
-	    IcebergSnapshotOperationType::DELETE);
+	auto allows_positional_deletes =
+	    table_metadata.PropertiesAllowPositionalDeletes(IcebergSnapshotOperationType::DELETE);
 	if (!allows_positional_deletes) {
-		auto delete_table_property = updated_table_entry.table_info.table_metadata.GetTableProperty(WRITE_DELETE_MODE);
+		auto delete_table_property = table_metadata.GetTableProperty(WRITE_DELETE_MODE);
 		auto error_message = IcebergCatalog::GetOnlyMergeOnReadSupportedErrorMessage(
 		    updated_table_entry.name.GetIdentifierName(), WRITE_DELETE_MODE, delete_table_property);
 		throw NotImplementedException(error_message);

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -415,14 +415,14 @@ SinkFinalizeType IcebergDelete::Finalize(Pipeline &pipeline, Event &event, Clien
 	if (!global_state.written_files.empty()) {
 		ApplyTableUpdate(
 		    table_info, iceberg_transaction,
-		    [&](IcebergTableInformation &tbl, IcebergTransactionData &transaction_data) {
+		    [&](IcebergTransactionTableState &tbl, IcebergTransactionData &transaction_data) {
 			    transaction_data.AddSnapshot(IcebergSnapshotOperationType::DELETE, std::move(iceberg_delete_files),
 			                                 std::move(global_state.altered_manifests));
 
 			    //! Add or overwrite the currently active transaction-local delete files
 			    for (auto &entry : global_state.written_files) {
 				    auto &delete_file = entry.second;
-				    if (table_info.table_metadata.iceberg_version >= 3) {
+				    if (tbl.GetMetadata().iceberg_version >= 3) {
 					    transaction_data.transactional_delete_files[delete_file.data_file_path] = delete_file.file_name;
 				    }
 			    }
@@ -514,9 +514,9 @@ PhysicalOperator &IcebergCatalog::PlanDelete(ClientContext &context, PhysicalPla
 	auto &irc_transaction = IcebergTransaction::Get(context, *this);
 	auto &alter = irc_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(table_entry.table_info);
-	auto &table_metadata = updated_table.table_metadata;
+	auto &table_metadata = updated_table.GetMetadata();
 	auto &schema = table_metadata.GetLatestSchema();
-	auto &updated_table_entry = *updated_table.schema_versions[schema.schema_id];
+	auto &updated_table_entry = updated_table.GetOrCreateSchemaEntry(schema);
 
 	auto iceberg_version = updated_table_entry.table_info.table_metadata.iceberg_version;
 	if (iceberg_version < 2) {

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -14,6 +14,7 @@
 
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
 #include "planning/iceberg_multi_file_reader.hpp"
@@ -412,19 +413,20 @@ SinkFinalizeType IcebergDelete::Finalize(Pipeline &pipeline, Event &event, Clien
 	auto iceberg_delete_files = GenerateDeleteManifestEntries(global_state);
 
 	if (!global_state.written_files.empty()) {
-		ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
-			auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
-			transaction_data.AddSnapshot(IcebergSnapshotOperationType::DELETE, std::move(iceberg_delete_files),
-			                             std::move(global_state.altered_manifests));
+		ApplyTableUpdate(
+		    table_info, iceberg_transaction,
+		    [&](IcebergTableInformation &tbl, IcebergTransactionData &transaction_data) {
+			    transaction_data.AddSnapshot(IcebergSnapshotOperationType::DELETE, std::move(iceberg_delete_files),
+			                                 std::move(global_state.altered_manifests));
 
-			//! Add or overwrite the currently active transaction-local delete files
-			for (auto &entry : global_state.written_files) {
-				auto &delete_file = entry.second;
-				if (table_info.table_metadata.iceberg_version >= 3) {
-					transaction_data.transactional_delete_files[delete_file.data_file_path] = delete_file.file_name;
-				}
-			}
-		});
+			    //! Add or overwrite the currently active transaction-local delete files
+			    for (auto &entry : global_state.written_files) {
+				    auto &delete_file = entry.second;
+				    if (table_info.table_metadata.iceberg_version >= 3) {
+					    transaction_data.transactional_delete_files[delete_file.data_file_path] = delete_file.file_name;
+				    }
+			    }
+		    });
 	}
 	return SinkFinalizeType::READY;
 }

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -413,20 +413,21 @@ SinkFinalizeType IcebergDelete::Finalize(Pipeline &pipeline, Event &event, Clien
 	auto iceberg_delete_files = GenerateDeleteManifestEntries(global_state);
 
 	if (!global_state.written_files.empty()) {
-		ApplyTableUpdate(
-		    table_info, iceberg_transaction,
-		    [&](IcebergTransactionTableState &tbl, IcebergTransactionData &transaction_data) {
-			    transaction_data.AddSnapshot(IcebergSnapshotOperationType::DELETE, std::move(iceberg_delete_files),
-			                                 std::move(global_state.altered_manifests));
+		ApplyTableUpdate(table_info, iceberg_transaction,
+		                 [&](IcebergTransactionTableState &tbl, IcebergTransactionData &transaction_data) {
+			                 transaction_data.AddSnapshot(tbl.GetMetadata(), IcebergSnapshotOperationType::DELETE,
+			                                              std::move(iceberg_delete_files),
+			                                              std::move(global_state.altered_manifests));
 
-			    //! Add or overwrite the currently active transaction-local delete files
-			    for (auto &entry : global_state.written_files) {
-				    auto &delete_file = entry.second;
-				    if (tbl.GetMetadata().iceberg_version >= 3) {
-					    transaction_data.transactional_delete_files[delete_file.data_file_path] = delete_file.file_name;
-				    }
-			    }
-		    });
+			                 //! Add or overwrite the currently active transaction-local delete files
+			                 for (auto &entry : global_state.written_files) {
+				                 auto &delete_file = entry.second;
+				                 if (tbl.GetMetadata().iceberg_version >= 3) {
+					                 transaction_data.transactional_delete_files[delete_file.data_file_path] =
+					                     delete_file.file_name;
+				                 }
+			                 }
+		                 });
 	}
 	return SinkFinalizeType::READY;
 }

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -383,7 +383,7 @@ void IcebergInsert::AddWrittenFiles(IcebergInsertGlobalState &global_state, Data
                                     optional_ptr<TableCatalogEntry> table) {
 	D_ASSERT(table);
 	auto &ic_table = table->Cast<IcebergTableEntry>();
-	auto &table_metadata = ic_table.table_info.table_metadata;
+	auto table_metadata = ic_table.GetTransactionTableMetadata();
 	global_state.AddFiles(chunk, ic_table.name.GetIdentifierName(), table_metadata);
 }
 
@@ -453,12 +453,13 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 		if (!written_files.empty()) {
 			ApplyTableUpdate(table_info, iceberg_transaction,
 			                 [&](IcebergTransactionTableState &tbl, IcebergTransactionData &transaction_data) {
-				                 transaction_data.AddUpdateSnapshot(
-				                     tbl.GetMetadata(), std::move(delete_manifest_entries), std::move(written_files),
-				                     std::move(delete_global_state.altered_manifests));
+				                 auto table_metadata = tbl.GetTransactionMetadata();
+				                 transaction_data.AddUpdateSnapshot(table_metadata, std::move(delete_manifest_entries),
+				                                                    std::move(written_files),
+				                                                    std::move(delete_global_state.altered_manifests));
 				                 for (auto &entry : delete_global_state.written_files) {
 					                 auto &delete_file = entry.second;
-					                 if (tbl.GetMetadata().iceberg_version >= 3) {
+					                 if (table_metadata.iceberg_version >= 3) {
 						                 transaction_data.transactional_delete_files[delete_file.data_file_path] =
 						                     delete_file.file_name;
 					                 }
@@ -471,7 +472,8 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 			ApplyTableUpdate(table_info, iceberg_transaction,
 			                 [&](IcebergTransactionTableState &tbl, IcebergTransactionData &transaction_data) {
 				                 IcebergManifestDeletes empty_deletes;
-				                 transaction_data.AddSnapshot(tbl.GetMetadata(), IcebergSnapshotOperationType::APPEND,
+				                 auto table_metadata = tbl.GetTransactionMetadata();
+				                 transaction_data.AddSnapshot(table_metadata, IcebergSnapshotOperationType::APPEND,
 				                                              std::move(written_files), std::move(empty_deletes));
 			                 });
 		}
@@ -980,7 +982,7 @@ PhysicalOperator &IcebergCatalog::PlanInsert(ClientContext &context, PhysicalPla
 	auto &irc_transaction = IcebergTransaction::Get(context, *this);
 	auto &alter = irc_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(table_entry.table_info);
-	auto &table_metadata = updated_table.GetMetadata();
+	auto table_metadata = updated_table.GetTransactionMetadata();
 	auto &schema = table_metadata.GetLatestSchema();
 	auto &updated_table_entry = updated_table.GetOrCreateSchemaEntry(schema);
 

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -452,13 +452,13 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 		auto delete_manifest_entries = IcebergDelete::GenerateDeleteManifestEntries(delete_global_state);
 		if (!written_files.empty()) {
 			ApplyTableUpdate(table_info, iceberg_transaction,
-			                 [&](IcebergTableInformation &tbl, IcebergTransactionData &transaction_data) {
+			                 [&](IcebergTransactionTableState &tbl, IcebergTransactionData &transaction_data) {
 				                 transaction_data.AddUpdateSnapshot(std::move(delete_manifest_entries),
 				                                                    std::move(written_files),
 				                                                    std::move(delete_global_state.altered_manifests));
 				                 for (auto &entry : delete_global_state.written_files) {
 					                 auto &delete_file = entry.second;
-					                 if (table_info.table_metadata.iceberg_version >= 3) {
+					                 if (tbl.GetMetadata().iceberg_version >= 3) {
 						                 transaction_data.transactional_delete_files[delete_file.data_file_path] =
 						                     delete_file.file_name;
 					                 }
@@ -469,7 +469,7 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 		// Regular insert: commit an append snapshot.
 		if (!written_files.empty()) {
 			ApplyTableUpdate(table_info, iceberg_transaction,
-			                 [&](IcebergTableInformation &tbl, IcebergTransactionData &transaction_data) {
+			                 [&](IcebergTransactionTableState &tbl, IcebergTransactionData &transaction_data) {
 				                 IcebergManifestDeletes empty_deletes;
 				                 transaction_data.AddSnapshot(IcebergSnapshotOperationType::APPEND,
 				                                              std::move(written_files), std::move(empty_deletes));
@@ -980,9 +980,9 @@ PhysicalOperator &IcebergCatalog::PlanInsert(ClientContext &context, PhysicalPla
 	auto &irc_transaction = IcebergTransaction::Get(context, *this);
 	auto &alter = irc_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(table_entry.table_info);
-	auto &table_metadata = updated_table.table_metadata;
+	auto &table_metadata = updated_table.GetMetadata();
 	auto &schema = table_metadata.GetLatestSchema();
-	auto &updated_table_entry = *updated_table.schema_versions[schema.schema_id];
+	auto &updated_table_entry = updated_table.GetOrCreateSchemaEntry(schema);
 
 	if (table_metadata.HasSortOrder()) {
 		auto &sort_spec = table_metadata.GetLatestSortOrder();

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -453,9 +453,9 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 		if (!written_files.empty()) {
 			ApplyTableUpdate(table_info, iceberg_transaction,
 			                 [&](IcebergTransactionTableState &tbl, IcebergTransactionData &transaction_data) {
-				                 transaction_data.AddUpdateSnapshot(std::move(delete_manifest_entries),
-				                                                    std::move(written_files),
-				                                                    std::move(delete_global_state.altered_manifests));
+				                 transaction_data.AddUpdateSnapshot(
+				                     tbl.GetMetadata(), std::move(delete_manifest_entries), std::move(written_files),
+				                     std::move(delete_global_state.altered_manifests));
 				                 for (auto &entry : delete_global_state.written_files) {
 					                 auto &delete_file = entry.second;
 					                 if (tbl.GetMetadata().iceberg_version >= 3) {
@@ -471,7 +471,7 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 			ApplyTableUpdate(table_info, iceberg_transaction,
 			                 [&](IcebergTransactionTableState &tbl, IcebergTransactionData &transaction_data) {
 				                 IcebergManifestDeletes empty_deletes;
-				                 transaction_data.AddSnapshot(IcebergSnapshotOperationType::APPEND,
+				                 transaction_data.AddSnapshot(tbl.GetMetadata(), IcebergSnapshotOperationType::APPEND,
 				                                              std::move(written_files), std::move(empty_deletes));
 			                 });
 		}

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -1027,7 +1027,7 @@ static unique_ptr<IcebergTableMetadata> BuildPlaceholderMetadata(BoundCreateTabl
 		schema->columns.push_back(std::move(col_def));
 	}
 	schema->last_column_id = static_cast<idx_t>(next_field_id - 1);
-	metadata->AddSchemaOrGetExisting(schema);
+	metadata->AddSchema(schema);
 	metadata->SetCurrentSchemaId(0);
 
 	// Build a placeholder partition spec from the parsed PARTITIONED BY clause so that

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -26,6 +26,7 @@
 #include "core/metadata/partition/iceberg_partition_spec.hpp"
 #include "planning/iceberg_multi_file_list.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "core/expression/iceberg_value.hpp"
 #include "core/expression/iceberg_transform.hpp"
 #include "storage/statistics/iceberg_variant_statistics.hpp"
@@ -450,27 +451,29 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 		auto &delete_global_state = update_delete_op->sink_state->Cast<IcebergDeleteGlobalState>();
 		auto delete_manifest_entries = IcebergDelete::GenerateDeleteManifestEntries(delete_global_state);
 		if (!written_files.empty()) {
-			ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
-				auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
-				transaction_data.AddUpdateSnapshot(std::move(delete_manifest_entries), std::move(written_files),
-				                                   std::move(delete_global_state.altered_manifests));
-				for (auto &entry : delete_global_state.written_files) {
-					auto &delete_file = entry.second;
-					if (table_info.table_metadata.iceberg_version >= 3) {
-						transaction_data.transactional_delete_files[delete_file.data_file_path] = delete_file.file_name;
-					}
-				}
-			});
+			ApplyTableUpdate(table_info, iceberg_transaction,
+			                 [&](IcebergTableInformation &tbl, IcebergTransactionData &transaction_data) {
+				                 transaction_data.AddUpdateSnapshot(std::move(delete_manifest_entries),
+				                                                    std::move(written_files),
+				                                                    std::move(delete_global_state.altered_manifests));
+				                 for (auto &entry : delete_global_state.written_files) {
+					                 auto &delete_file = entry.second;
+					                 if (table_info.table_metadata.iceberg_version >= 3) {
+						                 transaction_data.transactional_delete_files[delete_file.data_file_path] =
+						                     delete_file.file_name;
+					                 }
+				                 }
+			                 });
 		}
 	} else {
 		// Regular insert: commit an append snapshot.
 		if (!written_files.empty()) {
-			ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
-				auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
-				IcebergManifestDeletes empty_deletes;
-				transaction_data.AddSnapshot(IcebergSnapshotOperationType::APPEND, std::move(written_files),
-				                             std::move(empty_deletes));
-			});
+			ApplyTableUpdate(table_info, iceberg_transaction,
+			                 [&](IcebergTableInformation &tbl, IcebergTransactionData &transaction_data) {
+				                 IcebergManifestDeletes empty_deletes;
+				                 transaction_data.AddSnapshot(IcebergSnapshotOperationType::APPEND,
+				                                              std::move(written_files), std::move(empty_deletes));
+			                 });
 		}
 	}
 	return SinkFinalizeType::READY;

--- a/src/execution/operator/iceberg_update.cpp
+++ b/src/execution/operator/iceberg_update.cpp
@@ -242,9 +242,9 @@ PhysicalOperator &IcebergCatalog::PlanUpdate(ClientContext &context, PhysicalPla
 	auto &irc_transaction = IcebergTransaction::Get(context, *this);
 	auto &alter = irc_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(table_entry.table_info);
-	auto &table_metadata = updated_table.table_metadata;
+	auto &table_metadata = updated_table.GetMetadata();
 	auto &schema = table_metadata.GetLatestSchema();
-	auto &updated_table_entry = *updated_table.schema_versions[schema.schema_id];
+	auto &updated_table_entry = updated_table.GetOrCreateSchemaEntry(schema);
 
 	// Plan the copy operator with update_op as child.
 	// PlanCopyForInsert will add a partition projection on top if needed.

--- a/src/execution/operator/iceberg_update.cpp
+++ b/src/execution/operator/iceberg_update.cpp
@@ -23,7 +23,7 @@ IcebergUpdate::IcebergUpdate(PhysicalPlan &physical_plan, IcebergTableEntry &tab
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, {}, 1), table(table),
       columns(std::move(columns_p)), delete_op(delete_op_p), expressions(std::move(expressions_p)) {
 	children.push_back(child);
-	auto &table_metadata = table.table_info.table_metadata;
+	auto table_metadata = table.GetTransactionTableMetadata();
 	if (table_metadata.iceberg_version >= 3) {
 		//! For v3, _row_id is the virtual column appended right after physical columns by DuckDB
 		row_id_index = columns.size();
@@ -44,7 +44,7 @@ IcebergUpdate::IcebergUpdate(PhysicalPlan &physical_plan, IcebergTableEntry &tab
 IcebergUpdate &IcebergUpdate::PlanUpdateOperator(ClientContext &context, PhysicalPlanGenerator &planner,
                                                  IcebergTableEntry &table, LogicalUpdate &op,
                                                  PhysicalOperator &child_plan, IcebergCopyInput &copy_input) {
-	auto &table_metadata = table.table_info.table_metadata;
+	auto table_metadata = table.GetTransactionTableMetadata();
 
 	if (table_metadata.HasSortOrder()) {
 		auto &sort_spec = table_metadata.GetLatestSortOrder();
@@ -242,7 +242,7 @@ PhysicalOperator &IcebergCatalog::PlanUpdate(ClientContext &context, PhysicalPla
 	auto &irc_transaction = IcebergTransaction::Get(context, *this);
 	auto &alter = irc_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(table_entry.table_info);
-	auto &table_metadata = updated_table.GetMetadata();
+	auto table_metadata = updated_table.GetTransactionMetadata();
 	auto &schema = table_metadata.GetLatestSchema();
 	auto &updated_table_entry = updated_table.GetOrCreateSchemaEntry(schema);
 

--- a/src/execution/operator/merge_into/iceberg_merge_into.cpp
+++ b/src/execution/operator/merge_into/iceberg_merge_into.cpp
@@ -153,7 +153,7 @@ static unique_ptr<MergeIntoOperator> IcebergPlanMergeIntoAction(IcebergCatalog &
 	auto &irc_transaction = IcebergTransaction::Get(context, catalog);
 	auto &alter = irc_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(table_entry.table_info);
-	auto &table_metadata = updated_table.GetMetadata();
+	auto table_metadata = updated_table.GetTransactionMetadata();
 	auto &schema = table_metadata.GetLatestSchema();
 	auto &updated_table_entry = updated_table.GetOrCreateSchemaEntry(schema);
 

--- a/src/execution/operator/merge_into/iceberg_merge_into.cpp
+++ b/src/execution/operator/merge_into/iceberg_merge_into.cpp
@@ -153,9 +153,9 @@ static unique_ptr<MergeIntoOperator> IcebergPlanMergeIntoAction(IcebergCatalog &
 	auto &irc_transaction = IcebergTransaction::Get(context, catalog);
 	auto &alter = irc_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(table_entry.table_info);
-	auto &table_metadata = updated_table.table_metadata;
+	auto &table_metadata = updated_table.GetMetadata();
 	auto &schema = table_metadata.GetLatestSchema();
-	auto &updated_table_entry = *updated_table.schema_versions[schema.schema_id];
+	auto &updated_table_entry = updated_table.GetOrCreateSchemaEntry(schema);
 
 	auto iceberg_version = table_metadata.iceberg_version;
 

--- a/src/function/copy/iceberg_copy_function.cpp
+++ b/src/function/copy/iceberg_copy_function.cpp
@@ -59,7 +59,7 @@ CopyIcebergBindData::CopyIcebergBindData(const CopyInfo &info, vector<string> &&
 	table_schema =
 	    IcebergCreateTableRequest::CreateIcebergSchema(context, *table_metadata, columns, nullptr, last_column_id);
 	table_schema->schema_id = 0;
-	auto &result_schema = table_metadata->AddSchemaOrGetExisting(table_schema);
+	auto &result_schema = table_metadata->AddSchema(table_schema);
 	if (result_schema.schema_id != 0) {
 		throw InternalException("Iceberg COPY created non-0 schema id (%d)", result_schema.schema_id);
 	}

--- a/src/function/metadata/iceberg_table_properties_functions.cpp
+++ b/src/function/metadata/iceberg_table_properties_functions.cpp
@@ -176,10 +176,10 @@ static void SetIcebergTablePropertiesFunction(ClientContext &context, TableFunct
 	auto &table_info = iceberg_table->table_info;
 
 	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
-	ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
-		auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
-		transaction_data.TableSetProperties(bind_data.properties);
-	});
+	ApplyTableUpdate(table_info, iceberg_transaction,
+	                 [&](IcebergTableInformation &tbl, IcebergTransactionData &transaction_data) {
+		                 transaction_data.TableSetProperties(bind_data.properties);
+	                 });
 
 	auto schema = iceberg_table->schema.name;
 	auto table_name = iceberg_table->name;
@@ -205,10 +205,10 @@ static void RemoveIcebergTablePropertiesFunction(ClientContext &context, TableFu
 	auto iceberg_table = bind_data.iceberg_table;
 	auto &table_info = iceberg_table->table_info;
 	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
-	ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
-		auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
-		transaction_data.TableRemoveProperties(bind_data.remove_properties);
-	});
+	ApplyTableUpdate(table_info, iceberg_transaction,
+	                 [&](IcebergTableInformation &tbl, IcebergTransactionData &transaction_data) {
+		                 transaction_data.TableRemoveProperties(bind_data.remove_properties);
+	                 });
 
 	auto schema = iceberg_table->schema.name;
 	auto table_name = iceberg_table->name;

--- a/src/function/metadata/iceberg_table_properties_functions.cpp
+++ b/src/function/metadata/iceberg_table_properties_functions.cpp
@@ -177,7 +177,7 @@ static void SetIcebergTablePropertiesFunction(ClientContext &context, TableFunct
 
 	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
 	ApplyTableUpdate(table_info, iceberg_transaction,
-	                 [&](IcebergTableInformation &tbl, IcebergTransactionData &transaction_data) {
+	                 [&](IcebergTransactionTableState &tbl, IcebergTransactionData &transaction_data) {
 		                 transaction_data.TableSetProperties(bind_data.properties);
 	                 });
 
@@ -206,7 +206,7 @@ static void RemoveIcebergTablePropertiesFunction(ClientContext &context, TableFu
 	auto &table_info = iceberg_table->table_info;
 	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
 	ApplyTableUpdate(table_info, iceberg_transaction,
-	                 [&](IcebergTableInformation &tbl, IcebergTransactionData &transaction_data) {
+	                 [&](IcebergTransactionTableState &tbl, IcebergTransactionData &transaction_data) {
 		                 transaction_data.TableRemoveProperties(bind_data.remove_properties);
 	                 });
 

--- a/src/function/metadata/iceberg_table_properties_functions.cpp
+++ b/src/function/metadata/iceberg_table_properties_functions.cpp
@@ -126,7 +126,7 @@ static unique_ptr<FunctionData> RemoveIcebergTablePropertiesBind(ClientContext &
 	auto &remove_values = input.inputs[1];
 	auto &list_children = ListValue::GetChildren(remove_values);
 	for (idx_t col_idx = 0; col_idx < list_children.size(); col_idx++) {
-		auto &remove_property = StringValue::Get(list_children[0]);
+		auto &remove_property = StringValue::Get(list_children[col_idx]);
 		ret->remove_properties.push_back(remove_property);
 	}
 
@@ -176,16 +176,18 @@ static void SetIcebergTablePropertiesFunction(ClientContext &context, TableFunct
 	auto &table_info = iceberg_table->table_info;
 
 	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
+	idx_t property_count = 0;
 	ApplyTableUpdate(table_info, iceberg_transaction,
 	                 [&](IcebergTransactionTableState &tbl, IcebergTransactionData &transaction_data) {
 		                 transaction_data.TableSetProperties(bind_data.properties);
+		                 property_count = tbl.GetTransactionMetadata().table_properties.size();
 	                 });
 
 	auto schema = iceberg_table->schema.name;
 	auto table_name = iceberg_table->name;
 	global_state.properties_set = true;
 	// set success output, failure happens during transaction commit.
-	FlatVector::GetDataMutable<int64_t>(output.data[0])[0] = bind_data.properties.size();
+	FlatVector::GetDataMutable<int64_t>(output.data[0])[0] = property_count;
 	output.SetChildCardinality(1);
 }
 
@@ -205,16 +207,18 @@ static void RemoveIcebergTablePropertiesFunction(ClientContext &context, TableFu
 	auto iceberg_table = bind_data.iceberg_table;
 	auto &table_info = iceberg_table->table_info;
 	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
+	idx_t property_count = 0;
 	ApplyTableUpdate(table_info, iceberg_transaction,
 	                 [&](IcebergTransactionTableState &tbl, IcebergTransactionData &transaction_data) {
 		                 transaction_data.TableRemoveProperties(bind_data.remove_properties);
+		                 property_count = tbl.GetTransactionMetadata().table_properties.size();
 	                 });
 
 	auto schema = iceberg_table->schema.name;
 	auto table_name = iceberg_table->name;
 	global_state.properties_removed = true;
 	// set success output, failure happens during transaction commit.
-	FlatVector::GetDataMutable<int64_t>(output.data[0])[0] = table_info.table_metadata.table_properties.size();
+	FlatVector::GetDataMutable<int64_t>(output.data[0])[0] = property_count;
 	output.SetChildCardinality(1);
 }
 
@@ -231,10 +235,10 @@ static void GetIcebergTablePropertiesFunction(ClientContext &context, TableFunct
 	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
 	auto table_key = iceberg_table->table_info.GetTableKey();
 	auto table_txn_state = iceberg_transaction.GetLatestTableState(table_key);
-	const IcebergTableInformation &txn_table_info =
-	    table_txn_state ? table_txn_state->GetInfo() : iceberg_table->table_info;
+	auto metadata =
+	    table_txn_state ? table_txn_state->GetTransactionMetadata() : iceberg_table->GetTransactionTableMetadata();
 
-	const auto &properties = txn_table_info.table_metadata.GetTableProperties();
+	const auto &properties = metadata.GetTableProperties();
 	if (properties.empty()) {
 		output.SetChildCardinality(0);
 		return;

--- a/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
+++ b/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
@@ -20,7 +20,7 @@ struct IcebergAddSnapshot : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SNAPSHOT;
 
 public:
-	IcebergAddSnapshot(const IcebergTableInformation &table_info,
+	IcebergAddSnapshot(const IcebergTableMetadata &table_metadata,
 	                   IcebergSnapshotOperationType operation = IcebergSnapshotOperationType::OVERWRITE);
 
 public:

--- a/src/include/catalog/rest/api/iceberg_table_requirement.hpp
+++ b/src/include/catalog/rest/api/iceberg_table_requirement.hpp
@@ -20,8 +20,7 @@ enum class IcebergTableRequirementType : uint8_t {
 
 struct IcebergTableRequirement {
 public:
-	IcebergTableRequirement(IcebergTableRequirementType type, const IcebergTableInformation &table_info)
-	    : type(type), table_info(table_info) {
+	explicit IcebergTableRequirement(IcebergTableRequirementType type) : type(type) {
 	}
 	virtual ~IcebergTableRequirement() {
 	}
@@ -40,7 +39,6 @@ public:
 
 public:
 	IcebergTableRequirementType type;
-	const IcebergTableInformation &table_info;
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/api/iceberg_table_update.hpp
+++ b/src/include/catalog/rest/api/iceberg_table_update.hpp
@@ -57,7 +57,7 @@ public:
 
 struct IcebergTableUpdate {
 public:
-	IcebergTableUpdate(IcebergTableUpdateType type, const IcebergTableInformation &table_info);
+	explicit IcebergTableUpdate(IcebergTableUpdateType type);
 	virtual ~IcebergTableUpdate() {
 	}
 
@@ -78,7 +78,6 @@ public:
 
 public:
 	IcebergTableUpdateType type;
-	const IcebergTableInformation &table_info;
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/api/table_update.hpp
+++ b/src/include/catalog/rest/api/table_update.hpp
@@ -8,9 +8,11 @@
 #include "catalog/rest/api/iceberg_table_update.hpp"
 #include "catalog/rest/api/iceberg_table_requirement.hpp"
 #include "core/metadata/manifest/iceberg_manifest.hpp"
+#include "core/metadata/partition/iceberg_partition_spec.hpp"
 #include "core/metadata/schema/iceberg_table_schema.hpp"
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
 #include "core/metadata/snapshot/iceberg_snapshot.hpp"
+#include "core/metadata/sort/iceberg_sort_order.hpp"
 
 namespace duckdb {
 
@@ -44,6 +46,8 @@ struct AssertTableUUIDRequirement : public IcebergTableRequirement {
 
 	explicit AssertTableUUIDRequirement(const IcebergTableInformation &table_info);
 	void CreateRequirement(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
+
+	string uuid;
 };
 
 struct AssertCurrentSchemaIdRequirement : public IcebergTableRequirement {
@@ -88,50 +92,64 @@ struct AssertDefaultSpecIdRequirement : public IcebergTableRequirement {
 struct AssignUUIDUpdate : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ASSIGN_UUID;
 
-	explicit AssignUUIDUpdate(const IcebergTableInformation &table_info);
+	explicit AssignUUIDUpdate(string uuid);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+
+	string uuid;
 };
 
 struct UpgradeFormatVersion : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::UPGRADE_FORMAT_VERSION;
 
-	explicit UpgradeFormatVersion(const IcebergTableInformation &table_info);
+	explicit UpgradeFormatVersion(int32_t format_version);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+
+	int32_t format_version;
 };
 
 struct SetCurrentSchema : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_CURRENT_SCHEMA;
 
-	explicit SetCurrentSchema(const IcebergTableInformation &table_info);
+	explicit SetCurrentSchema(int32_t schema_id);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+
+	int32_t schema_id;
 };
 
 struct AddPartitionSpec : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_PARTITION_SPEC;
-	explicit AddPartitionSpec(const IcebergTableInformation &table_info);
+	explicit AddPartitionSpec(const IcebergPartitionSpec &partition_spec);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+
+	IcebergPartitionSpec partition_spec;
 };
 
 struct AddSortOrder : public IcebergTableUpdate {
 	static constexpr const int64_t DEFAULT_SORT_ORDER_ID = 0;
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SORT_ORDER;
 
-	explicit AddSortOrder(const IcebergTableInformation &table_info);
+	explicit AddSortOrder(const IcebergSortOrder &sort_order);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+
+	IcebergSortOrder sort_order;
 };
 
 struct SetDefaultSortOrder : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_DEFAULT_SORT_ORDER;
 
-	explicit SetDefaultSortOrder(const IcebergTableInformation &table_info);
+	explicit SetDefaultSortOrder(int32_t sort_order_id);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+
+	int32_t sort_order_id;
 };
 
 struct SetDefaultSpec : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_DEFAULT_SPEC;
 
-	explicit SetDefaultSpec(const IcebergTableInformation &table_info);
+	explicit SetDefaultSpec(int32_t spec_id);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+
+	int32_t spec_id;
 };
 
 struct SetProperties : public IcebergTableUpdate {
@@ -155,8 +173,10 @@ struct RemoveProperties : public IcebergTableUpdate {
 struct SetLocation : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_LOCATION;
 
-	explicit SetLocation(const IcebergTableInformation &table_info);
+	explicit SetLocation(string location);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+
+	string location;
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/api/table_update.hpp
+++ b/src/include/catalog/rest/api/table_update.hpp
@@ -20,7 +20,7 @@ struct IcebergTableInformation;
 
 struct AddSchemaUpdate : public IcebergTableUpdate {
 public:
-	explicit AddSchemaUpdate(const IcebergTableMetadata &table_metadata, int32_t schema_id);
+	AddSchemaUpdate(shared_ptr<IcebergTableSchema> schema, optional_idx last_column_id);
 
 public:
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SCHEMA;
@@ -28,7 +28,6 @@ public:
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 
 public:
-	int32_t schema_id;
 	optional_idx last_column_id;
 	string schema_json;
 	shared_ptr<IcebergTableSchema> schema;

--- a/src/include/catalog/rest/api/table_update.hpp
+++ b/src/include/catalog/rest/api/table_update.hpp
@@ -18,7 +18,8 @@ struct IcebergTableInformation;
 
 struct AddSchemaUpdate : public IcebergTableUpdate {
 public:
-	explicit AddSchemaUpdate(const IcebergTableInformation &table_info, int32_t schema_id);
+	explicit AddSchemaUpdate(const IcebergTableInformation &table_info, const IcebergTableMetadata &table_metadata,
+	                         int32_t schema_id);
 
 public:
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SCHEMA;
@@ -28,6 +29,7 @@ public:
 public:
 	int32_t schema_id;
 	optional_idx last_column_id;
+	string schema_json;
 };
 
 struct AssertCreateRequirement : public IcebergTableRequirement {
@@ -98,15 +100,14 @@ struct UpgradeFormatVersion : public IcebergTableUpdate {
 };
 
 struct SetCurrentSchema : public IcebergTableUpdate {
-	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::UPGRADE_FORMAT_VERSION;
+	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_CURRENT_SCHEMA;
 
 	explicit SetCurrentSchema(const IcebergTableInformation &table_info);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };
 
 struct AddPartitionSpec : public IcebergTableUpdate {
-	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::UPGRADE_FORMAT_VERSION;
-
+	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_PARTITION_SPEC;
 	explicit AddPartitionSpec(const IcebergTableInformation &table_info);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 };

--- a/src/include/catalog/rest/api/table_update.hpp
+++ b/src/include/catalog/rest/api/table_update.hpp
@@ -20,8 +20,7 @@ struct IcebergTableInformation;
 
 struct AddSchemaUpdate : public IcebergTableUpdate {
 public:
-	explicit AddSchemaUpdate(const IcebergTableInformation &table_info, const IcebergTableMetadata &table_metadata,
-	                         int32_t schema_id);
+	explicit AddSchemaUpdate(const IcebergTableMetadata &table_metadata, int32_t schema_id);
 
 public:
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SCHEMA;
@@ -32,6 +31,7 @@ public:
 	int32_t schema_id;
 	optional_idx last_column_id;
 	string schema_json;
+	shared_ptr<IcebergTableSchema> schema;
 };
 
 struct AssertCreateRequirement : public IcebergTableRequirement {
@@ -44,7 +44,7 @@ struct AssertCreateRequirement : public IcebergTableRequirement {
 struct AssertTableUUIDRequirement : public IcebergTableRequirement {
 	static constexpr const IcebergTableRequirementType TYPE = IcebergTableRequirementType::ASSERT_TABLE_UUID;
 
-	explicit AssertTableUUIDRequirement(const IcebergTableInformation &table_info);
+	explicit AssertTableUUIDRequirement(string uuid);
 	void CreateRequirement(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
 
 	string uuid;
@@ -53,7 +53,7 @@ struct AssertTableUUIDRequirement : public IcebergTableRequirement {
 struct AssertCurrentSchemaIdRequirement : public IcebergTableRequirement {
 	static constexpr const IcebergTableRequirementType TYPE = IcebergTableRequirementType::ASSERT_CURRENT_SCHEMA_ID;
 
-	explicit AssertCurrentSchemaIdRequirement(const IcebergTableInformation &table_info);
+	explicit AssertCurrentSchemaIdRequirement(int32_t current_schema_id);
 	void CreateRequirement(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
 
 	int32_t current_schema_id;
@@ -64,7 +64,7 @@ struct AssertLastAssignedFieldIdRequirement : public IcebergTableRequirement {
 	static constexpr const IcebergTableRequirementType TYPE =
 	    IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_FIELD_ID;
 
-	explicit AssertLastAssignedFieldIdRequirement(const IcebergTableInformation &table_info);
+	explicit AssertLastAssignedFieldIdRequirement(int32_t last_assigned_field_id);
 	void CreateRequirement(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
 
 	int32_t last_assigned_field_id;
@@ -74,7 +74,7 @@ struct AssertLastAssignedPartitionIdRequirement : public IcebergTableRequirement
 	static constexpr const IcebergTableRequirementType TYPE =
 	    IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_PARTITION_ID;
 
-	explicit AssertLastAssignedPartitionIdRequirement(const IcebergTableInformation &table_info);
+	explicit AssertLastAssignedPartitionIdRequirement(int32_t last_assigned_partition_id);
 	void CreateRequirement(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
 
 	int32_t last_assigned_partition_id;
@@ -83,7 +83,7 @@ struct AssertLastAssignedPartitionIdRequirement : public IcebergTableRequirement
 struct AssertDefaultSpecIdRequirement : public IcebergTableRequirement {
 	static constexpr const IcebergTableRequirementType TYPE = IcebergTableRequirementType::ASSERT_DEFAULT_SPEC_ID;
 
-	explicit AssertDefaultSpecIdRequirement(const IcebergTableInformation &table_info);
+	explicit AssertDefaultSpecIdRequirement(int32_t default_spec_id);
 	void CreateRequirement(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
 
 	int32_t default_spec_id;
@@ -155,7 +155,7 @@ struct SetDefaultSpec : public IcebergTableUpdate {
 struct SetProperties : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_PROPERTIES;
 
-	explicit SetProperties(const IcebergTableInformation &table_info, const case_insensitive_map_t<string> &properties);
+	explicit SetProperties(const case_insensitive_map_t<string> &properties);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 
 	case_insensitive_map_t<string> properties;
@@ -164,7 +164,7 @@ struct SetProperties : public IcebergTableUpdate {
 struct RemoveProperties : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::REMOVE_PROPERTIES;
 
-	explicit RemoveProperties(const IcebergTableInformation &table_info, const vector<string> &properties);
+	explicit RemoveProperties(const vector<string> &properties);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 
 	vector<string> properties;

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_entry.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_entry.hpp
@@ -21,7 +21,8 @@ public:
 	static virtual_column_map_t VirtualColumns();
 	virtual_column_map_t GetVirtualColumns() const override;
 	vector<column_t> GetRowIdColumns() const override;
-	const IcebergTableMetadata &GetTableMetadata() const;
+	const IcebergTableMetadata &GetBaseTableMetadata() const;
+	IcebergTableMetadata GetTransactionTableMetadata() const;
 	optional_ptr<IcebergTransactionData> GetTransactionData() const;
 
 public:

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_entry.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_entry.hpp
@@ -2,21 +2,27 @@
 #pragma once
 
 #include "catalog/rest/api/catalog_api.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 
 namespace duckdb {
 
 struct IcebergTableInformation;
+struct IcebergTransactionData;
+struct IcebergTransactionTableState;
 
 class IcebergTableEntry : public TableCatalogEntry {
 public:
 	IcebergTableEntry(IcebergTableInformation &table_info, Catalog &catalog, SchemaCatalogEntry &schema,
-	                  CreateTableInfo &info, optional_idx schema_id);
+	                  CreateTableInfo &info, optional_idx schema_id,
+	                  optional_ptr<IcebergTransactionTableState> transaction_state = nullptr);
 
 	static virtual_column_map_t VirtualColumns();
 	virtual_column_map_t GetVirtualColumns() const override;
 	vector<column_t> GetRowIdColumns() const override;
+	const IcebergTableMetadata &GetTableMetadata() const;
+	optional_ptr<IcebergTransactionData> GetTransactionData() const;
 
 public:
 	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id) override;
@@ -39,6 +45,7 @@ public:
 	IcebergTableInformation &table_info;
 	//! 'schema_id' used to create the entry, or invalid if this is a dummy
 	optional_idx schema_id;
+	optional_ptr<IcebergTransactionTableState> transaction_state;
 };
 
 struct IcebergTableEntryHashFunction {

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -60,6 +60,8 @@ public:
 	string GetTableKey() const;
 	IcebergTableMetadata CreateMetadataFromLog(ClientContext &context, int64_t transaction_start_millis,
 	                                           string &metadata_path) const;
+	IcebergTableMetadata GetTransactionStartMetadata(ClientContext &context,
+	                                                 IcebergTransaction &iceberg_transaction) const;
 	// we pass the transaction, because we are only allowed to copy table information state provded by the catalog
 	// from before our transaction start time.
 	IcebergTableInformation Copy(IcebergTransaction &iceberg_transaction) const;
@@ -70,6 +72,7 @@ public:
 	IcebergSnapshotLookup GetSnapshotLookup(IcebergTransaction &iceberg_transaction) const;
 	IcebergSnapshotLookup GetSnapshotLookup(ClientContext &context, optional_ptr<BoundAtClause> at) const;
 	IcebergSnapshotLookup GetSnapshotLookup(ClientContext &context) const;
+	IcebergSnapshotLookup GetSnapshotLookup(timestamp_t transaction_start) const;
 	bool TableIsEmpty(const IcebergSnapshotLookup &snapshot_lookup) const;
 	void InitializeFromLoadTableResult(const rest_api_objects::LoadTableResult &load_table_result,
 	                                   bool initialize_schemas = true);

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -6,7 +6,6 @@
 #include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
 #include "core/metadata/manifest/iceberg_manifest.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
-#include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "rest_catalog/objects/storage_credential.hpp"
 
 namespace duckdb {
@@ -14,6 +13,8 @@ class IcebergTableSchema;
 class ParsedExpression;
 struct CreateTableInfo;
 class IcebergSchemaEntry;
+class IcebergTransaction;
+struct IcebergTransactionData;
 struct IcebergManifestEntry;
 
 struct IRCAPITableCredentials {
@@ -45,16 +46,15 @@ public:
 	idx_t GetMaxSchemaId();
 	idx_t GetNextPartitionSpecId();
 	int64_t GetExistingSpecId(IcebergPartitionSpec &spec);
-	void SetPartitionedBy(IcebergTransaction &transaction, const vector<unique_ptr<ParsedExpression>> &partition_keys,
-	                      const IcebergTableSchema &schema, bool first_partition_spec = false);
+	void SetPartitionedBy(IcebergTransactionData &transaction_data,
+	                      const vector<unique_ptr<ParsedExpression>> &partition_keys, const IcebergTableSchema &schema,
+	                      bool first_partition_spec = false);
 	//! Build an IcebergPartitionSpec from parsed PARTITIONED BY expressions and a schema.
 	static IcebergPartitionSpec BuildPartitionSpec(const vector<unique_ptr<ParsedExpression>> &partition_keys,
 	                                               const IcebergTableSchema &schema, int32_t spec_id,
 	                                               idx_t base_partition_field_id);
 	IRCAPITableCredentials GetVendedCredentials(ClientContext &context);
 	const string &BaseFilePath() const;
-
-	IcebergTransactionData &GetOrCreateTransactionData(IcebergTransaction &transaction);
 
 	static string GetTableKey(const vector<string> &namespace_items, const string &table_name);
 	string GetTableKey() const;
@@ -71,7 +71,6 @@ public:
 	IcebergSnapshotLookup GetSnapshotLookup(ClientContext &context, optional_ptr<BoundAtClause> at) const;
 	IcebergSnapshotLookup GetSnapshotLookup(ClientContext &context) const;
 	bool TableIsEmpty(const IcebergSnapshotLookup &snapshot_lookup) const;
-	bool HasTransactionUpdates() const;
 	void InitializeFromLoadTableResult(const rest_api_objects::LoadTableResult &load_table_result,
 	                                   bool initialize_schemas = true);
 	void RefreshFromCatalog(ClientContext &context);
@@ -90,7 +89,6 @@ public:
 	unordered_map<int32_t, unique_ptr<IcebergTableEntry>> schema_versions;
 	// dummy entry to hold existence of a table, but no schema versions
 	unique_ptr<IcebergTableEntry> dummy_entry;
-	unique_ptr<IcebergTransactionData> transaction_data;
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -53,7 +53,7 @@ public:
 	static IcebergPartitionSpec BuildPartitionSpec(const vector<unique_ptr<ParsedExpression>> &partition_keys,
 	                                               const IcebergTableSchema &schema, int32_t spec_id,
 	                                               idx_t base_partition_field_id);
-	IRCAPITableCredentials GetVendedCredentials(ClientContext &context);
+	IRCAPITableCredentials GetVendedCredentials(ClientContext &context, const IcebergTableMetadata &table_metadata);
 	const string &BaseFilePath() const;
 
 	static string GetTableKey(const vector<string> &namespace_items, const string &table_name);

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -67,6 +67,7 @@ public:
 	IcebergTableInformation Copy(IcebergTransaction &iceberg_transaction) const;
 	// This copy is used for deletes, where we don't care about valid table state
 	IcebergTableInformation Copy(ClientContext &context) const;
+	std::optional<IcebergTableInformation> TryCopy(ClientContext &context) const;
 	void InitSchemaVersions();
 
 	IcebergSnapshotLookup GetSnapshotLookup(IcebergTransaction &iceberg_transaction) const;

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -57,19 +57,15 @@ public:
 		return *table;
 	}
 	const IcebergTableMetadata &GetBaseMetadata() const {
-		if (has_base_metadata) {
-			return base_metadata;
+		if (base_metadata) {
+			return *base_metadata;
 		}
 		return GetInfo().table_metadata;
 	}
 	void SetBaseMetadata(IcebergTableMetadata metadata) {
 		base_metadata = std::move(metadata);
-		has_base_metadata = true;
 	}
 	IcebergTableMetadata GetTransactionMetadata() const;
-	bool HasBaseMetadata() const {
-		return has_base_metadata;
-	}
 	optional_ptr<IcebergTransactionData> GetTransactionData() const {
 		return transaction_data.get();
 	}
@@ -105,8 +101,7 @@ private:
 	optional_ptr<IcebergTableInformation> table;
 	unique_ptr<IcebergTableInformation> owned_table;
 	IcebergTableStatus status;
-	bool has_base_metadata = false;
-	IcebergTableMetadata base_metadata;
+	optional<IcebergTableMetadata> base_metadata;
 	unordered_map<int32_t, unique_ptr<IcebergTableEntry>> schema_versions;
 	unique_ptr<IcebergTableEntry> dummy_entry;
 	unique_ptr<IcebergTransactionData> transaction_data;

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -33,12 +33,6 @@ public:
 	IcebergTransactionTableState(optional_ptr<IcebergTableInformation> table);
 
 public:
-	const IcebergTableInformation &GetBaseTableInfo() const {
-		return GetInfo();
-	}
-	const IcebergTableInformation &GetVisibleTableInfo() const {
-		return GetInfo();
-	}
 	IcebergTableInformation &GetInfo() {
 		if (owned_table) {
 			return *owned_table;
@@ -60,13 +54,7 @@ public:
 		return *table;
 	}
 	const IcebergTableMetadata &GetBaseMetadata() const {
-		if (base_metadata) {
-			return *base_metadata;
-		}
 		return GetInfo().table_metadata;
-	}
-	void SetBaseMetadata(IcebergTableMetadata metadata) {
-		base_metadata = std::move(metadata);
 	}
 	IcebergTableMetadata GetTransactionMetadata() const;
 	optional_ptr<IcebergTransactionData> GetTransactionData() const {
@@ -91,6 +79,9 @@ public:
 	bool HasOwnedTable() const {
 		return owned_table != nullptr;
 	}
+	bool IsTransactionLocalTable() const {
+		return transaction_local_table;
+	}
 	void SetStatus(IcebergTableStatus value) {
 		status = value;
 	}
@@ -101,17 +92,17 @@ public:
 		}
 		schema_versions.clear();
 		dummy_entry.reset();
-		base_metadata.reset();
 		transaction_data.reset();
 		owned_table.reset();
+		transaction_local_table = false;
 		table = value;
 	}
-	void SetOwnedTable(IcebergTableInformation &&value) {
+	void SetOwnedTable(IcebergTableInformation &&value, bool transaction_local = false) {
 		schema_versions.clear();
 		dummy_entry.reset();
-		base_metadata.reset();
 		transaction_data.reset();
 		owned_table = make_uniq<IcebergTableInformation>(std::move(value));
+		transaction_local_table = transaction_local;
 		table = *owned_table;
 	}
 
@@ -119,7 +110,7 @@ private:
 	optional_ptr<IcebergTableInformation> table;
 	unique_ptr<IcebergTableInformation> owned_table;
 	IcebergTableStatus status;
-	optional<IcebergTableMetadata> base_metadata;
+	bool transaction_local_table = false;
 	unordered_map<int32_t, unique_ptr<IcebergTableEntry>> schema_versions;
 	unique_ptr<IcebergTableEntry> dummy_entry;
 	unique_ptr<IcebergTransactionData> transaction_data;
@@ -154,7 +145,9 @@ public:
 	void DoSchemaPropertyUpdates(ClientContext &context);
 	IcebergCatalog &GetCatalog();
 	void DropSecrets(ClientContext &context);
-	TableTransactionInfo GetTransactionRequest(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
+	TableTransactionInfo GetTransactionRequest(IcebergTransactionAlterUpdate &alter_update,
+	                                           case_insensitive_map_t<IcebergTableInformation> &staged_tables,
+	                                           ClientContext &context);
 	void DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
 	void DoSingleTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
 	optional_ptr<IcebergTransactionTableState> GetLatestTableState(const string &table_key);
@@ -170,8 +163,8 @@ public:
 private:
 	bool CanUseMultiTableCommit(const IcebergTransactionAlterUpdate &alter_update) const;
 	void CleanupMetadataFiles(ClientContext &context, const vector<string> &paths);
-	void RefreshRetryTables(IcebergTransactionAlterUpdate &alter_update, const case_insensitive_set_t &table_keys,
-	                        ClientContext &context);
+	void RefreshRetryTables(IcebergTransactionAlterUpdate &alter_update,
+	                        case_insensitive_map_t<IcebergTableInformation> &retry_tables, ClientContext &context);
 	void CleanupFiles();
 
 private:

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -33,7 +33,10 @@ public:
 	IcebergTransactionTableState(optional_ptr<IcebergTableInformation> table);
 
 public:
-	IcebergTableInformation &GetBaseTableInfo() {
+	const IcebergTableInformation &GetBaseTableInfo() const {
+		return GetInfo();
+	}
+	const IcebergTableInformation &GetVisibleTableInfo() const {
 		return GetInfo();
 	}
 	IcebergTableInformation &GetInfo() {
@@ -84,6 +87,9 @@ public:
 	}
 	bool IsAlive() const {
 		return status == IcebergTableStatus::ALIVE;
+	}
+	bool HasOwnedTable() const {
+		return owned_table != nullptr;
 	}
 	void SetStatus(IcebergTableStatus value) {
 		status = value;

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -56,22 +56,19 @@ public:
 		}
 		return *table;
 	}
-	IcebergTableMetadata &GetMetadata() {
-		D_ASSERT(has_effective_metadata);
-		return effective_metadata;
-	}
-	const IcebergTableMetadata &GetMetadata() const {
-		if (has_effective_metadata) {
-			return effective_metadata;
+	const IcebergTableMetadata &GetBaseMetadata() const {
+		if (has_base_metadata) {
+			return base_metadata;
 		}
 		return GetInfo().table_metadata;
 	}
-	bool HasEffectiveMetadata() const {
-		return has_effective_metadata;
+	void SetBaseMetadata(IcebergTableMetadata metadata) {
+		base_metadata = std::move(metadata);
+		has_base_metadata = true;
 	}
-	void SetMetadata(IcebergTableMetadata metadata) {
-		effective_metadata = std::move(metadata);
-		has_effective_metadata = true;
+	IcebergTableMetadata GetTransactionMetadata() const;
+	bool HasBaseMetadata() const {
+		return has_base_metadata;
 	}
 	optional_ptr<IcebergTransactionData> GetTransactionData() const {
 		return transaction_data.get();
@@ -108,8 +105,8 @@ private:
 	optional_ptr<IcebergTableInformation> table;
 	unique_ptr<IcebergTableInformation> owned_table;
 	IcebergTableStatus status;
-	bool has_effective_metadata = false;
-	IcebergTableMetadata effective_metadata;
+	bool has_base_metadata = false;
+	IcebergTableMetadata base_metadata;
 	unordered_map<int32_t, unique_ptr<IcebergTableEntry>> schema_versions;
 	unique_ptr<IcebergTableEntry> dummy_entry;
 	unique_ptr<IcebergTransactionData> transaction_data;

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -89,10 +89,22 @@ public:
 		status = value;
 	}
 	void SetTable(IcebergTableInformation &value) {
+		if (owned_table && owned_table.get() == &value) {
+			table = *owned_table;
+			return;
+		}
+		schema_versions.clear();
+		dummy_entry.reset();
+		base_metadata.reset();
+		transaction_data.reset();
 		owned_table.reset();
 		table = value;
 	}
 	void SetOwnedTable(IcebergTableInformation &&value) {
+		schema_versions.clear();
+		dummy_entry.reset();
+		base_metadata.reset();
+		transaction_data.reset();
 		owned_table = make_uniq<IcebergTableInformation>(std::move(value));
 		table = *owned_table;
 	}

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -3,11 +3,14 @@
 
 #include "duckdb/transaction/transaction.hpp"
 #include "catalog/rest/iceberg_schema_set.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
 
 namespace duckdb {
 class IcebergCatalog;
 class IcebergSchemaEntry;
 class IcebergTableEntry;
+class IcebergTableSchema;
+class BoundAtClause;
 struct IcebergTransactionUpdate;
 struct IcebergTransactionAlterUpdate;
 struct IcebergTransactionDeleteUpdate;
@@ -30,13 +33,54 @@ public:
 	IcebergTransactionTableState(optional_ptr<IcebergTableInformation> table);
 
 public:
+	IcebergTableInformation &GetBaseTableInfo() {
+		return GetInfo();
+	}
 	IcebergTableInformation &GetInfo() {
+		if (owned_table) {
+			return *owned_table;
+		}
 		if (!table) {
 			throw InternalException("GetInfo called on IcebergTransactionTableState without a table, status: %d",
 			                        static_cast<uint8_t>(status));
 		}
 		return *table;
 	}
+	const IcebergTableInformation &GetInfo() const {
+		if (owned_table) {
+			return *owned_table;
+		}
+		if (!table) {
+			throw InternalException("GetInfo called on IcebergTransactionTableState without a table, status: %d",
+			                        static_cast<uint8_t>(status));
+		}
+		return *table;
+	}
+	IcebergTableMetadata &GetMetadata() {
+		D_ASSERT(has_effective_metadata);
+		return effective_metadata;
+	}
+	const IcebergTableMetadata &GetMetadata() const {
+		if (has_effective_metadata) {
+			return effective_metadata;
+		}
+		return GetInfo().table_metadata;
+	}
+	bool HasEffectiveMetadata() const {
+		return has_effective_metadata;
+	}
+	void SetMetadata(IcebergTableMetadata metadata) {
+		effective_metadata = std::move(metadata);
+		has_effective_metadata = true;
+	}
+	optional_ptr<IcebergTransactionData> GetTransactionData() const {
+		return transaction_data.get();
+	}
+	IcebergTransactionData &GetOrCreateTransactionData(IcebergTransaction &transaction);
+	optional_ptr<CatalogEntry> GetSchemaVersion(ClientContext &context, optional_ptr<BoundAtClause> at);
+	optional_ptr<CatalogEntry> GetLatestSchema(ClientContext &context);
+	IcebergTableEntry &GetOrCreateSchemaEntry(const IcebergTableSchema &table_schema);
+	IcebergTableEntry &GetOrCreateDummyEntry();
 
 public:
 	bool IsDroppedOrRenamed() const {
@@ -52,12 +96,23 @@ public:
 		status = value;
 	}
 	void SetTable(IcebergTableInformation &value) {
+		owned_table.reset();
 		table = value;
+	}
+	void SetOwnedTable(IcebergTableInformation &&value) {
+		owned_table = make_uniq<IcebergTableInformation>(std::move(value));
+		table = *owned_table;
 	}
 
 private:
 	optional_ptr<IcebergTableInformation> table;
+	unique_ptr<IcebergTableInformation> owned_table;
 	IcebergTableStatus status;
+	bool has_effective_metadata = false;
+	IcebergTableMetadata effective_metadata;
+	unordered_map<int32_t, unique_ptr<IcebergTableEntry>> schema_versions;
+	unique_ptr<IcebergTableEntry> dummy_entry;
+	unique_ptr<IcebergTransactionData> transaction_data;
 };
 
 struct SchemaPropertyUpdates {
@@ -77,6 +132,9 @@ public:
 	static IcebergTransaction &Get(ClientContext &context, Catalog &catalog);
 	AccessMode GetAccessMode() const {
 		return access_mode;
+	}
+	timestamp_t GetTransactionStartTimestamp() const {
+		return transaction_start_timestamp;
 	}
 	void DoTableUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
 	void DoTableDeletes(IcebergTransactionDeleteUpdate &delete_update, ClientContext &context);
@@ -110,6 +168,7 @@ private:
 	DatabaseInstance &db;
 	IcebergCatalog &catalog;
 	AccessMode access_mode;
+	timestamp_t transaction_start_timestamp;
 
 public:
 	//! Tables referenced by this transaction that have to stay alive for the duration of the transaction.
@@ -133,6 +192,6 @@ public:
 };
 
 void ApplyTableUpdate(IcebergTableInformation &table_info, IcebergTransaction &iceberg_transaction,
-                      const std::function<void(IcebergTableInformation &, IcebergTransactionData &)> &callback);
+                      const std::function<void(IcebergTransactionTableState &, IcebergTransactionData &)> &callback);
 
 } // namespace duckdb

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -12,6 +12,7 @@ struct IcebergTransactionUpdate;
 struct IcebergTransactionAlterUpdate;
 struct IcebergTransactionDeleteUpdate;
 struct IcebergTransactionRenameUpdate;
+struct IcebergTransactionData;
 
 struct TableTransactionInfo {
 	TableTransactionInfo() {};
@@ -93,6 +94,8 @@ public:
 	IcebergTransactionTableState &SetLatestTableState(const string &table_key, IcebergTableStatus status);
 	bool StartedBefore(timestamp_t timestamp_ms) const;
 	IcebergTransactionAlterUpdate &GetOrCreateAlter();
+	optional_ptr<IcebergTransactionData> GetTransactionData(const string &table_key) const;
+	bool HasTransactionUpdates(const string &table_key) const;
 	IcebergTableInformation &DeleteTable(IcebergTableInformation &table);
 	IcebergTableInformation &RenameTable(IcebergTableInformation &table, const string &new_name);
 
@@ -130,6 +133,6 @@ public:
 };
 
 void ApplyTableUpdate(IcebergTableInformation &table_info, IcebergTransaction &iceberg_transaction,
-                      const std::function<void(IcebergTableInformation &)> &callback);
+                      const std::function<void(IcebergTableInformation &, IcebergTransactionData &)> &callback);
 
 } // namespace duckdb

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -25,6 +25,7 @@ public:
 
 public:
 	int64_t GetCommitRetryCount() const;
+	bool HasUpdates() const;
 	bool SupportsAppendRetry() const;
 	bool RetryStateMatches(const IcebergTableInformation &table_info) const;
 

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -18,6 +18,7 @@ namespace duckdb {
 
 struct IcebergTableInformation;
 struct IcebergCreateTableRequest;
+class IcebergTableSchema;
 
 struct IcebergTransactionData {
 public:
@@ -30,14 +31,16 @@ public:
 	bool RetryStateMatches(const IcebergTableInformation &table_info) const;
 	IcebergTableMetadata GetTransactionMetadata(const IcebergTableMetadata &base_metadata) const;
 	void MarkCreateSeeded();
+	shared_ptr<IcebergTableSchema> AddSchemaOrGetExisting(const IcebergTableMetadata &base_metadata,
+	                                                      shared_ptr<IcebergTableSchema> schema, bool &created);
 
 	void AddSnapshot(const IcebergTableMetadata &table_metadata, IcebergSnapshotOperationType operation,
 	                 vector<IcebergManifestEntry> &&data_files, IcebergManifestDeletes &&altered_manifests);
 	void AddUpdateSnapshot(const IcebergTableMetadata &table_metadata, vector<IcebergManifestEntry> &&delete_files,
 	                       vector<IcebergManifestEntry> &&data_files, IcebergManifestDeletes &&altered_manifests);
 	// add a schema update for a table
-	void TableAddSchema(const IcebergTableMetadata &table_metadata, int32_t schema_id);
-	void TableSetCurrentSchema(const IcebergTableMetadata &table_metadata);
+	void TableAddSchema(shared_ptr<IcebergTableSchema> schema, optional_idx last_column_id);
+	void TableSetCurrentSchema(int32_t schema_id);
 	void TableAddAssertCreate();
 	void TableAddAssertUUID();
 	void TableAddAssertCurrentSchemaId();
@@ -79,6 +82,7 @@ public:
 	case_insensitive_map_t<string> transactional_delete_files;
 	//! Track the current row id for this transaction
 	int64_t next_row_id = 0;
+	unordered_map<int32_t, shared_ptr<IcebergTableSchema>> staged_schemas;
 
 	//! If we perform an update that relies on the current schema id staying unchanged
 	bool assert_schema_id = false;

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -34,7 +34,7 @@ public:
 	void AddUpdateSnapshot(vector<IcebergManifestEntry> &&delete_files, vector<IcebergManifestEntry> &&data_files,
 	                       IcebergManifestDeletes &&altered_manifests);
 	// add a schema update for a table
-	void TableAddSchema(int32_t schema_id);
+	void TableAddSchema(const IcebergTableMetadata &table_metadata, int32_t schema_id);
 	void TableSetCurrentSchema();
 	void TableAddAssertCreate();
 	void TableAddAssertUUID();

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -22,7 +22,8 @@ class IcebergTableSchema;
 
 struct IcebergTransactionData {
 public:
-	IcebergTransactionData(ClientContext &context, const IcebergTableInformation &table_info);
+	IcebergTransactionData(ClientContext &context, const IcebergTableInformation &table_info,
+	                       const IcebergTableMetadata &base_metadata);
 
 public:
 	int64_t GetCommitRetryCount() const;

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -28,6 +28,8 @@ public:
 	bool HasUpdates() const;
 	bool SupportsAppendRetry() const;
 	bool RetryStateMatches(const IcebergTableInformation &table_info) const;
+	IcebergTableMetadata GetTransactionMetadata(const IcebergTableMetadata &base_metadata) const;
+	void MarkCreateSeeded();
 
 	void AddSnapshot(const IcebergTableMetadata &table_metadata, IcebergSnapshotOperationType operation,
 	                 vector<IcebergManifestEntry> &&data_files, IcebergManifestDeletes &&altered_manifests);
@@ -39,9 +41,9 @@ public:
 	void TableAddAssertCreate();
 	void TableAddAssertUUID();
 	void TableAddAssertCurrentSchemaId();
-	void TableAddAssertLastAssignedFieldId();
-	void TableAddAssertLastAssignedPartitionId();
-	void TableAddAssertDefaultSpecId();
+	void TableAddAssertLastAssignedFieldId(const IcebergTableMetadata &table_metadata);
+	void TableAddAssertLastAssignedPartitionId(const IcebergTableMetadata &table_metadata);
+	void TableAddAssertDefaultSpecId(const IcebergTableMetadata &table_metadata);
 	void TableAssignUUID(const IcebergTableMetadata &table_metadata);
 	void TableAddUpradeFormatVersion(const IcebergTableMetadata &table_metadata);
 	void TableAddPartitionSpec(const IcebergTableMetadata &table_metadata);
@@ -54,6 +56,7 @@ public:
 
 private:
 	void CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata);
+	void ApplyMetadataUpdates(IcebergTableMetadata &metadata) const;
 
 public:
 	string initial_table_uuid;
@@ -83,6 +86,7 @@ public:
 	bool has_assert_create = false;
 	//! Whether the current schema of the table should be updated
 	bool set_schema_id = false;
+	idx_t metadata_view_update_offset = 0;
 	mutex lock;
 };
 

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -29,28 +29,28 @@ public:
 	bool SupportsAppendRetry() const;
 	bool RetryStateMatches(const IcebergTableInformation &table_info) const;
 
-	void AddSnapshot(IcebergSnapshotOperationType operation, vector<IcebergManifestEntry> &&data_files,
-	                 IcebergManifestDeletes &&altered_manifests);
-	void AddUpdateSnapshot(vector<IcebergManifestEntry> &&delete_files, vector<IcebergManifestEntry> &&data_files,
-	                       IcebergManifestDeletes &&altered_manifests);
+	void AddSnapshot(const IcebergTableMetadata &table_metadata, IcebergSnapshotOperationType operation,
+	                 vector<IcebergManifestEntry> &&data_files, IcebergManifestDeletes &&altered_manifests);
+	void AddUpdateSnapshot(const IcebergTableMetadata &table_metadata, vector<IcebergManifestEntry> &&delete_files,
+	                       vector<IcebergManifestEntry> &&data_files, IcebergManifestDeletes &&altered_manifests);
 	// add a schema update for a table
 	void TableAddSchema(const IcebergTableMetadata &table_metadata, int32_t schema_id);
-	void TableSetCurrentSchema();
+	void TableSetCurrentSchema(const IcebergTableMetadata &table_metadata);
 	void TableAddAssertCreate();
 	void TableAddAssertUUID();
 	void TableAddAssertCurrentSchemaId();
 	void TableAddAssertLastAssignedFieldId();
 	void TableAddAssertLastAssignedPartitionId();
 	void TableAddAssertDefaultSpecId();
-	void TableAssignUUID();
-	void TableAddUpradeFormatVersion();
-	void TableAddPartitionSpec();
-	void TableAddSortOrder();
-	void TableSetDefaultSortOrder();
-	void TableSetDefaultSpec();
+	void TableAssignUUID(const IcebergTableMetadata &table_metadata);
+	void TableAddUpradeFormatVersion(const IcebergTableMetadata &table_metadata);
+	void TableAddPartitionSpec(const IcebergTableMetadata &table_metadata);
+	void TableAddSortOrder(const IcebergTableMetadata &table_metadata);
+	void TableSetDefaultSortOrder(const IcebergTableMetadata &table_metadata);
+	void TableSetDefaultSpec(const IcebergTableMetadata &table_metadata);
 	void TableSetProperties(const case_insensitive_map_t<string> &properties);
 	void TableRemoveProperties(const vector<string> &properties);
-	void TableSetLocation();
+	void TableSetLocation(const IcebergTableMetadata &table_metadata);
 
 private:
 	void CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata);
@@ -60,6 +60,7 @@ public:
 	int32_t initial_schema_id;
 	int32_t initial_default_spec_id = 0;
 	optional_idx initial_default_sort_order_id;
+	int64_t commit_retry_count;
 
 	ClientContext &context;
 	const IcebergTableInformation &table_info;

--- a/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
@@ -89,7 +89,8 @@ public:
 	virtual ~IcebergTransactionRenameUpdate() override;
 
 public:
-	const IcebergTableInformation &table;
+	vector<string> source_namespace_items;
+	string source_name;
 	IcebergTableInformation new_table;
 	string new_name;
 };

--- a/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
@@ -52,17 +52,15 @@ public:
 
 public:
 	IcebergTableInformation &CreateTable(const string &table_key, IcebergTableInformation &&table);
-	IcebergTableInformation &GetOrInitializeTable(const IcebergTableInformation &table);
-	IcebergTransactionData &GetOrCreateTransactionData(IcebergTableInformation &table);
+	IcebergTransactionTableState &GetOrInitializeTable(IcebergTableInformation &table);
+	IcebergTransactionData &GetOrCreateTransactionData(IcebergTransactionTableState &table);
 	optional_ptr<IcebergTransactionData> GetTransactionData(const string &table_key) const;
-	optional_ptr<IcebergTransactionData> GetTransactionData(const IcebergTableInformation &table) const;
+	optional_ptr<IcebergTransactionData> GetTransactionData(const IcebergTransactionTableState &table) const;
 	bool HasTransactionUpdates(const string &table_key) const;
-	bool HasTransactionUpdates(const IcebergTableInformation &table) const;
+	bool HasTransactionUpdates(const IcebergTransactionTableState &table) const;
 	bool HasUpdates() const;
 	//! All the tables touched in this atomic block
-	case_insensitive_map_t<IcebergTableInformation> updated_tables;
-	//! Transaction-local changes for each touched table. The catalog table information never owns this state.
-	case_insensitive_map_t<unique_ptr<IcebergTransactionData>> table_transaction_data;
+	case_insensitive_map_t<IcebergTransactionTableState> updated_tables;
 	//! The tables successively committed (used if multi-table commit isn't available)
 	case_insensitive_set_t committed_tables;
 };

--- a/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
@@ -72,6 +72,7 @@ public:
 
 public:
 	IcebergTransactionDeleteUpdate(IcebergTransaction &transaction, const IcebergTableInformation &table);
+	IcebergTransactionDeleteUpdate(IcebergTransaction &transaction, IcebergTableInformation &&table);
 	virtual ~IcebergTransactionDeleteUpdate() override;
 
 public:
@@ -85,6 +86,8 @@ public:
 
 public:
 	IcebergTransactionRenameUpdate(IcebergTransaction &transaction, const IcebergTableInformation &table,
+	                               const string &new_name);
+	IcebergTransactionRenameUpdate(IcebergTransaction &transaction, IcebergTableInformation &&table,
 	                               const string &new_name);
 	virtual ~IcebergTransactionRenameUpdate() override;
 

--- a/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
@@ -8,6 +8,7 @@
 namespace duckdb {
 
 class IcebergTransaction;
+struct IcebergTransactionData;
 
 enum class IcebergTransactionUpdateType : uint8_t { ALTER, DELETE, RENAME };
 
@@ -52,9 +53,16 @@ public:
 public:
 	IcebergTableInformation &CreateTable(const string &table_key, IcebergTableInformation &&table);
 	IcebergTableInformation &GetOrInitializeTable(const IcebergTableInformation &table);
+	IcebergTransactionData &GetOrCreateTransactionData(IcebergTableInformation &table);
+	optional_ptr<IcebergTransactionData> GetTransactionData(const string &table_key) const;
+	optional_ptr<IcebergTransactionData> GetTransactionData(const IcebergTableInformation &table) const;
+	bool HasTransactionUpdates(const string &table_key) const;
+	bool HasTransactionUpdates(const IcebergTableInformation &table) const;
 	bool HasUpdates() const;
 	//! All the tables touched in this atomic block
 	case_insensitive_map_t<IcebergTableInformation> updated_tables;
+	//! Transaction-local changes for each touched table. The catalog table information never owns this state.
+	case_insensitive_map_t<unique_ptr<IcebergTransactionData>> table_transaction_data;
 	//! The tables successively committed (used if multi-table commit isn't available)
 	case_insensitive_set_t committed_tables;
 };

--- a/src/include/core/metadata/iceberg_table_metadata.hpp
+++ b/src/include/core/metadata/iceberg_table_metadata.hpp
@@ -15,6 +15,10 @@
 
 namespace duckdb {
 
+class ParsedExpression;
+class IcebergTableSchema;
+struct IcebergTransactionData;
+
 // common Iceberg table property keys
 const string WRITE_UPDATE_MODE = "write.update.mode";
 const string WRITE_DELETE_MODE = "write.delete.mode";
@@ -43,6 +47,7 @@ public:
 	static rest_api_objects::TableMetadata Parse(const string &path, FileSystem &fs,
 	                                             const string &metadata_compression_codec);
 	static IcebergTableMetadata FromTableMetadata(const rest_api_objects::TableMetadata &table_metadata);
+	IcebergTableMetadata Copy() const;
 	static string GetMetaDataPath(ClientContext &context, const string &path, FileSystem &fs,
 	                              const IcebergOptions &options);
 	optional_ptr<const IcebergSnapshot> GetLatestSnapshot() const;
@@ -83,6 +88,8 @@ public:
 
 	bool HasLastPartitionId() const;
 	int32_t GetLastPartitionFieldId() const;
+	idx_t GetNextPartitionSpecId() const;
+	int64_t GetExistingSpecId(const IcebergPartitionSpec &spec) const;
 
 	const case_insensitive_map_t<string> &GetTableProperties() const;
 	string GetTableProperty(string property_string) const;
@@ -90,6 +97,9 @@ public:
 	string ToJSON() const;
 	void WriteMetadata(ClientContext &context, const string &path) const;
 	void WriteVersionHint(ClientContext &context, const string &path, const string &metadata_json_path) const;
+	void SetPartitionedBy(IcebergTransactionData &transaction_data,
+	                      const vector<unique_ptr<ParsedExpression>> &partition_keys, const IcebergTableSchema &schema,
+	                      bool first_partition_spec = false);
 
 public:
 	void SetCurrentSchemaId(int32_t schema_id);

--- a/src/include/core/metadata/iceberg_table_metadata.hpp
+++ b/src/include/core/metadata/iceberg_table_metadata.hpp
@@ -105,7 +105,7 @@ public:
 	void SetCurrentSchemaId(int32_t schema_id);
 	int32_t GetCurrentSchemaId() const;
 
-	IcebergTableSchema &AddSchemaOrGetExisting(shared_ptr<IcebergTableSchema> schema);
+	IcebergTableSchema &AddSchema(shared_ptr<IcebergTableSchema> schema);
 	const unordered_map<int32_t, shared_ptr<IcebergTableSchema>> &GetSchemas() const;
 
 private:

--- a/src/planning/iceberg_optimizer.cpp
+++ b/src/planning/iceberg_optimizer.cpp
@@ -78,9 +78,7 @@ void GuaranteeEqualityDeleteColumnsOptimizer::VisitOperator(unique_ptr<LogicalOp
 				// column was deleted and exists most likely in an old schemas
 				// TODO: if the type of the equality delete column was evolved, then grabbing just any schema could be a
 				// problem
-				auto table = iceberg_list.GetTable();
-				D_ASSERT(table);
-				auto col_info = table->table_info.table_metadata.FindColumnByFieldId(fid);
+				auto col_info = iceberg_list.GetMetadata().FindColumnByFieldId(fid);
 				if (!col_info) {
 					throw InvalidConfigurationException(
 					    "column %d must apply equality deletes, but no schema has a column with that field id", fid);

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/rename_table_multiple.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/rename_table_multiple.test
@@ -1,0 +1,163 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/rename_table_multiple.test
+# group: [rename_table]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+statement ok
+SET default_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE';
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+statement ok
+drop table if exists my_datalake.default.rename_table_multiple_a;
+
+statement ok
+drop table if exists my_datalake.default.rename_table_multiple_b;
+
+statement ok
+drop table if exists my_datalake.default.rename_table_multiple_c;
+
+statement ok
+create table my_datalake.default.rename_table_multiple_a(a INTEGER, b VARCHAR);
+
+statement ok
+insert into my_datalake.default.rename_table_multiple_a values (10, 'ten');
+
+statement ok
+begin transaction
+
+statement ok
+alter table my_datalake.default.rename_table_multiple_a rename to rename_table_multiple_b;
+
+statement ok
+alter table my_datalake.default.rename_table_multiple_b rename to rename_table_multiple_c;
+
+statement error
+select * from my_datalake.default.rename_table_multiple_a
+----
+<REGEX>:.*does not exist!.*
+
+statement error
+select * from my_datalake.default.rename_table_multiple_b
+----
+<REGEX>:.*does not exist!.*
+
+statement ok
+insert into my_datalake.default.rename_table_multiple_c values (18, 'eighteen');
+
+query IT
+select * from my_datalake.default.rename_table_multiple_c order by a
+----
+10	ten
+18	eighteen
+
+statement ok
+alter table my_datalake.default.rename_table_multiple_c rename column a to id;
+
+statement ok
+insert into my_datalake.default.rename_table_multiple_c values (20, 'twenty');
+
+statement error
+select a from my_datalake.default.rename_table_multiple_c
+----
+<REGEX>:.*column "a" not found.*
+
+query I
+select id from my_datalake.default.rename_table_multiple_c order by id
+----
+10
+18
+20
+
+query IT
+select * from my_datalake.default.rename_table_multiple_c order by id
+----
+10	ten
+18	eighteen
+20	twenty
+
+statement ok
+commit
+
+statement error
+select * from my_datalake.default.rename_table_multiple_a
+----
+<REGEX>:.*does not exist!.*
+
+statement error
+select * from my_datalake.default.rename_table_multiple_b
+----
+<REGEX>:.*does not exist!.*
+
+statement error
+select a from my_datalake.default.rename_table_multiple_c
+----
+<REGEX>:.*column "a" not found.*
+
+query I
+select id from my_datalake.default.rename_table_multiple_c order by id
+----
+10
+18
+20
+
+query IT
+select * from my_datalake.default.rename_table_multiple_c order by id
+----
+10	ten
+18	eighteen
+20	twenty
+
+# Writing through an intermediate renamed handle blocks another rename in the same transaction.
+statement ok
+drop table if exists my_datalake.default.rename_table_multiple_a;
+
+statement ok
+drop table if exists my_datalake.default.rename_table_multiple_b;
+
+statement ok
+drop table if exists my_datalake.default.rename_table_multiple_c;
+
+statement ok
+create table my_datalake.default.rename_table_multiple_a(a INTEGER, b VARCHAR);
+
+statement ok
+insert into my_datalake.default.rename_table_multiple_a values (30, 'thirty');
+
+statement ok
+begin transaction
+
+statement ok
+alter table my_datalake.default.rename_table_multiple_a rename to rename_table_multiple_b;
+
+statement ok
+insert into my_datalake.default.rename_table_multiple_b values (35, 'thirty-five');
+
+query IT
+select * from my_datalake.default.rename_table_multiple_b order by a
+----
+30	thirty
+35	thirty-five
+
+statement error
+alter table my_datalake.default.rename_table_multiple_b rename to rename_table_multiple_c;
+----
+Catalog Error: This table (rename_table_multiple_b) was modified already, can't be renamed!
+
+statement ok
+rollback

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/rename_table_test.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/rename_table_test.test
@@ -99,6 +99,22 @@ statement error
 select * from my_datalake.default.renamed_table3
 ----
 
+statement ok
+begin transaction
+
+statement ok
+drop table my_datalake.default.renamed_table2
+
+statement ok
+rollback
+
+query I
+select * from my_datalake.default.renamed_table2 order by i
+----
+1
+2
+3
+
 # Test 3: Multiple renames in same transaction with commit
 statement ok
 begin transaction

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/rename_table_with_alter.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/rename_table_with_alter.test
@@ -1,0 +1,94 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/rename_table_with_alter.test
+# group: [rename_table]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+statement ok
+SET default_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE';
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+statement ok
+drop table if exists my_datalake.default.rename_table_with_alter_src;
+
+statement ok
+drop table if exists my_datalake.default.rename_table_with_alter_dst;
+
+statement ok
+create table my_datalake.default.rename_table_with_alter_src(i INTEGER, j VARCHAR);
+
+statement ok
+insert into my_datalake.default.rename_table_with_alter_src values (1, 'a');
+
+statement ok
+begin transaction
+
+statement ok
+alter table my_datalake.default.rename_table_with_alter_src rename to rename_table_with_alter_dst;
+
+statement error
+select * from my_datalake.default.rename_table_with_alter_src
+----
+
+statement ok
+alter table my_datalake.default.rename_table_with_alter_dst rename column j to payload;
+
+statement ok
+alter table my_datalake.default.rename_table_with_alter_dst add column k BOOLEAN;
+
+statement ok
+insert into my_datalake.default.rename_table_with_alter_dst values (2, 'b', false);
+
+statement error
+select j from my_datalake.default.rename_table_with_alter_dst
+----
+
+query T
+select payload from my_datalake.default.rename_table_with_alter_dst order by i
+----
+a
+b
+
+query ITT
+select * from my_datalake.default.rename_table_with_alter_dst order by i
+----
+1	a	NULL
+2	b	false
+
+statement ok
+commit
+
+statement error
+select * from my_datalake.default.rename_table_with_alter_src
+----
+
+statement error
+select j from my_datalake.default.rename_table_with_alter_dst
+----
+
+query T
+select payload from my_datalake.default.rename_table_with_alter_dst order by i
+----
+a
+b
+
+query ITT
+select * from my_datalake.default.rename_table_with_alter_dst order by i
+----
+1	a	NULL
+2	b	false

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table_as.test
@@ -95,17 +95,19 @@ drop table if exists nested_types_2;
 # create nested types table from test all types
 statement ok
 create table nested_types_2 as select
-int_array,
-double_array,
-array_filter(date_array, lambda x: (x != 'infinity' and x != '-infinity')),
-array_filter(timestamp_array, lambda x: (x != 'infinity' and x != '-infinity')),
-array_filter(timestamptz_array, lambda x: (x != 'infinity' and x != '-infinity')),
-varchar_array,
-nested_int_array,
-struct,
-struct_of_arrays,
-array_of_structs,
-map from test_all_types();
+	int_array,
+	double_array,
+	array_filter(date_array, lambda x: (x != 'infinity' and x != '-infinity')),
+	array_filter(timestamp_array, lambda x: (x != 'infinity' and x != '-infinity')),
+	array_filter(timestamptz_array, lambda x: (x != 'infinity' and x != '-infinity')),
+	varchar_array,
+	nested_int_array,
+	struct,
+	struct_of_arrays,
+	array_of_structs,
+	map
+from
+	test_all_types();
 
 query T nosort res2
 select * from nested_types_2;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/table_properties/test_set_table_properties.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/table_properties/test_set_table_properties.test
@@ -35,6 +35,42 @@ CALL set_iceberg_table_properties(my_datalake.default.test,
     }
 );
 
+statement ok
+begin transaction;
+
+statement ok
+CALL set_iceberg_table_properties(my_datalake.default.test,
+    {
+    'foo' : 'txn-buzz',
+    'txn-local-property' : 'visible'
+    }
+);
+
+statement ok
+CALL remove_iceberg_table_properties(my_datalake.default.test, ['page-write-size', 'write.update.mode']);
+
+query II
+select * from iceberg_table_properties(my_datalake.default.test)
+where key in ('write.update.mode', 'write.delete.mode', 'foo', 'page-write-size', 'txn-local-property')
+order by all;
+----
+foo	txn-buzz
+txn-local-property	visible
+write.delete.mode	copy-on-write
+
+statement ok
+rollback;
+
+query II
+select * from iceberg_table_properties(my_datalake.default.test)
+where key in ('write.update.mode', 'write.delete.mode', 'foo', 'page-write-size', 'txn-local-property')
+order by all;
+----
+foo	buzz
+page-write-size	10000
+write.delete.mode	copy-on-write
+write.update.mode	copy-on-write
+
 statement error
 CALL set_iceberg_table_properties(my_datalake.default.test,'blah');
 ----


### PR DESCRIPTION
This PR is related to #854 

We create a cleaner relationship between committed-state (IcebergTableInformation) and transaction-local-state (IcebergTransactionData)

### Old Relationship

`IcebergTableInformation` owns a `unique_ptr<IcebergTransactionData>` which holds the transaction-local state, if any.
Besides that, it holds the table metadata and the schema versions materialized as `IcebergTableEntry` items.
Whenever a transaction makes changes, those changes are directly made to the `IcebergTableInformation` and the table metadata that it holds.
Because of this, every connection needs to copy the `IcebergTableInformation`, removing any possibility for shared reuse of static data.

### New Relationship

`IcebergTableInformation` no longer holds a `unique_ptr<IcebergTransactionData>`, it should now be immutable throughout a transaction.
Instead we introduce the `IcebergTransactionTableState`, this now holds a reference to an `IcebergTableInformation`, along with `unique_ptr<IcebergTransactionData>` and new `IcebergTableEntry` items that are created during a transaction (through alter table).
The `IcebergTableInformation` is no longer modified by transaction-local changes, the `IcebergTableUpdate` items are now self-sufficient, enabling retries in the future.

This now enables a future optimization of caching the `IcebergTableInformation` between transactions, when we start using the `etag` to know that items haven't changed.