### PR TITLE
[ALTER] Add support for `COMMENT ON COLUMN`

### DIFF
--- a/src/catalog/rest/api/iceberg_create_table_request.cpp
+++ b/src/catalog/rest/api/iceberg_create_table_request.cpp
@@ -36,6 +36,11 @@ static void AddUnnamedField(yyjson_mut_doc *doc, yyjson_mut_val *field_obj, cons
 static void AddNamedField(yyjson_mut_doc *doc, yyjson_mut_val *field_obj, const IcebergColumnDefinition &column) {
 	yyjson_mut_obj_add_strcpy(doc, field_obj, "name", column.name.c_str());
 	yyjson_mut_obj_add_uint(doc, field_obj, "id", column.id);
+	yyjson_mut_obj_add_bool(doc, field_obj, "required", column.required);
+	if (column.doc) {
+		yyjson_mut_obj_add_strcpy(doc, field_obj, "doc", column.doc->c_str());
+	}
+
 	if (column.type.id() != LogicalTypeId::VARIANT && column.type.IsNested()) {
 		auto type_obj = yyjson_mut_obj_add_obj(doc, field_obj, "type");
 		AddUnnamedField(doc, type_obj, column);
@@ -46,12 +51,11 @@ static void AddNamedField(yyjson_mut_doc *doc, yyjson_mut_val *field_obj, const 
 		if (column.write_default && !column.write_default->IsNull()) {
 			(void)yyjson_mut_obj_add_obj(doc, field_obj, "write-default");
 		}
-		yyjson_mut_obj_add_bool(doc, field_obj, "required", column.required);
 		return;
 	}
-	yyjson_mut_obj_add_strcpy(doc, field_obj, "type", IcebergTypeHelper::LogicalTypeToIcebergType(column.type).c_str());
 
-	yyjson_mut_obj_add_bool(doc, field_obj, "required", column.required);
+	//! Write of non-struct type
+	yyjson_mut_obj_add_strcpy(doc, field_obj, "type", IcebergTypeHelper::LogicalTypeToIcebergType(column.type).c_str());
 	if (column.initial_default && !column.initial_default->IsNull()) {
 		auto primitive_type_value = IcebergTypeHelper::PrimitiveTypeFromValue(*column.initial_default);
 		yyjson_mut_obj_add_val(doc, field_obj, "initial-default",

--- a/src/catalog/rest/api/table_update.cpp
+++ b/src/catalog/rest/api/table_update.cpp
@@ -144,7 +144,6 @@ void SetCurrentSchema::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	auto &req = commit_state.table_change.updates.back();
 	req.set_current_schema_update = rest_api_objects::SetCurrentSchemaUpdate();
 	req.set_current_schema_update->base_update.action = "set-current-schema";
-	// TODO: should this be a different value? or is the rest catalog setting this again?
 	req.set_current_schema_update->schema_id = schema_id;
 }
 

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/parser/constraints/list.hpp"
 #include "duckdb/parser/parsed_data/alter_info.hpp"
 #include "duckdb/parser/parsed_data/alter_table_info.hpp"
+#include "duckdb/parser/parsed_data/comment_on_column_info.hpp"
 #include "duckdb/parser/parsed_data/create_index_info.hpp"
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
 #include "duckdb/parser/parsed_data/drop_info.hpp"
@@ -340,17 +341,13 @@ IcebergColumnDefinition &ResolveColumn(T &alter_table_info, const shared_ptr<Ice
 }
 
 void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) {
-	if (info.type != AlterType::ALTER_TABLE) {
-		throw NotImplementedException("Only ALTER TABLE is supported for Iceberg");
-	}
-	auto &alter_table_info = info.Cast<AlterTableInfo>();
 	auto &irc_transaction = GetICTransaction(transaction);
 	auto &context = transaction.GetContext();
 
-	EntryLookupInfo lookup(CatalogType::TABLE_ENTRY, alter_table_info.GetQualifiedName().Name());
+	EntryLookupInfo lookup(CatalogType::TABLE_ENTRY, QualifiedName(info.GetQualifiedName().Name()));
 	auto catalog_entry = tables.GetEntry(context, lookup);
 	if (!catalog_entry) {
-		throw CatalogException("Table with name \"%s\" does not exist!", alter_table_info.GetQualifiedName().Name());
+		throw CatalogException("Table with name \"%s\" does not exist!", info.GetQualifiedName().Name());
 	}
 	auto &table_entry = catalog_entry->Cast<IcebergTableEntry>();
 	auto &catalog_table_info = table_entry.table_info;
@@ -359,6 +356,33 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 	auto &updated_table = alter.GetOrInitializeTable(catalog_table_info);
 	auto &transaction_data = updated_table.GetOrCreateTransactionData(irc_transaction);
 	auto &current_schema = updated_table.table_metadata.GetLatestSchema();
+
+	if (info.type == AlterType::SET_COLUMN_COMMENT) {
+		auto &comment_info = info.Cast<SetColumnCommentInfo>();
+
+		auto new_schema = current_schema.Copy();
+		new_schema->schema_id++;
+
+		auto column_p = new_schema->GetMutableFromPath({comment_info.column_name}, nullptr);
+		if (!column_p) {
+			throw CatalogException("Column with name '%s' does not exist on the table '%s', COMMENT ON COLUMN failed",
+			                       comment_info.column_name, table_entry.name);
+		}
+
+		auto &column = *column_p;
+		column.doc = std::nullopt;
+		if (!comment_info.comment_value.IsNull()) {
+			column.doc = comment_info.comment_value.GetValue<string>();
+		}
+
+		IntroduceNewSchema(updated_table, transaction_data, new_schema);
+		return;
+	}
+
+	if (info.type != AlterType::ALTER_TABLE) {
+		throw NotImplementedException("Only ALTER TABLE is supported for Iceberg");
+	}
+	auto &alter_table_info = info.Cast<AlterTableInfo>();
 
 	switch (alter_table_info.alter_table_type) {
 	case AlterTableType::SET_PARTITIONED_BY: {

--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -298,17 +298,11 @@ int32_t IcebergTableMetadata::GetCurrentSchemaId() const {
 }
 
 IcebergTableSchema &IcebergTableMetadata::AddSchemaOrGetExisting(shared_ptr<IcebergTableSchema> schema) {
-	optional_ptr<IcebergTableSchema> existing_schema;
 	for (auto &it : schemas) {
 		auto &item = *it.second;
-
 		if (schema->Equals(item)) {
-			existing_schema = item;
-			break;
+			return item;
 		}
-	}
-	if (existing_schema) {
-		return *existing_schema;
 	}
 	auto new_schema_id = schema->schema_id;
 	auto res = schemas.emplace(new_schema_id, std::move(schema));

--- a/src/core/metadata/schema/iceberg_column_definition.cpp
+++ b/src/core/metadata/schema/iceberg_column_definition.cpp
@@ -347,9 +347,9 @@ ColumnDefinition IcebergColumnDefinition::GetColumnDefinition() const {
 		res.SetDefaultValue(make_uniq<ConstantExpression>(default_value));
 	}
 
-	if (!doc.empty()) {
+	if (doc) {
 		//! Surface the Iceberg field `doc` as the DuckDB column comment
-		res.SetComment(Value(doc));
+		res.SetComment(Value(*doc));
 	}
 	return res;
 }

--- a/src/include/core/metadata/schema/iceberg_column_definition.hpp
+++ b/src/include/core/metadata/schema/iceberg_column_definition.hpp
@@ -31,7 +31,6 @@ public:
 
 public:
 	void AddChild(unique_ptr<IcebergColumnDefinition> &&child);
-	void ReplaceChild(const string &name, unique_ptr<IcebergColumnDefinition> &&child);
 	void RemoveChild(const string &name);
 	optional_ptr<const IcebergColumnDefinition> GetChild(const string &name) const;
 	optional_ptr<const IcebergColumnDefinition> GetChild(idx_t index) const;
@@ -44,7 +43,7 @@ private:
 
 public:
 	int32_t id;
-	string doc;
+	optional<string> doc;
 	string name;
 	LogicalType type;
 	unique_ptr<Value> initial_default;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_column_comment.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_column_comment.test
@@ -1,0 +1,77 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_column_comment.test
+# group: [alter]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+statement ok
+SET default_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE';
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set enable_logging=true
+
+statement ok
+set logging_level='debug'
+
+statement ok
+drop table if exists my_datalake.default.comment_table;
+
+statement ok
+create table my_datalake.default.comment_table(
+	id INTEGER,
+	name VARCHAR,
+	payload STRUCT(city VARCHAR, zip INTEGER)
+);
+
+statement ok
+COMMENT ON COLUMN my_datalake.default.comment_table.id IS 'Primary identifier';
+
+statement ok
+describe my_datalake.default.comment_table;
+
+query II
+select column_name, comment from duckdb_columns()
+where database_name = 'my_datalake' and table_name = 'comment_table'
+order by column_index;
+----
+id	Primary identifier
+name	NULL
+payload	NULL
+
+statement ok
+COMMENT ON COLUMN my_datalake.default.comment_table.id IS NULL;
+
+# FIXME: we have to issue another query to re-fetch the updated state of the table
+statement ok
+select * from my_datalake.default.comment_table LIMIT 0;
+
+query II
+select column_name, comment from duckdb_columns()
+where database_name = 'my_datalake' and table_name = 'comment_table'
+order by column_index;
+----
+id	NULL
+name	NULL
+payload	NULL
+
+statement error
+COMMENT ON COLUMN my_datalake.default.comment_table.missing IS 'nope';
+----
+Catalog Error: Column with name 'missing' does not exist on the table 'comment_table', COMMENT ON COLUMN failed
+
+# Nested struct fields are not supported by COMMENT ON COLUMN yet. The parser
+# only supports relation qualification plus a single column identifier.
+statement error
+COMMENT ON COLUMN my_datalake.default.comment_table.payload.city IS 'nested city';
+----
+<REGEX>:(.*Parser Error.*Too many qualifications found.*|.*Parser Error.*Invalid column reference.*)


### PR DESCRIPTION
This PR is part of https://github.com/duckdblabs/duckdb-internal/issues/8512

### Limitations

Can only comment on top-level columns currently, due to parser limitations in DuckDB core.