### PR TITLE
Don't delete written files when the commit state is unknown

### DIFF
--- a/src/catalog/rest/api/catalog_api.cpp
+++ b/src/catalog/rest/api/catalog_api.cpp
@@ -28,16 +28,16 @@ void CommitResult::Throw(const string &url) const {
 	if (success) {
 		return;
 	}
+	// Throw HTTPException so the status lands in ExtraInfo()["status_code"] for commit-state classification.
 	if (error_) {
 		auto error_copy = error_->Copy();
 		error_copy._error.stack = vector<string>();
-		throw InvalidConfigurationException(
-		    "Request to '%s' returned a non-200 status code (%s). \n message: %s\n type: %s\n reason: %s\n", url,
+		throw HTTPException(
+		    *this, "Request to '%s' returned a non-200 status code (%s). \n message: %s\n type: %s\n reason: %s\n", url,
 		    EnumUtil::ToString(status), error_copy._error.message, error_copy._error.type, reason);
 	}
-	throw InvalidConfigurationException(
-	    "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s", url,
-	    EnumUtil::ToString(status), reason, body);
+	throw HTTPException(*this, "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s", url,
+	                    EnumUtil::ToString(status), reason, body);
 }
 
 vector<string> IRCAPI::ParseSchemaName(const string &namespace_name) {
@@ -388,6 +388,7 @@ static CommitResult BuildCommitResult(ClientContext &context, const unique_ptr<H
 	result.status = response->status;
 	result.reason = response->reason;
 	result.body = response->body;
+	result.headers = response->headers;
 	result.success = response->status == HTTPStatusCode::OK_200 || response->status == HTTPStatusCode::NoContent_204;
 	if (result.success) {
 		return result;
@@ -451,9 +452,9 @@ void IRCAPI::CommitTableDelete(ClientContext &context, IcebergCatalog &catalog, 
 	auto response = catalog.auth_handler->Request(RequestType::DELETE_REQUEST, context, url_builder, headers);
 	// Glue/S3Tables follow spec and return 204, apache/iceberg-rest-fixture docker image returns 200
 	if (response->status != HTTPStatusCode::NoContent_204 && response->status != HTTPStatusCode::OK_200) {
-		throw InvalidConfigurationException(
-		    "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
-		    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), response->reason, response->body);
+		throw HTTPException(*response, "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
+		                    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), response->reason,
+		                    response->body);
 	}
 }
 
@@ -469,9 +470,9 @@ void IRCAPI::CommitTableRename(ClientContext &context, IcebergCatalog &catalog, 
 	auto response = catalog.auth_handler->Request(RequestType::POST_REQUEST, context, url_builder, headers, body);
 	// Glue/S3Tables follow spec and return 204, apache/iceberg-rest-fixture docker image returns 200
 	if (response->status != HTTPStatusCode::NoContent_204 && response->status != HTTPStatusCode::OK_200) {
-		throw InvalidConfigurationException(
-		    "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
-		    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), response->reason, response->body);
+		throw HTTPException(*response, "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
+		                    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), response->reason,
+		                    response->body);
 	}
 }
 
@@ -484,9 +485,9 @@ void IRCAPI::CommitNamespaceCreate(ClientContext &context, IcebergCatalog &catal
 	LogPostBody(context, url_builder, body);
 	auto response = catalog.auth_handler->Request(RequestType::POST_REQUEST, context, url_builder, headers, body);
 	if (response->status != HTTPStatusCode::OK_200) {
-		throw InvalidConfigurationException(
-		    "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
-		    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), response->reason, response->body);
+		throw HTTPException(*response, "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
+		                    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), response->reason,
+		                    response->body);
 	}
 }
 
@@ -502,9 +503,9 @@ void IRCAPI::CommitNamespaceDrop(ClientContext &context, IcebergCatalog &catalog
 	auto response = catalog.auth_handler->Request(RequestType::DELETE_REQUEST, context, url_builder, headers, body);
 	// Glue/S3Tables follow spec and return 204, apache/iceberg-rest-fixture docker image returns 200
 	if (response->status != HTTPStatusCode::NoContent_204 && response->status != HTTPStatusCode::OK_200) {
-		throw InvalidConfigurationException(
-		    "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
-		    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), response->reason, response->body);
+		throw HTTPException(*response, "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
+		                    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), response->reason,
+		                    response->body);
 	}
 }
 
@@ -524,9 +525,9 @@ void IRCAPI::CommitNamespacePropertiesUpdate(ClientContext &context, IcebergCata
 	headers.Insert("Content-Type", "application/json");
 	auto response = catalog.auth_handler->Request(RequestType::POST_REQUEST, context, url_builder, headers, body);
 	if (response->status != HTTPStatusCode::OK_200) {
-		throw InvalidConfigurationException(
-		    "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
-		    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), response->reason, response->body);
+		throw HTTPException(*response, "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
+		                    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), response->reason,
+		                    response->body);
 	}
 }
 
