### PR TITLE
[Dev] Get rid of the `read_parquet(get_variable(...))` pattern in certain tests

### DIFF
--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/test_insert_into_partitioned_sorted_table.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/test_insert_into_partitioned_sorted_table.test
@@ -44,12 +44,6 @@ set variable table_sort_order_id = (
 );
 
 statement ok
-set variable table_data_glob = (
-	select metadata.location || '/data/*/*.parquet'
-	from iceberg_load_table_response(my_datalake.default.partitioned_sorted_insert_write_test)
-);
-
-statement ok
 insert into my_datalake.default.partitioned_sorted_insert_write_test
 values
 	(1, 2, 20),
@@ -108,7 +102,7 @@ with latest_files as (
 ),
 file_partition_counts as (
 	select filename, count(distinct p) as partition_count
-	from read_parquet(getvariable('table_data_glob'), filename=true)
+	from my_datalake.default.partitioned_sorted_insert_write_test
 	where filename in (select file_path from latest_files)
 	group by filename
 )
@@ -118,8 +112,9 @@ where partition_count != 1;
 ----
 0
 
-# Read every newly added parquet file back directly, then use file_row_number to
-# verify that rows are physically written in table sort-key order within each file.
+# Use the latest added file handles from the Iceberg scan itself, then use
+# file_row_number to verify that rows are physically written in table sort-key
+# order within each file.
 query I
 with latest_files as (
 	select file_path
@@ -136,7 +131,7 @@ ordered_rows as (
 		b,
 		lag(a) over(partition by filename order by file_row_number) prev_a,
 		lag(b) over(partition by filename order by file_row_number) prev_b
-	from read_parquet(getvariable('table_data_glob'), filename=true, file_row_number=true)
+	from my_datalake.default.partitioned_sorted_insert_write_test
 	where filename in (select file_path from latest_files)
 )
 select count(*)

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_into_sorted_table.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_into_sorted_table.test
@@ -90,8 +90,8 @@ set variable manifest_path = (
 	limit 1
 );
 
-# Read the newly written parquet file directly and use file_row_number to compare
-# each row against the previous one in physical write order.
+# Use the Iceberg scan handle and file_row_number to compare each row against
+# the previous one in physical write order.
 query I
 with ordered_rows as (
 	select
@@ -101,7 +101,8 @@ with ordered_rows as (
 		b,
 		lag(a) over(partition by filename order by file_row_number) prev_a,
 		lag(b) over(partition by filename order by file_row_number) prev_b
-	from read_parquet(getvariable('file_path'), filename=true, file_row_number=true)
+	from my_datalake.default.sorted_insert_write_test
+	where filename = getvariable('file_path')
 )
 select count(*)
 from ordered_rows

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_update_insert_partitioned_ordered.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_update_insert_partitioned_ordered.test
@@ -46,12 +46,6 @@ set variable table_sort_order_id = (
 );
 
 statement ok
-set variable table_data_glob = (
-	select metadata.location || '/data/*/*.parquet'
-	from iceberg_load_table_response(my_datalake.default.merge_update_insert_partitioned_ordered)
-);
-
-statement ok
 insert into my_datalake.default.merge_update_insert_partitioned_ordered values
 	(1, 1, 2, 20),
 	(2, 1, 1, 30),
@@ -98,8 +92,9 @@ set variable manifest_path = (
 	limit 1
 );
 
-# Read the newly added parquet files directly and use file_row_number so the test
-# checks the physical row order DuckDB wrote within each partition file.
+# Use the latest added file handles from the Iceberg scan itself so the test
+# checks both per-file partition isolation and the physical row order DuckDB
+# wrote within each partition file.
 query I
 with latest_files as (
 	select file_path
@@ -110,7 +105,7 @@ with latest_files as (
 ),
 file_partition_counts as (
 	select filename, count(distinct p) as partition_count
-	from read_parquet(getvariable('table_data_glob'), filename=true)
+	from my_datalake.default.merge_update_insert_partitioned_ordered
 	where filename in (select file_path from latest_files)
 	group by filename
 ),
@@ -122,7 +117,7 @@ ordered_rows as (
 		b,
 		lag(a) over(partition by filename order by file_row_number) prev_a,
 		lag(b) over(partition by filename order by file_row_number) prev_b
-	from read_parquet(getvariable('table_data_glob'), filename=true, file_row_number=true)
+	from my_datalake.default.merge_update_insert_partitioned_ordered
 	where filename in (select file_path from latest_files)
 )
 select

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_update_insert_partitioned_unordered.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_update_insert_partitioned_unordered.test
@@ -34,12 +34,6 @@ create table my_datalake.default.merge_update_insert_partitioned_unordered (
 partitioned by (p);
 
 statement ok
-set variable table_data_glob = (
-	select metadata.location || '/data/*/*.parquet'
-	from iceberg_load_table_response(my_datalake.default.merge_update_insert_partitioned_unordered)
-);
-
-statement ok
 insert into my_datalake.default.merge_update_insert_partitioned_unordered values
 	(1, 1, 2, 20),
 	(2, 1, 1, 30),
@@ -96,7 +90,7 @@ with latest_files as (
 ),
 file_partition_counts as (
 	select filename, count(distinct p) as partition_count
-	from read_parquet(getvariable('table_data_glob'), filename=true)
+	from my_datalake.default.merge_update_insert_partitioned_unordered
 	where filename in (select file_path from latest_files)
 	group by filename
 )

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_update_insert_unpartitioned_ordered.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_update_insert_unpartitioned_ordered.test
@@ -45,12 +45,6 @@ set variable table_sort_order_id = (
 );
 
 statement ok
-set variable table_data_glob = (
-	select metadata.location || '/data/*.parquet'
-	from iceberg_load_table_response(my_datalake.default.merge_update_insert_unpartitioned_ordered)
-);
-
-statement ok
 insert into my_datalake.default.merge_update_insert_unpartitioned_ordered values
 	(1, 1, 2, 20),
 	(2, 1, 1, 30),
@@ -97,7 +91,7 @@ set variable manifest_path = (
 	limit 1
 );
 
-# Read the newly added parquet files directly and use file_row_number so the test
+# Use the latest added file handles from the Iceberg scan itself so the test
 # checks the physical row order DuckDB wrote, not the logical query order.
 query I
 with latest_files as (
@@ -115,7 +109,7 @@ ordered_rows as (
 		b,
 		lag(a) over(partition by filename order by file_row_number) prev_a,
 		lag(b) over(partition by filename order by file_row_number) prev_b
-	from read_parquet(getvariable('table_data_glob'), filename=true, file_row_number=true)
+	from my_datalake.default.merge_update_insert_unpartitioned_ordered
 	where filename in (select file_path from latest_files)
 )
 select count(*)

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/bucket/bucket_integer.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/bucket/bucket_integer.test
@@ -67,11 +67,12 @@ set variable file_path = (
 	limit 1
 );
 
-# Read the parquet file back directly and assert the exact physical row order
-# by sorting on file_row_number.
+# Use the Iceberg scan handle and assert the exact physical row order by sorting
+# on file_row_number.
 query III
 select iceberg_bucket(4, val) as sort_key, id, val
-from read_parquet(getvariable('file_path'), file_row_number=true)
+from my_datalake.default.sort_bucket_integer
+where filename = getvariable('file_path')
 order by file_row_number;
 ----
 0	1	10

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/day/day_timestamp.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/day/day_timestamp.test
@@ -67,11 +67,12 @@ set variable file_path = (
 	limit 1
 );
 
-# Read the parquet file back directly and assert the exact physical row order
-# by sorting on file_row_number.
+# Use the Iceberg scan handle and assert the exact physical row order by sorting
+# on file_row_number.
 query IT
 select id, ts
-from read_parquet(getvariable('file_path'), file_row_number=true)
+from my_datalake.default.sort_day_timestamp
+where filename = getvariable('file_path')
 order by file_row_number;
 ----
 1	2020-01-04 03:00:00

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/day/day_timestamptz.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/day/day_timestamptz.test
@@ -60,7 +60,10 @@ set variable file_path = (
 );
 
 query IT
-select id, ts from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, ts
+from my_datalake.default.sort_day_timestamptz
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	2020-01-04 04:00:00+01
 2	2020-01-31 06:00:00+01

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/hour/hour_timestamp.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/hour/hour_timestamp.test
@@ -67,11 +67,12 @@ set variable file_path = (
 	limit 1
 );
 
-# Read the parquet file back directly and assert the exact physical row order
-# by sorting on file_row_number.
+# Use the Iceberg scan handle and assert the exact physical row order by sorting
+# on file_row_number.
 query IT
 select id, ts
-from read_parquet(getvariable('file_path'), file_row_number=true)
+from my_datalake.default.sort_hour_timestamp
+where filename = getvariable('file_path')
 order by file_row_number;
 ----
 1	2020-02-02 08:00:00

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_bigint.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_bigint.test
@@ -50,7 +50,10 @@ set variable file_path = (
 );
 
 query II
-select id, sort_col from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, sort_col
+from my_datalake.default.sort_identity_bigint
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	10
 2	10

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_binary.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_binary.test
@@ -43,7 +43,10 @@ set variable file_path = (
 );
 
 query II
-select id, sort_col from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, sort_col
+from my_datalake.default.sort_identity_binary
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	\x01
 2	\x01

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_bool.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_bool.test
@@ -42,7 +42,10 @@ set variable file_path = (
 );
 
 query II
-select id, sort_col from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, sort_col
+from my_datalake.default.sort_identity_bool
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	false
 2	false

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_date_and_string.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_date_and_string.test
@@ -43,7 +43,10 @@ set variable file_path = (
 );
 
 query IT
-select id, sort_col from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, sort_col
+from my_datalake.default.sort_identity_date
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	2020-01-01
 2	2020-01-01
@@ -77,7 +80,10 @@ set variable file_path = (
 );
 
 query IT
-select id, sort_col from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, sort_col
+from my_datalake.default.sort_identity_string
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	alpha
 2	alpha

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_decimal_bigint.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_decimal_bigint.test
@@ -43,7 +43,10 @@ set variable file_path = (
 );
 
 query II
-select id, sort_col from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, sort_col
+from my_datalake.default.sort_identity_decimal_bigint
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	10.00
 2	10.00

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_decimal_hugeint.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_decimal_hugeint.test
@@ -43,7 +43,10 @@ set variable file_path = (
 );
 
 query II
-select id, sort_col from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, sort_col
+from my_datalake.default.sort_identity_decimal_hugeint
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	10.00
 2	10.00

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_decimal_integer.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_decimal_integer.test
@@ -43,7 +43,10 @@ set variable file_path = (
 );
 
 query II
-select id, sort_col from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, sort_col
+from my_datalake.default.sort_identity_decimal_integer
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	10.00
 2	10.00

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_decimal_smallint.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_decimal_smallint.test
@@ -43,7 +43,10 @@ set variable file_path = (
 );
 
 query II
-select id, sort_col from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, sort_col
+from my_datalake.default.sort_identity_decimal_smallint
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	1.0
 2	1.0

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_double.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_double.test
@@ -42,7 +42,10 @@ set variable file_path = (
 );
 
 query II
-select id, sort_col from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, sort_col
+from my_datalake.default.sort_identity_double
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	1.5
 2	1.5

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_float.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_float.test
@@ -42,7 +42,10 @@ set variable file_path = (
 );
 
 query II
-select id, sort_col from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, sort_col
+from my_datalake.default.sort_identity_float
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	1.5
 2	1.5

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_integer.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_integer.test
@@ -72,11 +72,12 @@ set variable file_path = (
 	limit 1
 );
 
-# Read the newly written parquet file directly and assert the exact physical row
-# order by sorting on file_row_number.
+# Use the Iceberg scan handle and assert the exact physical row order by sorting
+# on file_row_number.
 query II
 select id, sort_col
-from read_parquet(getvariable('file_path'), file_row_number=true)
+from my_datalake.default.sort_identity_integer
+where filename = getvariable('file_path')
 order by file_row_number;
 ----
 1	10

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_time.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_time.test
@@ -43,7 +43,10 @@ set variable file_path = (
 );
 
 query IT
-select id, sort_col from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, sort_col
+from my_datalake.default.sort_identity_time
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	09:00:00
 2	09:00:00

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_timestamp.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_timestamp.test
@@ -43,7 +43,10 @@ set variable file_path = (
 );
 
 query IT
-select id, sort_col from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, sort_col
+from my_datalake.default.sort_identity_timestamp
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	2020-01-01 09:00:00
 2	2020-01-01 09:00:00

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_timestamptz.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/identity/identity_timestamptz.test
@@ -51,7 +51,10 @@ set variable file_path = (
 );
 
 query IT
-select id, sort_col from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, sort_col
+from my_datalake.default.sort_identity_timestamptz
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	2020-01-01 10:00:00+01
 2	2020-01-01 10:00:00+01

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/month/month_timestamp.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/month/month_timestamp.test
@@ -67,11 +67,12 @@ set variable file_path = (
 	limit 1
 );
 
-# Read the parquet file back directly and assert the exact physical row order
-# by sorting on file_row_number.
+# Use the Iceberg scan handle and assert the exact physical row order by sorting
+# on file_row_number.
 query IT
 select id, ts
-from read_parquet(getvariable('file_path'), file_row_number=true)
+from my_datalake.default.sort_month_timestamp
+where filename = getvariable('file_path')
 order by file_row_number;
 ----
 2	2019-12-31 05:00:00

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/truncate/truncate_integer.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/truncate/truncate_integer.test
@@ -67,11 +67,12 @@ set variable file_path = (
 	limit 1
 );
 
-# Read the parquet file back directly and assert the exact physical row order
-# by sorting on file_row_number.
+# Use the Iceberg scan handle and assert the exact physical row order by sorting
+# on file_row_number.
 query III
 select iceberg_truncate(10, val) as sort_key, id, val
-from read_parquet(getvariable('file_path'), file_row_number=true)
+from my_datalake.default.sort_truncate_integer
+where filename = getvariable('file_path')
 order by file_row_number;
 ----
 -10	2	-1

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/year/year_timestamp.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/year/year_timestamp.test
@@ -67,11 +67,12 @@ set variable file_path = (
 	limit 1
 );
 
-# Read the parquet file back directly and assert the exact physical row order
-# by sorting on file_row_number.
+# Use the Iceberg scan handle and assert the exact physical row order by sorting
+# on file_row_number.
 query IT
 select id, ts
-from read_parquet(getvariable('file_path'), file_row_number=true)
+from my_datalake.default.sort_year_timestamp
+where filename = getvariable('file_path')
 order by file_row_number;
 ----
 1	2019-07-04 03:00:00

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/year/year_timestamptz.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/sorting/year/year_timestamptz.test
@@ -60,7 +60,10 @@ set variable file_path = (
 );
 
 query IT
-select id, ts from read_parquet(getvariable('file_path'), file_row_number=true) order by file_row_number;
+select id, ts
+from my_datalake.default.sort_year_timestamptz
+where filename = getvariable('file_path')
+order by file_row_number;
 ----
 1	2019-07-04 05:00:00+02
 2	2020-12-31 06:00:00+01

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/partitions/test_update_into_partitioned_sorted_table.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/partitions/test_update_into_partitioned_sorted_table.test
@@ -44,12 +44,6 @@ set variable table_sort_order_id = (
 );
 
 statement ok
-set variable table_data_glob = (
-	select metadata.location || '/data/*/*.parquet'
-	from iceberg_load_table_response(my_datalake.default.partitioned_sorted_update_write_test)
-);
-
-statement ok
 insert into my_datalake.default.partitioned_sorted_update_write_test
 values
 	(1, 2, 20),
@@ -121,7 +115,7 @@ with latest_files as (
 ),
 file_partition_counts as (
 	select filename, count(distinct p) as partition_count
-	from read_parquet(getvariable('table_data_glob'), filename=true)
+	from my_datalake.default.partitioned_sorted_update_write_test
 	where filename in (select file_path from latest_files)
 	group by filename
 )
@@ -131,8 +125,9 @@ where partition_count != 1;
 ----
 0
 
-# Read every newly added parquet file back directly, then use file_row_number to
-# verify that rows are physically written in table sort-key order within each file.
+# Use the latest added file handles from the Iceberg scan itself, then use
+# file_row_number to verify that rows are physically written in table sort-key
+# order within each file.
 query I
 with latest_files as (
 	select file_path
@@ -149,7 +144,7 @@ ordered_rows as (
 		b,
 		lag(a) over(partition by filename order by file_row_number) prev_a,
 		lag(b) over(partition by filename order by file_row_number) prev_b
-	from read_parquet(getvariable('table_data_glob'), filename=true, file_row_number=true)
+	from my_datalake.default.partitioned_sorted_update_write_test
 	where filename in (select file_path from latest_files)
 )
 select count(*)

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_into_sorted_table.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_into_sorted_table.test
@@ -103,8 +103,8 @@ set variable manifest_path = (
 	limit 1
 );
 
-# Read the newly written parquet file directly and use file_row_number to compare
-# each row against the previous one in physical write order.
+# Use the Iceberg scan handle and file_row_number to compare each row against
+# the previous one in physical write order.
 query I
 with ordered_rows as (
 	select
@@ -114,7 +114,8 @@ with ordered_rows as (
 		b,
 		lag(a) over(partition by filename order by file_row_number) prev_a,
 		lag(b) over(partition by filename order by file_row_number) prev_b
-	from read_parquet(getvariable('file_path'), filename=true, file_row_number=true)
+	from my_datalake.default.sorted_update_write_test
+	where filename = getvariable('file_path')
 )
 select count(*)
 from ordered_rows


### PR DESCRIPTION
Fixes flaky CI issues: https://github.com/duckdb/duckdb-iceberg/actions/runs/28687450914/job/85113358772?pr=1138