### PR TITLE
feat: populate manifest column stats for iceberg_rewrite_data_files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ set(EXTENSION_SOURCES
 	src/planning/snapshot/iceberg_snapshot_lookup.cpp
 	src/storage/statistics/iceberg_variant_statistics.cpp
 	src/storage/statistics/iceberg_statistics.cpp
+	src/storage/statistics/iceberg_data_file_stats.cpp
 )
 
 add_subdirectory(src/rest_catalog/objects)

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -33,7 +33,7 @@
 #include "core/expression/iceberg_value.hpp"
 #include "core/expression/iceberg_metrics.hpp"
 #include "core/expression/iceberg_transform.hpp"
-#include "storage/statistics/iceberg_variant_statistics.hpp"
+#include "storage/statistics/iceberg_data_file_stats.hpp"
 #include "catalog/rest/api/iceberg_type.hpp"
 #include "catalog/rest/api/iceberg_create_table_request.hpp"
 #include "common/iceberg_utils.hpp"
@@ -105,17 +105,6 @@ unique_ptr<GlobalSinkState> IcebergInsert::GetGlobalSinkState(ClientContext &con
 // Sink
 //===--------------------------------------------------------------------===//
 
-static bool IsMapType(string col_name, IcebergTableSchema &table_schema) {
-	for (auto &col : table_schema.columns) {
-		if (col->name == col_name) {
-			if (col->type.id() == LogicalTypeId::MAP) {
-				return true;
-			}
-		}
-	}
-	return false;
-}
-
 static vector<idx_t> GetColumnPath(const ColumnIndex &column_index) {
 	vector<idx_t> path;
 	path.reserve(column_index.ChildIndexCount());
@@ -157,47 +146,6 @@ static bool CanWriteIdentityPartitionsDirectly(const IcebergPartitionSpec &spec,
 	return true;
 }
 
-static string ParseQuotedValue(const string &input, idx_t &pos) {
-	if (pos >= input.size() || input[pos] != '"') {
-		throw InvalidInputException("Failed to parse quoted value - expected a quote");
-	}
-	string result;
-	pos++;
-	for (; pos < input.size(); pos++) {
-		if (input[pos] == '"') {
-			pos++;
-			// check if this is an escaped quote
-			if (pos < input.size() && input[pos] == '"') {
-				// escaped quote
-				result += '"';
-				continue;
-			}
-			return result;
-		}
-		result += input[pos];
-	}
-	throw InvalidInputException("Failed to parse quoted value - unterminated quote");
-}
-
-static vector<string> ParseQuotedList(const string &input, char list_separator) {
-	vector<string> result;
-	if (input.empty()) {
-		return result;
-	}
-	idx_t pos = 0;
-	while (true) {
-		result.push_back(ParseQuotedValue(input, pos));
-		if (pos >= input.size()) {
-			break;
-		}
-		if (input[pos] != list_separator) {
-			throw InvalidInputException("Failed to parse list - expected a %s", string(1, list_separator));
-		}
-		pos++;
-	}
-	return result;
-}
-
 void IcebergInsertGlobalState::AddFiles(DataChunk &chunk, const string &table_name,
                                         const IcebergTableMetadata &table_metadata) {
 	// grab lock for written files vector
@@ -217,7 +165,6 @@ void IcebergInsertGlobalState::AddFiles(DataChunk &chunk, const string &table_na
 
 		// extract the column stats
 		auto column_stats = chunk.GetValue(4, r);
-		auto &map_children = MapValue::GetChildren(column_stats);
 
 		// column 5 is stats, which we can also use for partition information
 		auto partition_values = chunk.GetValue(5, r);
@@ -279,141 +226,10 @@ void IcebergInsertGlobalState::AddFiles(DataChunk &chunk, const string &table_na
 
 		insert_count += data_file.record_count;
 
-		// variant columns emit one stats entry per shredded leaf - accumulate them per variant column
-		// (keyed by field id) and serialize the lower/upper bound variants once all entries are seen
-		unordered_map<int32_t, IcebergVariantBounds> variant_bounds;
-
-		// Resolve the table-level metrics mode once; per-column overrides are resolved in the loop.
-		auto default_metrics = GetDefaultMetricsConfig(table_metadata);
-
-		for (idx_t col_idx = 0; col_idx < map_children.size(); col_idx++) {
-			auto &struct_children = StructValue::GetChildren(map_children[col_idx]);
-			auto &col_name = StringValue::Get(struct_children[0]);
-			auto &col_stats = MapValue::GetChildren(struct_children[1]);
-			auto column_names = ParseQuotedList(col_name, '.');
-			if (column_names[0] == "_row_id") {
-				continue;
-			}
-
-			optional_idx name_offset;
-			auto column_info_p = ic_schema->GetFromPath(StringsToIdentifiers(column_names), &name_offset);
-			if (!column_info_p) {
-				auto normalized_col_name = StringUtil::Join(column_names, ".");
-				throw InternalException("Column '%s' can not be found in the schema, but returned by RETURN_STATS",
-				                        normalized_col_name);
-			}
-			if (name_offset.IsValid()) {
-				// stats path descends into a variant column - buffer it for bounds serialization
-				variant_bounds[column_info_p->id].AddStatsEntry(column_names, name_offset.GetIndex(), col_stats);
-				continue;
-			}
-			auto &column_info = *column_info_p;
-			auto stats = IcebergColumnStats::ParseColumnStats(column_info.type, col_stats, context);
-
-			// a map type cannot violate not null constraints.
-			// Null value counts can be off since an empty map is the same as a null map.
-			bool is_map = IsMapType(column_names[0], *ic_schema);
-			if (!is_map && column_info.required && stats.null_count && *stats.null_count > 0) {
-				auto normalized_col_name = StringUtil::Join(column_names, ".");
-				throw ConstraintException("NOT NULL constraint failed: %s.%s", table_name, normalized_col_name);
-			}
-			// Resolve the metrics mode for this column: per-column override -> table default ->
-			// Iceberg's truncate(16) default.
-			auto metrics = GetColumnMetricsConfig(table_metadata, default_metrics, StringUtil::Join(column_names, "."));
-			if (metrics.mode == IcebergMetricsMode::NONE) {
-				// No metrics recorded for this column.
-				continue;
-			}
-			const bool write_bounds =
-			    metrics.mode == IcebergMetricsMode::TRUNCATE || metrics.mode == IcebergMetricsMode::FULL;
-
-			// go through stats and add upper and lower bounds
-			// Do serialization of values here in case we read transaction updates
-			if (write_bounds && stats.min) {
-				auto serialized_value =
-				    IcebergValue::SerializeValue(*stats.min, column_info.type, SerializeBound::LOWER_BOUND, metrics);
-				if (serialized_value.HasError()) {
-					throw InvalidConfigurationException(serialized_value.GetError());
-				} else if (serialized_value.HasValue()) {
-					data_file.lower_bounds[column_info.id] = serialized_value.GetValue();
-				}
-			}
-			if (write_bounds && stats.max) {
-				auto serialized_value =
-				    IcebergValue::SerializeValue(*stats.max, column_info.type, SerializeBound::UPPER_BOUND, metrics);
-				if (serialized_value.HasError()) {
-					throw InvalidConfigurationException(serialized_value.GetError());
-				} else if (serialized_value.HasValue()) {
-					data_file.upper_bounds[column_info.id] = serialized_value.GetValue();
-				}
-			}
-			// See Iceberg v3 (Appendix D) for geometry stats info
-			if (write_bounds && column_info.type.id() == LogicalTypeId::GEOMETRY && stats.has_bbox_xy) {
-				vector<double> lower {stats.bbox_xmin, stats.bbox_ymin};
-				vector<double> upper {stats.bbox_xmax, stats.bbox_ymax};
-				if (stats.has_bbox_z) {
-					lower.push_back(stats.bbox_zmin);
-					upper.push_back(stats.bbox_zmax);
-				} else if (stats.has_bbox_m) {
-					// Spark treats a 3-double bound as XYZ always, so for an
-					// XYM column we'd otherwise be misread as XYZ. Pad the Z slot with
-					// +infinity in both bounds so the encoding is unambiguously 4D and
-					// the M value lands in the right slot.
-					const auto z_max = GeometryExtent::UNKNOWN_MAX;
-					const auto z_min = GeometryExtent::UNKNOWN_MIN;
-					lower.push_back(z_min);
-					upper.push_back(z_max);
-				}
-				if (stats.has_bbox_m) {
-					lower.push_back(stats.bbox_mmin);
-					upper.push_back(stats.bbox_mmax);
-				}
-				const auto byte_count = lower.size() * sizeof(double);
-				data_file.lower_bounds[column_info.id] =
-				    Value::BLOB(const_data_ptr_cast<double>(lower.data()), byte_count);
-				data_file.upper_bounds[column_info.id] =
-				    Value::BLOB(const_data_ptr_cast<double>(upper.data()), byte_count);
-			}
-			if (stats.column_size_bytes) {
-				data_file.column_sizes[column_info.id] = *stats.column_size_bytes;
-			}
-			if (stats.null_count) {
-				data_file.null_value_counts[column_info.id] = *stats.null_count;
-			}
-			if (stats.num_values) {
-				//! Iceberg 'value_counts' is the total number of values (including nulls). The Parquet writer's
-				//! 'num_values' has the same semantics.
-				data_file.value_counts[column_info.id] = *stats.num_values;
-			}
-
-			//! nan_value_counts won't work, we can only indicate if they exist.
-			//! TODO: revisit when duckdb/duckdb can record nan_value_counts
-		}
+		PopulateDataFileColumnStatsFromReturnStats(context, data_file, column_stats, table_metadata, table_name);
 		DUCKDB_LOG(context, IcebergLogType,
 		           "Iceberg INSERT, wrote data_file '%s', record_count=%lld, file_size=%lld bytes", data_file.file_path,
 		           data_file.record_count, data_file.file_size_in_bytes);
-
-		// serialize the accumulated variant bounds into the data file's lower/upper bounds
-		for (auto &entry : variant_bounds) {
-			// Respect the column's metrics mode; skip bounds under none/counts.
-			auto variant_metrics = GetColumnMetricsConfig(table_metadata, default_metrics,
-			                                              GetColumnNameBySourceId(*ic_schema, entry.first));
-			if (variant_metrics.mode != IcebergMetricsMode::TRUNCATE &&
-			    variant_metrics.mode != IcebergMetricsMode::FULL) {
-				continue;
-			}
-			optional<string> lower_blob;
-			optional<string> upper_blob;
-			if (!entry.second.Finalize(context, lower_blob, upper_blob)) {
-				continue;
-			}
-			if (lower_blob) {
-				data_file.lower_bounds[entry.first] = Value::BLOB_RAW(*lower_blob);
-			}
-			if (upper_blob) {
-				data_file.upper_bounds[entry.first] = Value::BLOB_RAW(*upper_blob);
-			}
-		}
 
 		written_files.push_back(std::move(manifest_entry));
 	}

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -226,7 +226,7 @@ void IcebergInsertGlobalState::AddFiles(DataChunk &chunk, const string &table_na
 
 		insert_count += data_file.record_count;
 
-		PopulateDataFileColumnStatsFromReturnStats(context, data_file, column_stats, table_metadata, table_name);
+		IcebergDataFileStats::PopulateFromReturnStats(context, data_file, column_stats, table_metadata, table_name);
 		DUCKDB_LOG(context, IcebergLogType,
 		           "Iceberg INSERT, wrote data_file '%s', record_count=%lld, file_size=%lld bytes", data_file.file_path,
 		           data_file.record_count, data_file.file_size_in_bytes);

--- a/src/include/maintenance/rewrite_data_files_executor.hpp
+++ b/src/include/maintenance/rewrite_data_files_executor.hpp
@@ -22,9 +22,12 @@ struct RewriteExecutionResult {
 
 //! Convert one COPY RETURN_STATS row into an ADDED manifest entry. Partition
 //! values and sequence-number semantics come from the frozen rewrite plan.
-IcebergManifestEntry BuildRewriteManifestEntry(const vector<RewriteCandidate> &group, int64_t starting_sequence_number,
-                                               int64_t record_count, const string &produced_file,
-                                               int64_t file_size_in_bytes);
+//! Column stats / bounds are populated from the RETURN_STATS map.
+IcebergManifestEntry BuildRewriteManifestEntry(ClientContext &context, const vector<RewriteCandidate> &group,
+                                               int64_t starting_sequence_number, int64_t record_count,
+                                               const string &produced_file, int64_t file_size_in_bytes,
+                                               const Value &column_stats, const IcebergTableMetadata &table_metadata,
+                                               const string &table_name);
 
 //! Commit all completed rewrite groups as one Iceberg REPLACE snapshot.
 void CommitRewrite(ClientContext &context, const RewritePlan &plan, RewriteExecutionResult &result);

--- a/src/include/storage/statistics/iceberg_data_file_stats.hpp
+++ b/src/include/storage/statistics/iceberg_data_file_stats.hpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//! Shared helpers for populating Iceberg data-file column metrics from COPY
+//! RETURN_STATS. Used by INSERT and iceberg_rewrite_data_files.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/main/client_context.hpp"
+
+#include "core/metadata/manifest/iceberg_manifest.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
+
+namespace duckdb {
+
+//! Populate lower/upper bounds, value/null counts, and column sizes on
+//! `data_file` from one COPY RETURN_STATS `column_statistics` map value.
+//! Respects write.metadata.metrics.* and enforces NOT NULL constraints.
+void PopulateDataFileColumnStatsFromReturnStats(ClientContext &context, IcebergDataFile &data_file,
+                                                const Value &column_stats, const IcebergTableMetadata &table_metadata,
+                                                const string &table_name);
+
+} // namespace duckdb

--- a/src/include/storage/statistics/iceberg_data_file_stats.hpp
+++ b/src/include/storage/statistics/iceberg_data_file_stats.hpp
@@ -13,11 +13,12 @@
 
 namespace duckdb {
 
-//! Populate lower/upper bounds, value/null counts, and column sizes on
-//! `data_file` from one COPY RETURN_STATS `column_statistics` map value.
-//! Respects write.metadata.metrics.* and enforces NOT NULL constraints.
-void PopulateDataFileColumnStatsFromReturnStats(ClientContext &context, IcebergDataFile &data_file,
-                                                const Value &column_stats, const IcebergTableMetadata &table_metadata,
-                                                const string &table_name);
+struct IcebergDataFileStats {
+	//! Populate lower/upper bounds, value/null counts, and column sizes on
+	//! `data_file` from one COPY RETURN_STATS `column_statistics` map value.
+	//! Respects write.metadata.metrics.* and enforces NOT NULL constraints.
+	static void PopulateFromReturnStats(ClientContext &context, IcebergDataFile &data_file, const Value &column_stats,
+	                                    const IcebergTableMetadata &table_metadata, const string &table_name);
+};
 
 } // namespace duckdb

--- a/src/maintenance/rewrite_data_files_executor.cpp
+++ b/src/maintenance/rewrite_data_files_executor.cpp
@@ -10,12 +10,15 @@
 #include "catalog/rest/transaction/iceberg_transaction_metadata.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "core/metadata/schema/iceberg_table_schema.hpp"
+#include "storage/statistics/iceberg_data_file_stats.hpp"
 
 namespace duckdb {
 
-IcebergManifestEntry BuildRewriteManifestEntry(const vector<RewriteCandidate> &group, int64_t starting_sequence_number,
-                                               int64_t record_count, const string &produced_file,
-                                               int64_t file_size_in_bytes) {
+IcebergManifestEntry BuildRewriteManifestEntry(ClientContext &context, const vector<RewriteCandidate> &group,
+                                               int64_t starting_sequence_number, int64_t record_count,
+                                               const string &produced_file, int64_t file_size_in_bytes,
+                                               const Value &column_stats, const IcebergTableMetadata &table_metadata,
+                                               const string &table_name) {
 	if (group.empty()) {
 		throw InternalException("iceberg_rewrite_data_files: cannot build a manifest entry for an empty group");
 	}
@@ -32,6 +35,13 @@ IcebergManifestEntry BuildRewriteManifestEntry(const vector<RewriteCandidate> &g
 	//! The planner buckets candidates so every file in one group shares the same
 	//! partition tuple. Reuse candidate 0 instead of re-deriving it.
 	entry.data_file.partition_info = group.front().partition_info;
+	if (table_metadata.HasSortOrder()) {
+		auto &sort_order = table_metadata.GetLatestSortOrder();
+		if (sort_order.IsSorted()) {
+			entry.data_file.sort_order_id = sort_order.sort_order_id;
+		}
+	}
+	PopulateDataFileColumnStatsFromReturnStats(context, entry.data_file, column_stats, table_metadata, table_name);
 	return entry;
 }
 

--- a/src/maintenance/rewrite_data_files_executor.cpp
+++ b/src/maintenance/rewrite_data_files_executor.cpp
@@ -41,7 +41,7 @@ IcebergManifestEntry BuildRewriteManifestEntry(ClientContext &context, const vec
 			entry.data_file.sort_order_id = sort_order.sort_order_id;
 		}
 	}
-	PopulateDataFileColumnStatsFromReturnStats(context, entry.data_file, column_stats, table_metadata, table_name);
+	IcebergDataFileStats::PopulateFromReturnStats(context, entry.data_file, column_stats, table_metadata, table_name);
 	return entry;
 }
 

--- a/src/maintenance/rewrite_data_files_operator.cpp
+++ b/src/maintenance/rewrite_data_files_operator.cpp
@@ -147,19 +147,22 @@ SinkResultType PhysicalRewriteDataFiles::Sink(ExecutionContext &context, DataChu
                                               OperatorSinkInput &input) const {
 	auto &gstate = input.global_state.Cast<RewriteDataFilesGlobalState>();
 	for (idx_t row = 0; row < chunk.size(); row++) {
-		if (chunk.ColumnCount() < 4) {
+		//! COPY RETURN_STATS emits one row per produced file (prefixed with group_idx):
+		//!   0 group_idx
+		//!   1 filename
+		//!   2 count
+		//!   3 file_size_bytes
+		//!   4 footer_size_bytes
+		//!   5 column_statistics
+		//!   6 partition_keys
+		if (chunk.ColumnCount() < 6) {
 			throw InternalException(
-			    "iceberg_rewrite_data_files: expected COPY RETURN_STATS result with at least four columns");
+			    "iceberg_rewrite_data_files: expected COPY RETURN_STATS result with at least five columns");
 		}
 		auto group_idx = chunk.GetValue(0, row).GetValue<uint64_t>();
 		if (static_cast<idx_t>(group_idx) >= gstate.plan.file_groups.size()) {
 			throw InternalException("iceberg_rewrite_data_files: COPY returned unknown group index %lld", group_idx);
 		}
-		//! COPY RETURN_STATS emits one row per produced file:
-		//!   0 group_idx
-		//!   1 filename
-		//!   2 count
-		//! followed by file size, footer size, column stats, and partition keys.
 		auto produced_file = chunk.GetValue(1, row).GetValue<string>();
 		if (produced_file.empty()) {
 			throw InternalException("iceberg_rewrite_data_files: COPY for group %lld returned an empty file path",
@@ -167,9 +170,12 @@ SinkResultType PhysicalRewriteDataFiles::Sink(ExecutionContext &context, DataChu
 		}
 		auto count = NumericCast<int64_t>(chunk.GetValue(2, row).GetValue<uint64_t>());
 		auto file_size_in_bytes = NumericCast<int64_t>(chunk.GetValue(3, row).GetValue<uint64_t>());
+		auto column_stats = chunk.GetValue(5, row);
 		auto &group = gstate.plan.file_groups[group_idx];
-		auto entry = BuildRewriteManifestEntry(group, gstate.plan.starting_sequence_number, count, produced_file,
-		                                       file_size_in_bytes);
+		auto &table_info = *gstate.plan.table_info;
+		auto entry = BuildRewriteManifestEntry(
+		    gstate.context, group, gstate.plan.starting_sequence_number, count, produced_file, file_size_in_bytes,
+		    column_stats, table_info.table_metadata, gstate.plan.table_name.Name().GetIdentifierName());
 
 		{
 			lock_guard<mutex> guard(gstate.lock);

--- a/src/storage/statistics/iceberg_data_file_stats.cpp
+++ b/src/storage/statistics/iceberg_data_file_stats.cpp
@@ -1,0 +1,200 @@
+#include "storage/statistics/iceberg_data_file_stats.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/identifier.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/geometry.hpp"
+
+#include "core/expression/iceberg_metrics.hpp"
+#include "core/expression/iceberg_value.hpp"
+#include "core/metadata/schema/iceberg_table_schema.hpp"
+#include "storage/statistics/iceberg_statistics.hpp"
+#include "storage/statistics/iceberg_variant_statistics.hpp"
+
+namespace duckdb {
+
+namespace {
+
+static bool IsMapType(const string &col_name, IcebergTableSchema &table_schema) {
+	for (auto &col : table_schema.columns) {
+		if (col->name == col_name) {
+			if (col->type.id() == LogicalTypeId::MAP) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+static string GetColumnNameBySourceId(const IcebergTableSchema &schema, idx_t source_id) {
+	return schema.GetColumnByFieldId(source_id).name;
+}
+
+static string ParseQuotedValue(const string &input, idx_t &pos) {
+	if (pos >= input.size() || input[pos] != '"') {
+		throw InvalidInputException("Failed to parse quoted value - expected a quote");
+	}
+	string result;
+	pos++;
+	for (; pos < input.size(); pos++) {
+		if (input[pos] == '"') {
+			pos++;
+			if (pos < input.size() && input[pos] == '"') {
+				result += '"';
+				continue;
+			}
+			return result;
+		}
+		result += input[pos];
+	}
+	throw InvalidInputException("Failed to parse quoted value - unterminated quote");
+}
+
+static vector<string> ParseQuotedList(const string &input, char list_separator) {
+	vector<string> result;
+	if (input.empty()) {
+		return result;
+	}
+	idx_t pos = 0;
+	while (true) {
+		result.push_back(ParseQuotedValue(input, pos));
+		if (pos >= input.size()) {
+			break;
+		}
+		if (input[pos] != list_separator) {
+			throw InvalidInputException("Failed to parse list - expected a %s", string(1, list_separator));
+		}
+		pos++;
+	}
+	return result;
+}
+
+} // namespace
+
+void PopulateDataFileColumnStatsFromReturnStats(ClientContext &context, IcebergDataFile &data_file,
+                                                const Value &column_stats, const IcebergTableMetadata &table_metadata,
+                                                const string &table_name) {
+	if (column_stats.IsNull()) {
+		return;
+	}
+
+	auto table_current_schema_id = table_metadata.GetCurrentSchemaId();
+	auto &ic_schema = table_metadata.GetSchemas().at(table_current_schema_id);
+	auto &map_children = MapValue::GetChildren(column_stats);
+
+	//! Variant columns emit one stats entry per shredded leaf — accumulate them
+	//! per variant column and serialize bounds once all entries are seen.
+	unordered_map<int32_t, IcebergVariantBounds> variant_bounds;
+	auto default_metrics = GetDefaultMetricsConfig(table_metadata);
+
+	for (idx_t col_idx = 0; col_idx < map_children.size(); col_idx++) {
+		auto &struct_children = StructValue::GetChildren(map_children[col_idx]);
+		auto &col_name = StringValue::Get(struct_children[0]);
+		auto &col_stats = MapValue::GetChildren(struct_children[1]);
+		auto column_names = ParseQuotedList(col_name, '.');
+		if (column_names[0] == "_row_id") {
+			continue;
+		}
+
+		optional_idx name_offset;
+		auto column_info_p = ic_schema->GetFromPath(StringsToIdentifiers(column_names), &name_offset);
+		if (!column_info_p) {
+			auto normalized_col_name = StringUtil::Join(column_names, ".");
+			throw InternalException("Column '%s' can not be found in the schema, but returned by RETURN_STATS",
+			                        normalized_col_name);
+		}
+		if (name_offset.IsValid()) {
+			variant_bounds[column_info_p->id].AddStatsEntry(column_names, name_offset.GetIndex(), col_stats);
+			continue;
+		}
+		auto &column_info = *column_info_p;
+		auto stats = IcebergColumnStats::ParseColumnStats(column_info.type, col_stats, context);
+
+		//! Map types cannot violate NOT NULL; empty maps look like null maps.
+		bool is_map = IsMapType(column_names[0], *ic_schema);
+		if (!is_map && column_info.required && stats.null_count && *stats.null_count > 0) {
+			auto normalized_col_name = StringUtil::Join(column_names, ".");
+			throw ConstraintException("NOT NULL constraint failed: %s.%s", table_name, normalized_col_name);
+		}
+
+		auto metrics = GetColumnMetricsConfig(table_metadata, default_metrics, StringUtil::Join(column_names, "."));
+		if (metrics.mode == IcebergMetricsMode::NONE) {
+			continue;
+		}
+		const bool write_bounds =
+		    metrics.mode == IcebergMetricsMode::TRUNCATE || metrics.mode == IcebergMetricsMode::FULL;
+
+		if (write_bounds && stats.min) {
+			auto serialized_value =
+			    IcebergValue::SerializeValue(*stats.min, column_info.type, SerializeBound::LOWER_BOUND, metrics);
+			if (serialized_value.HasError()) {
+				throw InvalidConfigurationException(serialized_value.GetError());
+			} else if (serialized_value.HasValue()) {
+				data_file.lower_bounds[column_info.id] = serialized_value.GetValue();
+			}
+		}
+		if (write_bounds && stats.max) {
+			auto serialized_value =
+			    IcebergValue::SerializeValue(*stats.max, column_info.type, SerializeBound::UPPER_BOUND, metrics);
+			if (serialized_value.HasError()) {
+				throw InvalidConfigurationException(serialized_value.GetError());
+			} else if (serialized_value.HasValue()) {
+				data_file.upper_bounds[column_info.id] = serialized_value.GetValue();
+			}
+		}
+		//! Iceberg v3 Appendix D geometry bounding-box encoding.
+		if (write_bounds && column_info.type.id() == LogicalTypeId::GEOMETRY && stats.has_bbox_xy) {
+			vector<double> lower {stats.bbox_xmin, stats.bbox_ymin};
+			vector<double> upper {stats.bbox_xmax, stats.bbox_ymax};
+			if (stats.has_bbox_z) {
+				lower.push_back(stats.bbox_zmin);
+				upper.push_back(stats.bbox_zmax);
+			} else if (stats.has_bbox_m) {
+				//! Spark treats a 3-double bound as XYZ always; pad Z with
+				//! ±infinity so XYM encodes unambiguously as 4D.
+				const auto z_max = GeometryExtent::UNKNOWN_MAX;
+				const auto z_min = GeometryExtent::UNKNOWN_MIN;
+				lower.push_back(z_min);
+				upper.push_back(z_max);
+			}
+			if (stats.has_bbox_m) {
+				lower.push_back(stats.bbox_mmin);
+				upper.push_back(stats.bbox_mmax);
+			}
+			const auto byte_count = lower.size() * sizeof(double);
+			data_file.lower_bounds[column_info.id] = Value::BLOB(const_data_ptr_cast<double>(lower.data()), byte_count);
+			data_file.upper_bounds[column_info.id] = Value::BLOB(const_data_ptr_cast<double>(upper.data()), byte_count);
+		}
+		if (stats.column_size_bytes) {
+			data_file.column_sizes[column_info.id] = *stats.column_size_bytes;
+		}
+		if (stats.null_count) {
+			data_file.null_value_counts[column_info.id] = *stats.null_count;
+		}
+		if (stats.num_values) {
+			//! Iceberg value_counts includes nulls; Parquet num_values matches.
+			data_file.value_counts[column_info.id] = *stats.num_values;
+		}
+	}
+
+	for (auto &entry : variant_bounds) {
+		auto variant_metrics =
+		    GetColumnMetricsConfig(table_metadata, default_metrics, GetColumnNameBySourceId(*ic_schema, entry.first));
+		if (variant_metrics.mode != IcebergMetricsMode::TRUNCATE && variant_metrics.mode != IcebergMetricsMode::FULL) {
+			continue;
+		}
+		optional<string> lower_blob;
+		optional<string> upper_blob;
+		if (!entry.second.Finalize(context, lower_blob, upper_blob)) {
+			continue;
+		}
+		if (lower_blob) {
+			data_file.lower_bounds[entry.first] = Value::BLOB_RAW(*lower_blob);
+		}
+		if (upper_blob) {
+			data_file.upper_bounds[entry.first] = Value::BLOB_RAW(*upper_blob);
+		}
+	}
+}
+
+} // namespace duckdb

--- a/src/storage/statistics/iceberg_data_file_stats.cpp
+++ b/src/storage/statistics/iceberg_data_file_stats.cpp
@@ -71,9 +71,10 @@ static vector<string> ParseQuotedList(const string &input, char list_separator) 
 
 } // namespace
 
-void PopulateDataFileColumnStatsFromReturnStats(ClientContext &context, IcebergDataFile &data_file,
-                                                const Value &column_stats, const IcebergTableMetadata &table_metadata,
-                                                const string &table_name) {
+void IcebergDataFileStats::PopulateFromReturnStats(ClientContext &context, IcebergDataFile &data_file,
+                                                   const Value &column_stats,
+                                                   const IcebergTableMetadata &table_metadata,
+                                                   const string &table_name) {
 	if (column_stats.IsNull()) {
 		return;
 	}

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_column_stats.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_column_stats.test
@@ -1,0 +1,83 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_column_stats.test
+# description: rewritten files retain manifest column stats / bounds
+# group: [maintenance]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.rewrite_column_stats;
+
+statement ok
+create table my_datalake.default.rewrite_column_stats (id INTEGER, payload VARCHAR);
+
+statement ok
+insert into my_datalake.default.rewrite_column_stats values (1, 'a'), (2, 'b');
+
+statement ok
+insert into my_datalake.default.rewrite_column_stats values (10, 'j'), (20, 't');
+
+statement ok
+insert into my_datalake.default.rewrite_column_stats values (3, 'c'), (4, 'd');
+
+statement ok
+insert into my_datalake.default.rewrite_column_stats values (5, 'e'), (6, 'f');
+
+statement ok
+insert into my_datalake.default.rewrite_column_stats values (7, 'g'), (8, 'h');
+
+# Confirm pre-rewrite inserts already wrote column stats.
+query III
+select column_name, lower_bound, upper_bound
+from iceberg_column_stats(my_datalake.default.rewrite_column_stats)
+where status = 'ADDED' and column_name in ('id', 'payload')
+order by column_name, try_cast(lower_bound AS BIGINT) NULLS LAST, lower_bound;
+----
+id	1	2
+id	3	4
+id	5	6
+id	7	8
+id	10	20
+payload	a	b
+payload	c	d
+payload	e	f
+payload	g	h
+payload	j	t
+
+query III
+call iceberg_rewrite_data_files('my_datalake.default.rewrite_column_stats');
+----
+5	1	<REGEX>:[1-9][0-9]*
+
+# After rewrite there is a single ADDED data file whose bounds span the full table.
+query III
+select column_name, lower_bound, upper_bound
+from iceberg_column_stats(my_datalake.default.rewrite_column_stats)
+where status = 'ADDED' and column_name in ('id', 'payload')
+order by column_name;
+----
+id	1	20
+payload	a	t
+
+# File pruning still works via the rewritten bounds.
+query II
+explain analyze select * from my_datalake.default.rewrite_column_stats where id = 1;
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
+query II
+explain analyze select * from my_datalake.default.rewrite_column_stats where id = 999;
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 0.*
+
+statement ok
+drop table if exists my_datalake.default.rewrite_column_stats;


### PR DESCRIPTION
## Summary

This is a surgical follow-up to #1035 (`iceberg_rewrite_data_files`). Rewritten data files currently land in the manifest with only `record_count`, `file_size_in_bytes`, and the partition tuple, NOT the per-column statistics from the internal `COPY ... (RETURN_STATS)`.

As a result, compacted files lacked `lower_bounds` / `upper_bounds` / `value_counts` / `null_value_counts` / `column_sizes`, so file-level pruning and Iceberg metrics (`write.metadata.metrics.column.*`) stop working for anything produced by a rewrite. This was called out as a known limitation in the original PR.

This change populates those stats for rewritten files, reusing the exact code path that `INSERT` already uses.

## Changes

- Extract the `RETURN_STATS` → `IcebergDataFile` stats population out of `IcebergInsertGlobalState::AddFiles` into a shared helper `PopulateDataFileColumnStatsFromReturnStats` (`src/storage/statistics/iceberg_data_file_stats.{hpp,cpp}`).
- `INSERT` now delegates to the helper (pure refactor, no behavior change — mostly deletions).
- `BuildRewriteManifestEntry` / the rewrite `Sink` now read the `column_statistics` map from the COPY result and call the shared helper, so rewritten files carry identical bounds/metrics (including per-column metrics modes, variant bounds, and geometry bounding boxes). Rewritten files also inherit the table `sort_order_id` when configured.
- Add `rewrite_data_files_column_stats.test` asserting rewritten files retain column bounds and that pruning still skips non-matching files.

## Notes / follow-ups (not addressed here)

- `nan_value_counts` is still not populated (same limitation as INSERT; blocked on duckdb/duckdb recording NaN counts).
