### PR TITLE
[Dev] Separate `IcebergTableUpdate::CreateUpdate` from transaction-local version of the table metadata

### DIFF
--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -17,7 +17,7 @@ namespace duckdb {
 
 IcebergAddSnapshot::IcebergAddSnapshot(const IcebergTableInformation &table_info,
                                        IcebergSnapshotOperationType operation)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SNAPSHOT, table_info), operation(operation) {
+    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SNAPSHOT), operation(operation) {
 	//! FIXME: Do we also need to capture the current partition spec and sort order?
 	//! This is a bit of a code smell, the `IcebergTableInformation` should instead be const
 	//! and all transactional changes should live in the IcebergTransactionData
@@ -27,6 +27,10 @@ IcebergAddSnapshot::IcebergAddSnapshot(const IcebergTableInformation &table_info
 bool IcebergAddSnapshot::IsRetryable() const {
 	//! Only retry INSERT for now
 	return operation == IcebergSnapshotOperationType::APPEND;
+}
+
+void IcebergAddSnapshot::ApplyUpdate(IcebergTableMetadata &metadata) const {
+	(void)metadata;
 }
 
 static rest_api_objects::TableUpdate CreateAddSnapshotUpdate(const IcebergTableInformation &table_info,
@@ -195,7 +199,7 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 	const auto snapshot_id = IcebergSnapshot::NewSnapshotId();
 	const auto sequence_number = commit_state.next_sequence_number++;
 	auto uncommitted_manifest_files =
-	    CreateCommitManifestFiles(manifest_files, table_info, commit_state, snapshot_id, sequence_number);
+	    CreateCommitManifestFiles(manifest_files, commit_state.table_info, commit_state, snapshot_id, sequence_number);
 	D_ASSERT(!uncommitted_manifest_files.empty());
 
 	auto &fs = FileSystem::GetFileSystem(context);
@@ -230,7 +234,8 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 		auto &manifest_file = manifest_list_entry.file;
 		new_snapshot.metrics.AddManifestFile(manifest_file);
 
-		auto new_manifest_list_entry = WriteManifestListEntry(table_info, manifest_list_entry, avro_copy, db, context);
+		auto new_manifest_list_entry =
+		    WriteManifestListEntry(commit_state.table_info, manifest_list_entry, avro_copy, db, context);
 		commit_state.created_metadata_files.push_back(new_manifest_list_entry.file.manifest_path);
 		new_manifest_list.AddNewManifestFile(std::move(new_manifest_list_entry));
 
@@ -251,7 +256,8 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 	commit_state.latest_snapshot = commit_state.created_snapshots.back();
 
 	//! Finally add a Iceberg REST Catalog 'TableUpdate' to commit
-	commit_state.table_change.updates.push_back(CreateAddSnapshotUpdate(table_info, *commit_state.latest_snapshot));
+	commit_state.table_change.updates.push_back(
+	    CreateAddSnapshotUpdate(commit_state.table_info, *commit_state.latest_snapshot));
 }
 
 void IcebergAddSnapshot::AddManifestFile(IcebergManifestListEntry &&manifest_file) {

--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -29,10 +29,6 @@ bool IcebergAddSnapshot::IsRetryable() const {
 	return operation == IcebergSnapshotOperationType::APPEND;
 }
 
-void IcebergAddSnapshot::ApplyUpdate(IcebergTableMetadata &metadata) const {
-	(void)metadata;
-}
-
 static rest_api_objects::TableUpdate CreateAddSnapshotUpdate(const IcebergTableInformation &table_info,
                                                              const IcebergSnapshot &snapshot) {
 	rest_api_objects::TableUpdate table_update;

--- a/src/catalog/rest/api/iceberg_create_table_request.cpp
+++ b/src/catalog/rest/api/iceberg_create_table_request.cpp
@@ -196,6 +196,12 @@ void IcebergCreateTableRequest::PopulateSchema(yyjson_mut_doc *doc, yyjson_mut_v
 	}
 
 	yyjson_mut_obj_add_uint(doc, schema_json, "schema-id", schema.schema_id);
+	if (!schema.identifier_field_ids.empty()) {
+		auto identifier_field_ids = yyjson_mut_obj_add_arr(doc, schema_json, "identifier-field-ids");
+		for (const auto field_id : schema.identifier_field_ids) {
+			yyjson_mut_arr_add_int(doc, identifier_field_ids, field_id);
+		}
+	}
 }
 
 string IcebergCreateTableRequest::CreateTableToJSON(std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p) {

--- a/src/catalog/rest/api/iceberg_table_update.cpp
+++ b/src/catalog/rest/api/iceberg_table_update.cpp
@@ -72,7 +72,4 @@ void IcebergCommitState::LoadExistingManifests(vector<IcebergManifestListEntry> 
 IcebergTableUpdate::IcebergTableUpdate(IcebergTableUpdateType type) : type(type) {
 }
 
-void IcebergTableUpdate::ApplyUpdate(IcebergTableMetadata &metadata) const {
-}
-
 } // namespace duckdb

--- a/src/catalog/rest/api/iceberg_table_update.cpp
+++ b/src/catalog/rest/api/iceberg_table_update.cpp
@@ -1,6 +1,7 @@
 #include "catalog/rest/api/iceberg_table_update.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
 #include "planning/metadata_io/avro/avro_scan.hpp"
 #include "planning/metadata_io/manifest_list/iceberg_manifest_list_reader.hpp"
 
@@ -68,8 +69,10 @@ void IcebergCommitState::LoadExistingManifests(vector<IcebergManifestListEntry> 
 	AssignManifestFirstRowIds(table_info.table_metadata, current_snapshot, manifests, next_row_id);
 }
 
-IcebergTableUpdate::IcebergTableUpdate(IcebergTableUpdateType type, const IcebergTableInformation &table_info)
-    : type(type), table_info(table_info) {
+IcebergTableUpdate::IcebergTableUpdate(IcebergTableUpdateType type) : type(type) {
+}
+
+void IcebergTableUpdate::ApplyUpdate(IcebergTableMetadata &metadata) const {
 }
 
 } // namespace duckdb

--- a/src/catalog/rest/api/table_update.cpp
+++ b/src/catalog/rest/api/table_update.cpp
@@ -1,7 +1,6 @@
 #include "catalog/rest/api/table_update.hpp"
 #include "duckdb/common/exception.hpp"
 #include "catalog/rest/iceberg_table_set.hpp"
-#include "core/metadata/iceberg_table_metadata.hpp"
 
 namespace duckdb {
 
@@ -28,14 +27,6 @@ void AddSchemaUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 	}
 }
 
-void AddSchemaUpdate::ApplyUpdate(IcebergTableMetadata &metadata) const {
-	D_ASSERT(schema);
-	metadata.AddSchemaOrGetExisting(schema->Copy());
-	if (last_column_id.IsValid()) {
-		metadata.last_column_id = last_column_id;
-	}
-}
-
 AssignUUIDUpdate::AssignUUIDUpdate(string uuid)
     : IcebergTableUpdate(IcebergTableUpdateType::ASSIGN_UUID), uuid(std::move(uuid)) {
 }
@@ -48,10 +39,6 @@ void AssignUUIDUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	update.assign_uuidupdate->base_update.action = "assign-uuid";
 	// uuid most likely created by the rest catalog?
 	update.assign_uuidupdate->uuid = uuid;
-}
-
-void AssignUUIDUpdate::ApplyUpdate(IcebergTableMetadata &metadata) const {
-	metadata.table_uuid = uuid;
 }
 
 AssertCreateRequirement::AssertCreateRequirement()
@@ -147,10 +134,6 @@ void UpgradeFormatVersion::CreateUpdate(DatabaseInstance &db, ClientContext &con
 	req.upgrade_format_version_update->format_version = format_version;
 }
 
-void UpgradeFormatVersion::ApplyUpdate(IcebergTableMetadata &metadata) const {
-	metadata.iceberg_version = format_version;
-}
-
 SetCurrentSchema::SetCurrentSchema(int32_t schema_id)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_CURRENT_SCHEMA), schema_id(schema_id) {
 }
@@ -163,10 +146,6 @@ void SetCurrentSchema::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	req.set_current_schema_update->base_update.action = "set-current-schema";
 	// TODO: should this be a different value? or is the rest catalog setting this again?
 	req.set_current_schema_update->schema_id = schema_id;
-}
-
-void SetCurrentSchema::ApplyUpdate(IcebergTableMetadata &metadata) const {
-	metadata.SetCurrentSchemaId(schema_id);
 }
 
 AddPartitionSpec::AddPartitionSpec(const IcebergPartitionSpec &partition_spec)
