### PR TITLE
Truncate string lower bounds on code point boundaries

### DIFF
--- a/src/core/expression/iceberg_value.cpp
+++ b/src/core/expression/iceberg_value.cpp
@@ -240,11 +240,19 @@ DeserializeResult IcebergValue::DeserializeValue(const string_t &blob, const Log
 
 const idx_t IcebergValue::MAX_STRING_UPPERBOUND_LENGTH;
 
+// Largest length <= MAX_STRING_UPPERBOUND_LENGTH that does not split a multi-byte
+// UTF-8 character, so a truncated bound stays valid UTF-8.
+static idx_t TruncateToCodePointBoundary(const string &input) {
+	idx_t len = std::min<idx_t>(IcebergValue::MAX_STRING_UPPERBOUND_LENGTH, input.size());
+	while (len < input.size() && (static_cast<unsigned char>(input[len]) & 0xC0) == 0x80) {
+		len--;
+	}
+	return len;
+}
+
 string IcebergValue::TruncateString(const string &input) {
-	std::vector<unsigned char> bytes(input.begin(), input.end());
-	idx_t truncated_length = std::min<idx_t>(IcebergValue::MAX_STRING_UPPERBOUND_LENGTH, bytes.size());
-	bytes.resize(truncated_length);
-	return std::string(bytes.begin(), bytes.end());
+	// A prefix truncated on a code-point boundary is a valid lower bound (<= input).
+	return input.substr(0, TruncateToCodePointBoundary(input));
 }
 
 bool IcebergValue::TruncateAndIncrementString(const string &input, string &result) {
@@ -255,12 +263,9 @@ bool IcebergValue::TruncateAndIncrementString(const string &input, string &resul
 		return true;
 	}
 
-	// Truncate to at most MAX_STRING_UPPERBOUND_LENGTH bytes, backing off so we
-	// never split a multi-byte UTF-8 character.
-	idx_t len = IcebergValue::MAX_STRING_UPPERBOUND_LENGTH;
-	while (len > 0 && (static_cast<unsigned char>(input[len]) & 0xC0) == 0x80) {
-		len--;
-	}
+	// Truncate to a code-point boundary, then round up to a valid upper bound by
+	// incrementing the last code point below.
+	idx_t len = TruncateToCodePointBoundary(input);
 
 	// Round the truncated prefix up to a valid upper bound by incrementing the
 	// last code point to the next scalar value (skipping the UTF-16 surrogate

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_non_ascii_string_lower_bound.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_non_ascii_string_lower_bound.test
@@ -1,0 +1,61 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_non_ascii_string_lower_bound.test
+# description: A long non-ASCII string (multi-byte UTF-8) must produce a valid-UTF-8 lower bound; the min truncation backs off to a code point boundary instead of splitting a multi-byte character, so strict readers don't fail with "Failed to decode value as UTF-8".
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.non_ascii_lower_bound_test;
+
+statement ok
+create table my_datalake.default.non_ascii_lower_bound_test (
+    id int,
+    title varchar
+);
+
+# "El cliente quer" is 15 ASCII bytes, then 'í' (0xC3 0xAD): a byte-exact 16-byte
+# lower bound keeps the leading 0xC3 and drops the 0xAD, producing invalid UTF-8.
+statement ok
+insert into my_datalake.default.non_ascii_lower_bound_test values
+    (1, 'El cliente querído resolver el problema'),
+    (2, 'zzzz ascii tail that is comfortably long');
+
+# Data round-trips intact.
+query IT
+select id, title from my_datalake.default.non_ascii_lower_bound_test order by id;
+----
+1	El cliente querído resolver el problema
+2	zzzz ascii tail that is comfortably long
+
+statement ok
+set variable mp = (select manifest_path from iceberg_metadata(my_datalake.default.non_ascii_lower_bound_test) order by manifest_sequence_number desc limit 1);
+
+# The varchar column (field id 2) gets a lower bound.
+query I
+select count(*) from (
+    select unnest(map_keys(lower_bounds)) k
+    from (select unnest(data_file) from read_avro(getvariable('mp')))
+) where k = 2;
+----
+1
+
+# And it is a valid lower bound: decoded (valid UTF-8), it is <= the column's min value.
+query I
+select decode(lb) <= (select min(title) from my_datalake.default.non_ascii_lower_bound_test)
+from (
+    select unnest(map_keys(lower_bounds)) k, unnest(map_values(lower_bounds)) lb
+    from (select unnest(data_file) from read_avro(getvariable('mp')))
+) where k = 2;
+----
+true


### PR DESCRIPTION
Similar to #1022 (which made string **upper** bounds code-point-safe and explicitly left the lower bound on plain truncation) — this fixes the **lower** bound.

## Problem

`IcebergValue::TruncateString` (the `SerializeBound::LOWER_BOUND` path for `VARCHAR`) truncates to a raw 16-byte prefix with no UTF-8 validation. When the cut lands inside a multi-byte code point, the written `data_file.lower_bounds` entry is **invalid UTF-8**. DuckDB's own reader tolerates it, but strict Iceberg readers reject it — e.g. Trino/Athena reading `$partitions` / `$manifests` fail with:

```
GENERIC_INTERNAL_ERROR: Failed to decode value as UTF-8: java.nio.HeapByteBuffer[pos=0 lim=16 cap=16]
```

even though the table data itself reads fine. This shows up in practice on free-text columns with accents / em-dashes (e.g. Spanish `í` = `0xC3 0xAD`, `—` = `0xE2 0x80 0x94`).

## Fix

Back the truncation off to the previous code-point boundary — a prefix truncated on a boundary is still a valid lower bound (a prefix is always `<=` the value), and stays valid UTF-8. This is the round-down counterpart of Iceberg-Java's `UnicodeUtil.truncateStringMin` (`TruncateAndIncrementString` already implements the round-up `truncateStringMax`).

The multi-byte back-off previously inlined in `TruncateAndIncrementString` is factored into a small `TruncateToCodePointBoundary` helper now shared by both bound paths, so the lower/upper truncation can't drift.

## Test

Adds `test_write_non_ascii_string_lower_bound.test`, mirroring the upper-bound test from #1022: inserts a long non-ASCII string, asserts the data round-trips and the written lower bound is valid UTF-8 and `<=` the column min.

## Validation

Reproduced the exact Athena failure and the fix on a real Glue catalog via an A/B: two tables with identical data differing only in the `title` lower bound — the byte-truncated bound (`…c3`) fails the `$partitions` read with the error above; the code-point-truncated bound (`…c3ad` = `"El cliente querí"`, what this patch produces) is accepted. Data scans succeed in both, confirming the fault is purely the manifest bound.

Relates to #1136.