### PR TITLE
Use optional instead of unique_ptr for retry backoff

### DIFF
--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -10,6 +10,7 @@
 #include "yyjson.hpp"
 
 #include <chrono>
+#include <optional>
 #include <random>
 #include <thread>
 
@@ -525,7 +526,7 @@ void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate
 	//! The retry policy is the tables' folded (most-lenient) config, produced by GetTransactionRequest.
 	//! It is stable across attempts (same tables), so the backoff state is created once, lazily, from
 	//! the first staged request and reused for every retry.
-	unique_ptr<IcebergRetryBackoff> backoff;
+	std::optional<IcebergRetryBackoff> backoff;
 	for (idx_t attempt = 0;; attempt++) {
 		auto transaction_info = GetTransactionRequest(alter_update, context);
 		if (transaction_info.request.table_changes.empty()) {
@@ -533,7 +534,7 @@ void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate
 			return;
 		}
 		if (!backoff) {
-			backoff = make_uniq<IcebergRetryBackoff>(transaction_info.retry_config);
+			backoff.emplace(transaction_info.retry_config);
 		}
 
 		std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
@@ -572,7 +573,7 @@ void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdat
 		auto &table_key = entry.first;
 		//! Backoff state is created once per table (lazily, from the first staged commit's config)
 		//! and reused across this table's retries.
-		unique_ptr<IcebergRetryBackoff> backoff;
+		std::optional<IcebergRetryBackoff> backoff;
 		for (idx_t attempt = 0;; attempt++) {
 			if (alter_update.committed_tables.count(table_key)) {
 				break;
@@ -584,7 +585,7 @@ void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdat
 
 			auto table_transaction_info = StageSingleTableCommit(db, table_info, context);
 			if (!backoff) {
-				backoff = make_uniq<IcebergRetryBackoff>(table_transaction_info.retry_config);
+				backoff.emplace(table_transaction_info.retry_config);
 			}
 			auto &table_change = table_transaction_info.request;
 			D_ASSERT(table_change.identifier);


### PR DESCRIPTION
Small follow-up to #1122.

@Tishj left two nits on #1122 (`optional<IcebergRetryBackoff>` instead of `unique_ptr`, no heap allocation needed) but the PR was merged before I addressed them. This does exactly that: both backoff instances in `iceberg_transaction.cpp` now use `std::optional<IcebergRetryBackoff>` with lazy `emplace()` instead of `make_uniq`.

No behavior change - purely avoids the heap allocation. Rebuilt, retry-config test passes, format.py clean.