### PR TITLE
Guard against cache miss when renaming a table

### DIFF
--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -600,7 +600,12 @@ IcebergTableInformation IcebergTableInformation::Copy(ClientContext &context) co
 	{
 		lock_guard<std::mutex> cache_lock(catalog.table_request_cache.Lock());
 		auto cached_result = catalog.table_request_cache.Get(context, table_key, cache_lock, false);
-		D_ASSERT(cached_result);
+		if (!cached_result) {
+			throw InvalidConfigurationException(
+			    "Cannot copy table '%s': its metadata is not present in the cache. It must be loaded before it is "
+			    "copied (e.g. renamed).",
+			    table_key);
+		}
 		auto &cached_table_result = *cached_result->load_table_result;
 		ret.InitializeFromLoadTableResult(cached_table_result, false);
 	}

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -902,6 +902,8 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 	lock_guard<mutex> cache_guard(table_request_cache.Lock());
 	auto cache = table_request_cache.Get(client_context, table_key, cache_guard, false);
 	if (cache) {
+		//! FIXME: Because the cache is global, this could be overwriting an existing entry, this should be fixed in the
+		//! future
 		table_request_cache.SetOrOverwriteInternal(cache_guard, client_context, new_table_key, cache->expire_timestamp,
 		                                           std::move(cache->load_table_result));
 		table_request_cache.ExpireInternal(cache_guard, client_context, table_key);

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -893,15 +893,19 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 
 	auto locked_context = context.lock();
 	auto &client_context = *locked_context;
-	//! FIXME: just like the other place, this can easily go wrong
-	//! Migrate the MetadataCache
+	//! Migrate the MetadataCache from the old table key to the new one. The entry is only present if
+	//! the table was loaded into the cache before the rename; when it is absent there is nothing to
+	//! migrate (the next access under the new name will repopulate it), so skip rather than
+	//! dereference a null cache entry.
 	auto new_table_key = new_table.GetTableKey();
 	auto &table_request_cache = catalog.table_request_cache;
 	lock_guard<mutex> cache_guard(table_request_cache.Lock());
 	auto cache = table_request_cache.Get(client_context, table_key, cache_guard, false);
-	table_request_cache.SetOrOverwriteInternal(cache_guard, client_context, new_table_key, cache->expire_timestamp,
-	                                           std::move(cache->load_table_result));
-	table_request_cache.ExpireInternal(cache_guard, client_context, table_key);
+	if (cache) {
+		table_request_cache.SetOrOverwriteInternal(cache_guard, client_context, new_table_key, cache->expire_timestamp,
+		                                           std::move(cache->load_table_result));
+		table_request_cache.ExpireInternal(cache_guard, client_context, table_key);
+	}
 	return state->GetInfo();
 }
 


### PR DESCRIPTION
Small robustness fix for a FIXME in `RenameTable`.

`IcebergTransaction::RenameTable` migrates the metadata cache from the old table key to the new one:
```cpp
auto cache = table_request_cache.Get(client_context, table_key, cache_guard, false);
table_request_cache.SetOrOverwriteInternal(..., cache->expire_timestamp, std::move(cache->load_table_result));
```
`Get` returns `nullptr` on a cache miss (it does not throw), so the following `cache->...` is a null dereference when the renamed table's entry is not in the cache. This now skips the migration when the entry is absent - there is nothing to migrate, and the next access under the new name repopulates it.

The FIXME said "just like the other place" - that other place is `IcebergTableInformation::Copy` (on the rename call path), which had the same pattern guarded only by a debug-only `D_ASSERT`, so a release build would null-deref on a miss. Since `Copy` genuinely needs the cached result, it now throws `InvalidConfigurationException` on a miss instead of dereferencing null (and avoids `InternalException`, which would invalidate the session).

No new test: the miss is very hard to reach from SQL (the binder resolves - and thus caches - the source table before a RENAME), so I could not construct a reproducer that exercises the miss path without the cache being repopulated first. Existing rename coverage (`rename_table_test.test`, 110 assertions) confirms the hit path is unchanged.