@@ -562,17 +563,19 @@ rest_api_objects::LoadTableResult IRCAPI::CommitNewTable(ClientContext &context,
 		auto response =
 		    catalog.auth_handler->Request(RequestType::POST_REQUEST, context, url_builder, headers, create_table_json);
 		if (response->status != HTTPStatusCode::OK_200) {
-			throw InvalidConfigurationException(
-			    "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
+			throw HTTPException(
+			    *response, "Request to '%s' returned a non-200 status code (%s), with reason: %s, body: %s",
 			    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status), response->reason, response->body);
 		}
 		auto doc = ICUtils::APIResultToDoc(response->body);
 		auto *root = yyjson_doc_get_root(doc.get());
 		auto load_table_result = rest_api_objects::LoadTableResult::FromJSON(root);
 		return load_table_result;
+	} catch (const HTTPException &) {
+		// Non-200 already classified by HTTP status; rethrow so the status survives.
+		throw;
 	} catch (const std::exception &e) {
-		throw InvalidConfigurationException("Request to '%s' returned a non-200 status code body: %s",
-		                                    url_builder.GetURLEncoded(), e.what());
+		throw InvalidConfigurationException("Request to '%s' failed: %s", url_builder.GetURLEncoded(), e.what());
 	}
 }
 
@@ -587,6 +590,7 @@ rest_api_objects::CatalogConfig IRCAPI::GetCatalogConfig(ClientContext &context,
 	HTTPHeaders headers(*context.db);
 	auto response = catalog.auth_handler->Request(RequestType::GET_REQUEST, context, url_builder, headers, body);
 	if (response->status != HTTPStatusCode::OK_200) {
+		// Attach-time config read (not a commit path), so this keeps InvalidConfigurationException.
 		throw InvalidConfigurationException("Request to '%s' returned a non-200 status code (%s), with reason: %s",
 		                                    url_builder.GetURLEncoded(), EnumUtil::ToString(response->status),
 		                                    response->reason);

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -379,6 +379,26 @@ static case_insensitive_set_t GetRetryTableKeys(const TableTransactionInfo &tran
 	return table_keys;
 }
 
+// 4xx = definitive rejection (commit did not land) -> delete the orphan. 5xx / no HTTP status
+// (connection error/timeout) = outcome unknown (may have landed) -> keep files. Status is in
+// extra_info (HTTPException) or the message "status code (<status>)" (fallback).
+static bool CommitStateUnknown(const ErrorData &error) {
+	auto &extra = error.ExtraInfo();
+	auto it = extra.find("status_code");
+	if (it != extra.end()) {
+		return it->second.empty() || it->second[0] != '4';
+	}
+	auto &msg = error.RawMessage();
+	auto pos = msg.find("status code (");
+	if (pos != string::npos) {
+		auto digit = msg.find_first_of("0123456789", pos);
+		if (digit != string::npos) {
+			return msg[digit] != '4';
+		}
+	}
+	return true;
+}
+
 void IcebergTransaction::Commit() {
 	if (transaction_updates.empty() && created_schemas.empty() && deleted_schemas.empty() &&
 	    schema_property_updates.empty()) {
@@ -423,6 +443,7 @@ void IcebergTransaction::Commit() {
 		DoSchemaDeletes(*temp_con_context);
 	} catch (std::exception &ex) {
 		ErrorData error(ex);
+		commit_state_unknown = CommitStateUnknown(error);
 		CleanupFiles();
 		DropSecrets(*temp_con_context);
 		temp_con.Rollback();
@@ -645,6 +666,10 @@ void IcebergTransaction::CleanupFiles() {
 		// certain catalogs don't allow deletes and will have a s3.deletes attribute in the config describing this
 		// aws s3 tables rejects deletes and will handle garbage collection on its own, any attempt to delete the files
 		// on the aws side will result in an error.
+		return;
+	}
+	if (commit_state_unknown) {
+		// Commit may have landed (CommitStateUnknownException); keep the files.
 		return;
 	}
 	ScopedTransaction temp_con(db);

--- a/src/include/catalog/rest/api/catalog_api.hpp
+++ b/src/include/catalog/rest/api/catalog_api.hpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/optional.hpp"
 #include "duckdb/common/enums/http_status_code.hpp"
+#include "duckdb/common/http_util.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/parser/parsed_data/create_secret_info.hpp"
 
@@ -57,6 +58,7 @@ public:
 	HTTPStatusCode status = HTTPStatusCode::OK_200;
 	string reason;
 	string body;
+	HTTPHeaders headers;
 	optional<rest_api_objects::IcebergErrorResponse> error_;
 };
 

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -102,6 +102,8 @@ private:
 	void RefreshRetryTables(IcebergTransactionAlterUpdate &alter_update, const case_insensitive_set_t &table_keys,
 	                        ClientContext &context);
 	void CleanupFiles();
+	//! Commit outcome unknown (5xx / no HTTP status); CleanupFiles() then keeps the written files.
+	bool commit_state_unknown = false;
 
 private:
 	DatabaseInstance &db;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_unknown_type.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_unknown_type.test
@@ -30,7 +30,7 @@ create table create_unknown_type (
 	b "NULL"
 );
 ----
-Invalid Configuration Error
+HTTP Error
 
 # Can't set DEFAULT to a non-null value
 statement error

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_infinity_timestamp.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_infinity_timestamp.test
@@ -83,14 +83,14 @@ create table my_datalake.default.test_timestamp_ns_inf WITH (
 	'format-version'='2'
 ) as select TIMESTAMP_NS 'infinity' timestamp_ns_type;
 ----
-<REGEX>:.*Invalid Configuration Error.*
+<REGEX>:.*HTTP Error.*
 
 statement error
 create table my_datalake.default.test_timestamp_ns_ninf WITH (
 	'format-version'='2'
 ) as select TIMESTAMP_NS '-infinity' timestamp_ns_type;
 ----
-<REGEX>:.*Invalid Configuration Error.*
+<REGEX>:.*HTTP Error.*
 
 statement ok
 drop table if exists my_datalake.default.test_infinities;


### PR DESCRIPTION
## Problem

`IcebergTransaction::Commit()` removes the data files a transaction wrote whenever the commit throws: the `catch` calls `CleanupFiles()`, and the `Rollback()` that follows calls it again.

That is correct for a **definitive** failure — a 4xx, e.g. a 409 conflict: the commit was rejected and did not land, so its files are genuine orphans. But it is wrong when the outcome is **unknown**: a 5xx, or a connection error with no response, may mean the commit actually **landed**, with the written files now referenced by the new, live snapshot. Deleting them then leaves the snapshot pointing at a missing file and permanently corrupts the table — surfaced as a read-time `404 / NoSuchKey` on the next scan of the current state. It gets more likely the busier the catalog is.

This is Iceberg's **"commit state unknown"** condition. The reference implementation throws `CommitStateUnknownException` precisely here and requires writers to **preserve** the written files, because the commit may have applied. Iceberg core has fixed this same class of cleanup-on-unknown-state corruption more than once:

- apache/iceberg#4673 — *Core: Fix table corruption from OOM during commit cleanup in Spark*
- apache/iceberg#13443 — *should not delete manifest files after getting `CommitStateUnknownException`*

## Fix

Two commits:

**1. Don't clean up on unknown commit state.** Classify the commit failure by HTTP status and only clean up on a **definitive 4xx** rejection. A **5xx**, or an error with **no HTTP status** (a connection error / timeout), leaves `commit_state_unknown` set, which makes `CleanupFiles()` a no-op so the written files are kept — if the commit truly failed they are unreferenced orphans (reclaimed by `remove_orphan_files`); if it landed they stay correctly referenced. The default is conservative: anything we can't read as a 4xx is treated as unknown, so we never delete a possibly-committed file. The guard lives inside `CleanupFiles()` because it has two callers (the `Commit()` catch and the subsequent `Rollback()`), so one chokepoint enforces the invariant for both.

**2. Throw `HTTPException` on non-200 REST responses.** So the status is available on the **throwing side** — `CommitStateUnknown` reads it from `ErrorData::ExtraInfo()["status_code"]` rather than parsing it out of the message. Previously `CommitResult::Throw` (the commit path) threw an `InvalidConfigurationException` carrying the status only in the message, so the consumer had to string-match it. Every REST call that produced *"returned a non-200 status code"* now throws `HTTPException` (which populates `status_code`/`reason`/`response_body` in `extra_info`): `CommitResult::Throw` plus the namespace/table/config `IRCAPI` calls. `CommitResult` carries no headers, so its `Throw()` uses the low-level `HTTPException` constructor with an empty header map. `CommitNewTable` rethrows a caught `HTTPException` as-is so a real non-200 isn't downgraded back to `InvalidConfigurationException` by its generic catch. The message-parse path in `CommitStateUnknown` is kept as a fallback.

## Testing

`test_transactional_updates_error_omits_stacktrace` exercises a 409 conflict on a multi-table commit and asserts the cleanup log fires — i.e. a definitive 4xx still cleans up, so there is no regression. Verified locally against the rest fixture. Happy to add a fixture-injected 5xx case asserting the files are preserved if that would help.
