### PR TITLE
[Manifest File/List] Break up the Avro `Sink` chunk into smaller `STANDARD_VECTOR_SIZE` chunks

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -2,8 +2,8 @@
 if (NOT EMSCRIPTEN)
   duckdb_extension_load(avro
   LOAD_TESTS
-  GIT_URL https://github.com/tishj/duckdb_avro
-  GIT_TAG 9cd473e541f60c938238a15f51656a3502484e29
+  GIT_URL https://github.com/duckdb/duckdb-avro
+  GIT_TAG 4d29140da73a97128de977d5e5bf4b54722a2b11
   SUBMODULES "third_party/avro-c"
 )
 endif()

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -2,8 +2,8 @@
 if (NOT EMSCRIPTEN)
   duckdb_extension_load(avro
   LOAD_TESTS
-  GIT_URL https://github.com/duckdb/duckdb-avro
-  GIT_TAG b1b9612069ded914a9f5106b60c8e61a5644e09f
+  GIT_URL https://github.com/tishj/duckdb_avro
+  GIT_TAG 9cd473e541f60c938238a15f51656a3502484e29
   SUBMODULES "third_party/avro-c"
 )
 endif()

--- a/src/core/metadata/manifest/iceberg_manifest.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest.cpp
@@ -4,7 +4,6 @@
 
 #include "duckdb/common/vector/flat_vector.hpp"
 #include "duckdb/common/vector/struct_vector.hpp"
-#include "duckdb/storage/external_file_cache/caching_file_system.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 
 #include "catalog/rest/iceberg_table_set.hpp"
@@ -747,38 +746,7 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	//! Populate the DataChunk with the data files
 
 	DataChunk chunk;
-	chunk.Initialize(allocator, types, manifest_entries.size());
-
-	auto status_writer = FlatVector::Writer<int32_t>(chunk.data[0], manifest_entries.size());
-	auto snapshot_id_writer = FlatVector::Writer<int64_t>(chunk.data[1], manifest_entries.size());
-	auto sequence_number_writer = FlatVector::Writer<int64_t>(chunk.data[2], manifest_entries.size());
-	auto file_sequence_number_writer = FlatVector::Writer<int64_t>(chunk.data[3], manifest_entries.size());
-	DataFileVectorWriters data_file_writers(chunk.data[4], manifest_entries.size(), table_metadata);
-
-	for (idx_t i = 0; i < manifest_entries.size(); i++) {
-		auto &manifest_entry = manifest_entries[i];
-		status_writer.WriteValue(static_cast<int32_t>(manifest_entry.status));
-		//! FIXME: this is missing logic, needs to be looked into
-		//! SPEC: Snapshot id where the file was added, or deleted if status is 2. Inherited when null.
-		// snapshot_id: long
-		if (manifest_entry.HasSnapshotId()) {
-			snapshot_id_writer.WriteValue(manifest_entry.GetSnapshotId());
-		} else {
-			snapshot_id_writer.WriteNull();
-		}
-		// sequence_number: long
-		// file_sequence_number: long
-		if (manifest_entry.status == IcebergManifestEntryStatusType::ADDED) {
-			sequence_number_writer.WriteNull();
-			file_sequence_number_writer.WriteNull();
-		} else {
-			sequence_number_writer.WriteValue(manifest_entry.GetSequenceNumber(manifest_file));
-			file_sequence_number_writer.WriteValue(manifest_entry.GetFileSequenceNumber(manifest_file));
-		}
-
-		data_file_writers.WriteRow(i, manifest_entry.data_file, extended_partition_info);
-	}
-	chunk.SetChildCardinality(manifest_entries.size());
+	chunk.Initialize(allocator, types, STANDARD_VECTOR_SIZE);
 
 	std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> schema_doc_p(yyjson_mut_doc_new(nullptr));
 	auto schema_doc = schema_doc_p.get();
@@ -815,23 +783,61 @@ idx_t WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManif
 	CopyFunctionBindInput input(copy_info);
 	input.file_extension = "avro";
 
