### PR TITLE
Fix flaky row order in merge_partition_insert.test

### DIFF
--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_partition_insert.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_partition_insert.test
@@ -44,7 +44,7 @@ MERGE INTO my_datalake.default.my_timeseries
     WHEN NOT MATCHED THEN INSERT;
 
 query II
-SELECT * FROM my_datalake.default.my_timeseries
+SELECT * FROM my_datalake.default.my_timeseries ORDER BY ts
 ----
 2025-09-15 00:00:00	42.0
 2025-09-17 00:00:00	42.0


### PR DESCRIPTION
SELECT * FROM my_datalake.default.my_timeseries had no ORDER BY, but the table ends up with two separate data files (one from the initial INSERT, one from MERGE INTO ... WHEN NOT MATCHED THEN INSERT), so scan order across files isn't guaranteed and the test occasionally observed rows in the wrong order despite correct values. Added ORDER BY ts to pin the actual invariant being tested.

Flake observed in https://github.com/duckdb/duckdb-iceberg/actions/runs/28495553875/job/84461467731?pr=1125#step:13:753