### PR TITLE
Add the avro key-value metadata of the Manifest to the `IcebergManifestListEntry` struct

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@ if (NOT EMSCRIPTEN)
   duckdb_extension_load(avro
   LOAD_TESTS
   GIT_URL https://github.com/duckdb/duckdb-avro
-  GIT_TAG 5f5f481d103497ac1907d7343a2ba2432fb4874e
+  GIT_TAG 1e59726d2660f967c070659fed15418fae2ed678
   SUBMODULES "third_party/avro-c"
 )
 endif()

--- a/src/include/core/metadata/manifest/iceberg_manifest_list.hpp
+++ b/src/include/core/metadata/manifest/iceberg_manifest_list.hpp
@@ -125,6 +125,8 @@ public:
 
 public:
 	IcebergManifestFile file;
+	//! The key-value metadata of the manifest file this entry describes
+	unordered_map<string, string> metadata;
 	vector<IcebergManifestEntry> manifest_entries;
 };
 

--- a/src/planning/metadata_io/avro/iceberg_avro_multi_file_reader.cpp
+++ b/src/planning/metadata_io/avro/iceberg_avro_multi_file_reader.cpp
@@ -1,5 +1,6 @@
 #include "planning/metadata_io/avro/iceberg_avro_multi_file_reader.hpp"
 
+#include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
@@ -7,18 +8,80 @@
 #include "duckdb/function/cast/bound_cast_data.hpp"
 #include "duckdb/common/vector/map_vector.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/parser/tableref/table_function_ref.hpp"
 
 #include "planning/metadata_io/avro/iceberg_avro_multi_file_list.hpp"
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
 #include "core/metadata/manifest/iceberg_manifest.hpp"
+#include "core/metadata/schema/iceberg_table_schema.hpp"
 #include "common/iceberg_utils.hpp"
 #include "planning/metadata_io/manifest/iceberg_manifest_reader.hpp"
 #include "planning/metadata_io/manifest_list/iceberg_manifest_list_reader.hpp"
+#include "rest_catalog/objects/schema.hpp"
+#include "yyjson.hpp"
 
 namespace duckdb {
 
 unique_ptr<MultiFileReader> IcebergAvroMultiFileReader::CreateInstance(const TableFunction &table) {
 	return make_uniq<IcebergAvroMultiFileReader>(table.function_info);
+}
+
+static unordered_map<string, string> GetAvroMetadata(ClientContext &context, const string &path) {
+	auto &instance = DatabaseInstance::GetDatabase(context);
+	auto &system_catalog = Catalog::GetSystemCatalog(instance);
+	auto transaction = CatalogTransaction::GetSystemTransaction(instance);
+	auto &schema = system_catalog.GetSchema(transaction, Identifier::DefaultSchema());
+	auto catalog_entry = schema.GetEntry(transaction, CatalogType::TABLE_FUNCTION_ENTRY, "avro_metadata");
+	if (!catalog_entry) {
+		throw InvalidInputException("Function with name \"avro_metadata\" not found!");
+	}
+
+	auto avro_metadata_function = catalog_entry->Cast<TableFunctionCatalogEntry>().functions.functions[0];
+
+	vector<Value> inputs;
+	inputs.emplace_back(path);
+	named_parameter_map_t named_parameters;
+	vector<LogicalType> input_types;
+	vector<Identifier> input_names;
+	TableFunctionRef empty;
+	vector<LogicalType> return_types;
+	vector<string> return_names;
+	TableFunctionBindInput bind_input(inputs, named_parameters, input_types, input_names, nullptr, nullptr,
+	                                  avro_metadata_function, empty);
+	auto bind_data = avro_metadata_function.bind(context, bind_input, return_types, return_names);
+
+	DataChunk chunk;
+	chunk.Initialize(context, return_types, STANDARD_VECTOR_SIZE);
+
+	ThreadContext thread_context(context);
+	ExecutionContext execution_context(context, thread_context, nullptr);
+
+	vector<column_t> column_ids;
+	for (idx_t i = 0; i < return_types.size(); i++) {
+		column_ids.push_back(i);
+	}
+	TableFunctionInitInput init_input(bind_data.get(), column_ids, vector<idx_t>(), nullptr);
+	auto global_state = avro_metadata_function.init_global(context, init_input);
+	unique_ptr<LocalTableFunctionState> local_state;
+	if (avro_metadata_function.init_local) {
+		local_state = avro_metadata_function.init_local(execution_context, init_input, global_state.get());
+	}
+
+	unordered_map<string, string> metadata;
+	do {
+		TableFunctionInput function_input(bind_data.get(), local_state.get(), global_state.get());
+		chunk.Reset();
+		avro_metadata_function.function(context, function_input, chunk);
+		chunk.Flatten();
+		for (idx_t row = 0; row < chunk.size(); row++) {
+			auto metadata_key = chunk.GetValue(0, row).GetValue<string>();
+			auto metadata_value = chunk.GetValue(1, row).GetValue<string>();
+			metadata.emplace(std::move(metadata_key), std::move(metadata_value));
+		}
+	} while (chunk.size() != 0);
+
+	return metadata;
 }
 
 namespace manifest_list {
@@ -483,6 +546,12 @@ ReaderInitializeType IcebergAvroMultiFileReader::InitializeReader(
 	auto get_function_info = function_info.get();
 	if (get_function_info) {
 		auto &avro_scan_info = get_function_info->Cast<IcebergAvroScanInfo>();
+		if (avro_scan_info.type == AvroScanInfoType::MANIFEST_FILE) {
+			auto &manifest_scan_info = avro_scan_info.Cast<IcebergManifestFileScanInfo>();
+			auto file_idx = reader_data.reader->file_list_idx.GetIndex();
+			auto &manifest_list_entry = manifest_scan_info.manifest_files[file_idx];
+			manifest_list_entry.metadata = GetAvroMetadata(context, manifest_list_entry.file.manifest_path);
+		}
 		for (auto &partition_spec : avro_scan_info.metadata.partition_specs) {
 			for (auto &spec_field : partition_spec.second.fields) {
 				if (StringUtil::CIEquals(spec_field.transform.RawType(), "day")) {


### PR DESCRIPTION
I can't imagine they added [this information](https://iceberg.apache.org/spec/#manifests) if it was entirely redundant
It's not entirely clear yet what it should be used for, but perhaps #1123 is a good candidate.