### PR TITLE
[Transaction] Disable grouping of statements that would break atomicity of the COMMIT

### DIFF
--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -352,25 +352,28 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 	auto &table_entry = catalog_entry->Cast<IcebergTableEntry>();
 	auto &catalog_table_info = table_entry.table_info;
 
-	if (alter_table_info.alter_table_type == AlterTableType::RENAME_TABLE) {
-		auto &rename_table_info = alter_table_info.Cast<RenameTableInfo>();
-		auto &new_name = rename_table_info.new_table_name;
+	if (info.type == AlterType::ALTER_TABLE) {
+		auto &alter_table_info = info.Cast<AlterTableInfo>();
+		if (alter_table_info.alter_table_type == AlterTableType::RENAME_TABLE) {
+			auto &rename_table_info = alter_table_info.Cast<RenameTableInfo>();
+			auto &new_name = rename_table_info.new_table_name;
 
-		EntryLookupInfo lookup(CatalogType::TABLE_ENTRY, new_name);
-		auto other_catalog_entry = tables.GetEntry(context, lookup);
-		if (other_catalog_entry) {
-			//! The table exists at this point, check if it was deleted/renamed in the transaction
-			auto &other_table_entry = other_catalog_entry->Cast<IcebergTableEntry>();
-			auto &other_table_info = other_table_entry.table_info;
-			auto other_table_key = other_table_info.GetTableKey();
-			auto state = irc_transaction.GetLatestTableState(other_table_key);
-			if (!state || state->IsAlive()) {
-				throw CatalogException("Table with name \"%s\" already exists!", new_name);
+			EntryLookupInfo lookup(CatalogType::TABLE_ENTRY, new_name);
+			auto other_catalog_entry = tables.GetEntry(context, lookup);
+			if (other_catalog_entry) {
+				//! The table exists at this point, check if it was deleted/renamed in the transaction
+				auto &other_table_entry = other_catalog_entry->Cast<IcebergTableEntry>();
+				auto &other_table_info = other_table_entry.table_info;
+				auto other_table_key = other_table_info.GetTableKey();
+				auto state = irc_transaction.GetLatestTableState(other_table_key);
+				if (!state || state->IsAlive()) {
+					throw CatalogException("Table with name \"%s\" already exists!", new_name);
+				}
+				D_ASSERT(state && state->IsDroppedOrRenamed());
 			}
-			D_ASSERT(state && state->IsDroppedOrRenamed());
+			irc_transaction.RenameTable(catalog_table_info, new_name.GetIdentifierName());
+			return;
 		}
-		irc_transaction.RenameTable(catalog_table_info, new_name.GetIdentifierName());
-		return;
 	}
 
 	auto &alter = irc_transaction.GetOrCreateAlter();

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -355,6 +355,27 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 	auto &table_entry = catalog_entry->Cast<IcebergTableEntry>();
 	auto &catalog_table_info = table_entry.table_info;
 
+	if (alter_table_info.alter_table_type == AlterTableType::RENAME_TABLE) {
+		auto &rename_table_info = alter_table_info.Cast<RenameTableInfo>();
+		auto &new_name = rename_table_info.new_table_name;
+
+		EntryLookupInfo lookup(CatalogType::TABLE_ENTRY, new_name);
+		auto other_catalog_entry = tables.GetEntry(context, lookup);
+		if (other_catalog_entry) {
+			//! The table exists at this point, check if it was deleted/renamed in the transaction
+			auto &other_table_entry = other_catalog_entry->Cast<IcebergTableEntry>();
+			auto &other_table_info = other_table_entry.table_info;
+			auto other_table_key = other_table_info.GetTableKey();
+			auto state = irc_transaction.GetLatestTableState(other_table_key);
+			if (!state || state->IsAlive()) {
+				throw CatalogException("Table with name \"%s\" already exists!", new_name);
+			}
+			D_ASSERT(state && state->IsDroppedOrRenamed());
+		}
+		irc_transaction.RenameTable(catalog_table_info, new_name.GetIdentifierName());
+		return;
+	}
+
 	auto &alter = irc_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(catalog_table_info);
 	auto &transaction_data = updated_table.GetOrCreateTransactionData(irc_transaction);
@@ -494,27 +515,6 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 
 		IntroduceNewSchema(updated_table, transaction_data, new_schema);
 		return;
-	}
-	case AlterTableType::RENAME_TABLE: {
-		auto &rename_table_info = alter_table_info.Cast<RenameTableInfo>();
-		auto &new_name = rename_table_info.new_table_name;
-
-		EntryLookupInfo lookup(CatalogType::TABLE_ENTRY, new_name);
-		auto other_catalog_entry = tables.GetEntry(context, lookup);
-		if (other_catalog_entry) {
-			//! The table exists at this point, check if it was deleted/renamed in the transaction
-			auto &other_table_entry = other_catalog_entry->Cast<IcebergTableEntry>();
-			auto &other_table_info = other_table_entry.table_info;
-			auto other_table_key = other_table_info.GetTableKey();
-			auto state = irc_transaction.GetLatestTableState(other_table_key);
-			if (!state || state->IsAlive()) {
-				throw CatalogException("Table with name \"%s\" already exists!", new_name);
-			}
-			//! The table is dropped or renamed by this transaction, so it's not a conflict anymore
-			D_ASSERT(state && state->IsDroppedOrRenamed());
-		}
-		irc_transaction.RenameTable(updated_table, new_name.GetIdentifierName());
-		break;
 	}
 	case AlterTableType::RENAME_COLUMN: {
 		auto &rename_info = alter_table_info.Cast<RenameColumnInfo>();

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -687,7 +687,7 @@ IcebergTransactionData &IcebergTableInformation::GetOrCreateTransactionData(Iceb
 	lock_guard<mutex> guard(transaction.lock);
 	if (!transaction_data) {
 		auto context = transaction.context.lock();
-		transaction_data = make_uniq<IcebergTransactionData>(*context, *this);
+		transaction_data = make_uniq<IcebergTransactionData>(*context, transaction, *this);
 	}
 	return *transaction_data;
 }

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -338,81 +338,12 @@ bool IcebergTransaction::HasTableUpdate() const {
 	return !std::holds_alternative<std::monostate>(transaction_update);
 }
 
-void IcebergTransaction::ThrowIfCannotStartUpdate(const char *requested_type) const {
-	if (!HasTableUpdate()) {
-		return;
-	}
-	throw TransactionException("Cannot start an Iceberg %s transaction update after a transaction update is already "
-	                           "active",
-	                           requested_type);
-}
-
 IcebergTransactionAlterUpdate *IcebergTransaction::GetAlterUpdate() {
 	return std::get_if<IcebergTransactionAlterUpdate>(&transaction_update);
 }
 
 const IcebergTransactionAlterUpdate *IcebergTransaction::GetAlterUpdate() const {
 	return std::get_if<IcebergTransactionAlterUpdate>(&transaction_update);
-}
-
-idx_t IcebergTransaction::CountAlterTableRequests() const {
-	auto alter_update = GetAlterUpdate();
-	if (!alter_update) {
-		return 0;
-	}
-	idx_t request_count = 0;
-	for (const auto &entry : alter_update->updated_tables) {
-		if (entry.second.HasTransactionUpdates()) {
-			request_count++;
-		}
-	}
-	return request_count;
-}
-
-idx_t IcebergTransaction::CountAlterTableRequestsExcluding(const string &table_key) const {
-	auto alter_update = GetAlterUpdate();
-	if (!alter_update) {
-		return 0;
-	}
-	idx_t request_count = 0;
-	for (const auto &entry : alter_update->updated_tables) {
-		if (entry.first != table_key && entry.second.HasTransactionUpdates()) {
-			request_count++;
-		}
-	}
-	return request_count;
-}
-
-bool IcebergTransaction::HasStandaloneTableRequests() const {
-	return std::holds_alternative<IcebergTransactionDeleteUpdate>(transaction_update) ||
-	       std::holds_alternative<IcebergTransactionRenameUpdate>(transaction_update);
-}
-
-void IcebergTransaction::ThrowIfNonAtomicAlterRequest(const string &table_key) const {
-	if (MultiTableCommitAvailable()) {
-		return;
-	}
-	if (HasStandaloneTableRequests()) {
-		throw TransactionException(
-		    "Iceberg REST Catalog cannot commit this transaction atomically because it mixes table updates with "
-		    "rename/drop requests without POST /transactions/commit support");
-	}
-	if (CountAlterTableRequestsExcluding(table_key) > 0) {
-		throw TransactionException(
-		    "Iceberg REST Catalog cannot commit this transaction atomically because it would update multiple tables "
-		    "without POST /transactions/commit support");
-	}
-}
-
-void IcebergTransaction::ThrowIfNonAtomicStandaloneRequest() const {
-	if (MultiTableCommitAvailable()) {
-		return;
-	}
-	if (CountAlterTableRequests() > 0) {
-		throw TransactionException(
-		    "Iceberg REST Catalog cannot commit this transaction atomically because it mixes table updates with "
-		    "rename/drop requests without POST /transactions/commit support");
-	}
 }
 
 void IcebergTransaction::CleanupMetadataFiles(ClientContext &context, const vector<string> &paths) {
@@ -915,8 +846,8 @@ IcebergTransactionAlterUpdate &IcebergTransaction::GetOrCreateAlter() {
 	}
 	auto alter_update = GetAlterUpdate();
 	if (!alter_update) {
-		ThrowIfCannotStartUpdate("alter");
-		throw InternalException("Expected active Iceberg alter transaction update");
+		throw TransactionException("Iceberg REST Catalog cannot commit this transaction atomically because it mixes "
+		                           "table updates with rename/drop requests");
 	}
 	return *alter_update;
 }
@@ -924,8 +855,10 @@ IcebergTransactionAlterUpdate &IcebergTransaction::GetOrCreateAlter() {
 IcebergTableInformation &IcebergTransaction::DeleteTable(IcebergTableInformation &table) {
 	auto table_key = table.GetTableKey();
 	auto state = GetLatestTableState(table_key);
-	ThrowIfNonAtomicStandaloneRequest();
-	ThrowIfCannotStartUpdate("delete");
+	if (HasTableUpdate()) {
+		throw TransactionException("Iceberg REST Catalog cannot commit this transaction atomically because it mixes "
+		                           "table updates with rename/drop requests");
+	}
 
 	const IcebergTableInformation *delete_source = &table;
 	if (state) {
@@ -940,17 +873,10 @@ IcebergTableInformation &IcebergTransaction::DeleteTable(IcebergTableInformation
 IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation &table, const string &new_name) {
 	auto table_key = table.GetTableKey();
 	auto state = GetLatestTableState(table_key);
-	if (state) {
-		auto &original_table = state->GetInfo();
-		if (original_table.HasTransactionUpdates()) {
-			if (!MultiTableCommitAvailable()) {
-				ThrowIfNonAtomicStandaloneRequest();
-			}
-			throw CatalogException("This table (%s) was modified already, can't be renamed!", table.name);
-		}
+	if (HasTableUpdate()) {
+		throw TransactionException("Iceberg REST Catalog cannot commit this transaction atomically because it mixes "
+		                           "table updates with rename/drop requests");
 	}
-	ThrowIfNonAtomicStandaloneRequest();
-	ThrowIfCannotStartUpdate("rename");
 
 	state = SetLatestTableState(table, IcebergTableStatus::RENAMED);
 

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -172,6 +172,14 @@ struct SingleTableStagedCommit {
 	IcebergRetryConfig retry_config;
 };
 
+struct MultiTableStagedCommit {
+	rest_api_objects::CommitTransactionRequest request;
+	vector<string> created_metadata_files;
+	case_insensitive_set_t table_keys;
+	bool retryable = false;
+	IcebergRetryConfig retry_config;
+};
+
 //! Per-retry-loop backoff state: decorrelated jitter (de-synchronizes a thundering herd of
 //! concurrent writers) plus a cumulative total-timeout budget. Independent RNG per loop so
 //! concurrent committers do not wake in lockstep.
@@ -278,20 +286,13 @@ static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, Iceb
 	return info;
 }
 
-} // namespace
-
-TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactionAlterUpdate &alter_update,
-                                                               ClientContext &context) {
-	TableTransactionInfo info;
+static MultiTableStagedCommit StageMultiTableCommit(DatabaseInstance &db, IcebergTransactionAlterUpdate &alter_update,
+                                                    ClientContext &context) {
+	MultiTableStagedCommit info;
 	auto &transaction = info.request;
 	bool all_retryable = true;
 	bool saw_table = false;
 	for (auto &updated_table : alter_update.updated_tables) {
-		auto &table_key = updated_table.first;
-		if (alter_update.committed_tables.count(table_key)) {
-			//! Already committed
-			continue;
-		}
 		auto &table_info = updated_table.second;
 		if (!table_info.HasTransactionUpdates()) {
 			//! No changes to commit
@@ -299,8 +300,10 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 		}
 
 		auto table_transaction_info = StageSingleTableCommit(db, table_info, context);
-		info.created_metadata_files.emplace(table_key, std::move(table_transaction_info.created_metadata_files));
-		info.table_requests.emplace(table_key, transaction.table_changes.size());
+		info.created_metadata_files.insert(info.created_metadata_files.end(),
+		                                   table_transaction_info.created_metadata_files.begin(),
+		                                   table_transaction_info.created_metadata_files.end());
+		info.table_keys.insert(updated_table.first);
 		transaction.table_changes.push_back(std::move(table_transaction_info.request));
 		//! Tables in one atomic transaction share a single retry loop, so fold their retry policies
 		//! into the most lenient one (first table seeds it, the rest are merged in).
@@ -312,6 +315,23 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 	info.retryable = saw_table && all_retryable;
 	return info;
 }
+
+static optional_ptr<IcebergTableInformation> GetSingleUpdatedTable(IcebergTransactionAlterUpdate &alter_update) {
+	optional_ptr<IcebergTableInformation> result;
+	for (auto &entry : alter_update.updated_tables) {
+		auto &table_info = entry.second;
+		if (!table_info.HasTransactionUpdates()) {
+			continue;
+		}
+		if (result) {
+			throw InternalException("Single-table Iceberg commit staged multiple tables");
+		}
+		result = table_info;
+	}
+	return result;
+}
+
+} // namespace
 
 bool IcebergTransaction::CanUseMultiTableCommit(const IcebergTransactionAlterUpdate &alter_update) const {
 	if (!MultiTableCommitAvailable()) {
@@ -403,22 +423,6 @@ static bool CommitIsRetryable(bool retryable, idx_t max_retries, const CommitRes
 	return true;
 }
 
-static vector<string> GetCreatedMetadataFiles(const TableTransactionInfo &transaction_info) {
-	vector<string> created_metadata_files;
-	for (const auto &entry : transaction_info.created_metadata_files) {
-		created_metadata_files.insert(created_metadata_files.end(), entry.second.begin(), entry.second.end());
-	}
-	return created_metadata_files;
-}
-
-static case_insensitive_set_t GetRetryTableKeys(const TableTransactionInfo &transaction_info) {
-	case_insensitive_set_t table_keys;
-	for (const auto &entry : transaction_info.table_requests) {
-		table_keys.insert(entry.first);
-	}
-	return table_keys;
-}
-
 // 4xx = definitive rejection (commit did not land) -> delete the orphan. 5xx / no HTTP status
 // (connection error/timeout) = outcome unknown (may have landed) -> keep files. Status is in
 // extra_info (HTTPException) or the message "status code (<status>)" (fallback).
@@ -496,8 +500,8 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	if (ic_catalog.attach_options.max_table_staleness_micros.IsValid()) {
-		for (auto &it : alter_update.committed_tables) {
-			ic_catalog.table_request_cache.Expire(context, it);
+		for (auto &entry : alter_update.updated_tables) {
+			ic_catalog.table_request_cache.Expire(context, entry.first);
 		}
 	}
 	DropSecrets(context);
@@ -540,12 +544,12 @@ void IcebergTransaction::DoTableRename(IcebergTransactionRenameUpdate &rename_up
 
 void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update,
                                                    ClientContext &context) {
-	//! The retry policy is the tables' folded (most-lenient) config, produced by GetTransactionRequest.
+	//! The retry policy is the tables' folded (most-lenient) config, produced by StageMultiTableCommit.
 	//! It is stable across attempts (same tables), so the backoff state is created once, lazily, from
 	//! the first staged request and reused for every retry.
 	std::optional<IcebergRetryBackoff> backoff;
 	for (idx_t attempt = 0;; attempt++) {
-		auto transaction_info = GetTransactionRequest(alter_update, context);
+		auto transaction_info = StageMultiTableCommit(db, alter_update, context);
 		if (transaction_info.request.table_changes.empty()) {
 			alter_update.updated_tables.clear();
 			return;
@@ -562,19 +566,14 @@ void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate
 		auto transaction_json = JsonDocToString(std::move(doc_p));
 		auto result = IRCAPI::CommitMultiTableUpdate(context, catalog, transaction_json);
 		if (result.Success()) {
-			for (auto &it : alter_update.updated_tables) {
-				alter_update.committed_tables.insert(it.first);
-			}
 			return;
 		}
-		auto created_metadata_files = GetCreatedMetadataFiles(transaction_info);
 		if (!CommitIsRetryable(transaction_info.retryable, transaction_info.retry_config.num_retries, result,
 		                       attempt)) {
 			result.Throw(catalog.GetBaseUrl().GetURLEncoded());
 		}
-		CleanupMetadataFiles(context, created_metadata_files);
-		auto table_keys = GetRetryTableKeys(transaction_info);
-		RefreshRetryTables(alter_update, table_keys, context);
+		CleanupMetadataFiles(context, transaction_info.created_metadata_files);
+		RefreshRetryTables(alter_update, transaction_info.table_keys, context);
 		//! Back off before the next attempt to de-synchronize concurrent writers; stop if the
 		//! cumulative retry budget (commit.retry.total-timeout-ms) would be exceeded.
 		if (!backoff->WaitBeforeRetry(attempt)) {
@@ -586,47 +585,40 @@ void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate
 void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update,
                                                     ClientContext &context) {
 	D_ASSERT(catalog.supported_urls.count("POST /v1/{prefix}/namespaces/{namespace}/tables/{table}"));
-	for (auto &entry : alter_update.updated_tables) {
-		auto &table_key = entry.first;
-		//! Backoff state is created once per table (lazily, from the first staged commit's config)
-		//! and reused across this table's retries.
-		std::optional<IcebergRetryBackoff> backoff;
-		for (idx_t attempt = 0;; attempt++) {
-			if (alter_update.committed_tables.count(table_key)) {
-				break;
-			}
-			auto &table_info = entry.second;
-			if (!table_info.HasTransactionUpdates()) {
-				break;
-			}
+	auto table_info = GetSingleUpdatedTable(alter_update);
+	if (!table_info) {
+		return;
+	}
+	auto table_key = table_info->GetTableKey();
+	//! Backoff state is created once (lazily, from the first staged commit's config) and reused
+	//! across retries for this single atomic request.
+	std::optional<IcebergRetryBackoff> backoff;
+	for (idx_t attempt = 0;; attempt++) {
+		auto table_transaction_info = StageSingleTableCommit(db, *table_info, context);
+		if (!backoff) {
+			backoff.emplace(table_transaction_info.retry_config);
+		}
+		auto &table_change = table_transaction_info.request;
+		D_ASSERT(table_change.identifier);
+		auto &identifier = *table_change.identifier;
+		auto transaction_json = ConstructTableUpdateJSON(table_change);
+		auto result =
+		    IRCAPI::CommitTableUpdate(context, catalog, identifier._namespace.value, identifier.name, transaction_json);
+		if (result.Success()) {
+			return;
+		}
 
-			auto table_transaction_info = StageSingleTableCommit(db, table_info, context);
-			if (!backoff) {
-				backoff.emplace(table_transaction_info.retry_config);
-			}
-			auto &table_change = table_transaction_info.request;
-			D_ASSERT(table_change.identifier);
-			auto &identifier = *table_change.identifier;
-			auto transaction_json = ConstructTableUpdateJSON(table_change);
-			auto result = IRCAPI::CommitTableUpdate(context, catalog, identifier._namespace.value, identifier.name,
-			                                        transaction_json);
-			if (result.Success()) {
-				alter_update.committed_tables.insert(table_key);
-				break;
-			}
-
-			if (!CommitIsRetryable(table_transaction_info.retryable, table_transaction_info.retry_config.num_retries,
-			                       result, attempt)) {
-				result.Throw(catalog.GetBaseUrl().GetURLEncoded());
-			}
-			CleanupMetadataFiles(context, table_transaction_info.created_metadata_files);
-			case_insensitive_set_t retry_tables;
-			retry_tables.insert(table_key);
-			RefreshRetryTables(alter_update, retry_tables, context);
-			//! Back off before the next attempt; stop if the retry budget would be exceeded.
-			if (!backoff->WaitBeforeRetry(attempt)) {
-				result.Throw(catalog.GetBaseUrl().GetURLEncoded());
-			}
+		if (!CommitIsRetryable(table_transaction_info.retryable, table_transaction_info.retry_config.num_retries,
+		                       result, attempt)) {
+			result.Throw(catalog.GetBaseUrl().GetURLEncoded());
+		}
+		CleanupMetadataFiles(context, table_transaction_info.created_metadata_files);
+		case_insensitive_set_t retry_tables;
+		retry_tables.insert(table_key);
+		RefreshRetryTables(alter_update, retry_tables, context);
+		//! Back off before the next attempt; stop if the retry budget would be exceeded.
+		if (!backoff->WaitBeforeRetry(attempt)) {
+			result.Throw(catalog.GetBaseUrl().GetURLEncoded());
 		}
 	}
 }
@@ -740,10 +732,6 @@ void IcebergTransaction::CleanupFiles() {
 
 	if (auto alter_update = GetAlterUpdate()) {
 		for (auto &up_table : alter_update->updated_tables) {
-			if (alter_update->committed_tables.count(up_table.first)) {
-				//! Successfully committed, no need to roll back
-				continue;
-			}
 			auto &table = up_table.second;
 			if (!table.transaction_data) {
 				// error occurred before transaction data was initialized
@@ -787,9 +775,6 @@ void IcebergTransaction::EvictCachedTables() {
 		    using T = std::decay_t<decltype(update)>;
 		    if constexpr (std::is_same_v<T, IcebergTransactionAlterUpdate>) {
 			    for (auto &up_table : update.updated_tables) {
-				    if (update.committed_tables.count(up_table.first)) {
-					    continue;
-				    }
 				    catalog.table_request_cache.Expire(temp_context, up_table.first);
 			    }
 		    } else if constexpr (std::is_same_v<T, IcebergTransactionDeleteUpdate>) {

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -314,8 +314,7 @@ TableTransactionInfo IcebergTransaction::GetTransactionRequest(IcebergTransactio
 }
 
 bool IcebergTransaction::CanUseMultiTableCommit(const IcebergTransactionAlterUpdate &alter_update) const {
-	if (catalog.attach_options.disable_multi_table_commit ||
-	    !catalog.supported_urls.count("POST /v1/{prefix}/transactions/commit")) {
+	if (!MultiTableCommitAvailable()) {
 		return false;
 	}
 	for (const auto &entry : alter_update.updated_tables) {
@@ -328,6 +327,80 @@ bool IcebergTransaction::CanUseMultiTableCommit(const IcebergTransactionAlterUpd
 		}
 	}
 	return true;
+}
+
+bool IcebergTransaction::MultiTableCommitAvailable() const {
+	return !catalog.attach_options.disable_multi_table_commit &&
+	       catalog.supported_urls.count("POST /v1/{prefix}/transactions/commit");
+}
+
+idx_t IcebergTransaction::CountAlterTableRequests() const {
+	idx_t request_count = 0;
+	for (const auto &transaction_update : transaction_updates) {
+		if (transaction_update->type != IcebergTransactionUpdateType::ALTER) {
+			continue;
+		}
+		auto &alter_update = transaction_update->Cast<IcebergTransactionAlterUpdate>();
+		for (const auto &entry : alter_update.updated_tables) {
+			if (entry.second.HasTransactionUpdates()) {
+				request_count++;
+			}
+		}
+	}
+	return request_count;
+}
+
+idx_t IcebergTransaction::CountAlterTableRequestsExcluding(const string &table_key) const {
+	idx_t request_count = 0;
+	for (const auto &transaction_update : transaction_updates) {
+		if (transaction_update->type != IcebergTransactionUpdateType::ALTER) {
+			continue;
+		}
+		auto &alter_update = transaction_update->Cast<IcebergTransactionAlterUpdate>();
+		for (const auto &entry : alter_update.updated_tables) {
+			if (entry.first != table_key && entry.second.HasTransactionUpdates()) {
+				request_count++;
+			}
+		}
+	}
+	return request_count;
+}
+
+bool IcebergTransaction::HasStandaloneTableRequests() const {
+	for (const auto &transaction_update : transaction_updates) {
+		if (transaction_update->type == IcebergTransactionUpdateType::DELETE ||
+		    transaction_update->type == IcebergTransactionUpdateType::RENAME) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void IcebergTransaction::ThrowIfNonAtomicAlterRequest(const string &table_key) const {
+	if (MultiTableCommitAvailable()) {
+		return;
+	}
+	if (HasStandaloneTableRequests()) {
+		throw TransactionException(
+		    "Iceberg REST Catalog cannot commit this transaction atomically because it mixes table updates with "
+		    "rename/drop requests without POST /transactions/commit support");
+	}
+	if (CountAlterTableRequestsExcluding(table_key) > 0) {
+		throw TransactionException(
+		    "Iceberg REST Catalog cannot commit this transaction atomically because it would update multiple tables "
+		    "without POST /transactions/commit support");
+	}
+}
+
+void IcebergTransaction::ThrowIfNonAtomicStandaloneRequest() const {
+	if (MultiTableCommitAvailable()) {
+		return;
+	}
+	if (CountAlterTableRequests() > 0) {
+		throw TransactionException(
+		    "Iceberg REST Catalog cannot commit this transaction atomically because it mixes table updates with "
+		    "rename/drop requests without POST /transactions/commit support");
+	}
 }
 
 void IcebergTransaction::CleanupMetadataFiles(ClientContext &context, const vector<string> &paths) {
@@ -861,6 +934,7 @@ IcebergTransactionAlterUpdate &IcebergTransaction::GetOrCreateAlter() {
 IcebergTableInformation &IcebergTransaction::DeleteTable(IcebergTableInformation &table) {
 	auto table_key = table.GetTableKey();
 	auto state = GetLatestTableState(table_key);
+	ThrowIfNonAtomicStandaloneRequest();
 
 	unique_ptr<IcebergTransactionDeleteUpdate> delete_update;
 	if (state) {
@@ -881,9 +955,13 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 	if (state) {
 		auto &original_table = state->GetInfo();
 		if (original_table.HasTransactionUpdates()) {
+			if (!MultiTableCommitAvailable()) {
+				ThrowIfNonAtomicStandaloneRequest();
+			}
 			throw CatalogException("This table (%s) was modified already, can't be renamed!", table.name);
 		}
 	}
+	ThrowIfNonAtomicStandaloneRequest();
 
 	state = SetLatestTableState(table, IcebergTableStatus::RENAMED);
 

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -349,6 +349,17 @@ bool IcebergTransaction::CanUseMultiTableCommit(const IcebergTransactionAlterUpd
 	return true;
 }
 
+void IcebergTransaction::VerifyAlterUpdateAtomicity(const IcebergTransactionAlterUpdate &alter_update) const {
+	if (alter_update.updated_tables.size() <= 1) {
+		return;
+	}
+	if (CanUseMultiTableCommit(alter_update)) {
+		return;
+	}
+	throw TransactionException("Iceberg REST Catalog cannot commit this transaction atomically because it would "
+	                           "require multiple table commit requests without atomic multi-table commit support");
+}
+
 bool IcebergTransaction::MultiTableCommitAvailable() const {
 	return !catalog.attach_options.disable_multi_table_commit &&
 	       catalog.supported_urls.count("POST /v1/{prefix}/transactions/commit");

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -334,46 +334,58 @@ bool IcebergTransaction::MultiTableCommitAvailable() const {
 	       catalog.supported_urls.count("POST /v1/{prefix}/transactions/commit");
 }
 
+bool IcebergTransaction::HasTableUpdate() const {
+	return !std::holds_alternative<std::monostate>(transaction_update);
+}
+
+void IcebergTransaction::ThrowIfCannotStartUpdate(const char *requested_type) const {
+	if (!HasTableUpdate()) {
+		return;
+	}
+	throw TransactionException("Cannot start an Iceberg %s transaction update after a transaction update is already "
+	                           "active",
+	                           requested_type);
+}
+
+IcebergTransactionAlterUpdate *IcebergTransaction::GetAlterUpdate() {
+	return std::get_if<IcebergTransactionAlterUpdate>(&transaction_update);
+}
+
+const IcebergTransactionAlterUpdate *IcebergTransaction::GetAlterUpdate() const {
+	return std::get_if<IcebergTransactionAlterUpdate>(&transaction_update);
+}
+
 idx_t IcebergTransaction::CountAlterTableRequests() const {
+	auto alter_update = GetAlterUpdate();
+	if (!alter_update) {
+		return 0;
+	}
 	idx_t request_count = 0;
-	for (const auto &transaction_update : transaction_updates) {
-		if (transaction_update->type != IcebergTransactionUpdateType::ALTER) {
-			continue;
-		}
-		auto &alter_update = transaction_update->Cast<IcebergTransactionAlterUpdate>();
-		for (const auto &entry : alter_update.updated_tables) {
-			if (entry.second.HasTransactionUpdates()) {
-				request_count++;
-			}
+	for (const auto &entry : alter_update->updated_tables) {
+		if (entry.second.HasTransactionUpdates()) {
+			request_count++;
 		}
 	}
 	return request_count;
 }
 
 idx_t IcebergTransaction::CountAlterTableRequestsExcluding(const string &table_key) const {
+	auto alter_update = GetAlterUpdate();
+	if (!alter_update) {
+		return 0;
+	}
 	idx_t request_count = 0;
-	for (const auto &transaction_update : transaction_updates) {
-		if (transaction_update->type != IcebergTransactionUpdateType::ALTER) {
-			continue;
-		}
-		auto &alter_update = transaction_update->Cast<IcebergTransactionAlterUpdate>();
-		for (const auto &entry : alter_update.updated_tables) {
-			if (entry.first != table_key && entry.second.HasTransactionUpdates()) {
-				request_count++;
-			}
+	for (const auto &entry : alter_update->updated_tables) {
+		if (entry.first != table_key && entry.second.HasTransactionUpdates()) {
+			request_count++;
 		}
 	}
 	return request_count;
 }
 
 bool IcebergTransaction::HasStandaloneTableRequests() const {
-	for (const auto &transaction_update : transaction_updates) {
-		if (transaction_update->type == IcebergTransactionUpdateType::DELETE ||
-		    transaction_update->type == IcebergTransactionUpdateType::RENAME) {
-			return true;
-		}
-	}
-	return false;
+	return std::holds_alternative<IcebergTransactionDeleteUpdate>(transaction_update) ||
+	       std::holds_alternative<IcebergTransactionRenameUpdate>(transaction_update);
 }
 
 void IcebergTransaction::ThrowIfNonAtomicAlterRequest(const string &table_key) const {
@@ -497,8 +509,7 @@ static bool CommitStateUnknown(const ErrorData &error) {
 }
 
 void IcebergTransaction::Commit() {
-	if (transaction_updates.empty() && created_schemas.empty() && deleted_schemas.empty() &&
-	    schema_property_updates.empty()) {
+	if (!HasTableUpdate() && created_schemas.empty() && deleted_schemas.empty() && schema_property_updates.empty()) {
 		return;
 	}
 
@@ -514,29 +525,20 @@ void IcebergTransaction::Commit() {
 	try {
 		DoSchemaCreates(*temp_con_context);
 		DoSchemaPropertyUpdates(*temp_con_context);
-		for (auto &transaction_update : transaction_updates) {
-			auto &type = transaction_update->type;
-			switch (type) {
-			case IcebergTransactionUpdateType::ALTER: {
-				auto &alter_update = transaction_update->Cast<IcebergTransactionAlterUpdate>();
-				DoTableUpdates(alter_update, *temp_con_context);
-				break;
-			}
-			case IcebergTransactionUpdateType::DELETE: {
-				auto &delete_update = transaction_update->Cast<IcebergTransactionDeleteUpdate>();
-				DoTableDeletes(delete_update, *temp_con_context);
-				break;
-			}
-			case IcebergTransactionUpdateType::RENAME: {
-				auto &rename_update = transaction_update->Cast<IcebergTransactionRenameUpdate>();
-				DoTableRename(rename_update, *temp_con_context);
-				break;
-			}
-			default:
-				throw InternalException("IcebergTransactionUpdateType (%d) not implemented",
-				                        static_cast<uint8_t>(type));
-			};
-		}
+		std::visit(
+		    [&](auto &update) {
+			    using T = std::decay_t<decltype(update)>;
+			    if constexpr (std::is_same_v<T, std::monostate>) {
+				    return;
+			    } else if constexpr (std::is_same_v<T, IcebergTransactionAlterUpdate>) {
+				    DoTableUpdates(update, *temp_con_context);
+			    } else if constexpr (std::is_same_v<T, IcebergTransactionDeleteUpdate>) {
+				    DoTableDeletes(update, *temp_con_context);
+			    } else if constexpr (std::is_same_v<T, IcebergTransactionRenameUpdate>) {
+				    DoTableRename(update, *temp_con_context);
+			    }
+		    },
+		    transaction_update);
 		DoSchemaDeletes(*temp_con_context);
 	} catch (std::exception &ex) {
 		ErrorData error(ex);
@@ -805,13 +807,9 @@ void IcebergTransaction::CleanupFiles() {
 	auto &temp_context = temp_con.GetContext();
 	auto &fs = FileSystem::GetFileSystem(temp_context);
 
-	for (auto &transaction_update : transaction_updates) {
-		if (transaction_update->type != IcebergTransactionUpdateType::ALTER) {
-			continue;
-		}
-		auto &alter_update = transaction_update->Cast<IcebergTransactionAlterUpdate>();
-		for (auto &up_table : alter_update.updated_tables) {
-			if (alter_update.committed_tables.count(up_table.first)) {
+	if (auto alter_update = GetAlterUpdate()) {
+		for (auto &up_table : alter_update->updated_tables) {
+			if (alter_update->committed_tables.count(up_table.first)) {
 				//! Successfully committed, no need to roll back
 				continue;
 			}
@@ -853,31 +851,21 @@ void IcebergTransaction::EvictCachedTables() {
 	}
 	ScopedTransaction temp_con(db);
 	auto &temp_context = temp_con.GetContext();
-	for (auto &transaction_update : transaction_updates) {
-		switch (transaction_update->type) {
-		case IcebergTransactionUpdateType::ALTER: {
-			auto &alter_update = transaction_update->Cast<IcebergTransactionAlterUpdate>();
-			for (auto &up_table : alter_update.updated_tables) {
-				if (alter_update.committed_tables.count(up_table.first)) {
-					//! Already committed (and its cache entry already evicted on that success)
-					continue;
-				}
-				catalog.table_request_cache.Expire(temp_context, up_table.first);
-			}
-			break;
-		}
-		case IcebergTransactionUpdateType::DELETE: {
-			auto &delete_update = transaction_update->Cast<IcebergTransactionDeleteUpdate>();
-			catalog.table_request_cache.Expire(temp_context, delete_update.deleted_table.GetTableKey());
-			break;
-		}
-		case IcebergTransactionUpdateType::RENAME: {
-			break;
-		}
-		default:
-			break;
-		}
-	}
+	std::visit(
+	    [&](auto &update) {
+		    using T = std::decay_t<decltype(update)>;
+		    if constexpr (std::is_same_v<T, IcebergTransactionAlterUpdate>) {
+			    for (auto &up_table : update.updated_tables) {
+				    if (update.committed_tables.count(up_table.first)) {
+					    continue;
+				    }
+				    catalog.table_request_cache.Expire(temp_context, up_table.first);
+			    }
+		    } else if constexpr (std::is_same_v<T, IcebergTransactionDeleteUpdate>) {
+			    catalog.table_request_cache.Expire(temp_context, update.deleted_table.GetTableKey());
+		    }
+	    },
+	    transaction_update);
 }
 
 void IcebergTransaction::Rollback() {
@@ -922,30 +910,30 @@ IcebergTransactionTableState &IcebergTransaction::SetLatestTableState(IcebergTab
 }
 
 IcebergTransactionAlterUpdate &IcebergTransaction::GetOrCreateAlter() {
-	if (transaction_updates.empty() || transaction_updates.back()->type != IcebergTransactionUpdateType::ALTER) {
-		auto alter_p = make_uniq<IcebergTransactionAlterUpdate>(*this);
-		auto &alter = *alter_p;
-		transaction_updates.push_back(std::move(alter_p));
-		return alter;
+	if (!HasTableUpdate()) {
+		transaction_update.emplace<IcebergTransactionAlterUpdate>(*this);
 	}
-	return transaction_updates.back()->Cast<IcebergTransactionAlterUpdate>();
+	auto alter_update = GetAlterUpdate();
+	if (!alter_update) {
+		ThrowIfCannotStartUpdate("alter");
+		throw InternalException("Expected active Iceberg alter transaction update");
+	}
+	return *alter_update;
 }
 
 IcebergTableInformation &IcebergTransaction::DeleteTable(IcebergTableInformation &table) {
 	auto table_key = table.GetTableKey();
 	auto state = GetLatestTableState(table_key);
 	ThrowIfNonAtomicStandaloneRequest();
+	ThrowIfCannotStartUpdate("delete");
 
-	unique_ptr<IcebergTransactionDeleteUpdate> delete_update;
+	const IcebergTableInformation *delete_source = &table;
 	if (state) {
-		auto &table_info = state->GetInfo();
-		delete_update = make_uniq<IcebergTransactionDeleteUpdate>(*this, table_info);
-	} else {
-		delete_update = make_uniq<IcebergTransactionDeleteUpdate>(*this, table);
+		delete_source = &state->GetInfo();
 	}
-	auto &deleted_table = delete_update->deleted_table;
+	transaction_update.emplace<IcebergTransactionDeleteUpdate>(*this, *delete_source);
+	auto &deleted_table = std::get<IcebergTransactionDeleteUpdate>(transaction_update).deleted_table;
 	state = SetLatestTableState(deleted_table, IcebergTableStatus::DROPPED);
-	transaction_updates.push_back(std::move(delete_update));
 	return state->GetInfo();
 }
 
@@ -962,13 +950,13 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 		}
 	}
 	ThrowIfNonAtomicStandaloneRequest();
+	ThrowIfCannotStartUpdate("rename");
 
 	state = SetLatestTableState(table, IcebergTableStatus::RENAMED);
 
 	//! Create the rename update, creating the new IcebergTableInformation in the process
-	auto rename = make_uniq<IcebergTransactionRenameUpdate>(*this, state->GetInfo(), new_name);
-	auto &rename_update = *rename;
-	transaction_updates.push_back(std::move(rename));
+	transaction_update.emplace<IcebergTransactionRenameUpdate>(*this, state->GetInfo(), new_name);
+	auto &rename_update = std::get<IcebergTransactionRenameUpdate>(transaction_update);
 
 	//! Update the state of the renamed table
 	auto &new_table = rename_update.new_table;

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -1,5 +1,7 @@
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 
+#include "catalog/rest/transaction/iceberg_transaction.hpp"
+
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
 #include "duckdb/common/types/uuid.hpp"
 
@@ -60,8 +62,9 @@ static void LoadExistingManifestList(ClientContext &context, const IcebergTableM
 	}
 }
 
-IcebergTransactionData::IcebergTransactionData(ClientContext &context, const IcebergTableInformation &table_info)
-    : context(context), table_info(table_info) {
+IcebergTransactionData::IcebergTransactionData(ClientContext &context, IcebergTransaction &transaction,
+                                               const IcebergTableInformation &table_info)
+    : context(context), transaction(transaction), table_info(table_info) {
 	initial_table_uuid = table_info.table_metadata.table_uuid;
 	if (table_info.table_metadata.next_row_id) {
 		next_row_id = *table_info.table_metadata.next_row_id;
@@ -71,6 +74,10 @@ IcebergTransactionData::IcebergTransactionData(ClientContext &context, const Ice
 	if (table_info.table_metadata.HasSortOrder()) {
 		initial_default_sort_order_id = table_info.table_metadata.default_sort_order_id;
 	}
+}
+
+void IcebergTransactionData::ValidateAtomicRequestShape() {
+	transaction.ThrowIfNonAtomicAlterRequest(table_info.GetTableKey());
 }
 
 int64_t IcebergTransactionData::GetCommitRetryCount() const {
@@ -188,6 +195,7 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 
 	alters.push_back(*add_snapshot);
 	updates.push_back(std::move(add_snapshot));
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&delete_files,
@@ -222,6 +230,7 @@ void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&de
 
 	alters.push_back(*add_snapshot);
 	updates.push_back(std::move(add_snapshot));
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddSchema(int32_t schema_id) {
@@ -233,33 +242,40 @@ void IcebergTransactionData::TableAddSchema(int32_t schema_id) {
 	updates.push_back(std::move(add_schema_update));
 	assert_schema_id = true;
 	pending_current_schema_id = schema_id;
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableSetCurrentSchema(int32_t schema_id) {
 	pending_current_schema_id = schema_id;
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAssignUUID() {
 	updates.push_back(make_uniq<AssignUUIDUpdate>(table_info.table_metadata.table_uuid));
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddAssertCreate() {
 	has_assert_create = true;
 	requirements.push_back(make_uniq<AssertCreateRequirement>());
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddAssertUUID() {
 	requirements.push_back(make_uniq<AssertTableUUIDRequirement>(table_info.table_metadata.table_uuid));
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddAssertCurrentSchemaId() {
 	assert_schema_id = true;
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddAssertLastAssignedFieldId() {
 	D_ASSERT(table_info.table_metadata.HasLastColumnId());
 	requirements.push_back(make_uniq<AssertLastAssignedFieldIdRequirement>(
 	    static_cast<int32_t>(table_info.table_metadata.GetLastColumnId())));
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddAssertLastAssignedPartitionId() {
@@ -268,43 +284,53 @@ void IcebergTransactionData::TableAddAssertLastAssignedPartitionId() {
 		last_assigned_partition_id = table_info.table_metadata.GetLastPartitionFieldId();
 	}
 	requirements.push_back(make_uniq<AssertLastAssignedPartitionIdRequirement>(last_assigned_partition_id));
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddAssertDefaultSpecId() {
 	requirements.push_back(make_uniq<AssertDefaultSpecIdRequirement>(table_info.table_metadata.default_spec_id));
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddUpradeFormatVersion() {
 	updates.push_back(make_uniq<UpgradeFormatVersion>(table_info.table_metadata.iceberg_version));
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddPartitionSpec() {
 	updates.push_back(make_uniq<AddPartitionSpec>(table_info.table_metadata.GetLatestPartitionSpec()));
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddSortOrder() {
 	updates.push_back(make_uniq<AddSortOrder>(table_info.table_metadata.GetLatestSortOrder()));
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableSetDefaultSortOrder() {
 	D_ASSERT(table_info.table_metadata.HasSortOrder());
 	updates.push_back(make_uniq<SetDefaultSortOrder>(table_info.table_metadata.GetLatestSortOrder().sort_order_id));
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableSetDefaultSpec() {
 	updates.push_back(make_uniq<SetDefaultSpec>(table_info.table_metadata.default_spec_id));
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableSetProperties(const case_insensitive_map_t<string> &properties) {
 	updates.push_back(make_uniq<SetProperties>(properties));
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableRemoveProperties(const vector<string> &properties) {
 	updates.push_back(make_uniq<RemoveProperties>(properties));
+	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableSetLocation() {
 	updates.push_back(make_uniq<SetLocation>(table_info.table_metadata.location));
+	ValidateAtomicRequestShape();
 }
 
 } // namespace duckdb

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -249,6 +249,9 @@ void IcebergTransactionData::TableAssignUUID() {
 void IcebergTransactionData::TableAddAssertCreate() {
 	has_assert_create = true;
 	requirements.push_back(make_uniq<AssertCreateRequirement>());
+	auto alter_update = transaction.GetAlterUpdate();
+	D_ASSERT(alter_update);
+	transaction.VerifyAlterUpdateAtomicity(*alter_update);
 }
 
 void IcebergTransactionData::TableAddAssertUUID() {

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -76,10 +76,6 @@ IcebergTransactionData::IcebergTransactionData(ClientContext &context, IcebergTr
 	}
 }
 
-void IcebergTransactionData::ValidateAtomicRequestShape() {
-	transaction.ThrowIfNonAtomicAlterRequest(table_info.GetTableKey());
-}
-
 int64_t IcebergTransactionData::GetCommitRetryCount() const {
 	static constexpr const int64_t DEFAULT_RETRY_COUNT = 4;
 	auto it = table_info.table_metadata.table_properties.find("commit.retry.num-retries");
@@ -195,7 +191,6 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 
 	alters.push_back(*add_snapshot);
 	updates.push_back(std::move(add_snapshot));
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&delete_files,
@@ -230,7 +225,6 @@ void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&de
 
 	alters.push_back(*add_snapshot);
 	updates.push_back(std::move(add_snapshot));
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddSchema(int32_t schema_id) {
@@ -242,40 +236,33 @@ void IcebergTransactionData::TableAddSchema(int32_t schema_id) {
 	updates.push_back(std::move(add_schema_update));
 	assert_schema_id = true;
 	pending_current_schema_id = schema_id;
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableSetCurrentSchema(int32_t schema_id) {
 	pending_current_schema_id = schema_id;
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAssignUUID() {
 	updates.push_back(make_uniq<AssignUUIDUpdate>(table_info.table_metadata.table_uuid));
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddAssertCreate() {
 	has_assert_create = true;
 	requirements.push_back(make_uniq<AssertCreateRequirement>());
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddAssertUUID() {
 	requirements.push_back(make_uniq<AssertTableUUIDRequirement>(table_info.table_metadata.table_uuid));
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddAssertCurrentSchemaId() {
 	assert_schema_id = true;
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddAssertLastAssignedFieldId() {
 	D_ASSERT(table_info.table_metadata.HasLastColumnId());
 	requirements.push_back(make_uniq<AssertLastAssignedFieldIdRequirement>(
 	    static_cast<int32_t>(table_info.table_metadata.GetLastColumnId())));
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddAssertLastAssignedPartitionId() {
@@ -284,53 +271,43 @@ void IcebergTransactionData::TableAddAssertLastAssignedPartitionId() {
 		last_assigned_partition_id = table_info.table_metadata.GetLastPartitionFieldId();
 	}
 	requirements.push_back(make_uniq<AssertLastAssignedPartitionIdRequirement>(last_assigned_partition_id));
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddAssertDefaultSpecId() {
 	requirements.push_back(make_uniq<AssertDefaultSpecIdRequirement>(table_info.table_metadata.default_spec_id));
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddUpradeFormatVersion() {
 	updates.push_back(make_uniq<UpgradeFormatVersion>(table_info.table_metadata.iceberg_version));
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddPartitionSpec() {
 	updates.push_back(make_uniq<AddPartitionSpec>(table_info.table_metadata.GetLatestPartitionSpec()));
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableAddSortOrder() {
 	updates.push_back(make_uniq<AddSortOrder>(table_info.table_metadata.GetLatestSortOrder()));
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableSetDefaultSortOrder() {
 	D_ASSERT(table_info.table_metadata.HasSortOrder());
 	updates.push_back(make_uniq<SetDefaultSortOrder>(table_info.table_metadata.GetLatestSortOrder().sort_order_id));
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableSetDefaultSpec() {
 	updates.push_back(make_uniq<SetDefaultSpec>(table_info.table_metadata.default_spec_id));
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableSetProperties(const case_insensitive_map_t<string> &properties) {
 	updates.push_back(make_uniq<SetProperties>(properties));
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableRemoveProperties(const vector<string> &properties) {
 	updates.push_back(make_uniq<RemoveProperties>(properties));
-	ValidateAtomicRequestShape();
 }
 
 void IcebergTransactionData::TableSetLocation() {
 	updates.push_back(make_uniq<SetLocation>(table_info.table_metadata.location));
-	ValidateAtomicRequestShape();
 }
 
 } // namespace duckdb

--- a/src/catalog/rest/transaction/iceberg_transaction_update.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_update.cpp
@@ -58,16 +58,8 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::GetOrInitializeTable(con
 	auto it = updated_tables.find(table_key);
 	if (it == updated_tables.end()) {
 		CheckWriteWriteConflict(table);
-
-		if (!transaction.MultiTableCommitAvailable()) {
-			if (!updated_tables.empty()) {
-				throw TransactionException("Iceberg REST Catalog cannot commit this transaction atomically because it "
-				                           "would update multiple tables "
-				                           "without POST /transactions/commit support");
-			}
-		}
-
 		it = updated_tables.emplace(table_key, CopyLatestState(transaction, table)).first;
+		transaction.VerifyAlterUpdateAtomicity(*this);
 		// Preserve the table_uuid from the original table info (resolved at transaction start).
 		// Copy() reads from the global request cache, which can be contaminated by another
 		// transaction's RENAME overwriting the entry with a different table's metadata.
@@ -97,6 +89,7 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::CreateTable(const string
 	if (!emplace_res.second) {
 		throw InternalException("Table %s was already created somehow?", table_key);
 	}
+	transaction.VerifyAlterUpdateAtomicity(*this);
 
 	transaction.current_table_data.emplace(table_key, IcebergTransactionTableState(emplace_res.first->second));
 	return emplace_res.first->second;

--- a/src/catalog/rest/transaction/iceberg_transaction_update.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_update.cpp
@@ -58,6 +58,15 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::GetOrInitializeTable(con
 	auto it = updated_tables.find(table_key);
 	if (it == updated_tables.end()) {
 		CheckWriteWriteConflict(table);
+
+		if (!transaction.MultiTableCommitAvailable()) {
+			if (!updated_tables.empty()) {
+				throw TransactionException("Iceberg REST Catalog cannot commit this transaction atomically because it "
+				                           "would update multiple tables "
+				                           "without POST /transactions/commit support");
+			}
+		}
+
 		it = updated_tables.emplace(table_key, CopyLatestState(transaction, table)).first;
 		// Preserve the table_uuid from the original table info (resolved at transaction start).
 		// Copy() reads from the global request cache, which can be contaminated by another

--- a/src/catalog/rest/transaction/iceberg_transaction_update.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_update.cpp
@@ -17,14 +17,8 @@ static IcebergTableInformation CopyLatestState(IcebergTransaction &transaction, 
 
 } // namespace
 
-IcebergTransactionUpdate::IcebergTransactionUpdate(IcebergTransaction &transaction, IcebergTransactionUpdateType type)
-    : transaction(transaction), type(type) {
-}
-IcebergTransactionUpdate::~IcebergTransactionUpdate() {
-}
-
 IcebergTransactionAlterUpdate::IcebergTransactionAlterUpdate(IcebergTransaction &transaction)
-    : IcebergTransactionUpdate(transaction, TYPE) {
+    : transaction(transaction) {
 }
 IcebergTransactionAlterUpdate::~IcebergTransactionAlterUpdate() {
 }
@@ -101,7 +95,7 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::CreateTable(const string
 
 IcebergTransactionDeleteUpdate::IcebergTransactionDeleteUpdate(IcebergTransaction &transaction,
                                                                const IcebergTableInformation &table)
-    : IcebergTransactionUpdate(transaction, TYPE), deleted_table(table.Copy(transaction)) {
+    : transaction(transaction), deleted_table(table.Copy(transaction)) {
 }
 IcebergTransactionDeleteUpdate::~IcebergTransactionDeleteUpdate() {
 }
@@ -109,8 +103,7 @@ IcebergTransactionDeleteUpdate::~IcebergTransactionDeleteUpdate() {
 IcebergTransactionRenameUpdate::IcebergTransactionRenameUpdate(IcebergTransaction &transaction,
                                                                const IcebergTableInformation &table,
                                                                const string &new_name)
-    : IcebergTransactionUpdate(transaction, TYPE), table(table), new_table(CopyLatestState(transaction, table)),
-      new_name(new_name) {
+    : transaction(transaction), table(table), new_table(CopyLatestState(transaction, table)), new_name(new_name) {
 	new_table.name = new_name;
 	if (!table.schema_versions.empty()) {
 		new_table.InitSchemaVersions();

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -4,15 +4,12 @@
 #include "duckdb/transaction/transaction.hpp"
 #include "catalog/rest/iceberg_schema_set.hpp"
 #include "catalog/rest/api/iceberg_retry.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_update.hpp"
 
 namespace duckdb {
 class IcebergCatalog;
 class IcebergSchemaEntry;
 class IcebergTableEntry;
-struct IcebergTransactionUpdate;
-struct IcebergTransactionAlterUpdate;
-struct IcebergTransactionDeleteUpdate;
-struct IcebergTransactionRenameUpdate;
 
 struct TableTransactionInfo {
 	TableTransactionInfo() {};
@@ -101,6 +98,10 @@ public:
 	IcebergTableInformation &RenameTable(IcebergTableInformation &table, const string &new_name);
 
 private:
+	bool HasTableUpdate() const;
+	void ThrowIfCannotStartUpdate(const char *requested_type) const;
+	IcebergTransactionAlterUpdate *GetAlterUpdate();
+	const IcebergTransactionAlterUpdate *GetAlterUpdate() const;
 	bool MultiTableCommitAvailable() const;
 	bool CanUseMultiTableCommit(const IcebergTransactionAlterUpdate &alter_update) const;
 	idx_t CountAlterTableRequests() const;
@@ -126,8 +127,8 @@ private:
 public:
 	//! Tables referenced by this transaction that have to stay alive for the duration of the transaction.
 	case_insensitive_map_t<shared_ptr<IcebergTableInformation>> tables;
-	vector<unique_ptr<IcebergTransactionUpdate>> transaction_updates;
-	//! The latest state of a table (either points into 'transaction_updates' or 'tables')
+	IcebergTransactionUpdate transaction_update;
+	//! The latest state of a table (either points into the active table update or 'tables')
 	case_insensitive_map_t<IcebergTransactionTableState> current_table_data;
 
 	unordered_set<string> created_schemas;

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -56,6 +56,7 @@ struct SchemaPropertyUpdates {
 class IcebergTransaction : public Transaction {
 public:
 	friend struct IcebergTransactionData;
+	friend struct IcebergTransactionAlterUpdate;
 
 	IcebergTransaction(IcebergCatalog &ic_catalog, TransactionManager &manager, ClientContext &context);
 	~IcebergTransaction() override;
@@ -92,6 +93,7 @@ private:
 	IcebergTransactionAlterUpdate *GetAlterUpdate();
 	const IcebergTransactionAlterUpdate *GetAlterUpdate() const;
 	bool CanUseMultiTableCommit(const IcebergTransactionAlterUpdate &alter_update) const;
+	void VerifyAlterUpdateAtomicity(const IcebergTransactionAlterUpdate &alter_update) const;
 	void CleanupMetadataFiles(ClientContext &context, const vector<string> &paths);
 	void RefreshRetryTables(IcebergTransactionAlterUpdate &alter_update, const case_insensitive_set_t &table_keys,
 	                        ClientContext &context);

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -96,19 +96,13 @@ public:
 	IcebergTransactionAlterUpdate &GetOrCreateAlter();
 	IcebergTableInformation &DeleteTable(IcebergTableInformation &table);
 	IcebergTableInformation &RenameTable(IcebergTableInformation &table, const string &new_name);
+	bool MultiTableCommitAvailable() const;
 
 private:
 	bool HasTableUpdate() const;
-	void ThrowIfCannotStartUpdate(const char *requested_type) const;
 	IcebergTransactionAlterUpdate *GetAlterUpdate();
 	const IcebergTransactionAlterUpdate *GetAlterUpdate() const;
-	bool MultiTableCommitAvailable() const;
 	bool CanUseMultiTableCommit(const IcebergTransactionAlterUpdate &alter_update) const;
-	idx_t CountAlterTableRequests() const;
-	idx_t CountAlterTableRequestsExcluding(const string &table_key) const;
-	bool HasStandaloneTableRequests() const;
-	void ThrowIfNonAtomicAlterRequest(const string &table_key) const;
-	void ThrowIfNonAtomicStandaloneRequest() const;
 	void CleanupMetadataFiles(ClientContext &context, const vector<string> &paths);
 	void RefreshRetryTables(IcebergTransactionAlterUpdate &alter_update, const case_insensitive_set_t &table_keys,
 	                        ClientContext &context);

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -11,16 +11,6 @@ class IcebergCatalog;
 class IcebergSchemaEntry;
 class IcebergTableEntry;
 
-struct TableTransactionInfo {
-	TableTransactionInfo() {};
-
-	rest_api_objects::CommitTransactionRequest request;
-	case_insensitive_map_t<idx_t> table_requests;
-	case_insensitive_map_t<vector<string>> created_metadata_files;
-	bool retryable = false;
-	IcebergRetryConfig retry_config;
-};
-
 enum class IcebergTableStatus : uint8_t { ALIVE, DROPPED, RENAMED, MISSING };
 
 struct IcebergTransactionTableState {
@@ -86,7 +76,6 @@ public:
 	void DoSchemaPropertyUpdates(ClientContext &context);
 	IcebergCatalog &GetCatalog();
 	void DropSecrets(ClientContext &context);
-	TableTransactionInfo GetTransactionRequest(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
 	void DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
 	void DoSingleTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
 	optional_ptr<IcebergTransactionTableState> GetLatestTableState(const string &table_key);

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -68,6 +68,8 @@ struct SchemaPropertyUpdates {
 
 class IcebergTransaction : public Transaction {
 public:
+	friend struct IcebergTransactionData;
+
 	IcebergTransaction(IcebergCatalog &ic_catalog, TransactionManager &manager, ClientContext &context);
 	~IcebergTransaction() override;
 
@@ -99,7 +101,13 @@ public:
 	IcebergTableInformation &RenameTable(IcebergTableInformation &table, const string &new_name);
 
 private:
+	bool MultiTableCommitAvailable() const;
 	bool CanUseMultiTableCommit(const IcebergTransactionAlterUpdate &alter_update) const;
+	idx_t CountAlterTableRequests() const;
+	idx_t CountAlterTableRequestsExcluding(const string &table_key) const;
+	bool HasStandaloneTableRequests() const;
+	void ThrowIfNonAtomicAlterRequest(const string &table_key) const;
+	void ThrowIfNonAtomicStandaloneRequest() const;
 	void CleanupMetadataFiles(ClientContext &context, const vector<string> &paths);
 	void RefreshRetryTables(IcebergTransactionAlterUpdate &alter_update, const case_insensitive_set_t &table_keys,
 	                        ClientContext &context);

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -55,7 +55,6 @@ public:
 
 private:
 	void CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata);
-	void ValidateAtomicRequestShape();
 
 public:
 	string initial_table_uuid;

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -22,7 +22,8 @@ struct IcebergCreateTableRequest;
 
 struct IcebergTransactionData {
 public:
-	IcebergTransactionData(ClientContext &context, const IcebergTableInformation &table_info);
+	IcebergTransactionData(ClientContext &context, IcebergTransaction &transaction,
+	                       const IcebergTableInformation &table_info);
 
 public:
 	int64_t GetCommitRetryCount() const;
@@ -54,6 +55,7 @@ public:
 
 private:
 	void CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata);
+	void ValidateAtomicRequestShape();
 
 public:
 	string initial_table_uuid;
@@ -62,6 +64,7 @@ public:
 	optional_idx initial_default_sort_order_id;
 
 	ClientContext &context;
+	IcebergTransaction &transaction;
 	const IcebergTableInformation &table_info;
 	//! schema updates etc.
 	vector<unique_ptr<IcebergTableUpdate>> updates;

--- a/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <variant>
+
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
@@ -9,51 +11,20 @@ namespace duckdb {
 
 class IcebergTransaction;
 
-enum class IcebergTransactionUpdateType : uint8_t { ALTER, DELETE, RENAME };
-
-struct IcebergTransactionUpdate {
-public:
-	IcebergTransactionUpdate(IcebergTransaction &transaction, IcebergTransactionUpdateType type);
-	virtual ~IcebergTransactionUpdate();
-
-public:
-	template <class TARGET>
-	TARGET &Cast() {
-		if (type != TARGET::TYPE) {
-			throw InternalException(
-			    "Failed to cast IcebergTransactionUpdate to type - IcebergTransactionUpdate type mismatch");
-		}
-		return reinterpret_cast<TARGET &>(*this);
-	}
-
-	template <class TARGET>
-	const TARGET &Cast() const {
-		if (type != TARGET::TYPE) {
-			throw InternalException(
-			    "Failed to cast IcebergTransactionUpdate to type - IcebergTransactionUpdate type mismatch");
-		}
-		return reinterpret_cast<const TARGET &>(*this);
-	}
-
-public:
-	IcebergTransaction &transaction;
-	IcebergTransactionUpdateType type;
-};
-
 //! Update a table with a regular alter
-struct IcebergTransactionAlterUpdate : public IcebergTransactionUpdate {
-public:
-	static constexpr const IcebergTransactionUpdateType TYPE = IcebergTransactionUpdateType::ALTER;
-
+struct IcebergTransactionAlterUpdate {
 public:
 	IcebergTransactionAlterUpdate(IcebergTransaction &transaction);
-	virtual ~IcebergTransactionAlterUpdate() override;
+	~IcebergTransactionAlterUpdate();
 
 public:
 	IcebergTableInformation &CreateTable(const string &table_key, IcebergTableInformation &&table);
 	IcebergTableInformation &GetOrInitializeTable(const IcebergTableInformation &table);
 	void CheckWriteWriteConflict(const IcebergTableInformation &table_info) const;
 	bool HasUpdates() const;
+
+public:
+	IcebergTransaction &transaction;
 	//! All the tables touched in this atomic block
 	case_insensitive_map_t<IcebergTableInformation> updated_tables;
 	//! The tables successively committed (used if multi-table commit isn't available)
@@ -61,32 +32,31 @@ public:
 };
 
 //! Drop a table
-struct IcebergTransactionDeleteUpdate : public IcebergTransactionUpdate {
-public:
-	static constexpr const IcebergTransactionUpdateType TYPE = IcebergTransactionUpdateType::DELETE;
-
+struct IcebergTransactionDeleteUpdate {
 public:
 	IcebergTransactionDeleteUpdate(IcebergTransaction &transaction, const IcebergTableInformation &table);
-	virtual ~IcebergTransactionDeleteUpdate() override;
+	~IcebergTransactionDeleteUpdate();
 
 public:
+	IcebergTransaction &transaction;
 	IcebergTableInformation deleted_table;
 };
 
 //! Rename a table
-struct IcebergTransactionRenameUpdate : public IcebergTransactionUpdate {
-public:
-	static constexpr const IcebergTransactionUpdateType TYPE = IcebergTransactionUpdateType::RENAME;
-
+struct IcebergTransactionRenameUpdate {
 public:
 	IcebergTransactionRenameUpdate(IcebergTransaction &transaction, const IcebergTableInformation &table,
 	                               const string &new_name);
-	virtual ~IcebergTransactionRenameUpdate() override;
+	~IcebergTransactionRenameUpdate();
 
 public:
+	IcebergTransaction &transaction;
 	const IcebergTableInformation &table;
 	IcebergTableInformation new_table;
 	string new_name;
 };
+
+using IcebergTransactionUpdate = std::variant<std::monostate, IcebergTransactionAlterUpdate,
+                                              IcebergTransactionDeleteUpdate, IcebergTransactionRenameUpdate>;
 
 } // namespace duckdb

--- a/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
@@ -27,8 +27,6 @@ public:
 	IcebergTransaction &transaction;
 	//! All the tables touched in this atomic block
 	case_insensitive_map_t<IcebergTableInformation> updated_tables;
-	//! The tables successively committed (used if multi-table commit isn't available)
-	case_insensitive_set_t committed_tables;
 };
 
 //! Drop a table

--- a/test/sql/local/catalog_custom_setup/fixture/attach_options/horizon_compatible_writes.test
+++ b/test/sql/local/catalog_custom_setup/fixture/attach_options/horizon_compatible_writes.test
@@ -56,10 +56,15 @@ statement ok
 CALL truncate_duckdb_logs();
 
 statement ok
-create table my_datalake.default.test_horizon_compatible_writes (id int, label varchar);
+create table my_datalake.default.test_horizon_compatible_writes (
+	id int,
+	label varchar
+);
 
 statement ok
-insert into my_datalake.default.test_horizon_compatible_writes values (1, 'created'), (2, 'inserted');
+insert into my_datalake.default.test_horizon_compatible_writes values
+	(1, 'created'),
+	(2, 'inserted');
 
 query II
 select * from my_datalake.default.test_horizon_compatible_writes order by all;
@@ -80,6 +85,18 @@ drop table if exists my_datalake.default.test_horizon_mixed_existing;
 
 statement ok
 drop table if exists my_datalake.default.test_horizon_mixed_empty_create;
+
+statement ok
+drop table if exists my_datalake.default.test_horizon_guard_a;
+
+statement ok
+drop table if exists my_datalake.default.test_horizon_guard_b;
+
+statement ok
+drop table if exists my_datalake.default.test_horizon_guard_c;
+
+statement ok
+drop table if exists my_datalake.default.test_horizon_guard_d;
 
 statement ok
 create table my_datalake.default.test_horizon_mixed_existing (id int, label varchar);
@@ -124,3 +141,138 @@ drop table if exists my_datalake.default.test_horizon_mixed_empty_create;
 
 statement ok
 drop table if exists my_datalake.default.test_horizon_mixed_existing;
+
+statement ok
+create table my_datalake.default.test_horizon_guard_a (id int, label varchar);
+
+statement ok
+create table my_datalake.default.test_horizon_guard_b (id int, label varchar);
+
+statement ok
+create table my_datalake.default.test_horizon_guard_c (id int, label varchar);
+
+statement ok
+insert into my_datalake.default.test_horizon_guard_a values (1, 'seed');
+
+statement ok
+insert into my_datalake.default.test_horizon_guard_b values (2, 'seed');
+
+statement ok
+insert into my_datalake.default.test_horizon_guard_c values (3, 'seed');
+
+statement ok
+begin transaction;
+
+statement ok
+insert into my_datalake.default.test_horizon_guard_a values (11, 'tx');
+
+statement error
+insert into my_datalake.default.test_horizon_guard_b values (22, 'tx');
+----
+<REGEX>:.*TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically.*
+
+statement ok
+rollback;
+
+query I
+select count(*) from my_datalake.default.test_horizon_guard_a where id = 11;
+----
+0
+
+statement ok
+begin transaction;
+
+statement ok
+insert into my_datalake.default.test_horizon_guard_a values (11, 'tx');
+
+statement error
+alter table my_datalake.default.test_horizon_guard_a rename to test_horizon_guard_d;
+----
+<REGEX>:.*TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically.*
+
+statement ok
+rollback;
+
+statement ok
+drop table if exists my_datalake.default.test_horizon_guard_d;
+
+statement ok
+begin transaction;
+
+statement ok
+insert into my_datalake.default.test_horizon_guard_a values (11, 'tx');
+
+statement error
+drop table my_datalake.default.test_horizon_guard_a;
+----
+<REGEX>:.*TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically.*
+
+statement ok
+rollback;
+
+statement ok
+drop table if exists my_datalake.default.test_horizon_guard_d;
+
+statement ok
+begin transaction;
+
+statement ok
+alter table my_datalake.default.test_horizon_guard_a rename to test_horizon_guard_d;
+
+statement error
+insert into my_datalake.default.test_horizon_guard_d values (44, 'tx');
+----
+<REGEX>:.*TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically.*
+
+statement ok
+rollback;
+
+statement ok
+drop table if exists my_datalake.default.test_horizon_guard_d;
+
+statement ok
+begin transaction;
+
+statement ok
+drop table my_datalake.default.test_horizon_guard_c;
+
+statement error
+insert into my_datalake.default.test_horizon_guard_b values (33, 'tx');
+----
+<REGEX>:.*TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically.*
+
+statement ok
+rollback;
+
+statement ok
+drop table if exists my_datalake.default.test_horizon_guard_d;
+
+statement ok
+begin transaction;
+
+statement ok
+create table my_datalake.default.test_horizon_guard_d as
+select 4 as id, 'new' as label;
+
+statement error
+alter table my_datalake.default.test_horizon_guard_d rename to test_horizon_guard_d_renamed;
+----
+<REGEX>:.*TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically.*
+
+statement ok
+rollback;
+
+statement ok
+drop table if exists my_datalake.default.test_horizon_guard_a;
+
+statement ok
+drop table if exists my_datalake.default.test_horizon_guard_b;
+
+statement ok
+drop table if exists my_datalake.default.test_horizon_guard_c;
+
+statement ok
+drop table if exists my_datalake.default.test_horizon_guard_d;
+
+statement ok
+drop table if exists my_datalake.default.test_horizon_guard_d_renamed;

--- a/test/sql/local/catalog_custom_setup/fixture/attach_options/horizon_compatible_writes.test
+++ b/test/sql/local/catalog_custom_setup/fixture/attach_options/horizon_compatible_writes.test
@@ -222,7 +222,7 @@ alter table my_datalake.default.test_horizon_guard_a rename to test_horizon_guar
 statement error
 insert into my_datalake.default.test_horizon_guard_d values (44, 'tx');
 ----
-<REGEX>:.*TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically.*
+<REGEX>:.*TransactionContext Error: Cannot start an Iceberg alter transaction update after a transaction update is already active.*
 
 statement ok
 rollback;
@@ -239,7 +239,7 @@ drop table my_datalake.default.test_horizon_guard_c;
 statement error
 insert into my_datalake.default.test_horizon_guard_b values (33, 'tx');
 ----
-<REGEX>:.*TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically.*
+<REGEX>:.*TransactionContext Error: Cannot start an Iceberg alter transaction update after a transaction update is already active.*
 
 statement ok
 rollback;

--- a/test/sql/local/catalog_custom_setup/fixture/attach_options/horizon_compatible_writes.test
+++ b/test/sql/local/catalog_custom_setup/fixture/attach_options/horizon_compatible_writes.test
@@ -110,8 +110,11 @@ begin transaction;
 statement ok
 create table my_datalake.default.test_horizon_mixed_empty_create (id int, label varchar);
 
-statement ok
+# Can't insert into another table, multi-table commits are disabled
+statement error
 insert into my_datalake.default.test_horizon_mixed_existing values (3, 'mixed');
+----
+TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically because it would update multiple tables without POST /transactions/commit support
 
 statement ok
 commit;
@@ -119,7 +122,6 @@ commit;
 query II
 select * from my_datalake.default.test_horizon_mixed_existing order by all;
 ----
-3	mixed
 
 query I
 select count(*) from my_datalake.default.test_horizon_mixed_empty_create;
@@ -222,7 +224,7 @@ alter table my_datalake.default.test_horizon_guard_a rename to test_horizon_guar
 statement error
 insert into my_datalake.default.test_horizon_guard_d values (44, 'tx');
 ----
-<REGEX>:.*TransactionContext Error: Cannot start an Iceberg alter transaction update after a transaction update is already active.*
+TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically because it mixes table updates with rename/drop requests
 
 statement ok
 rollback;
@@ -239,7 +241,7 @@ drop table my_datalake.default.test_horizon_guard_c;
 statement error
 insert into my_datalake.default.test_horizon_guard_b values (33, 'tx');
 ----
-<REGEX>:.*TransactionContext Error: Cannot start an Iceberg alter transaction update after a transaction update is already active.*
+TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically because it mixes table updates with rename/drop requests
 
 statement ok
 rollback;

--- a/test/sql/local/catalog_custom_setup/fixture/attach_options/horizon_compatible_writes.test
+++ b/test/sql/local/catalog_custom_setup/fixture/attach_options/horizon_compatible_writes.test
@@ -114,7 +114,7 @@ create table my_datalake.default.test_horizon_mixed_empty_create (id int, label 
 statement error
 insert into my_datalake.default.test_horizon_mixed_existing values (3, 'mixed');
 ----
-TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically because it would update multiple tables without POST /transactions/commit support
+TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically because it would require multiple table commit requests without atomic multi-table commit support
 
 statement ok
 commit;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/create_and_rename.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/create_and_rename.test
@@ -87,7 +87,7 @@ ALTER TABLE my_datalake.default.renamed_table RENAME TO rename_table
 statement error con2
 insert into my_datalake.default.rename_table VALUES (false)
 ----
-TransactionContext Error: Cannot start an Iceberg alter transaction update after a transaction update is already active
+TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically because it mixes table updates with rename/drop requests
 
 statement error con2
 select * from my_datalake.default.rename_table;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/create_and_rename.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/create_and_rename.test
@@ -70,7 +70,9 @@ statement ok con2
 begin transaction
 
 statement ok con1
-create table my_datalake.default.rename_table(a varchar)
+create table my_datalake.default.rename_table(
+	a varchar
+)
 
 # Can't be seen by con2
 statement error con2
@@ -82,22 +84,26 @@ Catalog Error: Table with name rename_table does not exist!
 statement ok con2
 ALTER TABLE my_datalake.default.renamed_table RENAME TO rename_table
 
-statement ok con2
+statement error con2
 insert into my_datalake.default.rename_table VALUES (false)
+----
+TransactionContext Error: Cannot start an Iceberg alter transaction update after a transaction update is already active
+
+statement error con2
+select * from my_datalake.default.rename_table;
+----
+TransactionContext Error: Current transaction is aborted (please ROLLBACK)
 
 statement ok con2
-commit
+abort
 
-query I
+statement error
 select * from my_datalake.default.rename_table order by all
 ----
-false
-true
+Catalog Error: Table with name rename_table does not exist!
 
-statement error con1
+statement ok con1
 commit
-----
-<REGEX>:.*TransactionContext Error: Failed to commit:.*
 
 # Then do the same but commit the CREATE first
 
@@ -118,7 +124,9 @@ statement ok con2
 begin transaction
 
 statement ok con1
-create table my_datalake.default.rename_table(a varchar)
+create table my_datalake.default.rename_table(
+	a varchar
+)
 
 # Can't be seen by con2
 statement error con2

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/rename_table_after_modifications.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/rename_table_after_modifications.test
@@ -43,19 +43,30 @@ insert into my_datalake.default.rename_table VALUES (
 	'test', true
 )
 
-# FIXME: support renaming a table with outstanding updates
 statement error
 ALTER TABLE my_datalake.default.rename_table RENAME TO renamed_table
 ----
-Catalog Error: This table (rename_table) was modified already, can't be renamed!
+TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically because it mixes table updates with rename/drop requests
 
 statement error
 select * from my_datalake.default.renamed_table
 ----
 Catalog Error: Table with name renamed_table does not exist!
 
+# Transaction invalidated, needs to be separate statements
 statement ok
-commit
+abort
+
+statement ok
+create table my_datalake.default.rename_table(
+	a VARCHAR,
+	b BOOLEAN
+);
+
+statement ok
+insert into my_datalake.default.rename_table VALUES (
+	'test', true
+)
 
 statement error
 select * from my_datalake.default.renamed_table

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/rename_table_test.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/rename_table_test.test
@@ -106,26 +106,31 @@ begin transaction
 statement ok
 alter table my_datalake.default.renamed_table2 rename to renamed_table3
 
-statement ok
+statement error
 alter table my_datalake.default.renamed_table3 rename to renamed_table1
+----
+<REGEX>:.*TransactionContext Error: Cannot start an Iceberg rename transaction update after a transaction update is already active.*
 
 statement ok
-commit
+rollback
 
 query I
-select * from my_datalake.default.renamed_table1 order by i
+select * from my_datalake.default.renamed_table2 order by i
 ----
 1
 2
 3
 
 statement error
-select * from my_datalake.default.renamed_table2
+select * from my_datalake.default.renamed_table3
 ----
 
 # Test 4: Rename to existing table name (should fail)
 statement ok
-create table my_datalake.default.renamed_table2(i INTEGER);
+create table my_datalake.default.renamed_table1(i INTEGER);
+
+statement ok
+insert into my_datalake.default.renamed_table1 values (1), (2), (3);
 
 statement error
 alter table my_datalake.default.renamed_table1 rename to renamed_table2
@@ -244,29 +249,26 @@ select * from my_datalake.default.renamed_table2 order by i
 10
 20
 
-statement ok
+statement error
 insert into my_datalake.default.renamed_table2 values (30);
-
-query I
-select * from my_datalake.default.renamed_table2 order by i
 ----
-10
-20
-30
+<REGEX>:.*TransactionContext Error: Cannot start an Iceberg alter transaction update after a transaction update is already active.*
 
 statement ok
-commit
+rollback
 
 query I
-select * from my_datalake.default.renamed_table2 order by i
+select * from my_datalake.default.renamed_table1 order by i
 ----
 10
 20
-30
 
 # Test 7: Two concurrent transactions - isolation
 statement ok
 drop table if exists my_datalake.default.renamed_table2;
+
+statement ok
+drop table if exists my_datalake.default.renamed_table1;
 
 statement ok
 create table my_datalake.default.renamed_table1(i INTEGER);
@@ -339,24 +341,28 @@ begin transaction
 statement ok
 drop table my_datalake.default.renamed_table2;
 
-statement ok
-alter table my_datalake.default.renamed_table1 rename to renamed_table2;
-
-query I
-select * from my_datalake.default.renamed_table2 order by i
-----
-1
-2
-
-statement ok
-commit
-
-query I
-select * from my_datalake.default.renamed_table2 order by i
-----
-1
-2
-
 statement error
-select * from my_datalake.default.renamed_table1
+alter table my_datalake.default.renamed_table1 rename to renamed_table2;
 ----
+<REGEX>:.*TransactionContext Error: Cannot start an Iceberg rename transaction update after a transaction update is already active.*
+
+statement ok
+rollback
+
+query I
+select * from my_datalake.default.renamed_table1 order by i
+----
+1
+2
+
+query I
+select * from my_datalake.default.renamed_table2 order by i
+----
+a
+b
+
+query I
+select * from my_datalake.default.renamed_table1 order by i
+----
+1
+2

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/rename_table_test.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/rename_table/rename_table_test.test
@@ -109,7 +109,7 @@ alter table my_datalake.default.renamed_table2 rename to renamed_table3
 statement error
 alter table my_datalake.default.renamed_table3 rename to renamed_table1
 ----
-<REGEX>:.*TransactionContext Error: Cannot start an Iceberg rename transaction update after a transaction update is already active.*
+TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically because it mixes table updates with rename/drop requests
 
 statement ok
 rollback
@@ -232,7 +232,7 @@ select * from my_datalake.default.renamed_table1 order by i
 statement error
 alter table my_datalake.default.renamed_table1 rename to renamed_table2
 ----
-Catalog Error: This table (renamed_table1) was modified already, can't be renamed!
+TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically because it mixes table updates with rename/drop requests
 
 statement ok
 commit
@@ -247,12 +247,11 @@ query I
 select * from my_datalake.default.renamed_table2 order by i
 ----
 10
-20
 
 statement error
 insert into my_datalake.default.renamed_table2 values (30);
 ----
-<REGEX>:.*TransactionContext Error: Cannot start an Iceberg alter transaction update after a transaction update is already active.*
+TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically because it mixes table updates with rename/drop requests
 
 statement ok
 rollback
@@ -261,7 +260,6 @@ query I
 select * from my_datalake.default.renamed_table1 order by i
 ----
 10
-20
 
 # Test 7: Two concurrent transactions - isolation
 statement ok
@@ -344,7 +342,7 @@ drop table my_datalake.default.renamed_table2;
 statement error
 alter table my_datalake.default.renamed_table1 rename to renamed_table2;
 ----
-<REGEX>:.*TransactionContext Error: Cannot start an Iceberg rename transaction update after a transaction update is already active.*
+TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically because it mixes table updates with rename/drop requests
 
 statement ok
 rollback

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/concurrent_table_swap.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/concurrent_table_swap.test
@@ -69,12 +69,24 @@ from my_datalake.default.accounts;
 statement ok con1
 DROP TABLE my_datalake.default.accounts;
 
+# Can't DROP and RENAME in the same transaction
+statement error con1
+ALTER TABLE my_datalake.default.external_accounts RENAME TO accounts;
+----
+TransactionContext Error: Cannot start an Iceberg rename transaction update after a transaction update is already active
+
+statement ok con1
+ABORT;
+
+# Perform the changes one at a time instead
+statement ok con1
+DROP TABLE my_datalake.default.accounts;
+
 statement ok con1
 ALTER TABLE my_datalake.default.external_accounts RENAME TO accounts;
 
 # --- con2: funds transfer ---
 # Alice wants to pay 500 to Bob
-# con2 still thinks this is Alice and Bob, but it's actually changing the corporations now
 statement ok con2
 UPDATE my_datalake.default.accounts
 SET balance = balance - 500.00
@@ -84,9 +96,6 @@ statement ok con2
 UPDATE my_datalake.default.accounts
 SET balance = balance + 500.00
 WHERE account_id = 2;
-
-statement ok con1
-COMMIT;
 
 # con2 must be rejected, the table it resolved no longer exists under that identity
 statement error con2

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/concurrent_table_swap.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/concurrent_table_swap.test
@@ -73,7 +73,7 @@ DROP TABLE my_datalake.default.accounts;
 statement error con1
 ALTER TABLE my_datalake.default.external_accounts RENAME TO accounts;
 ----
-TransactionContext Error: Cannot start an Iceberg rename transaction update after a transaction update is already active
+TransactionContext Error: Iceberg REST Catalog cannot commit this transaction atomically because it mixes table updates with rename/drop requests
 
 statement ok con1
 ABORT;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_multi_table_commit_integrity.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_multi_table_commit_integrity.test
@@ -43,8 +43,10 @@ statement ok
 drop table if exists my_datalake.default.cleanup_new_tbl;
 
 # ---------------------------------------------------------------------------
-# con1: begin transaction, INSERT into all 20 tables, CREATE TABLE 
-# (forces has_assert_create -> per-table commit fallback loop)
+# con1: begin transaction, INSERT into all 20 tables, then try to CREATE TABLE.
+# The staged create adds assert-create semantics, which means the transaction
+# would need multiple non-atomic table commit requests and must fail
+# immediately instead of reaching COMMIT.
 # ---------------------------------------------------------------------------
 
 statement ok con1
@@ -58,56 +60,22 @@ insert into my_datalake.default.cleanup_tbl_{i} values
 
 endloop
 
-statement ok con1
+statement error con1
 create table my_datalake.default.cleanup_new_tbl (
 	id int,
 	val varchar
 );
-
-statement ok con1
-insert into my_datalake.default.cleanup_new_tbl values
-	(1, 'from_con1');
-
-# ---------------------------------------------------------------------------
-# con2: INSERT into tbl_10 to create a 409 conflict for con1
-# ---------------------------------------------------------------------------
-
-statement ok con2
-insert into my_datalake.default.cleanup_tbl_10 values
-	(2, 'from_con2');
-
-# ---------------------------------------------------------------------------
-# con1: commit — per-table fallback loop.
-# Some tables commit before tbl_0 hits 409. CleanupFiles() then deletes
-# data files for ALL tables, corrupting the already-committed ones.
-# ---------------------------------------------------------------------------
-
-statement error con1
-commit
 ----
 <REGEX>:.*
 
+statement ok con1
+rollback
+
 # ---------------------------------------------------------------------------
-# Verification: every table should still be readable.
-#
-# If CleanupFiles() deleted data files for already-committed tables,
-# these queries will fail with IO errors — proving the data corruption.
+# Verification: every table should still be readable and unchanged.
 # ---------------------------------------------------------------------------
 
-# tbl_0 is the conflicted table — con1's insert was rejected.
-# It should still be readable (not corrupted). Con2's insert may or may not
-# be visible depending on catalog cache state, so we just verify it doesn't
-# throw an IO error.
-statement ok
-select * from my_datalake.default.cleanup_tbl_0;
-
-# All other tables should be readable with just their seed data.
-# If CleanupFiles() deleted data files for already-committed tables,
-# these queries will fail with HTTP 404 / IO errors.
 loop i 0 20
-
-onlyif i=10
-continue
 
 query I
 select id from my_datalake.default.cleanup_tbl_{i} where val = 'seed' order by id;
@@ -116,12 +84,9 @@ select id from my_datalake.default.cleanup_tbl_{i} where val = 'seed' order by i
 
 endloop
 
-# Verify that the commit to tbl_10 failed
-query IT
-select * from my_datalake.default.cleanup_tbl_10 order by id;
+statement error
+select * from my_datalake.default.cleanup_new_tbl;
 ----
-0	seed
-2	from_con2
 
 # ---------------------------------------------------------------------------
 # Cleanup


### PR DESCRIPTION
We've previously attempted to work around limitations in the REST Catalog API, but have recently come to the opinion that this was doing more harm than good.

We can't guarantee that all requests would succeed, so a failed COMMIT could result in half-committing the changes made in a transaction.
So we'll no longer try to pretend that we can.
