### PR TITLE
Serialize boolean column bounds in manifests (stale skip from before duckdb#20222)

### DIFF
--- a/src/core/expression/iceberg_value.cpp
+++ b/src/core/expression/iceberg_value.cpp
@@ -503,13 +503,21 @@ SerializeResult IcebergValue::SerializeValue(Value input_value, const LogicalTyp
 		auto ret = SerializeResult(column_type, ret_val);
 		return ret;
 	}
+	case LogicalTypeId::BOOLEAN: {
+		//! Iceberg serializes boolean bounds as a single byte: 0x00 = false, 0x01 = true.
+		//! The value arrives as a string ("0"/"1" from parquet RETURN_STATS column stats —
+		//! proper since duckdb#20222 — or "true"/"false" from the partition-value VARCHAR
+		//! cast in the manifest-list writer); the BOOLEAN cast accepts both forms.
+		const uint8_t val = input_value.DefaultCastAs(LogicalType::BOOLEAN).GetValue<bool>() ? 1 : 0;
+		auto serialized_val = Value::BLOB(const_data_ptr_cast(&val), sizeof(uint8_t));
+		auto ret = SerializeResult(column_type, serialized_val);
+		return ret;
+	}
 		// GEOMETRY and VARIANT bounds are not produced via this string-Value path;
 		// they require multi-double / variant-binary encodings built inline at the
 		// stats-collection site (see IcebergInsertGlobalState::AddFiles).
 	case LogicalTypeId::GEOMETRY:
 	case LogicalTypeId::VARIANT:
-		// boolean does not yet return proper values so we skip
-	case LogicalTypeId::BOOLEAN:
 	default:
 		break;
 	}

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_boolean_bounds.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_boolean_bounds.test
@@ -1,0 +1,50 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_boolean_bounds.test
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require icu
+
+require core_functions
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+create schema if not exists my_datalake.default;
+
+statement ok
+drop table if exists my_datalake.default.bounds_boolean;
+
+statement ok
+create table my_datalake.default.bounds_boolean (
+b_mixed BOOLEAN,
+b_all_true BOOLEAN,
+b_all_false BOOLEAN,
+b_with_nulls BOOLEAN
+);
+
+statement ok
+insert into my_datalake.default.bounds_boolean values
+(false, true, false, NULL),
+(true, true, false, true);
+
+# Boolean bounds are serialized as a single byte (0x00 = false, 0x01 = true);
+# before this they were skipped entirely (a leftover from before duckdb#20222,
+# when RETURN_STATS did not produce boolean min/max), so readers could not
+# prune on boolean columns at all.
+query III
+select column_name, upper_bound, lower_bound from iceberg_column_stats(my_datalake.default.bounds_boolean) order by all;
+----
+b_all_false	false	false
+b_all_true	true	true
+b_mixed	true	false
+b_with_nulls	true	true


### PR DESCRIPTION
`IcebergValue::SerializeValue` currently skips `LogicalTypeId::BOOLEAN` with the comment *"boolean does not yet return proper values so we skip"* (from #640). That was true at the time — `COPY ... RETURN_STATS` didn't produce boolean min/max — but duckdb/duckdb#20222 fixed that in core a week later, and this switch never got revisited.

The effect today: boolean columns get no lower/upper bounds in data-file manifest entries and no partition summaries in the manifest list, so no reader can prune on them. That bites hardest on tables *partitioned* by a boolean (the common SCD2 layout, `PARTITIONED BY (is_current, ...)`) — every engine scans both partitions' files unconditionally.

This removes the skip and serializes booleans per the Iceberg spec (single byte, `0x00` = false / `0x01` = true). Both input shapes reaching this path are covered by the BOOLEAN cast: `"0"`/`"1"` from the RETURN_STATS column stats, and `"true"`/`"false"` from the partition-value VARCHAR cast in the manifest-list writer. The deserialize side already handles single-byte boolean bounds, so round-trips are symmetric.

On layering: we checked whether any of this belongs in core — it doesn't appear to. The stats *values* now flow correctly from core (#20222); what's missing is only the Iceberg-specific bound encoding, which lives here next to every other type's case in the same switch.

Test: writes a table with all-true / all-false / mixed / null-bearing boolean columns and asserts the bounds via `iceberg_column_stats()` — NULL bounds without the change, exact single-byte bounds with it.

We've been running this against production V3 merge-on-read tables (SCD2 with `is_current` as a partition column) — bounds come out partition-exact: `0x01/0x01` on current files, `0x00/0x00` on history files.
