### PR TITLE
Only assign first_row_id to data manifests in the manifest list

### DIFF
--- a/src/core/metadata/manifest/iceberg_manifest_list.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest_list.cpp
@@ -50,7 +50,8 @@ IcebergManifestListEntry IcebergManifestListEntry::CreateFromEntries(FileSystem 
 	IcebergManifestListEntry manifest_list_entry(manifest_file_path);
 	auto &manifest_file = manifest_list_entry.file;
 	manifest_file.manifest_path = manifest_file_path;
-	if (table_metadata.iceberg_version >= 3) {
+	if (table_metadata.iceberg_version >= 3 && manifest_content_type == IcebergManifestContentType::DATA) {
+		//! 'first_row_id' is only assigned to data manifests (row lineage), deletes manifests leave it null
 		manifest_file.has_first_row_id = true;
 		manifest_file.first_row_id = next_row_id;
 	}

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/test_row_lineage_write.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/test_row_lineage_write.test
@@ -142,3 +142,19 @@ select _last_updated_sequence_number, _row_id, id, data from my_datalake.default
 2	3	4	d_u1
 5	7	6	replaced
 7	11	7	g_new
+
+# The manifest list only assigns 'first_row_id' to data manifests, deletes manifests leave it null
+statement ok
+SET VARIABLE row_lineage_manifest_list = (
+	SELECT manifest_list FROM iceberg_snapshots(my_datalake.default.duckdb_row_lineage)
+	ORDER BY sequence_number DESC LIMIT 1
+);
+
+query III
+SELECT
+	count(*) FILTER (WHERE content = 1) > 0,
+	count(*) FILTER (WHERE content = 1 AND first_row_id IS NOT NULL),
+	count(*) FILTER (WHERE content = 0 AND first_row_id IS NULL)
+FROM read_avro(getvariable('row_lineage_manifest_list'));
+----
+true	0	0


### PR DESCRIPTION
### What

On V3 tables, `CreateFromEntries` assigns `first_row_id` (manifest list field 520) to **every** new manifest, including deletes manifests. Per the Iceberg V3 spec the field is only assigned to data manifests — it drives row-id inheritance, which doesn't apply to delete files — and Java's `SnapshotProducer` writes null for deletes manifests.

This PR gates the assignment on the manifest content type, so deletes manifests leave the field null (the writer already handles the null branch via `WriteNull()`).

### Why it matters

Readers that consume `first_row_id` for row-lineage purposes can mis-handle a deletes manifest that carries a value, and the output diverges from what Java writes for the same table. The row-id arithmetic itself is unchanged — `next_row_id` was only ever advanced for DATA entries — so assigned `_row_id` values are unaffected; only the serialized manifest list changes.

### Testing

Extended `test_row_lineage_write.test` with a manifest-list assertion: deletes manifests have a null `first_row_id`, data manifests a non-null one. The new assertion fails without the fix (deletes manifests show up with values) and passes with it; the existing `_row_id` / `_last_updated_sequence_number` expectations in the test are untouched, confirming the allocation behavior is unchanged.