-	{
-		ThreadContext thread_context(context);
-		ExecutionContext execution_context(context, thread_context, nullptr);
-		auto bind_data = copy.copy_to_bind(context, input, names, types);
+	ThreadContext thread_context(context);
+	ExecutionContext execution_context(context, thread_context, nullptr);
+	auto bind_data = copy.copy_to_bind(context, input, names, types);
 
-		auto global_state = copy.copy_to_initialize_global(context, *bind_data, path);
-		auto local_state = copy.copy_to_initialize_local(execution_context, *bind_data);
+	auto global_state = copy.copy_to_initialize_global(context, *bind_data, path);
+	auto local_state = copy.copy_to_initialize_local(execution_context, *bind_data);
+	CopyFunctionFileStatistics stats;
+	copy.copy_to_get_written_statistics(context, *bind_data, *global_state, stats);
 
+	for (idx_t offset = 0; offset < manifest_entries.size(); offset += STANDARD_VECTOR_SIZE) {
+		const auto chunk_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, manifest_entries.size() - offset);
+		if (offset > 0) {
+			chunk.Reset();
+		}
+
+		auto status_writer = FlatVector::Writer<int32_t>(chunk.data[0], chunk_count);
+		auto snapshot_id_writer = FlatVector::Writer<int64_t>(chunk.data[1], chunk_count);
+		auto sequence_number_writer = FlatVector::Writer<int64_t>(chunk.data[2], chunk_count);
+		auto file_sequence_number_writer = FlatVector::Writer<int64_t>(chunk.data[3], chunk_count);
+		DataFileVectorWriters data_file_writers(chunk.data[4], chunk_count, table_metadata);
+
+		for (idx_t i = 0; i < chunk_count; i++) {
+			auto &manifest_entry = manifest_entries[offset + i];
+			status_writer.WriteValue(static_cast<int32_t>(manifest_entry.status));
+			//! FIXME: this is missing logic, needs to be looked into
+			//! SPEC: Snapshot id where the file was added, or deleted if status is 2. Inherited when null.
+			// snapshot_id: long
+			if (manifest_entry.HasSnapshotId()) {
+				snapshot_id_writer.WriteValue(manifest_entry.GetSnapshotId());
+			} else {
+				snapshot_id_writer.WriteNull();
+			}
+			// sequence_number: long
+			// file_sequence_number: long
+			if (manifest_entry.status == IcebergManifestEntryStatusType::ADDED) {
+				sequence_number_writer.WriteNull();
+				file_sequence_number_writer.WriteNull();
+			} else {
+				sequence_number_writer.WriteValue(manifest_entry.GetSequenceNumber(manifest_file));
+				file_sequence_number_writer.WriteValue(manifest_entry.GetFileSequenceNumber(manifest_file));
+			}
+
+			data_file_writers.WriteRow(i, manifest_entry.data_file, extended_partition_info);
+		}
+
+		chunk.SetChildCardinality(chunk_count);
 		copy.copy_to_sink(execution_context, *bind_data, *global_state, *local_state, chunk);
-		copy.copy_to_combine(execution_context, *bind_data, *global_state, *local_state);
-		copy.copy_to_finalize(context, *bind_data, *global_state);
 	}
-
-	auto file_system = CachingFileSystem::Get(context);
-	auto file_handle = file_system.OpenFile(path, FileOpenFlags::FILE_FLAGS_READ);
-	auto manifest_length = file_handle->GetFileSize();
-	return manifest_length;
+	copy.copy_to_combine(execution_context, *bind_data, *global_state, *local_state);
+	copy.copy_to_finalize(context, *bind_data, *global_state);
+	if (stats.row_count != manifest_entries.size()) {
+		throw InternalException("Avro copy for manifest failed, expected %d written, found only %d",
+		                        manifest_entries.size(), stats.row_count);
+	}
+	return stats.file_size_bytes;
 }
 
 } // namespace manifest_file

--- a/src/core/metadata/manifest/iceberg_manifest_list.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest_list.cpp
@@ -504,8 +504,7 @@ void WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManife
 	//! Populate the DataChunk with the manifests
 	auto &manifest_files = manifest_list.GetManifestFilesConst();
 	DataChunk data;
-	data.Initialize(allocator, metadata.types, manifest_files.size());
-	ManifestListVectorWriters writers(data, manifest_files.size());
+	data.Initialize(allocator, metadata.types, STANDARD_VECTOR_SIZE);
 
 	idx_t next_row_id;
 	if (table_metadata.has_next_row_id) {
@@ -513,13 +512,6 @@ void WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManife
 	} else {
 		next_row_id = 0;
 	}
-
-	for (idx_t i = 0; i < manifest_files.size(); i++) {
-		const auto &manifest_entry = manifest_files[i];
-		const auto &manifest = manifest_entry.file;
-		writers.WriteRow(manifest, table_metadata.iceberg_version >= 3 ? &next_row_id : nullptr);
-	}
-	data.SetChildCardinality(manifest_files.size());
 
 	CopyInfo copy_info;
 	copy_info.is_from = false;