@@ -191,14 +170,6 @@ void AddPartitionSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	}
 }
 
-void AddPartitionSpec::ApplyUpdate(IcebergTableMetadata &metadata) const {
-	metadata.partition_specs.erase(partition_spec.spec_id);
-	metadata.partition_specs.emplace(partition_spec.spec_id, partition_spec);
-	if (!partition_spec.fields.empty()) {
-		metadata.last_partition_field_id = partition_spec.fields.back().partition_field_id;
-	}
-}
-
 AddSortOrder::AddSortOrder(const IcebergSortOrder &sort_order)
     : IcebergTableUpdate(IcebergTableUpdateType::ADD_SORT_ORDER), sort_order(sort_order) {
 }
@@ -219,11 +190,6 @@ void AddSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context, Ic
 	}
 }
 
-void AddSortOrder::ApplyUpdate(IcebergTableMetadata &metadata) const {
-	metadata.sort_specs.erase(sort_order.sort_order_id);
-	metadata.sort_specs.emplace(sort_order.sort_order_id, sort_order);
-}
-
 SetDefaultSortOrder::SetDefaultSortOrder(int32_t sort_order_id)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SORT_ORDER), sort_order_id(sort_order_id) {
 }
@@ -235,10 +201,6 @@ void SetDefaultSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &cont
 	req.set_default_sort_order_update = rest_api_objects::SetDefaultSortOrderUpdate();
 	req.set_default_sort_order_update->base_update.action = "set-default-sort-order";
 	req.set_default_sort_order_update->sort_order_id = sort_order_id;
-}
-
-void SetDefaultSortOrder::ApplyUpdate(IcebergTableMetadata &metadata) const {
-	metadata.default_sort_order_id = sort_order_id;
 }
 
 SetDefaultSpec::SetDefaultSpec(int32_t spec_id)
@@ -254,10 +216,6 @@ void SetDefaultSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 	req.set_default_spec_update->spec_id = spec_id;
 }
 
-void SetDefaultSpec::ApplyUpdate(IcebergTableMetadata &metadata) const {
-	metadata.default_spec_id = spec_id;
-}
-
 SetProperties::SetProperties(const case_insensitive_map_t<string> &properties)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES), properties(properties) {
 }
@@ -268,12 +226,6 @@ void SetProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context, I
 	req.set_properties_update = rest_api_objects::SetPropertiesUpdate();
 	req.set_properties_update->base_update.action = "set-properties";
 	req.set_properties_update->updates = properties;
-}
-
-void SetProperties::ApplyUpdate(IcebergTableMetadata &metadata) const {
-	for (auto &entry : properties) {
-		metadata.table_properties[entry.first] = entry.second;
-	}
 }
 
 RemoveProperties::RemoveProperties(const vector<string> &properties)
@@ -289,12 +241,6 @@ void RemoveProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	req.remove_properties_update->removals = properties;
 }
 
-void RemoveProperties::ApplyUpdate(IcebergTableMetadata &metadata) const {
-	for (auto &entry : properties) {
-		metadata.table_properties.erase(entry);
-	}
-}
-
 SetLocation::SetLocation(string location)
     : IcebergTableUpdate(IcebergTableUpdateType::SET_LOCATION), location(std::move(location)) {
 }
@@ -305,10 +251,6 @@ void SetLocation::CreateUpdate(DatabaseInstance &db, ClientContext &context, Ice
 	req.set_location_update = rest_api_objects::SetLocationUpdate();
 	req.set_location_update->base_update.action = "set-location";
 	req.set_location_update->location = location;
-}
-
-void SetLocation::ApplyUpdate(IcebergTableMetadata &metadata) const {
-	metadata.location = location;
 }
 
 } // namespace duckdb

--- a/src/catalog/rest/api/table_update.cpp
+++ b/src/catalog/rest/api/table_update.cpp
@@ -1,55 +1,43 @@
 #include "catalog/rest/api/table_update.hpp"
 #include "duckdb/common/exception.hpp"
 #include "catalog/rest/iceberg_table_set.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
 
 namespace duckdb {
 
-static rest_api_objects::Schema CopySchema(const IcebergTableSchema &schema) {
-	// the rest api objects are currently not copyable. Without having to modify generated code
-	//  the easiest way to copy for now is to write the schema to string, then parse it again
-	std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
-	yyjson_mut_doc *doc = doc_p.get();
-	auto root_object = yyjson_mut_obj(doc);
-	yyjson_mut_doc_set_root(doc, root_object);
-	IcebergCreateTableRequest::PopulateSchema(doc, root_object, schema);
-	auto schema_str = ICUtils::JsonToString(std::move(doc_p));
-
-	// Parse it back as immutable
-	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> new_doc(
-	    yyjson_read(schema_str.c_str(), strlen(schema_str.c_str()), 0));
-	yyjson_val *val = yyjson_doc_get_root(new_doc.get());
-	return rest_api_objects::Schema::FromJSON(val);
-}
-
-AddSchemaUpdate::AddSchemaUpdate(const IcebergTableInformation &table_info, int32_t schema_id)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA, table_info), schema_id(schema_id) {
-	if (table_info.table_metadata.HasLastColumnId()) {
-		last_column_id = table_info.table_metadata.GetLastColumnId();
+AddSchemaUpdate::AddSchemaUpdate(shared_ptr<IcebergTableSchema> schema_p, optional_idx last_column_id_p)
+    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA), last_column_id(last_column_id_p),
+      schema(std::move(schema_p)) {
+	if (!schema) {
+		throw InternalException("(AddSchemaUpdate) Missing schema payload");
 	}
 }
 
 void AddSchemaUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
                                    IcebergCommitState &commit_state) const {
+	(void)db;
+	(void)context;
 	commit_state.table_change.updates.push_back(rest_api_objects::TableUpdate());
 	auto &update = commit_state.table_change.updates.back();
 	update.add_schema_update = rest_api_objects::AddSchemaUpdate();
 	update.add_schema_update->base_update.action = "add-schema";
-
-	auto &schemas = table_info.table_metadata.GetSchemas();
-	auto it = schemas.find(schema_id);
-	if (it == schemas.end()) {
-		throw InternalException("(AddSchemaUpdate) Couldn't find schema with id: %d", schema_id);
-	}
-	auto &schema = it->second;
-	update.add_schema_update->schema = CopySchema(*schema.get());
+	update.add_schema_update->schema = schema->ToRESTObject();
 	// last-column-id is technically deprecated in AddSchemaUpdate, but some catalogs still use it (nessie).
 	if (last_column_id.IsValid()) {
 		update.add_schema_update->last_column_id = last_column_id.GetIndex();
 	}
 }
 
-AssignUUIDUpdate::AssignUUIDUpdate(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SCHEMA, table_info) {
+void AddSchemaUpdate::ApplyUpdate(IcebergTableMetadata &metadata) const {
+	D_ASSERT(schema);
+	metadata.AddSchemaOrGetExisting(schema->Copy());
+	if (last_column_id.IsValid()) {
+		metadata.last_column_id = last_column_id;
+	}
+}
+
+AssignUUIDUpdate::AssignUUIDUpdate(string uuid)
+    : IcebergTableUpdate(IcebergTableUpdateType::ASSIGN_UUID), uuid(std::move(uuid)) {
 }
 
 void AssignUUIDUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -59,11 +47,15 @@ void AssignUUIDUpdate::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	update.assign_uuidupdate = rest_api_objects::AssignUUIDUpdate();
 	update.assign_uuidupdate->base_update.action = "assign-uuid";
 	// uuid most likely created by the rest catalog?
-	update.assign_uuidupdate->uuid = table_info.table_metadata.table_uuid;
+	update.assign_uuidupdate->uuid = uuid;
 }
 
