### PR TITLE
[Dev] Use `VectorWriter` API to produce `manifest_entry` data

### DIFF
--- a/src/core/metadata/manifest/iceberg_manifest.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest.cpp
@@ -2,6 +2,8 @@
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
 #include "core/metadata/manifest/iceberg_avro_codec.hpp"
 
+#include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
 #include "duckdb/storage/external_file_cache/caching_file_system.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 
@@ -218,137 +220,6 @@ LogicalType IcebergDataFile::GetType(const IcebergTableMetadata &metadata, const
 	return LogicalType::STRUCT(std::move(children));
 }
 
-Value IcebergDataFile::ToValue(const IcebergTableMetadata &table_metadata, const LogicalType &type) const {
-	vector<Value> children;
-
-	// content: int
-	children.push_back(Value::INTEGER(static_cast<int32_t>(content)));
-	// file_path: string
-	children.push_back(Value(file_path));
-	// file_format: string
-	children.push_back(Value(file_format));
-	// partition: struct(...)
-	if (partition_info.empty()) {
-		//! NOTE: Spark does *not* like it when this column is NULL, so we populate it with an empty struct value
-		//! instead
-		children.push_back(
-		    Value::STRUCT(child_list_t<Value> {{"__duckdb_empty_struct_marker", Value(LogicalTypeId::VARCHAR)}}));
-	} else {
-		child_list_t<Value> partition_children;
-		auto extended_partition_info = GetExtendedPartitionInfo(table_metadata);
-		for (auto &entry : extended_partition_info) {
-			auto new_value = Value();
-			string error_message;
-			LogicalType partition_result_type;
-			switch (entry.transform.Type()) {
-			case IcebergTransformType::IDENTITY: {
-				if (entry.source_type.IsNested()) {
-					throw NotImplementedException("Using an identity partition on a nested column");
-				}
-				partition_result_type = entry.source_type;
-				break;
-			}
-			case IcebergTransformType::BUCKET:
-			case IcebergTransformType::TRUNCATE:
-				partition_result_type = LogicalType::VARCHAR;
-				break;
-			case IcebergTransformType::DAY:
-			case IcebergTransformType::MONTH:
-			case IcebergTransformType::YEAR:
-			case IcebergTransformType::HOUR:
-				partition_result_type = LogicalType::BIGINT;
-				break;
-			case IcebergTransformType::INVALID:
-			case IcebergTransformType::VOID: {
-				throw InvalidInputException("Cannot use transform type %s in IcebergDataFile::ToValue %s",
-				                            entry.transform.RawType());
-				break;
-			}
-			default:
-				throw InvalidInputException("Unrecognized transform %s", entry.transform.RawType());
-			}
-			const LogicalType actual_type = partition_result_type;
-			bool cast_worked = entry.value.DefaultTryCastAs(actual_type, new_value, &error_message, true);
-			if (cast_worked) {
-				partition_children.emplace_back(entry.name, new_value);
-			} else {
-				throw InvalidInputException("Could not cast %s to %s", entry.value.type().ToString(),
-				                            actual_type.ToString());
-			}
-		}
-		children.push_back(Value::STRUCT(partition_children));
-	}
-
-	// record_count: long
-	children.push_back(Value::BIGINT(record_count));
-	// file_size_in_bytes: long
-	children.push_back(Value::BIGINT(file_size_in_bytes));
-
-	child_list_t<LogicalType> bounds_types;
-	bounds_types.emplace_back("key", LogicalType::INTEGER);
-	bounds_types.emplace_back("value", LogicalType::BLOB);
-
-	vector<Value> lower_bounds_values;
-	// lower bounds: map<int, binary>
-	for (auto &child : lower_bounds) {
-		lower_bounds_values.push_back(Value::STRUCT({{"key", child.first}, {"value", child.second}}));
-	}
-	children.push_back(Value::MAP(LogicalType::STRUCT(bounds_types), lower_bounds_values));
-
-	vector<Value> upper_bounds_values;
-	// upper bounds: map<int, binary>
-	for (auto &child : upper_bounds) {
-		upper_bounds_values.push_back(Value::STRUCT({{"key", child.first}, {"value", child.second}}));
-	}
-	children.push_back(Value::MAP(LogicalType::STRUCT(bounds_types), upper_bounds_values));
-
-	// counts struct (shared shape for value_counts / null_value_counts)
-	child_list_t<LogicalType> null_value_count_types;
-	null_value_count_types.emplace_back("key", LogicalType::INTEGER);
-	null_value_count_types.emplace_back("value", LogicalType::BIGINT);
-
-	// value_counts
-	vector<Value> value_counts_values;
-	for (auto &child : value_counts) {
-		value_counts_values.push_back(Value::STRUCT({{"key", child.first}, {"value", child.second}}));
-	}
-	children.push_back(Value::MAP(LogicalType::STRUCT(null_value_count_types), value_counts_values));
-
-	// null_value_counts
-	vector<Value> null_value_counts_values;
-	for (auto &child : null_value_counts) {
-		null_value_counts_values.push_back(Value::STRUCT({{"key", child.first}, {"value", child.second}}));
-	}
-	children.push_back(Value::MAP(LogicalType::STRUCT(null_value_count_types), null_value_counts_values));
-
-	// equality_ids: list<int> (empty for non equality-delete files)
-	vector<Value> equality_id_values;
-	for (auto &id : equality_ids) {
-		equality_id_values.push_back(Value::INTEGER(id));
-	}
-	if (equality_id_values.empty()) {
-		//! Not an equality-delete file - emit a NULL list rather than an empty list.
-		children.push_back(Value(LogicalType::LIST(LogicalType::INTEGER)));
-	} else {
-		children.push_back(Value::LIST(LogicalType::INTEGER, std::move(equality_id_values)));
-	}
-
-	// referenced_data_file
-	if (table_metadata.iceberg_version >= 3) {
-		children.push_back(Value(referenced_data_file));
-	}
-	// content_size_in_bytes
-	if (table_metadata.iceberg_version >= 3) {
-		children.push_back(content_size_in_bytes);
-	}
-	// content_offset
-	if (table_metadata.iceberg_version >= 3) {
-		children.push_back(content_offset);
-	}
-
-	return Value::STRUCT(type, children);
-}
-
 void IcebergManifestEntry::SetSequenceNumber(sequence_number_t value) {
 	has_sequence_number = true;
 	sequence_number = value;
@@ -403,6 +274,203 @@ static Value CreateFieldID(int32_t field_id, bool nullable) {
 }
 
 namespace manifest_file {
+
+using IntIntMapWriter = VectorWriter<VectorListType<VectorStructType<int32_t, int64_t>>>;
+using IntStringMapWriter = VectorWriter<VectorListType<VectorStructType<int32_t, string_t>>>;
+using Int32ListWriter = VectorWriter<VectorListType<int32_t>>;
+using Int64ListWriter = VectorWriter<VectorListType<int64_t>>;
+
+template <class MAP>
+static void WriteIntIntMap(IntIntMapWriter &writer, const MAP &map) {
+	auto list = writer.WriteList(map.size());
+	auto it = map.begin();
+	for (auto &entry_writer : list) {
+		auto &entry = *it++;
+		entry_writer.WriteValue([&](auto &key_writer, auto &value_writer) {
+			key_writer.WriteValue(entry.first);
+			value_writer.WriteValue(entry.second);
+		});
+	}
+}
+
+static void WriteBoundsMap(IntStringMapWriter &writer, const unordered_map<int32_t, Value> &bounds) {
+	auto list = writer.WriteList(bounds.size());
+	auto it = bounds.begin();
+	for (auto &entry_writer : list) {
+		auto &entry = *it++;
+		entry_writer.WriteValue([&](auto &key_writer, auto &value_writer) {
+			key_writer.WriteValue(entry.first);
+			if (entry.second.IsNull()) {
+				value_writer.WriteNull();
+			} else {
+				value_writer.WriteValue(entry.second.GetValueUnsafe<string_t>());
+			}
+		});
+	}
+}
+
+static void WriteInt32List(Int32ListWriter &writer, const vector<int32_t> &values) {
+	auto list = writer.WriteList(values.size());
+	auto it = values.begin();
+	for (auto &entry_writer : list) {
+		entry_writer.WriteValue(*it++);
+	}
+}
+
+static void WriteInt64List(Int64ListWriter &writer, const vector<int64_t> &values) {
+	auto list = writer.WriteList(values.size());
+	auto it = values.begin();
+	for (auto &entry_writer : list) {
+		entry_writer.WriteValue(*it++);
+	}
+}
+
+static void WritePartitionValue(Vector &vector, idx_t row_idx, const Value &value) {
+	if (value.IsNull()) {
+		FlatVector::SetNull(vector, row_idx, true);
+		return;
+	}
+	Value cast_value;
+	string error_message;
+	if (!value.DefaultTryCastAs(vector.GetType(), cast_value, &error_message, true)) {
+		throw InvalidInputException("Could not cast partition value %s to %s", value.type().ToString(),
+		                            vector.GetType().ToString());
+	}
+	vector.SetValue(row_idx, cast_value);
+}
+
+static void WritePartitionStructRow(Vector &partition_vector, idx_t row_idx, const IcebergDataFile &data_file,
+                                    const IcebergTableMetadata &table_metadata,
+                                    const vector<IcebergExtendedPartitionInfo> &schema_partition_info) {
+	auto &partition_children = StructVector::GetEntries(partition_vector);
+	if (schema_partition_info.empty()) {
+		D_ASSERT(!partition_children.empty());
+		FlatVector::SetNull(partition_children[0], row_idx, true);
+		return;
+	}
+
+	unordered_map<uint64_t, const Value *> value_by_field_id;
+	for (auto &entry : data_file.GetExtendedPartitionInfo(table_metadata)) {
+		value_by_field_id.emplace(entry.field_id, &entry.value);
+	}
+	for (idx_t child_idx = 0; child_idx < schema_partition_info.size(); child_idx++) {
+		auto &schema_entry = schema_partition_info[child_idx];
+		auto value_it = value_by_field_id.find(schema_entry.field_id);
+		if (value_it == value_by_field_id.end()) {
+			FlatVector::SetNull(partition_children[child_idx], row_idx, true);
+			continue;
+		}
+		WritePartitionValue(partition_children[child_idx], row_idx, *value_it->second);
+	}
+}
+
+static void WriteDataFileRow(const IcebergTableMetadata &table_metadata, Vector &data_file_vector, idx_t row_idx,
+                             const IcebergDataFile &data_file,
+                             const vector<IcebergExtendedPartitionInfo> &schema_partition_info) {
+	auto &data_file_entries = StructVector::GetEntries(data_file_vector);
+	idx_t entry_index = 0;
+
+	if (table_metadata.iceberg_version >= 2) {
+		auto content_writer = FlatVector::Writer<int32_t>(data_file_entries[entry_index++], 1, row_idx);
+		content_writer.WriteValue(static_cast<int32_t>(data_file.content));
+	}
+
+	auto file_path_writer = FlatVector::Writer<string_t>(data_file_entries[entry_index++], 1, row_idx);
+	file_path_writer.WriteValue(string_t(data_file.file_path));
+
+	auto file_format_writer = FlatVector::Writer<string_t>(data_file_entries[entry_index++], 1, row_idx);
+	file_format_writer.WriteValue(string_t(data_file.file_format));
+
+	WritePartitionStructRow(data_file_entries[entry_index++], row_idx, data_file, table_metadata,
+	                        schema_partition_info);
+
+	auto record_count_writer = FlatVector::Writer<int64_t>(data_file_entries[entry_index++], 1, row_idx);
+	record_count_writer.WriteValue(data_file.record_count);
+
+	auto file_size_writer = FlatVector::Writer<int64_t>(data_file_entries[entry_index++], 1, row_idx);
+	file_size_writer.WriteValue(data_file.file_size_in_bytes);
+
+	auto column_sizes_writer = FlatVector::Writer<VectorListType<VectorStructType<int32_t, int64_t>>>(
+	    data_file_entries[entry_index++], 1, row_idx);
+	WriteIntIntMap(column_sizes_writer, data_file.column_sizes);
+
+	auto value_counts_writer = FlatVector::Writer<VectorListType<VectorStructType<int32_t, int64_t>>>(
+	    data_file_entries[entry_index++], 1, row_idx);
+	WriteIntIntMap(value_counts_writer, data_file.value_counts);
+
+	auto null_value_counts_writer = FlatVector::Writer<VectorListType<VectorStructType<int32_t, int64_t>>>(
+	    data_file_entries[entry_index++], 1, row_idx);
+	WriteIntIntMap(null_value_counts_writer, data_file.null_value_counts);
+
+	auto nan_value_counts_writer = FlatVector::Writer<VectorListType<VectorStructType<int32_t, int64_t>>>(
+	    data_file_entries[entry_index++], 1, row_idx);
+	WriteIntIntMap(nan_value_counts_writer, data_file.nan_value_counts);
+
+	auto lower_bounds_writer = FlatVector::Writer<VectorListType<VectorStructType<int32_t, string_t>>>(
+	    data_file_entries[entry_index++], 1, row_idx);
+	WriteBoundsMap(lower_bounds_writer, data_file.lower_bounds);
+
+	auto upper_bounds_writer = FlatVector::Writer<VectorListType<VectorStructType<int32_t, string_t>>>(
+	    data_file_entries[entry_index++], 1, row_idx);
+	WriteBoundsMap(upper_bounds_writer, data_file.upper_bounds);
+
+	auto split_offsets_writer =
+	    FlatVector::Writer<VectorListType<int64_t>>(data_file_entries[entry_index++], 1, row_idx);
+	if (data_file.split_offsets.empty()) {
+		split_offsets_writer.WriteNull();
+	} else {
+		WriteInt64List(split_offsets_writer, data_file.split_offsets);
+	}
+
+	auto equality_ids_writer =
+	    FlatVector::Writer<VectorListType<int32_t>>(data_file_entries[entry_index++], 1, row_idx);
+	if (data_file.equality_ids.empty()) {
+		equality_ids_writer.WriteNull();
+	} else {
+		WriteInt32List(equality_ids_writer, data_file.equality_ids);
+	}
+
+	auto sort_order_writer = FlatVector::Writer<int32_t>(data_file_entries[entry_index++], 1, row_idx);
+	if (data_file.has_sort_order_id) {
+		sort_order_writer.WriteValue(data_file.sort_order_id);
+	} else {
+		sort_order_writer.WriteNull();
+	}
+
+	if (table_metadata.iceberg_version >= 3) {
+		auto first_row_id_writer = FlatVector::Writer<int64_t>(data_file_entries[entry_index++], 1, row_idx);
+		if (data_file.HasFirstRowId()) {
+			first_row_id_writer.WriteValue(data_file.GetFirstRowId());
+		} else {
+			first_row_id_writer.WriteNull();
+		}
+	}
+
+	if (table_metadata.iceberg_version >= 2) {
+		auto referenced_data_file_writer = FlatVector::Writer<string_t>(data_file_entries[entry_index++], 1, row_idx);
+		if (data_file.referenced_data_file.empty()) {
+			referenced_data_file_writer.WriteNull();
+		} else {
+			referenced_data_file_writer.WriteValue(string_t(data_file.referenced_data_file));
+		}
+	}
+
+	if (table_metadata.iceberg_version >= 3) {
+		auto content_offset_writer = FlatVector::Writer<int64_t>(data_file_entries[entry_index++], 1, row_idx);
+		if (data_file.content_offset.IsNull()) {
+			content_offset_writer.WriteNull();
+		} else {
+			content_offset_writer.WriteValue(data_file.content_offset.GetValue<int64_t>());
+		}
+
+		auto content_size_writer = FlatVector::Writer<int64_t>(data_file_entries[entry_index++], 1, row_idx);
+		if (data_file.content_size_in_bytes.IsNull()) {
+			content_size_writer.WriteNull();
+		} else {
+			content_size_writer.WriteValue(data_file.content_size_in_bytes.GetValue<int64_t>());
+		}
+	}
+}
 
 static LogicalType PartitionStructType(vector<IcebergExtendedPartitionInfo> extended_partition_info) {
 	child_list_t<LogicalType> children;
@@ -476,9 +544,11 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	child_list_t<Value> data_file_field_ids;
 	child_list_t<LogicalType> children;
 
-	// content: int
-	children.emplace_back("content", LogicalType::INTEGER);
-	data_file_field_ids.emplace_back("content", CreateFieldID(CONTENT, false));
+	if (table_metadata.iceberg_version >= 2) {
+		// content: int
+		children.emplace_back("content", LogicalType::INTEGER);
+		data_file_field_ids.emplace_back("content", CreateFieldID(CONTENT, false));
+	}
 
 	// file_path: string
 	children.emplace_back("file_path", LogicalType::VARCHAR);
@@ -510,11 +580,73 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	children.emplace_back("file_size_in_bytes", LogicalType::BIGINT);
 	data_file_field_ids.emplace_back("file_size_in_bytes", CreateFieldID(FILE_SIZE_IN_BYTES, false));
 
-	//! NOTE: These are optional but we should probably add them, to support better filtering
-	//! column_sizes
-	//! value_counts
-	//! null_value_counts
-	//! nan_value_count
+	child_list_t<LogicalType> null_value_counts_fields;
+	null_value_counts_fields.emplace_back("key", LogicalType::INTEGER);
+	null_value_counts_fields.emplace_back("value", LogicalType::BIGINT);
+
+	// column_sizes: map<int, long>
+	children.emplace_back("column_sizes", LogicalType::MAP(LogicalType::STRUCT(null_value_counts_fields)));
+
+	child_list_t<Value> column_sizes_record_field_ids;
+	column_sizes_record_field_ids.emplace_back("__duckdb_field_id", Value::INTEGER(COLUMN_SIZES));
+	child_list_t<Value> column_sizes_key_field;
+	column_sizes_key_field.emplace_back("__duckdb_field_id", Value::INTEGER(COLUMN_SIZES_KEY));
+	column_sizes_key_field.emplace_back("__duckdb_nullable", Value::BOOLEAN(false));
+	column_sizes_record_field_ids.emplace_back("key", Value::STRUCT(column_sizes_key_field));
+	child_list_t<Value> column_sizes_value_field;
+	column_sizes_value_field.emplace_back("__duckdb_field_id", Value::INTEGER(COLUMN_SIZES_VALUE));
+	column_sizes_value_field.emplace_back("__duckdb_nullable", Value::BOOLEAN(false));
+	column_sizes_record_field_ids.emplace_back("value", Value::STRUCT(column_sizes_value_field));
+
+	data_file_field_ids.emplace_back("column_sizes", Value::STRUCT(column_sizes_record_field_ids));
+
+	// value_counts: map<int, long>
+	children.emplace_back("value_counts", LogicalType::MAP(LogicalType::STRUCT(null_value_counts_fields)));
+
+	child_list_t<Value> value_counts_record_field_ids;
+	value_counts_record_field_ids.emplace_back("__duckdb_field_id", Value::INTEGER(VALUE_COUNTS));
+	child_list_t<Value> value_counts_key_field;
+	value_counts_key_field.emplace_back("__duckdb_field_id", Value::INTEGER(VALUE_COUNTS_KEY));
+	value_counts_key_field.emplace_back("__duckdb_nullable", Value::BOOLEAN(false));
+	value_counts_record_field_ids.emplace_back("key", Value::STRUCT(value_counts_key_field));
+	child_list_t<Value> value_counts_value_field;
+	value_counts_value_field.emplace_back("__duckdb_field_id", Value::INTEGER(VALUE_COUNTS_VALUE));
+	value_counts_value_field.emplace_back("__duckdb_nullable", Value::BOOLEAN(false));
+	value_counts_record_field_ids.emplace_back("value", Value::STRUCT(value_counts_value_field));
+
+	data_file_field_ids.emplace_back("value_counts", Value::STRUCT(value_counts_record_field_ids));
+
+	// null_value_counts: map<int, long>
+	children.emplace_back("null_value_counts", LogicalType::MAP(LogicalType::STRUCT(null_value_counts_fields)));
+
+	child_list_t<Value> null_values_counts_record_field_ids;
+	null_values_counts_record_field_ids.emplace_back("__duckdb_field_id", Value::INTEGER(NULL_VALUE_COUNTS));
+	child_list_t<Value> null_value_counts_key_field;
+	null_value_counts_key_field.emplace_back("__duckdb_field_id", Value::INTEGER(NULL_VALUE_COUNTS_KEY));
+	null_value_counts_key_field.emplace_back("__duckdb_nullable", Value::BOOLEAN(false));
+	null_values_counts_record_field_ids.emplace_back("key", Value::STRUCT(null_value_counts_key_field));
+	child_list_t<Value> null_value_counts_value_field;
+	null_value_counts_value_field.emplace_back("__duckdb_field_id", Value::INTEGER(NULL_VALUE_COUNTS_VALUE));
+	null_value_counts_value_field.emplace_back("__duckdb_nullable", Value::BOOLEAN(false));
+	null_values_counts_record_field_ids.emplace_back("value", Value::STRUCT(null_value_counts_value_field));
+
+	data_file_field_ids.emplace_back("null_value_counts", Value::STRUCT(null_values_counts_record_field_ids));
+
+	// nan_value_counts: map<int, long>
+	children.emplace_back("nan_value_counts", LogicalType::MAP(LogicalType::STRUCT(null_value_counts_fields)));
+
+	child_list_t<Value> nan_value_counts_record_field_ids;
+	nan_value_counts_record_field_ids.emplace_back("__duckdb_field_id", Value::INTEGER(NAN_VALUE_COUNTS));
+	child_list_t<Value> nan_value_counts_key_field;
+	nan_value_counts_key_field.emplace_back("__duckdb_field_id", Value::INTEGER(NAN_VALUE_COUNTS_KEY));
+	nan_value_counts_key_field.emplace_back("__duckdb_nullable", Value::BOOLEAN(false));
+	nan_value_counts_record_field_ids.emplace_back("key", Value::STRUCT(nan_value_counts_key_field));
+	child_list_t<Value> nan_value_counts_value_field;
+	nan_value_counts_value_field.emplace_back("__duckdb_field_id", Value::INTEGER(NAN_VALUE_COUNTS_VALUE));
+	nan_value_counts_value_field.emplace_back("__duckdb_nullable", Value::BOOLEAN(false));
+	nan_value_counts_record_field_ids.emplace_back("value", Value::STRUCT(nan_value_counts_value_field));
+
+	data_file_field_ids.emplace_back("nan_value_counts", Value::STRUCT(nan_value_counts_record_field_ids));
 
 	// lower bounds struct
 	child_list_t<LogicalType> bounds_fields;
@@ -553,43 +685,13 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	upper_bound_record_field_ids.emplace_back("value", Value::STRUCT(upper_bounds_value_field));
 
 	data_file_field_ids.emplace_back("upper_bounds", Value::STRUCT(upper_bound_record_field_ids));
+	// split_offsets: list<long>
+	children.emplace_back("split_offsets", LogicalType::LIST(LogicalType::BIGINT));
 
-	// counts struct (shared shape for value_counts / null_value_counts)
-	child_list_t<LogicalType> null_value_counts_fields;
-	null_value_counts_fields.emplace_back("key", LogicalType::INTEGER);
-	null_value_counts_fields.emplace_back("value", LogicalType::BIGINT);
-
-	// value_counts: map<int, long>
-	children.emplace_back("value_counts", LogicalType::MAP(LogicalType::STRUCT(null_value_counts_fields)));
-
-	child_list_t<Value> value_counts_record_field_ids;
-	value_counts_record_field_ids.emplace_back("__duckdb_field_id", Value::INTEGER(VALUE_COUNTS));
-	child_list_t<Value> value_counts_key_field;
-	value_counts_key_field.emplace_back("__duckdb_field_id", Value::INTEGER(VALUE_COUNTS_KEY));
-	value_counts_key_field.emplace_back("__duckdb_nullable", Value::BOOLEAN(false));
-	value_counts_record_field_ids.emplace_back("key", Value::STRUCT(value_counts_key_field));
-	child_list_t<Value> value_counts_value_field;
-	value_counts_value_field.emplace_back("__duckdb_field_id", Value::INTEGER(VALUE_COUNTS_VALUE));
-	value_counts_value_field.emplace_back("__duckdb_nullable", Value::BOOLEAN(false));
-	value_counts_record_field_ids.emplace_back("value", Value::STRUCT(value_counts_value_field));
-
-	data_file_field_ids.emplace_back("value_counts", Value::STRUCT(value_counts_record_field_ids));
-
-	// null_value_counts: map<int, long>
-	children.emplace_back("null_value_counts", LogicalType::MAP(LogicalType::STRUCT(null_value_counts_fields)));
-
-	child_list_t<Value> null_values_counts_record_field_ids;
-	null_values_counts_record_field_ids.emplace_back("__duckdb_field_id", Value::INTEGER(NULL_VALUE_COUNTS));
-	child_list_t<Value> null_value_counts_key_field;
-	null_value_counts_key_field.emplace_back("__duckdb_field_id", Value::INTEGER(NULL_VALUE_COUNTS_KEY));
-	null_value_counts_key_field.emplace_back("__duckdb_nullable", Value::BOOLEAN(false));
-	null_values_counts_record_field_ids.emplace_back("key", Value::STRUCT(null_value_counts_key_field));
-	child_list_t<Value> null_value_counts_value_field;
-	null_value_counts_value_field.emplace_back("__duckdb_field_id", Value::INTEGER(NULL_VALUE_COUNTS_VALUE));
-	null_value_counts_value_field.emplace_back("__duckdb_nullable", Value::BOOLEAN(false));
-	null_values_counts_record_field_ids.emplace_back("value", Value::STRUCT(null_value_counts_value_field));
-
-	data_file_field_ids.emplace_back("null_value_counts", Value::STRUCT(null_values_counts_record_field_ids));
+	child_list_t<Value> split_offsets_list_field;
+	split_offsets_list_field.emplace_back("list", CreateFieldID(SPLIT_OFFSETS_ELEMENT, false));
+	split_offsets_list_field.emplace_back("__duckdb_field_id", Value::INTEGER(SPLIT_OFFSETS));
+	data_file_field_ids.emplace_back("split_offsets", Value::STRUCT(split_offsets_list_field));
 
 	// equality_ids: list<int> - the field-ids an equality-delete file applies to
 	children.emplace_back("equality_ids", LogicalType::LIST(LogicalType::INTEGER));
@@ -599,23 +701,33 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	equality_ids_list_field.emplace_back("__duckdb_field_id", Value::INTEGER(EQUALITY_IDS));
 	data_file_field_ids.emplace_back("equality_ids", Value::STRUCT(equality_ids_list_field));
 
-	// referenced_data_file
+	// sort_order_id: optional int
+	children.emplace_back("sort_order_id", LogicalType::INTEGER);
+	data_file_field_ids.emplace_back("sort_order_id", CreateFieldID(SORT_ORDER_ID, true));
+
 	if (table_metadata.iceberg_version >= 3) {
-		// referenced_data_file: long
+		// first_row_id: optional long
+		children.emplace_back("first_row_id", LogicalType::BIGINT);
+		data_file_field_ids.emplace_back("first_row_id", CreateFieldID(FIRST_ROW_ID, true));
+	}
+
+	// referenced_data_file
+	if (table_metadata.iceberg_version >= 2) {
+		// referenced_data_file: string
 		children.emplace_back("referenced_data_file", LogicalType::VARCHAR);
 		data_file_field_ids.emplace_back("referenced_data_file", CreateFieldID(REFERENCED_DATA_FILE, true));
-	}
-	// content_size_in_bytes
-	if (table_metadata.iceberg_version >= 3) {
-		// content_size_in_bytes: long
-		children.emplace_back("content_size_in_bytes", LogicalType::BIGINT);
-		data_file_field_ids.emplace_back("content_size_in_bytes", CreateFieldID(CONTENT_SIZE_IN_BYTES, true));
 	}
 	// content_offset
 	if (table_metadata.iceberg_version >= 3) {
 		// content_offset: long
 		children.emplace_back("content_offset", LogicalType::BIGINT);
 		data_file_field_ids.emplace_back("content_offset", CreateFieldID(CONTENT_OFFSET, true));
+	}
+	// content_size_in_bytes
+	if (table_metadata.iceberg_version >= 3) {
+		// content_size_in_bytes: long
+		children.emplace_back("content_size_in_bytes", LogicalType::BIGINT);
+		data_file_field_ids.emplace_back("content_size_in_bytes", CreateFieldID(CONTENT_SIZE_IN_BYTES, true));
 	}
 
 	// data_file: struct(...)
@@ -630,34 +742,33 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	DataChunk chunk;
 	chunk.Initialize(allocator, types, manifest_entries.size());
 
+	auto status_writer = FlatVector::Writer<int32_t>(chunk.data[0], manifest_entries.size());
+	auto snapshot_id_writer = FlatVector::Writer<int64_t>(chunk.data[1], manifest_entries.size());
+	auto sequence_number_writer = FlatVector::Writer<int64_t>(chunk.data[2], manifest_entries.size());
+	auto file_sequence_number_writer = FlatVector::Writer<int64_t>(chunk.data[3], manifest_entries.size());
+
 	for (idx_t i = 0; i < manifest_entries.size(); i++) {
 		auto &manifest_entry = manifest_entries[i];
-		idx_t col_idx = 0;
-
-		// status: int
-		chunk.data[col_idx++].Append(Value::INTEGER(static_cast<int32_t>(manifest_entry.status)));
+		status_writer.WriteValue(static_cast<int32_t>(manifest_entry.status));
 		//! FIXME: this is missing logic, needs to be looked into
 		//! SPEC: Snapshot id where the file was added, or deleted if status is 2. Inherited when null.
 		// snapshot_id: long
 		if (manifest_entry.HasSnapshotId()) {
-			chunk.data[col_idx++].Append(Value::BIGINT(manifest_entry.GetSnapshotId()));
+			snapshot_id_writer.WriteValue(manifest_entry.GetSnapshotId());
 		} else {
-			chunk.data[col_idx++].Append(Value(LogicalType::BIGINT));
+			snapshot_id_writer.WriteNull();
 		}
 		// sequence_number: long
 		// file_sequence_number: long
 		if (manifest_entry.status == IcebergManifestEntryStatusType::ADDED) {
-			chunk.data[col_idx++].Append(Value(LogicalType::BIGINT));
-			chunk.data[col_idx++].Append(Value(LogicalType::BIGINT));
+			sequence_number_writer.WriteNull();
+			file_sequence_number_writer.WriteNull();
 		} else {
-			chunk.data[col_idx++].Append(Value::BIGINT(manifest_entry.GetFileSequenceNumber(manifest_file)));
-			chunk.data[col_idx++].Append(Value::BIGINT(manifest_entry.GetSequenceNumber(manifest_file)));
+			sequence_number_writer.WriteValue(manifest_entry.GetSequenceNumber(manifest_file));
+			file_sequence_number_writer.WriteValue(manifest_entry.GetFileSequenceNumber(manifest_file));
 		}
 
-		auto &data_file = manifest_entry.data_file;
-		// data_file: struct(...)
-		chunk.data[col_idx].Append(data_file.ToValue(table_metadata, chunk.data[col_idx].GetType()));
-		col_idx++;
+		WriteDataFileRow(table_metadata, chunk.data[4], i, manifest_entry.data_file, extended_partition_info);
 	}
 	chunk.SetChildCardinality(manifest_entries.size());
 

--- a/src/core/metadata/manifest/iceberg_manifest.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest.cpp
@@ -52,26 +52,16 @@ struct DataFileVectorWriters {
 	      upper_bounds(data_file_entries[UPPER_BOUNDS_INDEX], row_count, 0),
 	      split_offsets(data_file_entries[SPLIT_OFFSETS_INDEX], row_count, 0),
 	      equality_ids(data_file_entries[EQUALITY_IDS_INDEX], row_count, 0),
-	      sort_order_id(data_file_entries[SORT_ORDER_ID_INDEX], row_count, 0),
-	      content(HasV2Fields(table_metadata)
-	                  ? optional<VectorWriter<int32_t>>(std::in_place, data_file_entries[CONTENT_INDEX], row_count, 0)
-	                  : std::nullopt),
-	      referenced_data_file(HasV2Fields(table_metadata)
-	                               ? optional<VectorWriter<string_t>>(
-	                                     std::in_place, data_file_entries[REFERENCED_DATA_FILE_INDEX], row_count, 0)
-	                               : std::nullopt),
-	      first_row_id(
-	          HasV3Fields(table_metadata)
-	              ? optional<VectorWriter<int64_t>>(std::in_place, data_file_entries[FIRST_ROW_ID_INDEX], row_count, 0)
-	              : std::nullopt),
-	      content_offset(HasV3Fields(table_metadata)
-	                         ? optional<VectorWriter<int64_t>>(std::in_place, data_file_entries[CONTENT_OFFSET_INDEX],
-	                                                           row_count, 0)
-	                         : std::nullopt),
-	      content_size_in_bytes(HasV3Fields(table_metadata)
-	                                ? optional<VectorWriter<int64_t>>(
-	                                      std::in_place, data_file_entries[CONTENT_SIZE_IN_BYTES_INDEX], row_count, 0)
-	                                : std::nullopt) {
+	      sort_order_id(data_file_entries[SORT_ORDER_ID_INDEX], row_count, 0) {
+		if (table_metadata.iceberg_version >= 2) {
+			content.emplace(data_file_entries[CONTENT_INDEX], row_count, 0);
+			referenced_data_file.emplace(data_file_entries[REFERENCED_DATA_FILE_INDEX], row_count, 0);
+		}
+		if (table_metadata.iceberg_version >= 3) {
+			first_row_id.emplace(data_file_entries[FIRST_ROW_ID_INDEX], row_count, 0);
+			content_offset.emplace(data_file_entries[CONTENT_OFFSET_INDEX], row_count, 0);
+			content_size_in_bytes.emplace(data_file_entries[CONTENT_SIZE_IN_BYTES_INDEX], row_count, 0);
+		}
 	}
 
 	void WriteRow(idx_t row_idx, const IcebergDataFile &data_file,
@@ -167,12 +157,6 @@ private:
 	static constexpr idx_t FIRST_ROW_ID_INDEX = 16;
 	static constexpr idx_t CONTENT_OFFSET_INDEX = 17;
 	static constexpr idx_t CONTENT_SIZE_IN_BYTES_INDEX = 18;
-	static bool HasV2Fields(const IcebergTableMetadata &table_metadata) {
-		return table_metadata.iceberg_version >= 2;
-	}
-	static bool HasV3Fields(const IcebergTableMetadata &table_metadata) {
-		return table_metadata.iceberg_version >= 3;
-	}
 
 public:
 	const IcebergTableMetadata &table_metadata;

--- a/src/core/metadata/manifest/iceberg_manifest.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest.cpp
@@ -13,7 +13,183 @@
 #include "core/expression/iceberg_value.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
 
+#include <optional>
+
 namespace duckdb {
+
+namespace {
+
+using std::optional;
+
+using IntIntMapWriter = VectorWriter<VectorListType<VectorStructType<int32_t, int64_t>>>;
+using IntStringMapWriter = VectorWriter<VectorListType<VectorStructType<int32_t, string_t>>>;
+using Int32ListWriter = VectorWriter<VectorListType<int32_t>>;
+using Int64ListWriter = VectorWriter<VectorListType<int64_t>>;
+
+template <class MAP>
+static void WriteIntIntMap(IntIntMapWriter &writer, const MAP &map);
+static void WriteBoundsMap(IntStringMapWriter &writer, const duckdb::unordered_map<int32_t, Value> &bounds);
+static void WriteInt32List(Int32ListWriter &writer, const duckdb::vector<int32_t> &values);
+static void WriteInt64List(Int64ListWriter &writer, const duckdb::vector<int64_t> &values);
+static void WritePartitionStructRow(Vector &partition_vector, idx_t row_idx, const IcebergDataFile &data_file,
+                                    const IcebergTableMetadata &table_metadata,
+                                    const duckdb::vector<IcebergExtendedPartitionInfo> &schema_partition_info);
+
+struct DataFileVectorWriters {
+	explicit DataFileVectorWriters(Vector &data_file_vector, idx_t row_count,
+	                               const IcebergTableMetadata &table_metadata)
+	    : table_metadata(table_metadata), data_file_entries(StructVector::GetEntries(data_file_vector)),
+	      content(table_metadata.iceberg_version >= 2
+	                  ? optional<VectorWriter<int32_t>>(std::in_place, data_file_entries[entry_index], row_count, 0)
+	                  : std::nullopt),
+	      file_path(data_file_entries[entry_index + static_cast<idx_t>(content.has_value())], row_count, 0),
+	      file_format(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 1], row_count, 0),
+	      partition(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 2]),
+	      record_count(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 3], row_count, 0),
+	      file_size_in_bytes(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 4], row_count,
+	                         0),
+	      column_sizes(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 5], row_count, 0),
+	      value_counts(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 6], row_count, 0),
+	      null_value_counts(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 7], row_count, 0),
+	      nan_value_counts(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 8], row_count, 0),
+	      lower_bounds(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 9], row_count, 0),
+	      upper_bounds(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 10], row_count, 0),
+	      split_offsets(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 11], row_count, 0),
+	      equality_ids(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 12], row_count, 0),
+	      sort_order_id(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 13], row_count, 0),
+	      first_row_id(table_metadata.iceberg_version >= 3
+	                       ? optional<VectorWriter<int64_t>>(
+	                             std::in_place,
+	                             data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 14],
+	                             row_count, 0)
+	                       : std::nullopt),
+	      referenced_data_file(table_metadata.iceberg_version >= 2
+	                               ? optional<VectorWriter<string_t>>(
+	                                     std::in_place,
+	                                     data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 14 +
+	                                                       static_cast<idx_t>(first_row_id.has_value())],
+	                                     row_count, 0)
+	                               : std::nullopt),
+	      content_offset(table_metadata.iceberg_version >= 3
+	                         ? optional<VectorWriter<int64_t>>(
+	                               std::in_place,
+	                               data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 14 +
+	                                                 static_cast<idx_t>(first_row_id.has_value()) +
+	                                                 static_cast<idx_t>(referenced_data_file.has_value())],
+	                               row_count, 0)
+	                         : std::nullopt),
+	      content_size_in_bytes(table_metadata.iceberg_version >= 3
+	                                ? optional<VectorWriter<int64_t>>(
+	                                      std::in_place,
+	                                      data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 14 +
+	                                                        static_cast<idx_t>(first_row_id.has_value()) +
+	                                                        static_cast<idx_t>(referenced_data_file.has_value()) +
+	                                                        static_cast<idx_t>(content_offset.has_value())],
+	                                      row_count, 0)
+	                                : std::nullopt) {
+	}
+
+	void WriteRow(idx_t row_idx, const IcebergDataFile &data_file,
+	              const duckdb::vector<IcebergExtendedPartitionInfo> &schema_partition_info) {
+		if (content) {
+			content->WriteValue(static_cast<int32_t>(data_file.content));
+		}
+
+		file_path.WriteValue(string_t(data_file.file_path));
+		file_format.WriteValue(string_t(data_file.file_format));
+
+		WritePartitionStructRow(partition, row_idx, data_file, table_metadata, schema_partition_info);
+
+		record_count.WriteValue(data_file.record_count);
+		file_size_in_bytes.WriteValue(data_file.file_size_in_bytes);
+
+		WriteIntIntMap(column_sizes, data_file.column_sizes);
+		WriteIntIntMap(value_counts, data_file.value_counts);
+		WriteIntIntMap(null_value_counts, data_file.null_value_counts);
+		WriteIntIntMap(nan_value_counts, data_file.nan_value_counts);
+
+		WriteBoundsMap(lower_bounds, data_file.lower_bounds);
+		WriteBoundsMap(upper_bounds, data_file.upper_bounds);
+
+		if (data_file.split_offsets.empty()) {
+			split_offsets.WriteNull();
+		} else {
+			WriteInt64List(split_offsets, data_file.split_offsets);
+		}
+
+		if (data_file.equality_ids.empty()) {
+			equality_ids.WriteNull();
+		} else {
+			WriteInt32List(equality_ids, data_file.equality_ids);
+		}
+
+		if (data_file.has_sort_order_id) {
+			sort_order_id.WriteValue(data_file.sort_order_id);
+		} else {
+			sort_order_id.WriteNull();
+		}
+
+		if (first_row_id) {
+			if (data_file.HasFirstRowId()) {
+				first_row_id->WriteValue(data_file.GetFirstRowId());
+			} else {
+				first_row_id->WriteNull();
+			}
+		}
+
+		if (referenced_data_file) {
+			if (data_file.referenced_data_file.empty()) {
+				referenced_data_file->WriteNull();
+			} else {
+				referenced_data_file->WriteValue(string_t(data_file.referenced_data_file));
+			}
+		}
+
+		if (content_offset) {
+			if (data_file.content_offset.IsNull()) {
+				content_offset->WriteNull();
+			} else {
+				content_offset->WriteValue(data_file.content_offset.GetValue<int64_t>());
+			}
+		}
+
+		if (content_size_in_bytes) {
+			if (data_file.content_size_in_bytes.IsNull()) {
+				content_size_in_bytes->WriteNull();
+			} else {
+				content_size_in_bytes->WriteValue(data_file.content_size_in_bytes.GetValue<int64_t>());
+			}
+		}
+	}
+
+private:
+	static constexpr idx_t entry_index = 0;
+
+public:
+	const IcebergTableMetadata &table_metadata;
+	duckdb::vector<Vector> &data_file_entries;
+	optional<VectorWriter<int32_t>> content;
+	VectorWriter<string_t> file_path;
+	VectorWriter<string_t> file_format;
+	Vector &partition;
+	VectorWriter<int64_t> record_count;
+	VectorWriter<int64_t> file_size_in_bytes;
+	IntIntMapWriter column_sizes;
+	IntIntMapWriter value_counts;
+	IntIntMapWriter null_value_counts;
+	IntIntMapWriter nan_value_counts;
+	IntStringMapWriter lower_bounds;
+	IntStringMapWriter upper_bounds;
+	Int64ListWriter split_offsets;
+	Int32ListWriter equality_ids;
+	VectorWriter<int32_t> sort_order_id;
+	optional<VectorWriter<int64_t>> first_row_id;
+	optional<VectorWriter<string_t>> referenced_data_file;
+	optional<VectorWriter<int64_t>> content_offset;
+	optional<VectorWriter<int64_t>> content_size_in_bytes;
+};
+
+} // namespace
 
 string IcebergManifestEntryContentTypeToString(IcebergManifestEntryContentType type) {
 	switch (type) {
@@ -273,12 +449,7 @@ static Value CreateFieldID(int32_t field_id, bool nullable) {
 	return Value::STRUCT(fields);
 }
 
-namespace manifest_file {
-
-using IntIntMapWriter = VectorWriter<VectorListType<VectorStructType<int32_t, int64_t>>>;
-using IntStringMapWriter = VectorWriter<VectorListType<VectorStructType<int32_t, string_t>>>;
-using Int32ListWriter = VectorWriter<VectorListType<int32_t>>;
-using Int64ListWriter = VectorWriter<VectorListType<int64_t>>;
+namespace {
 
 template <class MAP>
 static void WriteIntIntMap(IntIntMapWriter &writer, const MAP &map) {
@@ -364,113 +535,9 @@ static void WritePartitionStructRow(Vector &partition_vector, idx_t row_idx, con
 	}
 }
 
-static void WriteDataFileRow(const IcebergTableMetadata &table_metadata, Vector &data_file_vector, idx_t row_idx,
-                             const IcebergDataFile &data_file,
-                             const vector<IcebergExtendedPartitionInfo> &schema_partition_info) {
-	auto &data_file_entries = StructVector::GetEntries(data_file_vector);
-	idx_t entry_index = 0;
+} // namespace
 
-	if (table_metadata.iceberg_version >= 2) {
-		auto content_writer = FlatVector::Writer<int32_t>(data_file_entries[entry_index++], 1, row_idx);
-		content_writer.WriteValue(static_cast<int32_t>(data_file.content));
-	}
-
-	auto file_path_writer = FlatVector::Writer<string_t>(data_file_entries[entry_index++], 1, row_idx);
-	file_path_writer.WriteValue(string_t(data_file.file_path));
-
-	auto file_format_writer = FlatVector::Writer<string_t>(data_file_entries[entry_index++], 1, row_idx);
-	file_format_writer.WriteValue(string_t(data_file.file_format));
-
-	WritePartitionStructRow(data_file_entries[entry_index++], row_idx, data_file, table_metadata,
-	                        schema_partition_info);
-
-	auto record_count_writer = FlatVector::Writer<int64_t>(data_file_entries[entry_index++], 1, row_idx);
-	record_count_writer.WriteValue(data_file.record_count);
-
-	auto file_size_writer = FlatVector::Writer<int64_t>(data_file_entries[entry_index++], 1, row_idx);
-	file_size_writer.WriteValue(data_file.file_size_in_bytes);
-
-	auto column_sizes_writer = FlatVector::Writer<VectorListType<VectorStructType<int32_t, int64_t>>>(
-	    data_file_entries[entry_index++], 1, row_idx);
-	WriteIntIntMap(column_sizes_writer, data_file.column_sizes);
-
-	auto value_counts_writer = FlatVector::Writer<VectorListType<VectorStructType<int32_t, int64_t>>>(
-	    data_file_entries[entry_index++], 1, row_idx);
-	WriteIntIntMap(value_counts_writer, data_file.value_counts);
-
-	auto null_value_counts_writer = FlatVector::Writer<VectorListType<VectorStructType<int32_t, int64_t>>>(
-	    data_file_entries[entry_index++], 1, row_idx);
-	WriteIntIntMap(null_value_counts_writer, data_file.null_value_counts);
-
-	auto nan_value_counts_writer = FlatVector::Writer<VectorListType<VectorStructType<int32_t, int64_t>>>(
-	    data_file_entries[entry_index++], 1, row_idx);
-	WriteIntIntMap(nan_value_counts_writer, data_file.nan_value_counts);
-
-	auto lower_bounds_writer = FlatVector::Writer<VectorListType<VectorStructType<int32_t, string_t>>>(
-	    data_file_entries[entry_index++], 1, row_idx);
-	WriteBoundsMap(lower_bounds_writer, data_file.lower_bounds);
-
-	auto upper_bounds_writer = FlatVector::Writer<VectorListType<VectorStructType<int32_t, string_t>>>(
-	    data_file_entries[entry_index++], 1, row_idx);
-	WriteBoundsMap(upper_bounds_writer, data_file.upper_bounds);
-
-	auto split_offsets_writer =
-	    FlatVector::Writer<VectorListType<int64_t>>(data_file_entries[entry_index++], 1, row_idx);
-	if (data_file.split_offsets.empty()) {
-		split_offsets_writer.WriteNull();
-	} else {
-		WriteInt64List(split_offsets_writer, data_file.split_offsets);
-	}
-
-	auto equality_ids_writer =
-	    FlatVector::Writer<VectorListType<int32_t>>(data_file_entries[entry_index++], 1, row_idx);
-	if (data_file.equality_ids.empty()) {
-		equality_ids_writer.WriteNull();
-	} else {
-		WriteInt32List(equality_ids_writer, data_file.equality_ids);
-	}
-
-	auto sort_order_writer = FlatVector::Writer<int32_t>(data_file_entries[entry_index++], 1, row_idx);
-	if (data_file.has_sort_order_id) {
-		sort_order_writer.WriteValue(data_file.sort_order_id);
-	} else {
-		sort_order_writer.WriteNull();
-	}
-
-	if (table_metadata.iceberg_version >= 3) {
-		auto first_row_id_writer = FlatVector::Writer<int64_t>(data_file_entries[entry_index++], 1, row_idx);
-		if (data_file.HasFirstRowId()) {
-			first_row_id_writer.WriteValue(data_file.GetFirstRowId());
-		} else {
-			first_row_id_writer.WriteNull();
-		}
-	}
-
-	if (table_metadata.iceberg_version >= 2) {
-		auto referenced_data_file_writer = FlatVector::Writer<string_t>(data_file_entries[entry_index++], 1, row_idx);
-		if (data_file.referenced_data_file.empty()) {
-			referenced_data_file_writer.WriteNull();
-		} else {
-			referenced_data_file_writer.WriteValue(string_t(data_file.referenced_data_file));
-		}
-	}
-
-	if (table_metadata.iceberg_version >= 3) {
-		auto content_offset_writer = FlatVector::Writer<int64_t>(data_file_entries[entry_index++], 1, row_idx);
-		if (data_file.content_offset.IsNull()) {
-			content_offset_writer.WriteNull();
-		} else {
-			content_offset_writer.WriteValue(data_file.content_offset.GetValue<int64_t>());
-		}
-
-		auto content_size_writer = FlatVector::Writer<int64_t>(data_file_entries[entry_index++], 1, row_idx);
-		if (data_file.content_size_in_bytes.IsNull()) {
-			content_size_writer.WriteNull();
-		} else {
-			content_size_writer.WriteValue(data_file.content_size_in_bytes.GetValue<int64_t>());
-		}
-	}
-}
+namespace manifest_file {
 
 static LogicalType PartitionStructType(vector<IcebergExtendedPartitionInfo> extended_partition_info) {
 	child_list_t<LogicalType> children;
@@ -746,6 +813,7 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	auto snapshot_id_writer = FlatVector::Writer<int64_t>(chunk.data[1], manifest_entries.size());
 	auto sequence_number_writer = FlatVector::Writer<int64_t>(chunk.data[2], manifest_entries.size());
 	auto file_sequence_number_writer = FlatVector::Writer<int64_t>(chunk.data[3], manifest_entries.size());
+	DataFileVectorWriters data_file_writers(chunk.data[4], manifest_entries.size(), table_metadata);
 
 	for (idx_t i = 0; i < manifest_entries.size(); i++) {
 		auto &manifest_entry = manifest_entries[i];
@@ -768,7 +836,7 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 			file_sequence_number_writer.WriteValue(manifest_entry.GetFileSequenceNumber(manifest_file));
 		}
 
-		WriteDataFileRow(table_metadata, chunk.data[4], i, manifest_entry.data_file, extended_partition_info);
+		data_file_writers.WriteRow(i, manifest_entry.data_file, extended_partition_info);
 	}
 	chunk.SetChildCardinality(manifest_entries.size());
 

--- a/src/core/metadata/manifest/iceberg_manifest.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest.cpp
@@ -26,15 +26,6 @@ using IntStringMapWriter = VectorWriter<VectorListType<VectorStructType<int32_t,
 using Int32ListWriter = VectorWriter<VectorListType<int32_t>>;
 using Int64ListWriter = VectorWriter<VectorListType<int64_t>>;
 
-template <class WRITER>
-static optional<WRITER> MakeOptionalWriterAt(bool enabled, vector<Vector> &vectors, idx_t vector_idx, idx_t row_count,
-                                             idx_t row_idx) {
-	if (!enabled) {
-		return std::nullopt;
-	}
-	return optional<WRITER>(std::in_place, vectors[vector_idx], row_count, row_idx);
-}
-
 template <class MAP>
 static void WriteIntIntMap(IntIntMapWriter &writer, const MAP &map);
 static void WriteBoundsMap(IntStringMapWriter &writer, const unordered_map<int32_t, Value> &bounds);
@@ -48,33 +39,39 @@ struct DataFileVectorWriters {
 	explicit DataFileVectorWriters(Vector &data_file_vector, idx_t row_count,
 	                               const IcebergTableMetadata &table_metadata)
 	    : table_metadata(table_metadata), data_file_entries(StructVector::GetEntries(data_file_vector)),
-	      content(MakeOptionalWriterAt<VectorWriter<int32_t>>(HasV2Fields(table_metadata), data_file_entries,
-	                                                          entry_index, row_count, 0)),
-	      file_path(data_file_entries[BaseFieldOffset(table_metadata)], row_count, 0),
-	      file_format(data_file_entries[BaseFieldOffset(table_metadata) + 1], row_count, 0),
-	      partition(data_file_entries[BaseFieldOffset(table_metadata) + 2]),
-	      record_count(data_file_entries[BaseFieldOffset(table_metadata) + 3], row_count, 0),
-	      file_size_in_bytes(data_file_entries[BaseFieldOffset(table_metadata) + 4], row_count, 0),
-	      column_sizes(data_file_entries[BaseFieldOffset(table_metadata) + 5], row_count, 0),
-	      value_counts(data_file_entries[BaseFieldOffset(table_metadata) + 6], row_count, 0),
-	      null_value_counts(data_file_entries[BaseFieldOffset(table_metadata) + 7], row_count, 0),
-	      nan_value_counts(data_file_entries[BaseFieldOffset(table_metadata) + 8], row_count, 0),
-	      lower_bounds(data_file_entries[BaseFieldOffset(table_metadata) + 9], row_count, 0),
-	      upper_bounds(data_file_entries[BaseFieldOffset(table_metadata) + 10], row_count, 0),
-	      split_offsets(data_file_entries[BaseFieldOffset(table_metadata) + 11], row_count, 0),
-	      equality_ids(data_file_entries[BaseFieldOffset(table_metadata) + 12], row_count, 0),
-	      sort_order_id(data_file_entries[BaseFieldOffset(table_metadata) + 13], row_count, 0),
-	      first_row_id(MakeOptionalWriterAt<VectorWriter<int64_t>>(HasV3Fields(table_metadata), data_file_entries,
-	                                                               BaseFieldOffset(table_metadata) + 14, row_count, 0)),
-	      referenced_data_file(MakeOptionalWriterAt<VectorWriter<string_t>>(
-	          HasV2Fields(table_metadata), data_file_entries,
-	          BaseFieldOffset(table_metadata) + 14 + V3FieldCount(table_metadata), row_count, 0)),
-	      content_offset(MakeOptionalWriterAt<VectorWriter<int64_t>>(
-	          HasV3Fields(table_metadata), data_file_entries,
-	          BaseFieldOffset(table_metadata) + 14 + 1 + V3FieldCount(table_metadata), row_count, 0)),
-	      content_size_in_bytes(MakeOptionalWriterAt<VectorWriter<int64_t>>(
-	          HasV3Fields(table_metadata), data_file_entries,
-	          BaseFieldOffset(table_metadata) + 14 + 2 + V3FieldCount(table_metadata), row_count, 0)) {
+	      file_path(data_file_entries[FILE_PATH_INDEX], row_count, 0),
+	      file_format(data_file_entries[FILE_FORMAT_INDEX], row_count, 0),
+	      partition(data_file_entries[PARTITION_INDEX]),
+	      record_count(data_file_entries[RECORD_COUNT_INDEX], row_count, 0),
+	      file_size_in_bytes(data_file_entries[FILE_SIZE_IN_BYTES_INDEX], row_count, 0),
+	      column_sizes(data_file_entries[COLUMN_SIZES_INDEX], row_count, 0),
+	      value_counts(data_file_entries[VALUE_COUNTS_INDEX], row_count, 0),
+	      null_value_counts(data_file_entries[NULL_VALUE_COUNTS_INDEX], row_count, 0),
+	      nan_value_counts(data_file_entries[NAN_VALUE_COUNTS_INDEX], row_count, 0),
+	      lower_bounds(data_file_entries[LOWER_BOUNDS_INDEX], row_count, 0),
+	      upper_bounds(data_file_entries[UPPER_BOUNDS_INDEX], row_count, 0),
+	      split_offsets(data_file_entries[SPLIT_OFFSETS_INDEX], row_count, 0),
+	      equality_ids(data_file_entries[EQUALITY_IDS_INDEX], row_count, 0),
+	      sort_order_id(data_file_entries[SORT_ORDER_ID_INDEX], row_count, 0),
+	      content(HasV2Fields(table_metadata)
+	                  ? optional<VectorWriter<int32_t>>(std::in_place, data_file_entries[CONTENT_INDEX], row_count, 0)
+	                  : std::nullopt),
+	      referenced_data_file(HasV2Fields(table_metadata)
+	                               ? optional<VectorWriter<string_t>>(
+	                                     std::in_place, data_file_entries[REFERENCED_DATA_FILE_INDEX], row_count, 0)
+	                               : std::nullopt),
+	      first_row_id(
+	          HasV3Fields(table_metadata)
+	              ? optional<VectorWriter<int64_t>>(std::in_place, data_file_entries[FIRST_ROW_ID_INDEX], row_count, 0)
+	              : std::nullopt),
+	      content_offset(HasV3Fields(table_metadata)
+	                         ? optional<VectorWriter<int64_t>>(std::in_place, data_file_entries[CONTENT_OFFSET_INDEX],
+	                                                           row_count, 0)
+	                         : std::nullopt),
+	      content_size_in_bytes(HasV3Fields(table_metadata)
+	                                ? optional<VectorWriter<int64_t>>(
+	                                      std::in_place, data_file_entries[CONTENT_SIZE_IN_BYTES_INDEX], row_count, 0)
+	                                : std::nullopt) {
 	}
 
 	void WriteRow(idx_t row_idx, const IcebergDataFile &data_file,
@@ -151,24 +148,35 @@ struct DataFileVectorWriters {
 	}
 
 private:
-	static constexpr idx_t entry_index = 0;
+	static constexpr idx_t FILE_PATH_INDEX = 0;
+	static constexpr idx_t FILE_FORMAT_INDEX = 1;
+	static constexpr idx_t PARTITION_INDEX = 2;
+	static constexpr idx_t RECORD_COUNT_INDEX = 3;
+	static constexpr idx_t FILE_SIZE_IN_BYTES_INDEX = 4;
+	static constexpr idx_t COLUMN_SIZES_INDEX = 5;
+	static constexpr idx_t VALUE_COUNTS_INDEX = 6;
+	static constexpr idx_t NULL_VALUE_COUNTS_INDEX = 7;
+	static constexpr idx_t NAN_VALUE_COUNTS_INDEX = 8;
+	static constexpr idx_t LOWER_BOUNDS_INDEX = 9;
+	static constexpr idx_t UPPER_BOUNDS_INDEX = 10;
+	static constexpr idx_t SPLIT_OFFSETS_INDEX = 11;
+	static constexpr idx_t EQUALITY_IDS_INDEX = 12;
+	static constexpr idx_t SORT_ORDER_ID_INDEX = 13;
+	static constexpr idx_t CONTENT_INDEX = 14;
+	static constexpr idx_t REFERENCED_DATA_FILE_INDEX = 15;
+	static constexpr idx_t FIRST_ROW_ID_INDEX = 16;
+	static constexpr idx_t CONTENT_OFFSET_INDEX = 17;
+	static constexpr idx_t CONTENT_SIZE_IN_BYTES_INDEX = 18;
 	static bool HasV2Fields(const IcebergTableMetadata &table_metadata) {
 		return table_metadata.iceberg_version >= 2;
 	}
 	static bool HasV3Fields(const IcebergTableMetadata &table_metadata) {
 		return table_metadata.iceberg_version >= 3;
 	}
-	static idx_t BaseFieldOffset(const IcebergTableMetadata &table_metadata) {
-		return entry_index + static_cast<idx_t>(HasV2Fields(table_metadata));
-	}
-	static idx_t V3FieldCount(const IcebergTableMetadata &table_metadata) {
-		return static_cast<idx_t>(HasV3Fields(table_metadata));
-	}
 
 public:
 	const IcebergTableMetadata &table_metadata;
 	vector<Vector> &data_file_entries;
-	optional<VectorWriter<int32_t>> content;
 	VectorWriter<string_t> file_path;
 	VectorWriter<string_t> file_format;
 	Vector &partition;
@@ -183,8 +191,9 @@ public:
 	Int64ListWriter split_offsets;
 	Int32ListWriter equality_ids;
 	VectorWriter<int32_t> sort_order_id;
-	optional<VectorWriter<int64_t>> first_row_id;
+	optional<VectorWriter<int32_t>> content;
 	optional<VectorWriter<string_t>> referenced_data_file;
+	optional<VectorWriter<int64_t>> first_row_id;
 	optional<VectorWriter<int64_t>> content_offset;
 	optional<VectorWriter<int64_t>> content_size_in_bytes;
 };
@@ -344,10 +353,6 @@ LogicalType IcebergDataFile::GetType(const IcebergTableMetadata &metadata, const
 
 	child_list_t<LogicalType> children;
 
-	if (iceberg_version >= 2) {
-		// content: int
-		children.emplace_back("content", LogicalType::INTEGER);
-	}
 	// file_path: string
 	children.emplace_back("file_path", LogicalType::VARCHAR);
 	// file_format: string
@@ -376,20 +381,22 @@ LogicalType IcebergDataFile::GetType(const IcebergTableMetadata &metadata, const
 	children.emplace_back("equality_ids", LogicalType::LIST(LogicalType::INTEGER));
 	// sort_id: int
 	children.emplace_back("sort_order_id", LogicalType::INTEGER);
-	// first_row_id: long
-	if (iceberg_version >= 3) {
-		children.emplace_back("first_row_id", LogicalType::BIGINT);
-	}
-	// referenced_data_file: string
+
+	// v2-only suffix
 	if (iceberg_version >= 2) {
+		// content: int
+		children.emplace_back("content", LogicalType::INTEGER);
+		// referenced_data_file: string
 		children.emplace_back("referenced_data_file", LogicalType::VARCHAR);
 	}
-	// content_offset: long
+
+	// v3-only suffix
 	if (iceberg_version >= 3) {
+		// first_row_id: long
+		children.emplace_back("first_row_id", LogicalType::BIGINT);
+		// content_offset: long
 		children.emplace_back("content_offset", LogicalType::BIGINT);
-	}
-	// content_size_in_bytes: long
-	if (iceberg_version >= 3) {
+		// content_size_in_bytes: long
 		children.emplace_back("content_size_in_bytes", LogicalType::BIGINT);
 	}
 
@@ -612,12 +619,6 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	child_list_t<Value> data_file_field_ids;
 	child_list_t<LogicalType> children;
 
-	if (table_metadata.iceberg_version >= 2) {
-		// content: int
-		children.emplace_back("content", LogicalType::INTEGER);
-		data_file_field_ids.emplace_back("content", CreateFieldID(CONTENT, false));
-	}
-
 	// file_path: string
 	children.emplace_back("file_path", LogicalType::VARCHAR);
 	data_file_field_ids.emplace_back("file_path", CreateFieldID(FILE_PATH, false));
@@ -773,26 +774,27 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	children.emplace_back("sort_order_id", LogicalType::INTEGER);
 	data_file_field_ids.emplace_back("sort_order_id", CreateFieldID(SORT_ORDER_ID, true));
 
-	if (table_metadata.iceberg_version >= 3) {
-		// first_row_id: optional long
-		children.emplace_back("first_row_id", LogicalType::BIGINT);
-		data_file_field_ids.emplace_back("first_row_id", CreateFieldID(FIRST_ROW_ID, true));
-	}
-
-	// referenced_data_file
+	// v2-only suffix
 	if (table_metadata.iceberg_version >= 2) {
+		// content: int
+		children.emplace_back("content", LogicalType::INTEGER);
+		data_file_field_ids.emplace_back("content", CreateFieldID(CONTENT, false));
+
 		// referenced_data_file: string
 		children.emplace_back("referenced_data_file", LogicalType::VARCHAR);
 		data_file_field_ids.emplace_back("referenced_data_file", CreateFieldID(REFERENCED_DATA_FILE, true));
 	}
-	// content_offset
+
+	// v3-only suffix
 	if (table_metadata.iceberg_version >= 3) {
+		// first_row_id: optional long
+		children.emplace_back("first_row_id", LogicalType::BIGINT);
+		data_file_field_ids.emplace_back("first_row_id", CreateFieldID(FIRST_ROW_ID, true));
+
 		// content_offset: long
 		children.emplace_back("content_offset", LogicalType::BIGINT);
 		data_file_field_ids.emplace_back("content_offset", CreateFieldID(CONTENT_OFFSET, true));
-	}
-	// content_size_in_bytes
-	if (table_metadata.iceberg_version >= 3) {
+
 		// content_size_in_bytes: long
 		children.emplace_back("content_size_in_bytes", LogicalType::BIGINT);
 		data_file_field_ids.emplace_back("content_size_in_bytes", CreateFieldID(CONTENT_SIZE_IN_BYTES, true));

--- a/src/core/metadata/manifest/iceberg_manifest.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest.cpp
@@ -26,71 +26,59 @@ using IntStringMapWriter = VectorWriter<VectorListType<VectorStructType<int32_t,
 using Int32ListWriter = VectorWriter<VectorListType<int32_t>>;
 using Int64ListWriter = VectorWriter<VectorListType<int64_t>>;
 
+template <class WRITER>
+static optional<WRITER> MakeOptionalWriterAt(bool enabled, vector<Vector> &vectors, idx_t vector_idx, idx_t row_count,
+                                             idx_t row_idx) {
+	if (!enabled) {
+		return std::nullopt;
+	}
+	return optional<WRITER>(std::in_place, vectors[vector_idx], row_count, row_idx);
+}
+
 template <class MAP>
 static void WriteIntIntMap(IntIntMapWriter &writer, const MAP &map);
-static void WriteBoundsMap(IntStringMapWriter &writer, const duckdb::unordered_map<int32_t, Value> &bounds);
-static void WriteInt32List(Int32ListWriter &writer, const duckdb::vector<int32_t> &values);
-static void WriteInt64List(Int64ListWriter &writer, const duckdb::vector<int64_t> &values);
+static void WriteBoundsMap(IntStringMapWriter &writer, const unordered_map<int32_t, Value> &bounds);
+static void WriteInt32List(Int32ListWriter &writer, const vector<int32_t> &values);
+static void WriteInt64List(Int64ListWriter &writer, const vector<int64_t> &values);
 static void WritePartitionStructRow(Vector &partition_vector, idx_t row_idx, const IcebergDataFile &data_file,
                                     const IcebergTableMetadata &table_metadata,
-                                    const duckdb::vector<IcebergExtendedPartitionInfo> &schema_partition_info);
+                                    const vector<IcebergExtendedPartitionInfo> &schema_partition_info);
 
 struct DataFileVectorWriters {
 	explicit DataFileVectorWriters(Vector &data_file_vector, idx_t row_count,
 	                               const IcebergTableMetadata &table_metadata)
 	    : table_metadata(table_metadata), data_file_entries(StructVector::GetEntries(data_file_vector)),
-	      content(table_metadata.iceberg_version >= 2
-	                  ? optional<VectorWriter<int32_t>>(std::in_place, data_file_entries[entry_index], row_count, 0)
-	                  : std::nullopt),
-	      file_path(data_file_entries[entry_index + static_cast<idx_t>(content.has_value())], row_count, 0),
-	      file_format(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 1], row_count, 0),
-	      partition(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 2]),
-	      record_count(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 3], row_count, 0),
-	      file_size_in_bytes(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 4], row_count,
-	                         0),
-	      column_sizes(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 5], row_count, 0),
-	      value_counts(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 6], row_count, 0),
-	      null_value_counts(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 7], row_count, 0),
-	      nan_value_counts(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 8], row_count, 0),
-	      lower_bounds(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 9], row_count, 0),
-	      upper_bounds(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 10], row_count, 0),
-	      split_offsets(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 11], row_count, 0),
-	      equality_ids(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 12], row_count, 0),
-	      sort_order_id(data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 13], row_count, 0),
-	      first_row_id(table_metadata.iceberg_version >= 3
-	                       ? optional<VectorWriter<int64_t>>(
-	                             std::in_place,
-	                             data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 14],
-	                             row_count, 0)
-	                       : std::nullopt),
-	      referenced_data_file(table_metadata.iceberg_version >= 2
-	                               ? optional<VectorWriter<string_t>>(
-	                                     std::in_place,
-	                                     data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 14 +
-	                                                       static_cast<idx_t>(first_row_id.has_value())],
-	                                     row_count, 0)
-	                               : std::nullopt),
-	      content_offset(table_metadata.iceberg_version >= 3
-	                         ? optional<VectorWriter<int64_t>>(
-	                               std::in_place,
-	                               data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 14 +
-	                                                 static_cast<idx_t>(first_row_id.has_value()) +
-	                                                 static_cast<idx_t>(referenced_data_file.has_value())],
-	                               row_count, 0)
-	                         : std::nullopt),
-	      content_size_in_bytes(table_metadata.iceberg_version >= 3
-	                                ? optional<VectorWriter<int64_t>>(
-	                                      std::in_place,
-	                                      data_file_entries[entry_index + static_cast<idx_t>(content.has_value()) + 14 +
-	                                                        static_cast<idx_t>(first_row_id.has_value()) +
-	                                                        static_cast<idx_t>(referenced_data_file.has_value()) +
-	                                                        static_cast<idx_t>(content_offset.has_value())],
-	                                      row_count, 0)
-	                                : std::nullopt) {
+	      content(MakeOptionalWriterAt<VectorWriter<int32_t>>(HasV2Fields(table_metadata), data_file_entries,
+	                                                          entry_index, row_count, 0)),
+	      file_path(data_file_entries[BaseFieldOffset(table_metadata)], row_count, 0),
+	      file_format(data_file_entries[BaseFieldOffset(table_metadata) + 1], row_count, 0),
+	      partition(data_file_entries[BaseFieldOffset(table_metadata) + 2]),
+	      record_count(data_file_entries[BaseFieldOffset(table_metadata) + 3], row_count, 0),
+	      file_size_in_bytes(data_file_entries[BaseFieldOffset(table_metadata) + 4], row_count, 0),
+	      column_sizes(data_file_entries[BaseFieldOffset(table_metadata) + 5], row_count, 0),
+	      value_counts(data_file_entries[BaseFieldOffset(table_metadata) + 6], row_count, 0),
+	      null_value_counts(data_file_entries[BaseFieldOffset(table_metadata) + 7], row_count, 0),
+	      nan_value_counts(data_file_entries[BaseFieldOffset(table_metadata) + 8], row_count, 0),
+	      lower_bounds(data_file_entries[BaseFieldOffset(table_metadata) + 9], row_count, 0),
+	      upper_bounds(data_file_entries[BaseFieldOffset(table_metadata) + 10], row_count, 0),
+	      split_offsets(data_file_entries[BaseFieldOffset(table_metadata) + 11], row_count, 0),
+	      equality_ids(data_file_entries[BaseFieldOffset(table_metadata) + 12], row_count, 0),
+	      sort_order_id(data_file_entries[BaseFieldOffset(table_metadata) + 13], row_count, 0),
+	      first_row_id(MakeOptionalWriterAt<VectorWriter<int64_t>>(HasV3Fields(table_metadata), data_file_entries,
+	                                                               BaseFieldOffset(table_metadata) + 14, row_count, 0)),
+	      referenced_data_file(MakeOptionalWriterAt<VectorWriter<string_t>>(
+	          HasV2Fields(table_metadata), data_file_entries,
+	          BaseFieldOffset(table_metadata) + 14 + V3FieldCount(table_metadata), row_count, 0)),
+	      content_offset(MakeOptionalWriterAt<VectorWriter<int64_t>>(
+	          HasV3Fields(table_metadata), data_file_entries,
+	          BaseFieldOffset(table_metadata) + 14 + 1 + V3FieldCount(table_metadata), row_count, 0)),
+	      content_size_in_bytes(MakeOptionalWriterAt<VectorWriter<int64_t>>(
+	          HasV3Fields(table_metadata), data_file_entries,
+	          BaseFieldOffset(table_metadata) + 14 + 2 + V3FieldCount(table_metadata), row_count, 0)) {
 	}
 
 	void WriteRow(idx_t row_idx, const IcebergDataFile &data_file,
-	              const duckdb::vector<IcebergExtendedPartitionInfo> &schema_partition_info) {
+	              const vector<IcebergExtendedPartitionInfo> &schema_partition_info) {
 		if (content) {
 			content->WriteValue(static_cast<int32_t>(data_file.content));
 		}
@@ -164,10 +152,22 @@ struct DataFileVectorWriters {
 
 private:
 	static constexpr idx_t entry_index = 0;
+	static bool HasV2Fields(const IcebergTableMetadata &table_metadata) {
+		return table_metadata.iceberg_version >= 2;
+	}
+	static bool HasV3Fields(const IcebergTableMetadata &table_metadata) {
+		return table_metadata.iceberg_version >= 3;
+	}
+	static idx_t BaseFieldOffset(const IcebergTableMetadata &table_metadata) {
+		return entry_index + static_cast<idx_t>(HasV2Fields(table_metadata));
+	}
+	static idx_t V3FieldCount(const IcebergTableMetadata &table_metadata) {
+		return static_cast<idx_t>(HasV3Fields(table_metadata));
+	}
 
 public:
 	const IcebergTableMetadata &table_metadata;
-	duckdb::vector<Vector> &data_file_entries;
+	vector<Vector> &data_file_entries;
 	optional<VectorWriter<int32_t>> content;
 	VectorWriter<string_t> file_path;
 	VectorWriter<string_t> file_format;
@@ -520,8 +520,9 @@ static void WritePartitionStructRow(Vector &partition_vector, idx_t row_idx, con
 		return;
 	}
 
+	auto extended_partition_info = data_file.GetExtendedPartitionInfo(table_metadata);
 	unordered_map<uint64_t, const Value *> value_by_field_id;
-	for (auto &entry : data_file.GetExtendedPartitionInfo(table_metadata)) {
+	for (auto &entry : extended_partition_info) {
 		value_by_field_id.emplace(entry.field_id, &entry.value);
 	}
 	for (idx_t child_idx = 0; child_idx < schema_partition_info.size(); child_idx++) {

--- a/src/include/core/metadata/manifest/iceberg_manifest.hpp
+++ b/src/include/core/metadata/manifest/iceberg_manifest.hpp
@@ -67,9 +67,6 @@ struct IcebergPartitionInfo {
 
 struct IcebergDataFile {
 public:
-	Value ToValue(const IcebergTableMetadata &table_metadata, const LogicalType &type) const;
-
-public:
 	static map<idx_t, LogicalType> GetFieldIdToTypeMapping(const IcebergSnapshotScanInfo &snapshot_info,
 	                                                       const IcebergTableMetadata &metadata,
 	                                                       const unordered_set<int32_t> &partition_spec_ids);

--- a/src/planning/metadata_io/manifest/iceberg_manifest_reader.cpp
+++ b/src/planning/metadata_io/manifest/iceberg_manifest_reader.cpp
@@ -139,14 +139,6 @@ void ManifestReader::ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &
 	auto &data_file = chunk.data[vector_index++];
 	idx_t entry_index = 0;
 	auto &data_file_entries = StructVector::GetEntries(data_file);
-
-	optional_ptr<Vector> content;
-	optional<Int32Entries> content_entries;
-	if (iceberg_version >= 2) {
-		content = data_file_entries[entry_index++];
-		content_entries.emplace(content->Values<int32_t>());
-	}
-
 	auto &file_path = data_file_entries[entry_index++];
 	auto file_path_entries = file_path.Values<string_t>();
 
@@ -188,18 +180,23 @@ void ManifestReader::ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &
 	auto &sort_order_id = data_file_entries[entry_index++];
 	auto sort_order_id_entries = sort_order_id.Values<int32_t>();
 
+	optional_ptr<Vector> content;
+	optional<Int32Entries> content_entries;
+	optional_ptr<Vector> referenced_data_file;
+	optional<StringEntries> referenced_data_file_entries;
+	if (iceberg_version >= 2) {
+		content = data_file_entries[entry_index++];
+		content_entries.emplace(content->Values<int32_t>());
+
+		referenced_data_file = data_file_entries[entry_index++];
+		referenced_data_file_entries.emplace(referenced_data_file->Values<string_t>());
+	}
+
 	optional_ptr<Vector> first_row_id;
 	optional<Int64Entries> first_row_id_entries;
 	if (iceberg_version >= 3) {
 		first_row_id = data_file_entries[entry_index++];
 		first_row_id_entries.emplace(first_row_id->Values<int64_t>());
-	}
-
-	optional_ptr<Vector> referenced_data_file;
-	optional<StringEntries> referenced_data_file_entries;
-	if (iceberg_version >= 2) {
-		referenced_data_file = data_file_entries[entry_index++];
-		referenced_data_file_entries.emplace(referenced_data_file->Values<string_t>());
 	}
 	optional_ptr<Vector> content_offset;
 	optional<Int64Entries> content_offset_entries;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_append_retry_v3_row_lineage.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_append_retry_v3_row_lineage.test
@@ -51,6 +51,22 @@ commit
 statement ok con2
 commit
 
+statement ok
+SET VARIABLE append_retry_manifest = (
+	SELECT manifest_path FROM iceberg_metadata(my_datalake.default.append_retry_v3_row_lineage)
+	ORDER BY manifest_sequence_number DESC LIMIT 1
+);
+
+query IIII
+SELECT
+	first_row_id IS NULL,
+	referenced_data_file IS NULL,
+	content_offset IS NULL,
+	content_size_in_bytes IS NULL
+FROM (SELECT unnest(data_file) FROM read_avro(getvariable('append_retry_manifest')));
+----
+true	true	true	true
+
 query IIII
 select _last_updated_sequence_number, _row_id, id, payload
 from my_datalake.default.append_retry_v3_row_lineage

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_value_counts.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_value_counts.test
@@ -64,6 +64,17 @@ ORDER BY ALL;
 3	100
 4	100
 
+query IIIII
+SELECT
+	column_sizes IS NOT NULL,
+	nan_value_counts IS NOT NULL,
+	split_offsets IS NULL,
+	sort_order_id IS NULL,
+	referenced_data_file IS NULL
+FROM (SELECT unnest(data_file) FROM read_avro(getvariable('manifest_all_null')));
+----
+true	true	true	true	true
+
 # --- All NaN floats: value_counts = 100, null_value_counts = 0 ---
 statement ok
 DROP TABLE IF EXISTS my_datalake.default.value_counts_all_nan;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/test_row_lineage_write.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/test_row_lineage_write.test
@@ -40,6 +40,22 @@ insert into my_datalake.default.duckdb_row_lineage values
 	(4, 'd'),
 	(5, 'e');
 
+statement ok
+SET VARIABLE row_lineage_manifest = (
+	SELECT manifest_path FROM iceberg_metadata(my_datalake.default.duckdb_row_lineage)
+	ORDER BY manifest_sequence_number DESC LIMIT 1
+);
+
+query IIII
+SELECT
+	first_row_id IS NULL, -- Left NULL for inheritance purposes (OCC reasons)
+	referenced_data_file IS NULL,
+	content_offset IS NULL,
+	content_size_in_bytes IS NULL
+FROM (SELECT unnest(data_file) FROM read_avro(getvariable('row_lineage_manifest')));
+----
+true	true	true	true
+
 query IIII
 select _last_updated_sequence_number, _row_id, id, data from my_datalake.default.duckdb_row_lineage order by _row_id;
 ----


### PR DESCRIPTION
This PR reorders written fields to optimize for writing logic
Since all fields in the metadata are mapped by field-id, the physical offset shouldn't matter