@@ -544,7 +536,22 @@ void WriteToFile(const IcebergTableMetadata &table_metadata, const IcebergManife
 	auto global_state = copy.copy_to_initialize_global(context, *bind_data, manifest_list.GetPath());
 	auto local_state = copy.copy_to_initialize_local(execution_context, *bind_data);
 
-	copy.copy_to_sink(execution_context, *bind_data, *global_state, *local_state, data);
+	for (idx_t offset = 0; offset < manifest_files.size(); offset += STANDARD_VECTOR_SIZE) {
+		const auto chunk_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, manifest_files.size() - offset);
+		if (offset > 0) {
+			data.Reset();
+		}
+
+		ManifestListVectorWriters writers(data, chunk_count);
+		for (idx_t i = 0; i < chunk_count; i++) {
+			const auto &manifest_entry = manifest_files[offset + i];
+			const auto &manifest = manifest_entry.file;
+			writers.WriteRow(manifest, table_metadata.iceberg_version >= 3 ? &next_row_id : nullptr);
+		}
+
+		data.SetChildCardinality(chunk_count);
+		copy.copy_to_sink(execution_context, *bind_data, *global_state, *local_state, data);
+	}
 	copy.copy_to_combine(execution_context, *bind_data, *global_state, *local_state);
 	copy.copy_to_finalize(context, *bind_data, *global_state);
 }

--- a/test/configs/nessie.json
+++ b/test/configs/nessie.json
@@ -18,6 +18,7 @@
     {
       "reason": "V3 tests, not yet supported with Nessie",
       "paths": [
+        "test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_vector_writer_chunking.test_slow",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_delete_from_v3_table.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_deletion_vector_is_valid_puffin.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_to_v3_tables.test",

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_vector_writer_chunking.test_slow
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_vector_writer_chunking.test_slow
@@ -1,0 +1,83 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_manifest_vector_writer_chunking.test_slow
+# description: Regression for chunked VectorWriter output when writing large manifest and manifest-list Avro files
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.manifest_chunked_files;
+
+statement ok
+CREATE TABLE my_datalake.default.manifest_chunked_files (id INT, part INT)
+PARTITIONED BY (part)
+WITH (
+	'format-version' = 3
+);
+
+statement ok
+INSERT INTO my_datalake.default.manifest_chunked_files
+SELECT i, i FROM range(2050) t(i);
+
+statement ok
+SET VARIABLE large_manifest_path = (
+	SELECT manifest_path
+	FROM iceberg_metadata(my_datalake.default.manifest_chunked_files)
+	ORDER BY manifest_sequence_number DESC
+	LIMIT 1
+);
+
+query I
+SELECT count(*) FROM read_avro(getvariable('large_manifest_path'));
+----
+2050
+
+# Row ids don't get written to freshly inserted data
+query I
+SELECT count(data_file.first_row_id IS NULL)
+FROM read_avro(getvariable('large_manifest_path'));
+----
+2050
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.manifest_list_chunked_files;
+
+statement ok
+CREATE TABLE my_datalake.default.manifest_list_chunked_files (id INT)
+WITH (
+	'format-version' = 3
+);
+
+loop i 0 2050
+
+statement ok
+INSERT INTO my_datalake.default.manifest_list_chunked_files VALUES ({i});
+
+endloop
+
+statement ok
+SET VARIABLE large_manifest_list_path = (
+	SELECT manifest_list
+	FROM iceberg_snapshots(my_datalake.default.manifest_list_chunked_files)
+	ORDER BY sequence_number DESC
+	LIMIT 1
+);
+
+query I
+SELECT count(*) FROM read_avro(getvariable('large_manifest_list_path'));
+----
+2050
+
+query III
+SELECT count(first_row_id), min(first_row_id), max(first_row_id)
+FROM read_avro(getvariable('large_manifest_list_path'))
+WHERE content = 0;
+----
+2050	0	2049


### PR DESCRIPTION
This PR fixes a likely problem with manifest file/list producing code, chunks should be `STANDARD_VECTOR_SIZE` max, but we previously pushed everything into 1 chunk.

Also implements the use of `copy_to_get_written_statistics` of the Avro writer, added by https://github.com/duckdb/duckdb-avro/pull/105