-AssertCreateRequirement::AssertCreateRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_CREATE, table_info) {
+void AssignUUIDUpdate::ApplyUpdate(IcebergTableMetadata &metadata) const {
+	metadata.table_uuid = uuid;
+}
+
+AssertCreateRequirement::AssertCreateRequirement()
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_CREATE) {
 }
 
 void AssertCreateRequirement::CreateRequirement(DatabaseInstance &db, ClientContext &context,
@@ -74,8 +66,8 @@ void AssertCreateRequirement::CreateRequirement(DatabaseInstance &db, ClientCont
 	req.assert_create->type.value = "assert-create";
 }
 
-AssertTableUUIDRequirement::AssertTableUUIDRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_TABLE_UUID, table_info) {
+AssertTableUUIDRequirement::AssertTableUUIDRequirement(string uuid)
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_TABLE_UUID), uuid(std::move(uuid)) {
 }
 
 void AssertTableUUIDRequirement::CreateRequirement(DatabaseInstance &db, ClientContext &context,
@@ -84,12 +76,12 @@ void AssertTableUUIDRequirement::CreateRequirement(DatabaseInstance &db, ClientC
 	auto &req = commit_state.table_change.requirements.back();
 	req.assert_table_uuid = rest_api_objects::AssertTableUUID();
 	req.assert_table_uuid->type.value = "assert-table-uuid";
-	req.assert_table_uuid->uuid = commit_state.table_info.table_metadata.table_uuid;
+	req.assert_table_uuid->uuid = uuid;
 }
 
-AssertCurrentSchemaIdRequirement::AssertCurrentSchemaIdRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_CURRENT_SCHEMA_ID, table_info) {
-	current_schema_id = table_info.table_metadata.GetCurrentSchemaId();
+AssertCurrentSchemaIdRequirement::AssertCurrentSchemaIdRequirement(int32_t current_schema_id)
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_CURRENT_SCHEMA_ID),
+      current_schema_id(current_schema_id) {
 }
 
 void AssertCurrentSchemaIdRequirement::CreateRequirement(DatabaseInstance &db, ClientContext &context,
@@ -101,10 +93,9 @@ void AssertCurrentSchemaIdRequirement::CreateRequirement(DatabaseInstance &db, C
 	req.assert_current_schema_id->current_schema_id = current_schema_id;
 }
 
-AssertLastAssignedFieldIdRequirement::AssertLastAssignedFieldIdRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_FIELD_ID, table_info) {
-	D_ASSERT(table_info.table_metadata.HasLastColumnId());
-	last_assigned_field_id = static_cast<int32_t>(table_info.table_metadata.GetLastColumnId());
+AssertLastAssignedFieldIdRequirement::AssertLastAssignedFieldIdRequirement(int32_t last_assigned_field_id)
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_FIELD_ID),
+      last_assigned_field_id(last_assigned_field_id) {
 }
 
 void AssertLastAssignedFieldIdRequirement::CreateRequirement(DatabaseInstance &db, ClientContext &context,
@@ -116,16 +107,9 @@ void AssertLastAssignedFieldIdRequirement::CreateRequirement(DatabaseInstance &d
 	req.assert_last_assigned_field_id->last_assigned_field_id = last_assigned_field_id;
 }
 
-AssertLastAssignedPartitionIdRequirement::AssertLastAssignedPartitionIdRequirement(
-    const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_PARTITION_ID, table_info) {
-	if (table_info.table_metadata.HasLastPartitionId()) {
-		last_assigned_partition_id = table_info.table_metadata.GetLastPartitionFieldId();
-	} else {
-		// If no partition field IDs have been assigned, use 999 as the last assigned so 1000 becomes the
-		// next partition id. Based on assignments in v1 in https://iceberg.apache.org/spec/#partition-evolution
-		last_assigned_partition_id = 999;
-	}
+AssertLastAssignedPartitionIdRequirement::AssertLastAssignedPartitionIdRequirement(int32_t last_assigned_partition_id)
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_PARTITION_ID),
+      last_assigned_partition_id(last_assigned_partition_id) {
 }
 
 void AssertLastAssignedPartitionIdRequirement::CreateRequirement(DatabaseInstance &db, ClientContext &context,
@@ -137,9 +121,8 @@ void AssertLastAssignedPartitionIdRequirement::CreateRequirement(DatabaseInstanc
 	req.assert_last_assigned_partition_id->last_assigned_partition_id = last_assigned_partition_id;
 }
 
-AssertDefaultSpecIdRequirement::AssertDefaultSpecIdRequirement(const IcebergTableInformation &table_info)
-    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_DEFAULT_SPEC_ID, table_info) {
-	default_spec_id = table_info.table_metadata.default_spec_id;
+AssertDefaultSpecIdRequirement::AssertDefaultSpecIdRequirement(int32_t default_spec_id)
+    : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_DEFAULT_SPEC_ID), default_spec_id(default_spec_id) {
 }
 
 void AssertDefaultSpecIdRequirement::CreateRequirement(DatabaseInstance &db, ClientContext &context,
@@ -151,8 +134,8 @@ void AssertDefaultSpecIdRequirement::CreateRequirement(DatabaseInstance &db, Cli
 	req.assert_default_spec_id->default_spec_id = default_spec_id;
 }
 
-UpgradeFormatVersion::UpgradeFormatVersion(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::UPGRADE_FORMAT_VERSION, table_info) {
+UpgradeFormatVersion::UpgradeFormatVersion(int32_t format_version)
+    : IcebergTableUpdate(IcebergTableUpdateType::UPGRADE_FORMAT_VERSION), format_version(format_version) {
 }
 
 void UpgradeFormatVersion::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -161,11 +144,15 @@ void UpgradeFormatVersion::CreateUpdate(DatabaseInstance &db, ClientContext &con
 	auto &req = commit_state.table_change.updates.back();
 	req.upgrade_format_version_update = rest_api_objects::UpgradeFormatVersionUpdate();
 	req.upgrade_format_version_update->base_update.action = "upgrade-format-version";
-	req.upgrade_format_version_update->format_version = table_info.table_metadata.iceberg_version;
+	req.upgrade_format_version_update->format_version = format_version;
 }
 
-SetCurrentSchema::SetCurrentSchema(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_CURRENT_SCHEMA, table_info) {
+void UpgradeFormatVersion::ApplyUpdate(IcebergTableMetadata &metadata) const {
+	metadata.iceberg_version = format_version;
+}
+
+SetCurrentSchema::SetCurrentSchema(int32_t schema_id)
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_CURRENT_SCHEMA), schema_id(schema_id) {
 }
 
 void SetCurrentSchema::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -175,11 +162,15 @@ void SetCurrentSchema::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	req.set_current_schema_update = rest_api_objects::SetCurrentSchemaUpdate();
 	req.set_current_schema_update->base_update.action = "set-current-schema";
 	// TODO: should this be a different value? or is the rest catalog setting this again?
-	req.set_current_schema_update->schema_id = table_info.table_metadata.GetCurrentSchemaId();
+	req.set_current_schema_update->schema_id = schema_id;
 }
 
-AddPartitionSpec::AddPartitionSpec(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_PARTITION_SPEC, table_info) {
+void SetCurrentSchema::ApplyUpdate(IcebergTableMetadata &metadata) const {
+	metadata.SetCurrentSchemaId(schema_id);
+}
+
+AddPartitionSpec::AddPartitionSpec(const IcebergPartitionSpec &partition_spec)
+    : IcebergTableUpdate(IcebergTableUpdateType::ADD_PARTITION_SPEC), partition_spec(partition_spec) {
 }
 
 void AddPartitionSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -189,22 +180,27 @@ void AddPartitionSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	req.add_partition_spec_update = rest_api_objects::AddPartitionSpecUpdate();
 	req.add_partition_spec_update->base_update.action = "add-spec";
 	// need to get the spec id from table_info() so we can also check updated tables.
-	req.add_partition_spec_update->spec.spec_id = table_info.table_metadata.default_spec_id;
-	if (table_info.table_metadata.HasPartitionSpec()) {
-		auto &current_partition_spec = table_info.table_metadata.GetLatestPartitionSpec();
-		for (auto &field : current_partition_spec.fields) {
-			req.add_partition_spec_update->spec.fields.push_back(rest_api_objects::PartitionField());
-			auto &updated_field = req.add_partition_spec_update->spec.fields.back();
-			updated_field.name = field.GetPartitionSpecFieldName();
-			updated_field.transform.value = field.transform.RawType();
-			updated_field.field_id = field.partition_field_id;
-			updated_field.source_id = field.source_id;
-		}
+	req.add_partition_spec_update->spec.spec_id = partition_spec.spec_id;
+	for (auto &field : partition_spec.fields) {
+		req.add_partition_spec_update->spec.fields.push_back(rest_api_objects::PartitionField());
+		auto &updated_field = req.add_partition_spec_update->spec.fields.back();
+		updated_field.name = field.GetPartitionSpecFieldName();
+		updated_field.transform.value = field.transform.RawType();
+		updated_field.field_id = field.partition_field_id;
+		updated_field.source_id = field.source_id;
 	}
 }
 
-AddSortOrder::AddSortOrder(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SORT_ORDER, table_info) {
+void AddPartitionSpec::ApplyUpdate(IcebergTableMetadata &metadata) const {
+	metadata.partition_specs.erase(partition_spec.spec_id);
+	metadata.partition_specs.emplace(partition_spec.spec_id, partition_spec);
+	if (!partition_spec.fields.empty()) {
+		metadata.last_partition_field_id = partition_spec.fields.back().partition_field_id;
+	}
+}
+
+AddSortOrder::AddSortOrder(const IcebergSortOrder &sort_order)
+    : IcebergTableUpdate(IcebergTableUpdateType::ADD_SORT_ORDER), sort_order(sort_order) {
 }
 
 void AddSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const {
@@ -212,26 +208,24 @@ void AddSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context, Ic
 	auto &req = commit_state.table_change.updates.back();
 	req.add_sort_order_update = rest_api_objects::AddSortOrderUpdate();
 	req.add_sort_order_update->base_update.action = "add-sort-order";
-	if (table_info.table_metadata.HasSortOrder()) {
-		req.add_sort_order_update->sort_order.order_id = table_info.table_metadata.default_sort_order_id.GetIndex();
-	}
-
-	if (table_info.table_metadata.HasSortOrder()) {
-		// FIXME: is it correct to just get the latest sort order?
-		auto &current_sort_order = table_info.table_metadata.GetLatestSortOrder();
-		for (auto &field : current_sort_order.fields) {
-			req.add_sort_order_update->sort_order.fields.push_back(rest_api_objects::SortField());
-			auto &updated_field = req.add_sort_order_update->sort_order.fields.back();
-			updated_field.direction.value = field.direction;
-			updated_field.transform.value = field.transform.RawType();
-			updated_field.null_order.value = field.null_order;
-			updated_field.source_id = field.source_id;
-		}
+	req.add_sort_order_update->sort_order.order_id = sort_order.sort_order_id;
+	for (auto &field : sort_order.fields) {
+		req.add_sort_order_update->sort_order.fields.push_back(rest_api_objects::SortField());
+		auto &updated_field = req.add_sort_order_update->sort_order.fields.back();
+		updated_field.direction.value = field.direction;
+		updated_field.transform.value = field.transform.RawType();
+		updated_field.null_order.value = field.null_order;
+		updated_field.source_id = field.source_id;
 	}
 }
 
-SetDefaultSortOrder::SetDefaultSortOrder(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SORT_ORDER, table_info) {
+void AddSortOrder::ApplyUpdate(IcebergTableMetadata &metadata) const {
+	metadata.sort_specs.erase(sort_order.sort_order_id);
+	metadata.sort_specs.emplace(sort_order.sort_order_id, sort_order);
+}
+
+SetDefaultSortOrder::SetDefaultSortOrder(int32_t sort_order_id)
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SORT_ORDER), sort_order_id(sort_order_id) {
 }
 
 void SetDefaultSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -240,12 +234,15 @@ void SetDefaultSortOrder::CreateUpdate(DatabaseInstance &db, ClientContext &cont
 	auto &req = commit_state.table_change.updates.back();
 	req.set_default_sort_order_update = rest_api_objects::SetDefaultSortOrderUpdate();
 	req.set_default_sort_order_update->base_update.action = "set-default-sort-order";
-	D_ASSERT(table_info.table_metadata.HasSortOrder());
-	req.set_default_sort_order_update->sort_order_id = table_info.table_metadata.GetLatestSortOrder().sort_order_id;
+	req.set_default_sort_order_update->sort_order_id = sort_order_id;
 }
 
-SetDefaultSpec::SetDefaultSpec(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SPEC, table_info) {
+void SetDefaultSortOrder::ApplyUpdate(IcebergTableMetadata &metadata) const {
+	metadata.default_sort_order_id = sort_order_id;
+}
+
+SetDefaultSpec::SetDefaultSpec(int32_t spec_id)
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_DEFAULT_SPEC), spec_id(spec_id) {
 }
 
 void SetDefaultSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -254,12 +251,15 @@ void SetDefaultSpec::CreateUpdate(DatabaseInstance &db, ClientContext &context,
 	auto &req = commit_state.table_change.updates.back();
 	req.set_default_spec_update = rest_api_objects::SetDefaultSpecUpdate();
 	req.set_default_spec_update->base_update.action = "set-default-spec";
-	req.set_default_spec_update->spec_id = table_info.table_metadata.default_spec_id;
+	req.set_default_spec_update->spec_id = spec_id;
 }
 
-SetProperties::SetProperties(const IcebergTableInformation &table_info,
-                             const case_insensitive_map_t<string> &properties)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES, table_info), properties(properties) {
+void SetDefaultSpec::ApplyUpdate(IcebergTableMetadata &metadata) const {
+	metadata.default_spec_id = spec_id;
+}
+
+SetProperties::SetProperties(const case_insensitive_map_t<string> &properties)
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES), properties(properties) {
 }
 
 void SetProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const {
@@ -270,8 +270,14 @@ void SetProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context, I
 	req.set_properties_update->updates = properties;
 }
 
-RemoveProperties::RemoveProperties(const IcebergTableInformation &table_info, const vector<string> &properties)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_PROPERTIES, table_info), properties(properties) {
+void SetProperties::ApplyUpdate(IcebergTableMetadata &metadata) const {
+	for (auto &entry : properties) {
+		metadata.table_properties[entry.first] = entry.second;
+	}
+}
+
+RemoveProperties::RemoveProperties(const vector<string> &properties)
+    : IcebergTableUpdate(IcebergTableUpdateType::REMOVE_PROPERTIES), properties(properties) {
 }
 
 void RemoveProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context,
@@ -283,8 +289,14 @@ void RemoveProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	req.remove_properties_update->removals = properties;
 }
 
-SetLocation::SetLocation(const IcebergTableInformation &table_info)
-    : IcebergTableUpdate(IcebergTableUpdateType::SET_LOCATION, table_info) {
+void RemoveProperties::ApplyUpdate(IcebergTableMetadata &metadata) const {
+	for (auto &entry : properties) {
+		metadata.table_properties.erase(entry);
+	}
+}
+
+SetLocation::SetLocation(string location)
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_LOCATION), location(std::move(location)) {
 }
 
 void SetLocation::CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const {
@@ -292,7 +304,11 @@ void SetLocation::CreateUpdate(DatabaseInstance &db, ClientContext &context, Ice
 	auto &req = commit_state.table_change.updates.back();
 	req.set_location_update = rest_api_objects::SetLocationUpdate();
 	req.set_location_update->base_update.action = "set-location";
-	req.set_location_update->location = table_info.table_metadata.location;
+	req.set_location_update->location = location;
+}
+
+void SetLocation::ApplyUpdate(IcebergTableMetadata &metadata) const {
+	metadata.location = location;
 }
 
 } // namespace duckdb

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -321,7 +321,7 @@ void IntroduceNewSchema(IcebergTableInformation &updated_table, IcebergTransacti
 		updated_table.CreateSchemaVersion(result_schema);
 		transaction_data.TableAddSchema(new_schema_id);
 	} else {
-		transaction_data.TableSetCurrentSchema();
+		transaction_data.TableSetCurrentSchema(result_schema.schema_id);
 	}
 	updated_table.table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 }
@@ -546,7 +546,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			updated_table.CreateSchemaVersion(result_schema);
 			transaction_data.TableAddSchema(new_schema_id);
 		} else {
-			transaction_data.TableSetCurrentSchema();
+			transaction_data.TableSetCurrentSchema(result_schema.schema_id);
 		}
 		updated_table.table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 		return;
@@ -647,7 +647,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			updated_table.CreateSchemaVersion(result_schema);
 			transaction_data.TableAddSchema(new_schema_id);
 		} else {
-			transaction_data.TableSetCurrentSchema();
+			transaction_data.TableSetCurrentSchema(result_schema.schema_id);
 		}
 		updated_table.table_metadata.SetCurrentSchemaId(result_schema.schema_id);
 		return;

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -405,7 +405,6 @@ void IcebergTableInformation::SetPartitionedBy(IcebergTransaction &transaction,
 	if (!first_partition_spec) {
 		new_spec_id = GetNextPartitionSpecId();
 	}
-	auto &transaction_data = GetOrCreateTransactionData(transaction);
 
 	auto new_spec =
 	    BuildPartitionSpec(partition_keys, schema, static_cast<int32_t>(new_spec_id), base_partition_field_id);
@@ -415,13 +414,17 @@ void IcebergTableInformation::SetPartitionedBy(IcebergTransaction &transaction,
 	auto existing_spec_id = GetExistingSpecId(new_spec);
 	if (existing_spec_id) {
 		table_metadata.default_spec_id = *existing_spec_id;
-		transaction_data.TableSetDefaultSpec();
+		if (!first_partition_spec) {
+			auto &transaction_data = GetOrCreateTransactionData(transaction);
+			transaction_data.TableSetDefaultSpec();
+		}
 		return;
 	}
 
 	table_metadata.partition_specs.emplace(new_spec_id, std::move(new_spec));
 	table_metadata.default_spec_id = new_spec_id;
 	if (!first_partition_spec) {
+		auto &transaction_data = GetOrCreateTransactionData(transaction);
 		transaction_data.TableAddPartitionSpec();
 		transaction_data.TableSetDefaultSpec();
 	}
@@ -433,7 +436,6 @@ void IcebergTableInformation::SetSortedBy(IcebergTransaction &transaction, const
 	if (!first_sort_spec) {
 		new_sort_order_id = GetNextSortOrderId();
 	}
-	auto &transaction_data = GetOrCreateTransactionData(transaction);
 
 	auto new_sort_order = BuildSortOrder(orders, schema, static_cast<int32_t>(new_sort_order_id));
 
@@ -442,13 +444,17 @@ void IcebergTableInformation::SetSortedBy(IcebergTransaction &transaction, const
 	auto existing_sort_order_id = GetExistingSortOrderId(new_sort_order);
 	if (existing_sort_order_id) {
 		table_metadata.default_sort_order_id = *existing_sort_order_id;
-		transaction_data.TableSetDefaultSortOrder();
+		if (!first_sort_spec) {
+			auto &transaction_data = GetOrCreateTransactionData(transaction);
+			transaction_data.TableSetDefaultSortOrder();
+		}
 		return;
 	}
 
 	table_metadata.sort_specs.emplace(new_sort_order_id, std::move(new_sort_order));
 	table_metadata.default_sort_order_id = new_sort_order_id;
 	if (!first_sort_spec) {
+		auto &transaction_data = GetOrCreateTransactionData(transaction);
 		transaction_data.TableAddSortOrder();
 		transaction_data.TableSetDefaultSortOrder();
 	}

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -564,7 +564,7 @@ bool IcebergTableInformation::HasTransactionUpdates() const {
 	if (!data.requirements.empty()) {
 		return true;
 	}
-	if (data.set_schema_id) {
+	if (data.pending_current_schema_id.has_value()) {
 		return true;
 	}
 	if (data.assert_schema_id) {

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -394,40 +394,46 @@ IcebergSortOrder IcebergTableInformation::BuildSortOrder(const vector<OrderByNod
 	return new_sort_order;
 }
 
-void IcebergTableInformation::SetPartitionedBy(IcebergTransaction &transaction,
-                                               const vector<unique_ptr<ParsedExpression>> &partition_keys,
-                                               const IcebergTableSchema &schema, bool first_partition_spec) {
-	idx_t base_partition_field_id = 1000;
-	if (!first_partition_spec && table_metadata.HasLastPartitionId()) {
-		base_partition_field_id = table_metadata.GetLastPartitionFieldId() + 1;
-	}
-	idx_t new_spec_id = 0;
-	if (!first_partition_spec) {
-		new_spec_id = GetNextPartitionSpecId();
+void IcebergTableInformation::SetInitialPartitionSpec(const vector<unique_ptr<ParsedExpression>> &partition_keys,
+                                                      const IcebergTableSchema &schema) {
+	auto new_spec = BuildPartitionSpec(partition_keys, schema, 0, 1000);
+
+	// New tables should not already have a matching partition spec, but preserve the same behavior
+	// as the transactional path in case metadata was pre-populated before bootstrap.
+	if (auto existing_spec_id = GetExistingSpecId(new_spec)) {
+		table_metadata.default_spec_id = *existing_spec_id;
+		return;
 	}
 
-	auto new_spec =
-	    BuildPartitionSpec(partition_keys, schema, static_cast<int32_t>(new_spec_id), base_partition_field_id);
+	table_metadata.partition_specs.emplace(0, std::move(new_spec));
+	table_metadata.default_spec_id = 0;
+}
+
+void IcebergTableInformation::SetPartitionedBy(IcebergTransaction &transaction,
+                                               const vector<unique_ptr<ParsedExpression>> &partition_keys,
+                                               const IcebergTableSchema &schema) {
+	idx_t base_partition_field_id = 1000;
+	if (table_metadata.HasLastPartitionId()) {
+		base_partition_field_id = table_metadata.GetLastPartitionFieldId() + 1;
+	}
+	auto new_spec_id = static_cast<int32_t>(GetNextPartitionSpecId());
+
+	auto new_spec = BuildPartitionSpec(partition_keys, schema, new_spec_id, base_partition_field_id);
 
 	// if spec definition already exists in a previous spec definition, set it to that spec id
 	// (some catalog may allow duplicate definitions, others not)
 	auto existing_spec_id = GetExistingSpecId(new_spec);
+	auto &transaction_data = GetOrCreateTransactionData(transaction);
 	if (existing_spec_id) {
 		table_metadata.default_spec_id = *existing_spec_id;
-		if (!first_partition_spec) {
-			auto &transaction_data = GetOrCreateTransactionData(transaction);
-			transaction_data.TableSetDefaultSpec();
-		}
+		transaction_data.TableSetDefaultSpec();
 		return;
 	}
 
 	table_metadata.partition_specs.emplace(new_spec_id, std::move(new_spec));
 	table_metadata.default_spec_id = new_spec_id;
-	if (!first_partition_spec) {
-		auto &transaction_data = GetOrCreateTransactionData(transaction);
-		transaction_data.TableAddPartitionSpec();
-		transaction_data.TableSetDefaultSpec();
-	}
+	transaction_data.TableAddPartitionSpec();
+	transaction_data.TableSetDefaultSpec();
 }
 
 void IcebergTableInformation::SetSortedBy(IcebergTransaction &transaction, const vector<OrderByNode> &orders,

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -260,7 +260,7 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 
 	auto &current_schema = table_info.table_metadata.GetLatestSchema();
 	table_ptr->table_info.table_metadata.default_spec_id = 0;
-	table_ptr->table_info.SetPartitionedBy(iceberg_transaction, info.partition_keys, current_schema, true);
+	table_ptr->table_info.SetInitialPartitionSpec(info.partition_keys, current_schema);
 
 	// Immediately create the table with stage_create = true to get metadata & data location(s)
 	// transaction commit will either commit with data (OR) create the table with stage_create = false

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -214,12 +214,11 @@ static void CreateTableRequirements(DatabaseInstance &db, ClientContext &context
 		requirement->CreateRequirement(db, context, commit_state);
 	}
 	if (!has_assert_create && NeedsAssertSchemaId(transaction_data, commit_state.table_info)) {
-		AssertCurrentSchemaIdRequirement requirement(commit_state.table_info);
-		requirement.current_schema_id = transaction_data.initial_schema_id;
+		AssertCurrentSchemaIdRequirement requirement(transaction_data.initial_schema_id);
 		requirement.CreateRequirement(db, context, commit_state);
 	}
 	if (!has_assert_create && commit_state.table_info.HasTransactionUpdates()) {
-		auto uuid_requirement = AssertTableUUIDRequirement(commit_state.table_info);
+		auto uuid_requirement = AssertTableUUIDRequirement(transaction_data.initial_table_uuid);
 		uuid_requirement.CreateRequirement(db, context, commit_state);
 	}
 	if (current_snapshot && !transaction_data.alters.empty()) {
@@ -268,8 +267,8 @@ static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, Iceb
 		commit_state.table_change.updates.push_back(std::move(set_snapshot_ref_update));
 	}
 
-	if (transaction_data.set_schema_id) {
-		SetCurrentSchema update(table_info);
+	if (transaction_data.pending_current_schema_id.has_value()) {
+		SetCurrentSchema update(*transaction_data.pending_current_schema_id);
 		update.CreateUpdate(db, context, commit_state);
 	}
 

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -100,7 +100,7 @@ int64_t IcebergTransactionData::GetCommitRetryCount() const {
 }
 
 bool IcebergTransactionData::SupportsAppendRetry() const {
-	if (!requirements.empty() || set_schema_id) {
+	if (!requirements.empty() || pending_current_schema_id.has_value()) {
 		return false;
 	}
 	if (updates.empty()) {
@@ -223,27 +223,31 @@ void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&de
 }
 
 void IcebergTransactionData::TableAddSchema(int32_t schema_id) {
-	auto add_schema_update = make_uniq<AddSchemaUpdate>(table_info, schema_id);
+	auto schema = table_info.table_metadata.GetSchemaFromId(schema_id);
+	if (!schema) {
+		throw InternalException("(TableAddSchema) Couldn't find schema with id: %d", schema_id);
+	}
+	auto add_schema_update = make_uniq<AddSchemaUpdate>(schema->Copy(), table_info.table_metadata.last_column_id);
 	updates.push_back(std::move(add_schema_update));
 	assert_schema_id = true;
-	set_schema_id = true;
+	pending_current_schema_id = schema_id;
 }
 
-void IcebergTransactionData::TableSetCurrentSchema() {
-	set_schema_id = true;
+void IcebergTransactionData::TableSetCurrentSchema(int32_t schema_id) {
+	pending_current_schema_id = schema_id;
 }
 
 void IcebergTransactionData::TableAssignUUID() {
-	updates.push_back(make_uniq<AssignUUIDUpdate>(table_info));
+	updates.push_back(make_uniq<AssignUUIDUpdate>(table_info.table_metadata.table_uuid));
 }
 
 void IcebergTransactionData::TableAddAssertCreate() {
 	has_assert_create = true;
-	requirements.push_back(make_uniq<AssertCreateRequirement>(table_info));
+	requirements.push_back(make_uniq<AssertCreateRequirement>());
 }
 
 void IcebergTransactionData::TableAddAssertUUID() {
-	requirements.push_back(make_uniq<AssertTableUUIDRequirement>(table_info));
+	requirements.push_back(make_uniq<AssertTableUUIDRequirement>(table_info.table_metadata.table_uuid));
 }
 
 void IcebergTransactionData::TableAddAssertCurrentSchemaId() {
@@ -251,47 +255,54 @@ void IcebergTransactionData::TableAddAssertCurrentSchemaId() {
 }
 
 void IcebergTransactionData::TableAddAssertLastAssignedFieldId() {
-	requirements.push_back(make_uniq<AssertLastAssignedFieldIdRequirement>(table_info));
+	D_ASSERT(table_info.table_metadata.HasLastColumnId());
+	requirements.push_back(make_uniq<AssertLastAssignedFieldIdRequirement>(
+	    static_cast<int32_t>(table_info.table_metadata.GetLastColumnId())));
 }
 
 void IcebergTransactionData::TableAddAssertLastAssignedPartitionId() {
-	requirements.push_back(make_uniq<AssertLastAssignedPartitionIdRequirement>(table_info));
+	int32_t last_assigned_partition_id = 999;
+	if (table_info.table_metadata.HasLastPartitionId()) {
+		last_assigned_partition_id = table_info.table_metadata.GetLastPartitionFieldId();
+	}
+	requirements.push_back(make_uniq<AssertLastAssignedPartitionIdRequirement>(last_assigned_partition_id));
 }
 
 void IcebergTransactionData::TableAddAssertDefaultSpecId() {
-	requirements.push_back(make_uniq<AssertDefaultSpecIdRequirement>(table_info));
+	requirements.push_back(make_uniq<AssertDefaultSpecIdRequirement>(table_info.table_metadata.default_spec_id));
 }
 
 void IcebergTransactionData::TableAddUpradeFormatVersion() {
-	updates.push_back(make_uniq<UpgradeFormatVersion>(table_info));
+	updates.push_back(make_uniq<UpgradeFormatVersion>(table_info.table_metadata.iceberg_version));
 }
 
 void IcebergTransactionData::TableAddPartitionSpec() {
-	updates.push_back(make_uniq<AddPartitionSpec>(table_info));
+	updates.push_back(make_uniq<AddPartitionSpec>(table_info.table_metadata.GetLatestPartitionSpec()));
 }
 
 void IcebergTransactionData::TableAddSortOrder() {
-	updates.push_back(make_uniq<AddSortOrder>(table_info));
+	updates.push_back(make_uniq<AddSortOrder>(table_info.table_metadata.GetLatestSortOrder()));
 }
 
 void IcebergTransactionData::TableSetDefaultSortOrder() {
-	updates.push_back(make_uniq<SetDefaultSortOrder>(table_info));
+	D_ASSERT(table_info.table_metadata.HasSortOrder());
+	updates.push_back(make_uniq<SetDefaultSortOrder>(table_info.table_metadata.GetLatestSortOrder().sort_order_id));
 }
 
 void IcebergTransactionData::TableSetDefaultSpec() {
-	updates.push_back(make_uniq<SetDefaultSpec>(table_info));
+	updates.push_back(make_uniq<SetDefaultSpec>(table_info.table_metadata.default_spec_id));
 }
 
 void IcebergTransactionData::TableSetProperties(const case_insensitive_map_t<string> &properties) {
-	updates.push_back(make_uniq<SetProperties>(table_info, properties));
+	updates.push_back(make_uniq<SetProperties>(properties));
 }
 
 void IcebergTransactionData::TableRemoveProperties(const vector<string> &properties) {
-	updates.push_back(make_uniq<RemoveProperties>(table_info, properties));
+	updates.push_back(make_uniq<RemoveProperties>(properties));
 }
 
 void IcebergTransactionData::TableSetLocation() {
-	updates.push_back(make_uniq<SetLocation>(table_info));
+	updates.push_back(make_uniq<SetLocation>(table_info.table_metadata.location));
 }
 
 } // namespace duckdb

--- a/src/core/metadata/schema/iceberg_table_schema.cpp
+++ b/src/core/metadata/schema/iceberg_table_schema.cpp
@@ -1,5 +1,6 @@
 #include "core/metadata/schema/iceberg_table_schema.hpp"
 
+#include "catalog/rest/api/iceberg_create_table_request.hpp"
 #include "duckdb/common/exception.hpp"
 #include "common/iceberg_utils.hpp"
 #include "rest_catalog/objects/list.hpp"
@@ -18,6 +19,21 @@ shared_ptr<IcebergTableSchema> IcebergTableSchema::ParseSchema(const rest_api_ob
 		res->identifier_field_ids = *identifier_field_ids;
 	}
 	return res;
+}
+
+rest_api_objects::Schema IcebergTableSchema::ToRESTObject() const {
+	std::unique_ptr<yyjson_mut_doc, YyjsonDocDeleter> doc_p(yyjson_mut_doc_new(nullptr));
+	yyjson_mut_doc *doc = doc_p.get();
+	auto root_object = yyjson_mut_obj(doc);
+	yyjson_mut_doc_set_root(doc, root_object);
+	IcebergCreateTableRequest::PopulateSchema(doc, root_object, *this);
+	auto schema_json = ICUtils::JsonToString(std::move(doc_p));
+
+	std::unique_ptr<yyjson_doc, YyjsonDocDeleter> parsed_doc(yyjson_read(schema_json.c_str(), schema_json.size(), 0));
+	if (!parsed_doc) {
+		throw InternalException("Failed to parse generated schema JSON");
+	}
+	return rest_api_objects::Schema::FromJSON(yyjson_doc_get_root(parsed_doc.get()));
 }
 
 void IcebergTableSchema::PopulateSourceIdMap(unordered_map<uint64_t, ColumnIndex> &source_to_column_id,
@@ -132,6 +148,7 @@ shared_ptr<IcebergTableSchema> IcebergTableSchema::Copy() const {
 	auto res = make_shared_ptr<IcebergTableSchema>();
 	res->schema_id = schema_id;
 	res->last_column_id = last_column_id;
+	res->identifier_field_ids = identifier_field_ids;
 	for (auto &column : columns) {
 		res->columns.push_back(column->Copy());
 	}
@@ -142,6 +159,7 @@ shared_ptr<IcebergTableSchema> IcebergTableSchema::RemoveColumn(const string &na
 	auto res = make_shared_ptr<IcebergTableSchema>();
 	res->schema_id = schema_id + 1;
 	res->last_column_id = last_column_id;
+	res->identifier_field_ids = identifier_field_ids;
 	for (auto &column : columns) {
 		if (column->name == name) {
 			column_id = column->id;

--- a/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
+++ b/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
@@ -25,6 +25,7 @@ public:
 
 public:
 	bool IsRetryable() const override;
+	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 	void ConstructManifestList(IcebergManifestList &manifest_list, CopyFunction &avro_copy, DatabaseInstance &db,
 	                           IcebergCommitState &commit_state) const;
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;

--- a/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
+++ b/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
@@ -25,7 +25,6 @@ public:
 
 public:
 	bool IsRetryable() const override;
-	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 	void ConstructManifestList(IcebergManifestList &manifest_list, CopyFunction &avro_copy, DatabaseInstance &db,
 	                           IcebergCommitState &commit_state) const;
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;

--- a/src/include/catalog/rest/api/iceberg_table_requirement.hpp
+++ b/src/include/catalog/rest/api/iceberg_table_requirement.hpp
@@ -5,7 +5,7 @@
 
 namespace duckdb {
 
-struct IcebergTableInformation;
+struct IcebergCommitState;
 
 enum class IcebergTableRequirementType : uint8_t {
 	ASSERT_CREATE,
@@ -20,8 +20,7 @@ enum class IcebergTableRequirementType : uint8_t {
 
 struct IcebergTableRequirement {
 public:
-	IcebergTableRequirement(IcebergTableRequirementType type, const IcebergTableInformation &table_info)
-	    : type(type), table_info(table_info) {
+	explicit IcebergTableRequirement(IcebergTableRequirementType type) : type(type) {
 	}
 	virtual ~IcebergTableRequirement() {
 	}
@@ -40,7 +39,6 @@ public:
 
 public:
 	IcebergTableRequirementType type;
-	const IcebergTableInformation &table_info;
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/api/iceberg_table_update.hpp
+++ b/src/include/catalog/rest/api/iceberg_table_update.hpp
@@ -7,7 +7,6 @@
 
 namespace duckdb {
 
-struct IcebergTableMetadata;
 struct IcebergTableInformation;
 struct IcebergTransactionData;
 
@@ -64,7 +63,6 @@ public:
 
 public:
 	virtual void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const = 0;
-	virtual void ApplyUpdate(IcebergTableMetadata &metadata) const = 0;
 	virtual bool IsRetryable() const {
 		return false;
 	}

--- a/src/include/catalog/rest/api/iceberg_table_update.hpp
+++ b/src/include/catalog/rest/api/iceberg_table_update.hpp
@@ -7,6 +7,7 @@
 
 namespace duckdb {
 
+struct IcebergTableMetadata;
 struct IcebergTableInformation;
 struct IcebergTransactionData;
 
@@ -57,12 +58,13 @@ public:
 
 struct IcebergTableUpdate {
 public:
-	IcebergTableUpdate(IcebergTableUpdateType type, const IcebergTableInformation &table_info);
+	explicit IcebergTableUpdate(IcebergTableUpdateType type);
 	virtual ~IcebergTableUpdate() {
 	}
 
 public:
 	virtual void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const = 0;
+	virtual void ApplyUpdate(IcebergTableMetadata &metadata) const = 0;
 	virtual bool IsRetryable() const {
 		return false;
 	}
@@ -78,7 +80,6 @@ public:
 
 public:
 	IcebergTableUpdateType type;
-	const IcebergTableInformation &table_info;
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/api/table_update.hpp
+++ b/src/include/catalog/rest/api/table_update.hpp
@@ -8,9 +8,11 @@
 #include "catalog/rest/api/iceberg_table_update.hpp"
 #include "catalog/rest/api/iceberg_table_requirement.hpp"
 #include "core/metadata/manifest/iceberg_manifest.hpp"
+#include "core/metadata/partition/iceberg_partition_spec.hpp"
 #include "core/metadata/schema/iceberg_table_schema.hpp"
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
 #include "core/metadata/snapshot/iceberg_snapshot.hpp"
+#include "core/metadata/sort/iceberg_sort_order.hpp"
 
 namespace duckdb {
 
@@ -18,36 +20,39 @@ struct IcebergTableInformation;
 
 struct AddSchemaUpdate : public IcebergTableUpdate {
 public:
-	explicit AddSchemaUpdate(const IcebergTableInformation &table_info, int32_t schema_id);
+	AddSchemaUpdate(shared_ptr<IcebergTableSchema> schema, optional_idx last_column_id);
 
 public:
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SCHEMA;
 
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 
 public:
-	int32_t schema_id;
 	optional_idx last_column_id;
+	shared_ptr<IcebergTableSchema> schema;
 };
 
 struct AssertCreateRequirement : public IcebergTableRequirement {
 	static constexpr const IcebergTableRequirementType TYPE = IcebergTableRequirementType::ASSERT_CREATE;
 
-	explicit AssertCreateRequirement(const IcebergTableInformation &table_info);
+	AssertCreateRequirement();
 	void CreateRequirement(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
 };
 
 struct AssertTableUUIDRequirement : public IcebergTableRequirement {
 	static constexpr const IcebergTableRequirementType TYPE = IcebergTableRequirementType::ASSERT_TABLE_UUID;
 
-	explicit AssertTableUUIDRequirement(const IcebergTableInformation &table_info);
+	explicit AssertTableUUIDRequirement(string uuid);
 	void CreateRequirement(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
+
+	string uuid;
 };
 
 struct AssertCurrentSchemaIdRequirement : public IcebergTableRequirement {
 	static constexpr const IcebergTableRequirementType TYPE = IcebergTableRequirementType::ASSERT_CURRENT_SCHEMA_ID;
 
-	explicit AssertCurrentSchemaIdRequirement(const IcebergTableInformation &table_info);
+	explicit AssertCurrentSchemaIdRequirement(int32_t current_schema_id);
 	void CreateRequirement(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
 
 	int32_t current_schema_id;
@@ -58,7 +63,7 @@ struct AssertLastAssignedFieldIdRequirement : public IcebergTableRequirement {
 	static constexpr const IcebergTableRequirementType TYPE =
 	    IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_FIELD_ID;
 
-	explicit AssertLastAssignedFieldIdRequirement(const IcebergTableInformation &table_info);
+	explicit AssertLastAssignedFieldIdRequirement(int32_t last_assigned_field_id);
 	void CreateRequirement(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
 
 	int32_t last_assigned_field_id;
@@ -68,7 +73,7 @@ struct AssertLastAssignedPartitionIdRequirement : public IcebergTableRequirement
 	static constexpr const IcebergTableRequirementType TYPE =
 	    IcebergTableRequirementType::ASSERT_LAST_ASSIGNED_PARTITION_ID;
 
-	explicit AssertLastAssignedPartitionIdRequirement(const IcebergTableInformation &table_info);
+	explicit AssertLastAssignedPartitionIdRequirement(int32_t last_assigned_partition_id);
 	void CreateRequirement(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
 
 	int32_t last_assigned_partition_id;
@@ -77,7 +82,7 @@ struct AssertLastAssignedPartitionIdRequirement : public IcebergTableRequirement
 struct AssertDefaultSpecIdRequirement : public IcebergTableRequirement {
 	static constexpr const IcebergTableRequirementType TYPE = IcebergTableRequirementType::ASSERT_DEFAULT_SPEC_ID;
 
-	explicit AssertDefaultSpecIdRequirement(const IcebergTableInformation &table_info);
+	explicit AssertDefaultSpecIdRequirement(int32_t default_spec_id);
 	void CreateRequirement(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
 
 	int32_t default_spec_id;
@@ -86,58 +91,79 @@ struct AssertDefaultSpecIdRequirement : public IcebergTableRequirement {
 struct AssignUUIDUpdate : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ASSIGN_UUID;
 
-	explicit AssignUUIDUpdate(const IcebergTableInformation &table_info);
+	explicit AssignUUIDUpdate(string uuid);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
+
+	string uuid;
 };
 
 struct UpgradeFormatVersion : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::UPGRADE_FORMAT_VERSION;
 
-	explicit UpgradeFormatVersion(const IcebergTableInformation &table_info);
+	explicit UpgradeFormatVersion(int32_t format_version);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
+
+	int32_t format_version;
 };
 
 struct SetCurrentSchema : public IcebergTableUpdate {
-	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::UPGRADE_FORMAT_VERSION;
+	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_CURRENT_SCHEMA;
 
-	explicit SetCurrentSchema(const IcebergTableInformation &table_info);
+	explicit SetCurrentSchema(int32_t schema_id);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
+
+	int32_t schema_id;
 };
 
 struct AddPartitionSpec : public IcebergTableUpdate {
-	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::UPGRADE_FORMAT_VERSION;
-
-	explicit AddPartitionSpec(const IcebergTableInformation &table_info);
+	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_PARTITION_SPEC;
+	explicit AddPartitionSpec(const IcebergPartitionSpec &partition_spec);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
+
+	IcebergPartitionSpec partition_spec;
 };
 
 struct AddSortOrder : public IcebergTableUpdate {
 	static constexpr const int64_t DEFAULT_SORT_ORDER_ID = 0;
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SORT_ORDER;
 
-	explicit AddSortOrder(const IcebergTableInformation &table_info);
+	explicit AddSortOrder(const IcebergSortOrder &sort_order);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
+
+	IcebergSortOrder sort_order;
 };
 
 struct SetDefaultSortOrder : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_DEFAULT_SORT_ORDER;
 
-	explicit SetDefaultSortOrder(const IcebergTableInformation &table_info);
+	explicit SetDefaultSortOrder(int32_t sort_order_id);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
+
+	int32_t sort_order_id;
 };
 
 struct SetDefaultSpec : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_DEFAULT_SPEC;
 
-	explicit SetDefaultSpec(const IcebergTableInformation &table_info);
+	explicit SetDefaultSpec(int32_t spec_id);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
+
+	int32_t spec_id;
 };
 
 struct SetProperties : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_PROPERTIES;
 
-	explicit SetProperties(const IcebergTableInformation &table_info, const case_insensitive_map_t<string> &properties);
+	explicit SetProperties(const case_insensitive_map_t<string> &properties);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 
 	case_insensitive_map_t<string> properties;
 };
@@ -145,8 +171,9 @@ struct SetProperties : public IcebergTableUpdate {
 struct RemoveProperties : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::REMOVE_PROPERTIES;
 
-	explicit RemoveProperties(const IcebergTableInformation &table_info, const vector<string> &properties);
+	explicit RemoveProperties(const vector<string> &properties);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 
 	vector<string> properties;
 };
@@ -154,8 +181,11 @@ struct RemoveProperties : public IcebergTableUpdate {
 struct SetLocation : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_LOCATION;
 
-	explicit SetLocation(const IcebergTableInformation &table_info);
+	explicit SetLocation(string location);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
+
+	string location;
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/api/table_update.hpp
+++ b/src/include/catalog/rest/api/table_update.hpp
@@ -26,7 +26,6 @@ public:
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SCHEMA;
 
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
-	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 
 public:
 	optional_idx last_column_id;
@@ -93,7 +92,6 @@ struct AssignUUIDUpdate : public IcebergTableUpdate {
 
 	explicit AssignUUIDUpdate(string uuid);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
-	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 
 	string uuid;
 };
@@ -103,7 +101,6 @@ struct UpgradeFormatVersion : public IcebergTableUpdate {
 
 	explicit UpgradeFormatVersion(int32_t format_version);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
-	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 
 	int32_t format_version;
 };
@@ -113,7 +110,6 @@ struct SetCurrentSchema : public IcebergTableUpdate {
 
 	explicit SetCurrentSchema(int32_t schema_id);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
-	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 
 	int32_t schema_id;
 };
@@ -122,7 +118,6 @@ struct AddPartitionSpec : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_PARTITION_SPEC;
 	explicit AddPartitionSpec(const IcebergPartitionSpec &partition_spec);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
-	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 
 	IcebergPartitionSpec partition_spec;
 };
@@ -133,7 +128,6 @@ struct AddSortOrder : public IcebergTableUpdate {
 
 	explicit AddSortOrder(const IcebergSortOrder &sort_order);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
-	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 
 	IcebergSortOrder sort_order;
 };
@@ -143,7 +137,6 @@ struct SetDefaultSortOrder : public IcebergTableUpdate {
 
 	explicit SetDefaultSortOrder(int32_t sort_order_id);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
-	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 
 	int32_t sort_order_id;
 };
@@ -153,7 +146,6 @@ struct SetDefaultSpec : public IcebergTableUpdate {
 
 	explicit SetDefaultSpec(int32_t spec_id);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
-	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 
 	int32_t spec_id;
 };
@@ -163,7 +155,6 @@ struct SetProperties : public IcebergTableUpdate {
 
 	explicit SetProperties(const case_insensitive_map_t<string> &properties);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
-	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 
 	case_insensitive_map_t<string> properties;
 };
@@ -173,7 +164,6 @@ struct RemoveProperties : public IcebergTableUpdate {
 
 	explicit RemoveProperties(const vector<string> &properties);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
-	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 
 	vector<string> properties;
 };
@@ -183,7 +173,6 @@ struct SetLocation : public IcebergTableUpdate {
 
 	explicit SetLocation(string location);
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
-	void ApplyUpdate(IcebergTableMetadata &metadata) const override;
 
 	string location;
 };

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -47,8 +47,10 @@ public:
 	idx_t GetNextSortOrderId();
 	optional<int64_t> GetExistingSpecId(IcebergPartitionSpec &spec);
 	optional<int64_t> GetExistingSortOrderId(IcebergSortOrder &sort_order);
+	void SetInitialPartitionSpec(const vector<unique_ptr<ParsedExpression>> &partition_keys,
+	                             const IcebergTableSchema &schema);
 	void SetPartitionedBy(IcebergTransaction &transaction, const vector<unique_ptr<ParsedExpression>> &partition_keys,
-	                      const IcebergTableSchema &schema, bool first_partition_spec = false);
+	                      const IcebergTableSchema &schema);
 	void SetSortedBy(IcebergTransaction &transaction, const vector<OrderByNode> &orders,
 	                 const IcebergTableSchema &schema, bool first_sort_spec = false);
 	//! Build an IcebergPartitionSpec from parsed PARTITIONED BY expressions and a schema.

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "duckdb/common/optional.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/function/copy_function.hpp"
 
@@ -34,7 +35,7 @@ public:
 	                       IcebergManifestDeletes &&altered_manifests);
 	// add a schema update for a table
 	void TableAddSchema(int32_t schema_id);
-	void TableSetCurrentSchema();
+	void TableSetCurrentSchema(int32_t schema_id);
 	void TableAddAssertCreate();
 	void TableAddAssertUUID();
 	void TableAddAssertCurrentSchemaId();
@@ -79,8 +80,8 @@ public:
 	bool assert_schema_id = false;
 	//! Whether this transaction explicitly requires the table to be newly created.
 	bool has_assert_create = false;
-	//! Whether the current schema of the table should be updated
-	bool set_schema_id = false;
+	//! The schema id that should become current when the commit is staged.
+	optional<int32_t> pending_current_schema_id;
 	mutex lock;
 };
 

--- a/src/include/core/metadata/schema/iceberg_table_schema.hpp
+++ b/src/include/core/metadata/schema/iceberg_table_schema.hpp
@@ -1,18 +1,18 @@
 #pragma once
 
 #include "duckdb/common/column_index.hpp"
+#include "duckdb/common/optional.hpp"
 
 #include "core/metadata/schema/iceberg_column_definition.hpp"
 #include "rest_catalog/objects/schema.hpp"
 #include "rest_catalog/objects/add_schema_update.hpp"
-
-#include <optional>
 
 namespace duckdb {
 
 class IcebergTableSchema {
 public:
 	static shared_ptr<IcebergTableSchema> ParseSchema(const rest_api_objects::Schema &schema);
+	rest_api_objects::Schema ToRESTObject() const;
 
 public:
 	static void PopulateSourceIdMap(unordered_map<uint64_t, ColumnIndex> &source_to_column_id,

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/test_polaris.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/polaris/test_polaris.test
@@ -2,6 +2,10 @@
 # description: test integration with iceberg catalog read
 # group: [polaris]
 
+# Needs:
+# - default.quickstart_table (read-only)
+# - default.all_types_table (read-only)
+
 require-env CATALOG_TEST_CONFIG_SETUP polaris
 
 require avro


### PR DESCRIPTION
Salvage parts of #1117 

`IcebergTableUpdate` should contain all data it needs to represent the change (not reference a piece of `IcebergTableMetadata`), this is necessary to enable retries of updates.

### Misc change

`identifier_field_ids` of `IcebergTableSchema` was apparently not being copied/converted by existing methods
