### PR TITLE
Add AWS-agnostic access-delegation hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(EXTENSION_SOURCES
 	src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
 	src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
 	src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+	src/catalog/rest/iceberg_access_delegation.cpp
 	src/catalog/rest/iceberg_catalog.cpp
 	src/catalog/rest/iceberg_schema_set.cpp
 	src/catalog/rest/iceberg_table_set.cpp

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
@@ -14,6 +14,7 @@
 #include "duckdb/planner/tableref/bound_at_clause.hpp"
 
 #include "catalog/rest/iceberg_catalog.hpp"
+#include "catalog/rest/iceberg_access_delegation.hpp"
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
 #include "catalog/rest/api/catalog_api.hpp"
 #include "planning/iceberg_multi_file_reader.hpp"
@@ -50,6 +51,12 @@ void AddHTTPSecretsToOptions(SecretEntry &http_secret_entry, case_insensitive_ma
 void IcebergTableEntry::PrepareIcebergScanFromEntry(ClientContext &context) const {
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	auto &secret_manager = SecretManager::Get(context);
+
+	// An access-delegation provider, if configured, vends its own scan credentials in place of the
+	// catalog's vended credentials.
+	if (IcebergAccessDelegation::PrepareScanCredentials(table_info, context, nullptr)) {
+		return;
+	}
 
 	if (ic_catalog.attach_options.access_mode != IRCAccessDelegationMode::VENDED_CREDENTIALS) {
 		// assume secret already exists
@@ -248,6 +255,10 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 	D_ASSERT(file_bind_data.file_list);
 	auto &ic_file_list = file_bind_data.file_list->Cast<IcebergMultiFileList>();
 	ic_file_list.SetTable(this);
+
+	// Let the active access-delegation provider (if any) install mandatory scan filters for this table.
+	IcebergAccessDelegation::ApplyMandatoryScanFilters(table_info, context, *scan_info, ic_file_list, iceberg_schema);
+
 	return iceberg_scan_function;
 }
 

--- a/src/catalog/rest/iceberg_access_delegation.cpp
+++ b/src/catalog/rest/iceberg_access_delegation.cpp
@@ -1,0 +1,92 @@
+#include "catalog/rest/iceberg_access_delegation.hpp"
+
+#include "catalog/rest/iceberg_catalog.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+
+#include "duckdb/main/extension_helper.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+
+namespace duckdb {
+
+optional_ptr<IcebergAccessDelegationProvider> IcebergAccessDelegation::GetActiveProvider(IcebergCatalog &catalog,
+                                                                                         ClientContext &context) {
+	auto &provider_name = catalog.attach_options.access_delegation_provider;
+	if (provider_name.empty()) {
+		return nullptr;
+	}
+	auto registry = IcebergPluginRegistry::TryGet(context);
+	if (!registry) {
+		return nullptr;
+	}
+	return registry->GetProvider(provider_name);
+}
+
+void IcebergAccessDelegation::ResolveProviderForAttach(IcebergAttachOptions &options, ClientContext &context) {
+	if (options.access_delegation_provider.empty()) {
+		return;
+	}
+	auto &provider_name = options.access_delegation_provider;
+	auto &registry = IcebergPluginRegistry::GetOrCreate(context);
+	auto provider = registry.GetProvider(provider_name);
+	if (!provider) {
+		// The provider lives in a separate community extension named after the mode; autoload it so
+		// `ATTACH ... (ACCESS_DELEGATION_MODE 'lake_formation')` works without an explicit LOAD.
+		ExtensionHelper::AutoLoadExtension(context, provider_name);
+		provider = registry.GetProvider(provider_name);
+	}
+	if (!provider) {
+		throw InvalidConfigurationException(
+		    "ACCESS_DELEGATION_MODE '%s' did not register an Iceberg access delegation provider. Is the '%s' "
+		    "extension installed and loadable?",
+		    provider_name, provider_name);
+	}
+	provider->ValidateAttachOptions(options);
+}
+
+void IcebergAccessDelegation::OnTableLoaded(IcebergTableInformation &table_info, ClientContext &context) {
+	auto provider = GetActiveProvider(table_info.catalog, context);
+	if (!provider) {
+		return;
+	}
+	IcebergAccessDelegationContext dctx {table_info.catalog, table_info, context};
+	provider->OnTableLoaded(dctx);
+}
+
+bool IcebergAccessDelegation::PrepareScanCredentials(IcebergTableInformation &table_info, ClientContext &context,
+                                                     optional_ptr<const vector<Value>> partition_values) {
+	auto provider = GetActiveProvider(table_info.catalog, context);
+	if (!provider) {
+		return false;
+	}
+	IcebergAccessDelegationContext dctx {table_info.catalog, table_info, context};
+	auto credentials = provider->GetScanCredentials(dctx, partition_values);
+	if (credentials.config) {
+		auto &secret_manager = SecretManager::Get(context);
+		(void)secret_manager.CreateSecret(context, *credentials.config);
+	}
+	return true;
+}
+
+void IcebergAccessDelegation::ApplyMandatoryScanFilters(IcebergTableInformation &table_info, ClientContext &context,
+                                                        IcebergScanInfo &scan_info, IcebergMultiFileList &file_list,
+                                                        const IcebergTableSchema &schema) {
+	auto provider = GetActiveProvider(table_info.catalog, context);
+	if (!provider) {
+		return;
+	}
+	IcebergAccessDelegationContext dctx {table_info.catalog, table_info, context};
+	provider->ApplyMandatoryScanFilters(dctx, scan_info, file_list, schema);
+}
+
+void IcebergAccessDelegation::OnPartitionFile(IcebergTableInformation &table_info, ClientContext &context,
+                                              const vector<IcebergPartitionInfo> &partition_info,
+                                              const string &file_path) {
+	auto provider = GetActiveProvider(table_info.catalog, context);
+	if (!provider) {
+		return;
+	}
+	IcebergAccessDelegationContext dctx {table_info.catalog, table_info, context};
+	provider->OnPartitionFile(dctx, partition_info, file_path);
+}
+
+} // namespace duckdb

--- a/src/catalog/rest/iceberg_access_delegation.cpp
+++ b/src/catalog/rest/iceberg_access_delegation.cpp
@@ -30,14 +30,20 @@ void IcebergAccessDelegation::ResolveProviderForAttach(IcebergAttachOptions &opt
 	auto provider = registry.GetProvider(provider_name);
 	if (!provider) {
 		// The provider lives in a separate community extension named after the mode; autoload it so
-		// `ATTACH ... (ACCESS_DELEGATION_MODE 'lake_formation')` works without an explicit LOAD.
-		ExtensionHelper::AutoLoadExtension(context, provider_name);
-		provider = registry.GetProvider(provider_name);
+		// `ATTACH ... (ACCESS_DELEGATION_MODE 'lake_formation')` works without an explicit LOAD. Swallow
+		// autoload failures here so we can surface a single, clear access-mode error below regardless of
+		// whether the extension is missing or simply did not register a provider.
+		try {
+			ExtensionHelper::AutoLoadExtension(context, provider_name);
+			provider = registry.GetProvider(provider_name);
+		} catch (std::exception &) {
+		}
 	}
 	if (!provider) {
 		throw InvalidConfigurationException(
-		    "ACCESS_DELEGATION_MODE '%s' did not register an Iceberg access delegation provider. Is the '%s' "
-		    "extension installed and loadable?",
+		    "Unrecognized access mode '%s'. Built-in options are 'vended_credentials' and 'none'; any other "
+		    "value must name an extension that registers an Iceberg access-delegation provider, but the '%s' "
+		    "extension could not be loaded or did not register one.",
 		    provider_name, provider_name);
 	}
 	provider->ValidateAttachOptions(options);

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -17,6 +17,7 @@
 #include "common/iceberg_utils.hpp"
 #include "iceberg_logging.hpp"
 #include "catalog/rest/api/api_utils.hpp"
+#include "catalog/rest/iceberg_access_delegation.hpp"
 #include "catalog/rest/storage/iceberg_authorization.hpp"
 #include "catalog/rest/storage/authorization/oauth2.hpp"
 #include "catalog/rest/storage/authorization/sigv4.hpp"
@@ -618,9 +619,11 @@ unique_ptr<Catalog> IcebergCatalog::Attach(optional_ptr<StorageExtensionInfo> st
 		} else if (access_mode_string == "none") {
 			attach_options.access_mode = IRCAccessDelegationMode::NONE;
 		} else {
-			throw InvalidInputException(
-			    "Unrecognized access mode '%s'. Supported options are 'vended_credentials' and 'none'",
-			    access_mode_string);
+			// Any other value names an access-delegation provider supplied by an external extension
+			// (e.g. 'lake_formation'). Such a provider vends its own object-storage credentials, so the
+			// built-in vended-credentials delegation header must not be sent on IRC requests.
+			attach_options.access_delegation_provider = access_mode_string;
+			attach_options.access_mode = IRCAccessDelegationMode::NONE;
 		}
 	}
 	if (attach_options.authorization_type == IcebergAuthorizationType::INVALID) {
@@ -645,6 +648,10 @@ unique_ptr<Catalog> IcebergCatalog::Attach(optional_ptr<StorageExtensionInfo> st
 	default:
 		throw InternalException("Authorization Type (%s) not implemented", authorization_type_string);
 	}
+
+	//! If an access-delegation provider was requested, resolve it (autoloading its extension) and let it
+	//! validate and consume any provider-specific attach options before we reject unhandled options.
+	IcebergAccessDelegation::ResolveProviderForAttach(attach_options, context);
 
 	//! We throw if there are any additional options not handled by previous steps
 	if (!attach_options.options.empty()) {

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -15,6 +15,7 @@
 #include "catalog/rest/api/catalog_utils.hpp"
 #include "iceberg_logging.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
+#include "catalog/rest/iceberg_access_delegation.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
 #include "catalog/rest/storage/authorization/sigv4.hpp"
@@ -44,6 +45,9 @@ bool IcebergTableSet::FillEntry(ClientContext &context, IcebergTableInformation 
 		if (cached_result) {
 			// Use the cached result instead of making a new request
 			table.InitializeFromLoadTableResult(*cached_result->load_table_result);
+			// The IRC cache holds Iceberg metadata only; a delegation provider's policy is caller-specific
+			// and must be (re)loaded even when the table load is served from cache.
+			IcebergAccessDelegation::OnTableLoaded(table, context);
 			return true;
 		}
 	}
@@ -75,6 +79,7 @@ bool IcebergTableSet::FillEntry(ClientContext &context, IcebergTableInformation 
 		auto &load_table_result = *cached_table_result->load_table_result;
 		table.InitializeFromLoadTableResult(load_table_result);
 	}
+	IcebergAccessDelegation::OnTableLoaded(table, context);
 	return true;
 }
 

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -7,6 +7,7 @@
 #include "core/metadata/manifest/iceberg_manifest.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
+#include "catalog/rest/iceberg_access_delegation.hpp"
 #include "rest_catalog/objects/storage_credential.hpp"
 
 namespace duckdb {
@@ -90,6 +91,10 @@ public:
 	// dummy entry to hold existence of a table, but no schema versions
 	unique_ptr<IcebergTableEntry> dummy_entry;
 	unique_ptr<IcebergTransactionData> transaction_data;
+
+	//! Opaque per-table state owned by the active access-delegation provider (if any). Iceberg never
+	//! inspects its concrete type; the provider downcasts it. See IcebergAccessDelegationProvider.
+	shared_ptr<IcebergDelegationTableState> delegation_state;
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/iceberg_access_delegation.hpp
+++ b/src/include/catalog/rest/iceberg_access_delegation.hpp
@@ -1,0 +1,165 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// catalog/rest/iceberg_access_delegation.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/storage/object_cache.hpp"
+
+namespace duckdb {
+
+class ClientContext;
+class DatabaseInstance;
+class IcebergCatalog;
+class IcebergTableSchema;
+struct IcebergTableInformation;
+struct IcebergAttachOptions;
+struct IcebergScanInfo;
+struct IcebergMultiFileList;
+struct IcebergPartitionInfo;
+struct IRCAPITableCredentials;
+
+//! Opaque, provider-owned per-table state. Iceberg stores it on IcebergTableInformation
+//! without knowing its concrete type; a delegation provider downcasts it to its own state.
+struct IcebergDelegationTableState {
+	virtual ~IcebergDelegationTableState() = default;
+};
+
+//! Everything a delegation provider needs to act on a single table.
+struct IcebergAccessDelegationContext {
+	IcebergCatalog &catalog;
+	IcebergTableInformation &table_info;
+	ClientContext &context;
+};
+
+//! Extension point for "access delegation" on an attached Iceberg (REST) catalog.
+//!
+//! An access-delegation provider decides how object-storage credentials are obtained for a
+//! scan, and may enforce mandatory scan filters. The iceberg extension itself ships no
+//! provider; external extensions (e.g. the `lake_formation` community extension) register
+//! one. The interface is intentionally free of any AWS/cloud-specific types so that iceberg
+//! can drop direct cloud SDK dependencies over time without affecting providers.
+class IcebergAccessDelegationProvider {
+public:
+	virtual ~IcebergAccessDelegationProvider() = default;
+
+	//! The provider name. Selected via `ATTACH ... (ACCESS_DELEGATION_MODE '<name>')`. Iceberg
+	//! autoloads the extension whose name matches this when no provider is registered yet.
+	virtual string GetProviderName() const = 0;
+
+	//! Validate (and consume) provider-specific attach options. Provider-specific keys arrive in
+	//! `options.options`; the provider should read and erase the ones it owns so iceberg's
+	//! "unhandled options" check does not reject them.
+	virtual void ValidateAttachOptions(IcebergAttachOptions &options) = 0;
+
+	//! Called once a table's Iceberg metadata is available (cache hit or fresh load). Providers
+	//! load and cache any external policy here, typically into `table_info` delegation state.
+	virtual void OnTableLoaded(IcebergAccessDelegationContext &dctx) = 0;
+
+	//! Produce object-storage credentials for a scan, as a DuckDB secret definition. When
+	//! `partition_values` is set, credentials should be scoped to that partition.
+	virtual IRCAPITableCredentials GetScanCredentials(IcebergAccessDelegationContext &dctx,
+	                                                  optional_ptr<const vector<Value>> partition_values) = 0;
+
+	//! Apply any mandatory scan filters for this table. Providers may push column filters onto the
+	//! file list and store a bound filter on `scan_info` (see IcebergScanInfo::mandatory_delegation_filter_*),
+	//! which iceberg re-applies above the scan as a safety net.
+	virtual void ApplyMandatoryScanFilters(IcebergAccessDelegationContext &dctx, IcebergScanInfo &scan_info,
+	                                       IcebergMultiFileList &file_list, const IcebergTableSchema &schema) = 0;
+
+	//! Called while enumerating data files. Providers that vend per-partition credentials can refresh
+	//! the relevant secret here.
+	virtual void OnPartitionFile(IcebergAccessDelegationContext &dctx,
+	                             const vector<IcebergPartitionInfo> &partition_info, const string &file_path) = 0;
+};
+
+//! Database-wide registry of access-delegation providers. Stored on DuckDB's ObjectCache so that
+//! the iceberg extension and provider extensions (which are separate loadable binaries) can share it.
+//!
+//! Every method is defined inline on purpose: a provider extension is linked only against DuckDB
+//! core, not against the iceberg extension, so it can call these (and DuckDB-core symbols) but not
+//! iceberg's out-of-line functions. Shared state therefore flows exclusively through DuckDB-core
+//! containers (ObjectCache, shared_ptr) and virtual dispatch on IcebergAccessDelegationProvider.
+class IcebergPluginRegistry : public ObjectCacheEntry {
+public:
+	void RegisterProvider(shared_ptr<IcebergAccessDelegationProvider> provider) {
+		lock_guard<mutex> guard(lock);
+		providers[provider->GetProviderName()] = std::move(provider);
+	}
+	optional_ptr<IcebergAccessDelegationProvider> GetProvider(const string &provider_name) {
+		lock_guard<mutex> guard(lock);
+		auto entry = providers.find(provider_name);
+		if (entry == providers.end()) {
+			return nullptr;
+		}
+		return entry->second.get();
+	}
+
+	//! ObjectCacheEntry interface
+	string GetObjectType() override {
+		return ObjectType();
+	}
+	optional_idx GetEstimatedCacheMemory() const override {
+		// Invalid index => non-evictable: the registry must outlive any scan.
+		return optional_idx();
+	}
+	static string ObjectType() {
+		return "iceberg_access_delegation_registry";
+	}
+
+	//! Fetch (creating if absent) the registry for this database.
+	static IcebergPluginRegistry &GetOrCreate(ClientContext &context) {
+		auto &cache = ObjectCache::GetObjectCache(context);
+		return *cache.GetOrCreate<IcebergPluginRegistry>(ObjectType());
+	}
+	//! Fetch the registry if it exists, else nullptr.
+	static optional_ptr<IcebergPluginRegistry> TryGet(ClientContext &context) {
+		auto &cache = ObjectCache::GetObjectCache(context);
+		return cache.Get<IcebergPluginRegistry>(ObjectType()).get();
+	}
+	//! DatabaseInstance overload, usable from an extension's Load() (no ClientContext required). Reaches
+	//! the same per-database ObjectCache as the ClientContext overloads.
+	static IcebergPluginRegistry &GetOrCreate(DatabaseInstance &db) {
+		auto &cache = db.GetObjectCache();
+		return *cache.GetOrCreate<IcebergPluginRegistry>(ObjectType());
+	}
+
+private:
+	mutex lock;
+	case_insensitive_map_t<shared_ptr<IcebergAccessDelegationProvider>> providers;
+};
+
+//! Free functions used by iceberg's catalog/scan code to dispatch to the active provider (if any).
+//! All are no-ops when the attached catalog has no delegation provider configured.
+struct IcebergAccessDelegation {
+	//! Returns the provider configured for `catalog` (by attach option), or nullptr.
+	static optional_ptr<IcebergAccessDelegationProvider> GetActiveProvider(IcebergCatalog &catalog,
+	                                                                       ClientContext &context);
+	//! Resolve and validate the provider during ATTACH, autoloading its extension if needed.
+	static void ResolveProviderForAttach(IcebergAttachOptions &options, ClientContext &context);
+	//! Dispatch IcebergAccessDelegationProvider::OnTableLoaded for the active provider.
+	static void OnTableLoaded(IcebergTableInformation &table_info, ClientContext &context);
+	//! Create the scan credential secret via the active provider. Returns true if a provider handled it.
+	static bool PrepareScanCredentials(IcebergTableInformation &table_info, ClientContext &context,
+	                                   optional_ptr<const vector<Value>> partition_values);
+	//! Dispatch IcebergAccessDelegationProvider::ApplyMandatoryScanFilters for the active provider.
+	static void ApplyMandatoryScanFilters(IcebergTableInformation &table_info, ClientContext &context,
+	                                      IcebergScanInfo &scan_info, IcebergMultiFileList &file_list,
+	                                      const IcebergTableSchema &schema);
+	//! Dispatch IcebergAccessDelegationProvider::OnPartitionFile for the active provider.
+	static void OnPartitionFile(IcebergTableInformation &table_info, ClientContext &context,
+	                            const vector<IcebergPartitionInfo> &partition_info, const string &file_path);
+};
+
+} // namespace duckdb

--- a/src/include/catalog/rest/storage/iceberg_authorization.hpp
+++ b/src/include/catalog/rest/storage/iceberg_authorization.hpp
@@ -34,7 +34,13 @@ struct IcebergAttachOptions {
 	bool purge_requested = false;
 	IRCAccessDelegationMode access_mode = IRCAccessDelegationMode::VENDED_CREDENTIALS;
 	IcebergAuthorizationType authorization_type = IcebergAuthorizationType::INVALID;
+	// Name of an access-delegation provider (registered by an external extension) selected via
+	// ACCESS_DELEGATION_MODE. Empty for the built-in 'vended_credentials' / 'none' modes.
+	string access_delegation_provider;
 	unordered_map<string, Value> options;
+	// Attach options consumed by the access-delegation provider during validation. Moved here out of
+	// `options` so they don't trip the "unhandled options" check; read back by the provider at runtime.
+	unordered_map<string, Value> delegation_options;
 	// max staleness for cached table metadata in minutes (optional - if not set, always request fresh metadata)
 	optional_idx max_table_staleness_micros;
 };

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -154,6 +154,14 @@ public:
 	const IcebergSnapshotScanInfo &GetSnapshot() const;
 	const IcebergTableSchema &GetSchema() const;
 	IcebergTableEntry *GetTable() const;
+	//! Defined inline so external access-delegation provider extensions (separate loadable binaries that
+	//! link only against DuckDB core, not iceberg) can call them.
+	const shared_ptr<IcebergScanInfo> &GetScanInfo() const {
+		return shared_state->scan_info;
+	}
+	void PushTableFilter(column_t column_idx, unique_ptr<ExpressionFilter> filter) {
+		table_filters.PushFilter(column_idx, std::move(filter));
+	}
 	void SetTable(IcebergTableEntry *table);
 	void SetOptions(const IcebergOptions &options);
 

--- a/src/include/planning/iceberg_optimizer.hpp
+++ b/src/include/planning/iceberg_optimizer.hpp
@@ -21,6 +21,18 @@ public:
 	void VisitOperator(unique_ptr<LogicalOperator> &op);
 };
 
+//! Re-applies an access-delegation provider's mandatory scan filter (stored on IcebergScanInfo) above
+//! the iceberg scan as a LogicalFilter. This is a generic, provider-agnostic safety net: it ensures the
+//! filter is enforced even if bind-time table filters were elided or a user predicate tried to bypass it.
+class DelegationRowFilterOptimizer {
+public:
+	ClientContext &context;
+
+public:
+	DelegationRowFilterOptimizer(ClientContext &context);
+	void VisitOperator(unique_ptr<LogicalOperator> &op);
+};
+
 class IcebergOptimizer {
 public:
 	static OptimizerExtension Create();

--- a/src/include/planning/snapshot/iceberg_scan_info.hpp
+++ b/src/include/planning/snapshot/iceberg_scan_info.hpp
@@ -9,6 +9,9 @@
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "planning/snapshot/iceberg_snapshot_scan_info.hpp"
 
+#include "duckdb/parser/parsed_expression.hpp"
+#include "duckdb/planner/expression.hpp"
+
 namespace duckdb {
 
 struct IcebergTransactionData;
@@ -38,6 +41,12 @@ public:
 
 	IcebergSnapshotScanInfo snapshot_info;
 	const IcebergTableSchema &schema;
+
+	//! A mandatory scan filter installed by the active access-delegation provider (e.g. a Lake
+	//! Formation row filter). The bound form is re-applied above the scan by the iceberg optimizer
+	//! so user predicates cannot widen it; both are null when no provider/filter is active.
+	unique_ptr<ParsedExpression> mandatory_delegation_filter_parsed;
+	unique_ptr<Expression> mandatory_delegation_filter_bound;
 };
 
 } // namespace duckdb

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -36,6 +36,8 @@
 #include "planning/metadata_io/manifest/iceberg_manifest_reader.hpp"
 #include "planning/metadata_io/manifest_list/iceberg_manifest_list_reader.hpp"
 #include "planning/metadata_io/manifest_list/bound_iceberg_manifest_list_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/iceberg_access_delegation.hpp"
 
 namespace duckdb {
 
@@ -992,6 +994,14 @@ OpenFileInfo IcebergMultiFileList::GetFileInternal(idx_t file_id, lock_guard<mut
 		auto &fs = FileSystem::GetFileSystem(context);
 		file_path = IcebergUtils::GetFullPath(iceberg_path, path, fs);
 	}
+
+	auto table = GetTable();
+	if (table && !data_file.partition_info.empty()) {
+		// An access-delegation provider may vend credentials scoped per partition; give it a chance to
+		// refresh the relevant secret as we discover each file. No-op when no provider is active.
+		IcebergAccessDelegation::OnPartitionFile(table->table_info, context, data_file.partition_info, file_path);
+	}
+
 	OpenFileInfo res(file_path);
 	auto extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
 	extended_info->options["file_size"] = Value::UBIGINT(data_file.file_size_in_bytes);

--- a/src/planning/iceberg_optimizer.cpp
+++ b/src/planning/iceberg_optimizer.cpp
@@ -12,6 +12,8 @@
 #include "planning/iceberg_multi_file_list.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 
 namespace duckdb {
 
@@ -134,12 +136,63 @@ void GuaranteeEqualityDeleteColumnsOptimizer::VisitOperator(unique_ptr<LogicalOp
 	}
 }
 
+DelegationRowFilterOptimizer::DelegationRowFilterOptimizer(ClientContext &context) : context(context) {
+}
+
+static unique_ptr<Expression> RemapFilterBindings(Expression &expr, const vector<ColumnBinding> &bindings) {
+	auto copy = expr.Copy();
+	ExpressionIterator::EnumerateExpression(copy, [&](unique_ptr<Expression> &child) {
+		if (child->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+			auto &colref = child->Cast<BoundColumnRefExpression>();
+			if (colref.Binding().column_index < bindings.size()) {
+				colref.BindingMutable() = bindings[colref.Binding().column_index];
+			}
+		}
+	});
+	return copy;
+}
+
+void DelegationRowFilterOptimizer::VisitOperator(unique_ptr<LogicalOperator> &op) {
+	for (idx_t child_index = 0; child_index < op->children.size(); child_index++) {
+		auto &child = op->children[child_index];
+		if (child->type != LogicalOperatorType::LOGICAL_GET) {
+			VisitOperator(child);
+			continue;
+		}
+		auto &get = child->Cast<LogicalGet>();
+		if (get.function.name != "iceberg_scan" || !get.bind_data) {
+			VisitOperator(child);
+			continue;
+		}
+		auto &mfbd = get.bind_data->Cast<MultiFileBindData>();
+		if (!mfbd.file_list) {
+			continue;
+		}
+		auto &iceberg_list = mfbd.file_list->Cast<IcebergMultiFileList>();
+		auto &scan_info = iceberg_list.GetScanInfo();
+		if (!scan_info || !scan_info->mandatory_delegation_filter_bound) {
+			continue;
+		}
+
+		// Re-apply the provider's mandatory filter above the scan even if bind-time table_filters were
+		// elided or the user added predicates that try to bypass it.
+		auto bindings = get.GetColumnBindings();
+		auto remapped = RemapFilterBindings(*scan_info->mandatory_delegation_filter_bound, bindings);
+		auto filter = make_uniq<LogicalFilter>();
+		filter->expressions.push_back(std::move(remapped));
+		filter->children.push_back(std::move(op->children[child_index]));
+		op->children[child_index] = std::move(filter);
+	}
+}
+
 void IcebergOptimizer::PreOptimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
 	GuaranteeEqualityDeleteColumnsOptimizer guarantee_equality_delete_columns_optimizer(input.context);
+	DelegationRowFilterOptimizer delegation_row_filter_optimizer(input.context);
 	if (plan->children.size() == 0) {
 		return;
 	}
 	guarantee_equality_delete_columns_optimizer.VisitOperator(plan);
+	delegation_row_filter_optimizer.VisitOperator(plan);
 }
 
 OptimizerExtension IcebergOptimizer::Create() {

--- a/test/sql/local/catalog_custom_setup/nessie/test_nessie.test
+++ b/test/sql/local/catalog_custom_setup/nessie/test_nessie.test
@@ -43,7 +43,7 @@ attach '' as my_datalake (
     SECRET 'my_secret'
 );
 ----
-<REGEX>:.*Unrecognized access mode.*Supported options are 'vended_credentials' and 'none'.*
+<REGEX>:.*Unrecognized access mode.*Built-in options are 'vended_credentials' and 'none'.*
 
 statement ok
 attach 'warehouse' as my_datalake (


### PR DESCRIPTION
## Use Case

Goal is to allow authentication using external authentication mechanisms without bloating `duckdb-iceberg` repo.

For example, to use all S3 Tables features, you need to use AWS Lake Formation auth, basically.

# Description

Introduce a provider-agnostic extension point so external extensions can supply scan-time credentials and mandatory row filters without any AWS/Lake-Formation code living in duckdb-iceberg.

- `IcebergPluginRegistry` (stored on the database ObjectCache) plus an IcebergAccessDelegationProvider interface and dispatch helpers.
- Generic mandatory_delegation_filter_* slots on IcebergScanInfo and a DelegationRowFilterOptimizer that re-applies them above LOGICAL_GET.
- Dispatch call sites in ATTACH option parsing, table load, scan credential prep, mandatory filter binding, and per-partition refresh.
- Opaque per-table delegation state on IcebergTableInformation; a generic access_delegation_provider string + delegation_options passthrough.

