### PR TITLE
Prune all-null data files for constant comparisons

### DIFF
--- a/src/planning/pruning/iceberg_predicate.cpp
+++ b/src/planning/pruning/iceberg_predicate.cpp
@@ -61,6 +61,12 @@ static bool MatchBoundsConstant(const Value &constant, ExpressionType comparison
 		return false;
 	}
 
+	if (!stats.has_not_null && comparison_type != ExpressionType::COMPARE_DISTINCT_FROM &&
+	    comparison_type != ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+		// An all-null column (Iceberg omits its bounds) only matches a null-safe comparison.
+		return false;
+	}
+
 	if (!stats.upper_bound || !stats.lower_bound) {
 		// we do not have upper or lower bounds, assume the file matches.
 		return true;

--- a/src/planning/pruning/iceberg_predicate.cpp
+++ b/src/planning/pruning/iceberg_predicate.cpp
@@ -63,7 +63,9 @@ static bool MatchBoundsConstant(const Value &constant, ExpressionType comparison
 
 	if (!stats.has_not_null && comparison_type != ExpressionType::COMPARE_DISTINCT_FROM &&
 	    comparison_type != ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
-		// An all-null column (Iceberg omits its bounds) only matches a null-safe comparison.
+		// has_not_null is false when every row of this column is NULL. Ordinary comparisons
+		// against a constant cannot match NULL so the file can be pruned. IS [NOT] DISTINCT FROM
+		// must consider NULL so cannot be pruned.
 		return false;
 	}
 

--- a/test/sql/local/iceberg_scans/is_not_null.test
+++ b/test/sql/local/iceberg_scans/is_not_null.test
@@ -67,7 +67,19 @@ select * from my_datalake.default.is_not_null WHERE value IS NOT NULL ORDER BY i
 6	baz
 8	blah
 
-# Using the logs (which contains the data_file path), join it against the iceberg metadata to sum the record_counts of the skipped data files
+statement ok
+CALL truncate_duckdb_logs();
+
+# A comparison against a non-null constant cannot match an all-null column. Iceberg writes no
+# lower/upper bounds for the all-null 'value' file (ids 1-3), so min/max cannot prune it — the
+# null/value counts do. Only that file is skipped: the file holding 'blah' is kept, and the file
+# with other non-null values is kept (its bounds cover 'blah') and correctly returns no rows.
+query II
+select * from my_datalake.default.is_not_null WHERE value = 'blah' ORDER BY id ASC;
+----
+8	blah
+
+# Exactly the all-null file (record_count 3) is skipped, not the files that hold non-null values.
 query I
 SELECT SUM(meta.record_count) AS total_record_count
 FROM (
@@ -78,3 +90,25 @@ JOIN ICEBERG_METADATA(my_datalake.default.is_not_null) meta
 ON logs.msg = meta.file_path;
 ----
 3
+
+# IS NOT DISTINCT FROM NULL (= IS NULL) must match the all-null file's rows, not prune it as a non-null constant comparison would.
+query II
+select * from my_datalake.default.is_not_null WHERE value IS NOT DISTINCT FROM NULL ORDER BY id ASC;
+----
+1	NULL
+2	NULL
+3	NULL
+7	NULL
+
+# IS DISTINCT FROM a non-null constant also matches the all-null file (NULL differs from any value), so nothing is pruned.
+query II
+select * from my_datalake.default.is_not_null WHERE value IS DISTINCT FROM 'zzz' ORDER BY id ASC;
+----
+1	NULL
+2	NULL
+3	NULL
+4	foo
+5	bar
+6	baz
+7	NULL
+8	blah

--- a/test/sql/local/iceberg_scans/is_not_null.test
+++ b/test/sql/local/iceberg_scans/is_not_null.test
@@ -70,10 +70,9 @@ select * from my_datalake.default.is_not_null WHERE value IS NOT NULL ORDER BY i
 statement ok
 CALL truncate_duckdb_logs();
 
-# A comparison against a non-null constant cannot match an all-null column. Iceberg writes no
-# lower/upper bounds for the all-null 'value' file (ids 1-3), so min/max cannot prune it — the
-# null/value counts do. Only that file is skipped: the file holding 'blah' is kept, and the file
-# with other non-null values is kept (its bounds cover 'blah') and correctly returns no rows.
+# The 'value' column is all-NULL in the file holding ids 1-3, so has_not_null is false and the
+# file is pruned: an ordinary comparison against a constant cannot match NULL. The file holding
+# 'blah' is kept and returns its row; the file with other non-null values is kept and returns none.
 query II
 select * from my_datalake.default.is_not_null WHERE value = 'blah' ORDER BY id ASC;
 ----


### PR DESCRIPTION
I found "WHERE foo = 'blah'" does not skip files where foo is always NULL, but `WHERE foo = 'blah' and foo IS NOT NULL` did, and I trace that to this missing predicate. We were missing the inference that a constant implies NOT NULL and ranges that only match NULL cannot bound a constant.

(first PR attempt ran into difficult because DISTINCT foo = 'blah') does need to consider if NULL values exist 