### PR TITLE
Enable metadata-only MIN/MAX from Iceberg manifest column bounds (e.g., `MAX(updated_at)`)

### DIFF
--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/multi_file/multi_file_data.hpp"
 #include "duckdb/common/list.hpp"
 #include "duckdb/common/unordered_map.hpp"
+#include "duckdb/function/partition_stats.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
@@ -30,6 +31,32 @@
 #include "planning/metadata_io/manifest/bound_iceberg_manifest_entry.hpp"
 
 namespace duckdb {
+
+//! Exposes per-column min/max from Iceberg manifest data_file.lower_bounds /
+//! upper_bounds to DuckDB's PartitionStatistics API. Used by
+//! StatisticsPropagator::TryExecuteAggregates for metadata-only MIN/MAX.
+//!
+//! Intentionally reads manifest column bounds — not Iceberg partition-statistics
+//! files (https://iceberg.apache.org/spec/#partition-statistics), which carry
+//! only counts/sizes and have no per-column min/max.
+struct IcebergPartitionRowGroup : public PartitionRowGroup {
+public:
+	IcebergPartitionRowGroup(const vector<unique_ptr<IcebergColumnDefinition>> &schema,
+	                         vector<reference<const IcebergDataFile>> data_files);
+
+public:
+	unique_ptr<BaseStatistics> GetColumnStatistics(const StorageIndex &storage_index) override;
+	bool MinMaxIsExact(const BaseStatistics &stats, const StorageIndex &storage_index) override;
+
+public:
+	const vector<unique_ptr<IcebergColumnDefinition>> &schema;
+	vector<reference<const IcebergDataFile>> data_files;
+
+private:
+	//! Numeric/temporal types whose Iceberg bounds are stored without truncation.
+	//! FLOAT/DOUBLE are excluded (NaN semantics). VARCHAR/BLOB bounds may be truncated.
+	static bool SupportsExactMinMaxBounds(const LogicalType &type);
+};
 
 struct IcebergTableFilters {
 	using filter_set_t = unordered_map<idx_t, unique_ptr<ExpressionFilter>>;

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -32,6 +32,8 @@
 
 namespace duckdb {
 
+struct IcebergMultiFileList;
+
 //! Exposes per-column min/max from Iceberg manifest data_file.lower_bounds /
 //! upper_bounds to DuckDB's PartitionStatistics API. Used by
 //! StatisticsPropagator::TryExecuteAggregates for metadata-only MIN/MAX.
@@ -39,23 +41,26 @@ namespace duckdb {
 //! Intentionally reads manifest column bounds — not Iceberg partition-statistics
 //! files (https://iceberg.apache.org/spec/#partition-statistics), which carry
 //! only counts/sizes and have no per-column min/max.
+//!
+//! Data-file entries are materialized lazily on first GetColumnStatistics call so
+//! COUNT(*)-only partition-stats requests avoid draining every matching file.
 struct IcebergPartitionRowGroup : public PartitionRowGroup {
 public:
-	IcebergPartitionRowGroup(const vector<unique_ptr<IcebergColumnDefinition>> &schema,
-	                         vector<reference<const IcebergDataFile>> data_files);
+	explicit IcebergPartitionRowGroup(const IcebergMultiFileList &file_list);
 
 public:
 	unique_ptr<BaseStatistics> GetColumnStatistics(const StorageIndex &storage_index) override;
 	bool MinMaxIsExact(const BaseStatistics &stats, const StorageIndex &storage_index) override;
 
-public:
-	const vector<unique_ptr<IcebergColumnDefinition>> &schema;
-	vector<reference<const IcebergDataFile>> data_files;
-
 private:
+	void EnsureDataFilesMaterialized();
 	//! Numeric/temporal types whose Iceberg bounds are stored without truncation.
 	//! FLOAT/DOUBLE are excluded (NaN semantics). VARCHAR/BLOB bounds may be truncated.
 	static bool SupportsExactMinMaxBounds(const LogicalType &type);
+
+	const IcebergMultiFileList &file_list;
+	vector<reference<const IcebergDataFile>> data_files;
+	bool data_files_materialized = false;
 };
 
 struct IcebergTableFilters {
@@ -96,7 +101,6 @@ private:
 };
 
 class IcebergTableEntry;
-struct IcebergMultiFileList;
 struct RowGroupOrderOptions;
 
 struct IcebergManifestScanningState {
@@ -168,6 +172,8 @@ public:
 };
 
 struct IcebergMultiFileList : public MultiFileList {
+	friend struct IcebergPartitionRowGroup;
+
 public:
 	IcebergMultiFileList(ClientContext &context, shared_ptr<IcebergScanInfo> scan_info, const string &path,
 	                     const IcebergOptions &options);
@@ -233,6 +239,10 @@ protected:
 	//! Reorder (and prune, when a LIMIT is present) the materialized data files by the
 	//! ORDER BY column's per-file min/max bounds, mirroring the native RowGroupReorderer.
 	void EnsureScanOrderApplied(lock_guard<mutex> &guard) const;
+
+	//! Drain matching data-file entries so column bounds are available for MIN/MAX.
+	//! Called lazily from IcebergPartitionRowGroup — not from GetStatistics (COUNT(*)).
+	void EnsureDataFilesMaterialized(vector<reference<const IcebergDataFile>> &result) const;
 
 	//! NOTE: this requires the lock because it modifies the 'data_files' vector, potentially invalidating references
 	optional_ptr<const BoundIcebergManifestEntry> GetDataFile(idx_t file_id, lock_guard<mutex> &guard) const;

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/multi_file/multi_file_data.hpp"
 #include "duckdb/common/list.hpp"
 #include "duckdb/common/unordered_map.hpp"
+#include "duckdb/function/partition_stats.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
@@ -32,6 +33,33 @@ namespace duckdb {
 class IcebergTableSchemaVersion;
 class IcebergScanPlanProvider;
 struct IcebergScanPlanContext;
+
+//! Exposes per-column min/max from Iceberg manifest data_file.lower_bounds /
+//! upper_bounds to DuckDB's PartitionStatistics API. Used by
+//! StatisticsPropagator::TryExecuteAggregates for metadata-only MIN/MAX.
+//!
+//! Intentionally reads manifest column bounds — not Iceberg partition-statistics
+//! files (https://iceberg.apache.org/spec/#partition-statistics), which carry
+//! only counts/sizes and have no per-column min/max.
+struct IcebergPartitionRowGroup : public PartitionRowGroup {
+public:
+	IcebergPartitionRowGroup(const vector<unique_ptr<IcebergColumnDefinition>> &schema,
+	                         vector<reference<const IcebergDataFile>> data_files);
+
+public:
+	unique_ptr<BaseStatistics> GetColumnStatistics(const StorageIndex &storage_index) override;
+	bool MinMaxIsExact(const BaseStatistics &stats, const StorageIndex &storage_index) override;
+
+public:
+	const vector<unique_ptr<IcebergColumnDefinition>> &schema;
+	vector<reference<const IcebergDataFile>> data_files;
+
+private:
+	//! Numeric/temporal types whose Iceberg bounds are stored without truncation.
+	//! FLOAT/DOUBLE are excluded (NaN semantics). VARCHAR/BLOB bounds may be truncated.
+	static bool SupportsExactMinMaxBounds(const LogicalType &type);
+};
+
 struct IcebergMultiFileList;
 struct IcebergMultiFileReader;
 struct IcebergDeleteFileReference;

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -30,6 +30,8 @@
 
 namespace duckdb {
 
+struct IcebergMultiFileList;
+
 class IcebergTableSchemaVersion;
 class IcebergScanPlanProvider;
 struct IcebergScanPlanContext;
@@ -41,30 +43,35 @@ struct IcebergScanPlanContext;
 //! Intentionally reads manifest column bounds — not Iceberg partition-statistics
 //! files (https://iceberg.apache.org/spec/#partition-statistics), which carry
 //! only counts/sizes and have no per-column min/max.
+//!
+//! Data-file entries are materialized lazily on first GetColumnStatistics call so
+//! COUNT(*)-only partition-stats requests avoid draining every matching file.
 struct IcebergPartitionRowGroup : public PartitionRowGroup {
 public:
-	IcebergPartitionRowGroup(const vector<unique_ptr<IcebergColumnDefinition>> &schema,
-	                         vector<reference<const IcebergDataFile>> data_files);
+	explicit IcebergPartitionRowGroup(const IcebergMultiFileList &file_list);
 
 public:
 	unique_ptr<BaseStatistics> GetColumnStatistics(const StorageIndex &storage_index) override;
-	bool MinMaxIsExact(const BaseStatistics &stats, const StorageIndex &storage_index) override;
-
-public:
-	const vector<unique_ptr<IcebergColumnDefinition>> &schema;
-	vector<reference<const IcebergDataFile>> data_files;
+	bool MinMaxIsExact(const StorageIndex &storage_index) override;
+	bool HasPendingWrites() override;
 
 private:
+	void EnsureDataFilesMaterialized();
 	//! Numeric/temporal types whose Iceberg bounds are stored without truncation.
 	//! FLOAT/DOUBLE are excluded (NaN semantics). VARCHAR/BLOB bounds may be truncated.
 	static bool SupportsExactMinMaxBounds(const LogicalType &type);
+
+	const IcebergMultiFileList &file_list;
+	vector<reference<const IcebergDataFile>> data_files;
+	bool data_files_materialized = false;
 };
 
-struct IcebergMultiFileList;
 struct IcebergMultiFileReader;
 struct IcebergDeleteFileReference;
 
 struct IcebergMultiFileList : public MultiFileList {
+	friend struct IcebergPartitionRowGroup;
+
 public:
 	IcebergMultiFileList(ClientContext &context, shared_ptr<IcebergScanInfo> scan_info, const string &path,
 	                     const IcebergOptions &options);
@@ -126,6 +133,10 @@ private:
 	const IcebergManifestFile &GetManifestFileForEntry(const BoundIcebergManifestEntry &entry,
 	                                                   IcebergManifestContentType type) const
 	    DUCKDB_REQUIRES(shared_state->lock);
+
+	//! Drain matching data-file entries so column bounds are available for MIN/MAX.
+	//! Called lazily from IcebergPartitionRowGroup — not from GetStatistics (COUNT(*)).
+	void EnsureDataFilesMaterialized(vector<reference<const IcebergDataFile>> &result) const;
 
 	//! Whether a delete file's manifest entry can apply to any file selected by the current scan filter.
 	//! Delete files are pruned on partition only: one whose partition is excluded by the filter cannot

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -21,6 +21,7 @@
 #include "duckdb/execution/executor.hpp"
 #include "duckdb/optimizer/filter_combiner.hpp"
 #include "duckdb/function/scalar/struct_utils.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
 #include "duckdb/storage/table/row_group_reorderer.hpp"
 
 #include "planning/iceberg_multi_file_reader.hpp"
@@ -544,15 +545,125 @@ const IcebergManifestFile &IcebergMultiFileList::GetManifestFileForEntry(const B
 	}
 }
 
+IcebergPartitionRowGroup::IcebergPartitionRowGroup(const vector<unique_ptr<IcebergColumnDefinition>> &schema_p,
+                                                   vector<reference<const IcebergDataFile>> data_files_p)
+    : schema(schema_p), data_files(std::move(data_files_p)) {
+}
+
+bool IcebergPartitionRowGroup::SupportsExactMinMaxBounds(const LogicalType &type) {
+	//! FLOAT/DOUBLE are excluded because of the Iceberg spec (not a DuckDB limit):
+	//! the spec defines float/double manifest lower_bounds/upper_bounds to *exclude*
+	//! NaN (tracked separately via nan_value_counts) and to treat -0.0 == +0.0.
+	//! SQL MIN/MAX in DuckDB orders NaN as the largest value, so a file containing
+	//! NaN would have an upper_bound that disagrees with the true MAX. The manifest
+	//! bounds are therefore not a safe source of truth for exact float/double
+	//! MIN/MAX, so we fall back to scanning for those types.
+	//! See https://iceberg.apache.org/spec/#appendix-d-single-value-serialization
+	if (type.id() == LogicalTypeId::FLOAT || type.id() == LogicalTypeId::DOUBLE) {
+		return false;
+	}
+	//! VARCHAR/BLOB are implicitly excluded here as well: the spec permits writers
+	//! to store *truncated* string/binary bounds (lower rounded down, upper rounded
+	//! up), which bound the true value but are not exact enough to fold MIN/MAX.
+	return type.IsNumeric() || type.IsTemporal();
+}
+
+unique_ptr<BaseStatistics> IcebergPartitionRowGroup::GetColumnStatistics(const StorageIndex &storage_index) {
+	//! Build exact table-level min/max for one column from Iceberg manifest bounds.
+	//! Returning nullptr tells StatisticsPropagator::TryExecuteAggregates to fall
+	//! back to a normal scan for MIN/MAX on this column.
+	//!
+	//! storage_index is the logical column position in the Iceberg schema (same
+	//! mapping LogicalGet uses for path-based iceberg_scan). Nested paths are
+	//! not supported — only top-level columns.
+
+	if (storage_index.HasChildren()) {
+		return nullptr;
+	}
+	auto col_idx = storage_index.GetPrimaryIndex();
+	if (col_idx >= schema.size()) {
+		return nullptr;
+	}
+	auto &column = *schema[col_idx];
+	auto &type = column.type;
+	//! Skip types whose written bounds are not exact (truncated strings, floats
+	//! with NaN). See SupportsExactMinMaxBounds.
+	if (!SupportsExactMinMaxBounds(type)) {
+		return nullptr;
+	}
+	if (data_files.empty()) {
+		return nullptr;
+	}
+
+	//! Iceberg keys bounds by field id (stable across renames), not by name/index.
+	const auto field_id = column.id;
+	//! Reduce per-file [lower, upper] into a single table-wide [min, max].
+	//! Each file's lower_bound is the exact min of that file (for allowlisted
+	//! types), so min(lower across files) is the exact table MIN — same for MAX.
+	optional<Value> global_min;
+	optional<Value> global_max;
+	for (auto &file_ref : data_files) {
+		auto &data_file = file_ref.get();
+		auto lower_it = data_file.lower_bounds.find(field_id);
+		auto upper_it = data_file.upper_bounds.find(field_id);
+		//! Bounds are optional in the spec (e.g. all-null columns, metrics=none).
+		//! If any file lacks them we cannot prove an exact global min/max.
+		if (lower_it == data_file.lower_bounds.end() || upper_it == data_file.upper_bounds.end()) {
+			return nullptr;
+		}
+		//! Manifest stores bounds as Iceberg binary blobs; decode to typed Values.
+		IcebergPredicateStats pred_stats;
+		try {
+			pred_stats =
+			    IcebergPredicateStats::DeserializeBounds(lower_it->second, upper_it->second, column.name, type);
+		} catch (...) {
+			//! Corrupt / unexpected encoding — be conservative and skip the fold.
+			return nullptr;
+		}
+		//! Null decoded bounds (e.g. all-null file) are not usable for MIN/MAX.
+		if (!pred_stats.lower_bound || !pred_stats.upper_bound || pred_stats.lower_bound->IsNull() ||
+		    pred_stats.upper_bound->IsNull()) {
+			return nullptr;
+		}
+		if (!global_min || *pred_stats.lower_bound < *global_min) {
+			global_min = *pred_stats.lower_bound;
+		}
+		if (!global_max || *pred_stats.upper_bound > *global_max) {
+			global_max = *pred_stats.upper_bound;
+		}
+	}
+	D_ASSERT(global_min && global_max);
+
+	//! Package as DuckDB NumericStats so TryExecuteAggregates / MinMaxIsExact
+	//! can fold SELECT MIN/MAX into a constant without scanning data files.
+	auto stats = NumericStats::CreateEmpty(type);
+	NumericStats::SetMin(stats, *global_min);
+	NumericStats::SetMax(stats, *global_max);
+	return stats.ToUnique();
+}
+
+bool IcebergPartitionRowGroup::MinMaxIsExact(const BaseStatistics &stats, const StorageIndex &storage_index) {
+	//! GetColumnStatistics only returns stats for exact-capable types when every
+	//! data file has usable (non-truncated) lower and upper bounds, so those
+	//! values are exact table min/max.
+	(void)stats;
+	(void)storage_index;
+	return true;
+}
+
 void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) const {
 	if (GetMetadata().iceberg_version == 1) {
 		//! We collect no statistics information from manifests for V1 tables.
 		return;
 	}
 
+	lock_guard<mutex> guard(shared_state->lock);
+	InitializeFiles(guard);
+
 	for (idx_t i = 0; i < delete_manifests.size(); i++) {
 		if (delete_manifest_matches[i]) {
-			//! if a matching delete manifest exists, return;
+			//! Matching delete manifests can invalidate data-file bounds / counts;
+			//! omit partition stats so MIN/MAX/COUNT(*) fall back to a scan.
 			return;
 		}
 	}
@@ -567,10 +678,25 @@ void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) co
 		count += manifest.added_rows_count;
 	}
 
+	//! Materialize data-file entries so column bounds are available for MIN/MAX.
+	idx_t materialized = 0;
+	while (GetDataFile(materialized, guard)) {
+		materialized++;
+	}
+	vector<reference<const IcebergDataFile>> data_files;
+	data_files.reserve(data_manifest_entries.size());
+	for (auto &entry : data_manifest_entries) {
+		data_files.push_back(entry.entry.data_file);
+	}
+
 	PartitionStatistics partition_stats;
 	partition_stats.count = count;
 	partition_stats.count_type = CountType::COUNT_EXACT;
-	result.push_back(partition_stats);
+	//! Manifest column bounds (not Iceberg partition-statistics files) — those
+	//! files have no per-column min/max.
+	partition_stats.partition_row_group =
+	    make_shared_ptr<IcebergPartitionRowGroup>(GetSchema().columns, std::move(data_files));
+	result.push_back(std::move(partition_stats));
 }
 
 void IcebergPredicateStats::SetLowerBound(const Value &new_lower_bound) {

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -551,6 +551,13 @@ IcebergPartitionRowGroup::IcebergPartitionRowGroup(const vector<unique_ptr<Icebe
 }
 
 bool IcebergPartitionRowGroup::SupportsExactMinMaxBounds(const LogicalType &type) {
+	//! Nested types (STRUCT/LIST/MAP/ARRAY/UNION) have no single composite bound in
+	//! the Iceberg manifest (bounds are keyed per primitive field id), so there is
+	//! nothing to fold into an exact table-level MIN/MAX. Excluding them here also
+	//! guards against a nested float/truncated leaf slipping past the checks below.
+	if (type.IsNested()) {
+		return false;
+	}
 	//! FLOAT/DOUBLE are excluded because of the Iceberg spec (not a DuckDB limit):
 	//! the spec defines float/double manifest lower_bounds/upper_bounds to *exclude*
 	//! NaN (tracked separately via nan_value_counts) and to treat -0.0 == +0.0.

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -545,9 +545,15 @@ const IcebergManifestFile &IcebergMultiFileList::GetManifestFileForEntry(const B
 	}
 }
 
-IcebergPartitionRowGroup::IcebergPartitionRowGroup(const vector<unique_ptr<IcebergColumnDefinition>> &schema_p,
-                                                   vector<reference<const IcebergDataFile>> data_files_p)
-    : schema(schema_p), data_files(std::move(data_files_p)) {
+IcebergPartitionRowGroup::IcebergPartitionRowGroup(const IcebergMultiFileList &file_list_p) : file_list(file_list_p) {
+}
+
+void IcebergPartitionRowGroup::EnsureDataFilesMaterialized() {
+	if (data_files_materialized) {
+		return;
+	}
+	data_files_materialized = true;
+	file_list.EnsureDataFilesMaterialized(data_files);
 }
 
 bool IcebergPartitionRowGroup::SupportsExactMinMaxBounds(const LogicalType &type) {
@@ -587,6 +593,7 @@ unique_ptr<BaseStatistics> IcebergPartitionRowGroup::GetColumnStatistics(const S
 	if (storage_index.HasChildren()) {
 		return nullptr;
 	}
+	auto &schema = file_list.GetSchema().columns;
 	auto col_idx = storage_index.GetPrimaryIndex();
 	if (col_idx >= schema.size()) {
 		return nullptr;
@@ -598,6 +605,8 @@ unique_ptr<BaseStatistics> IcebergPartitionRowGroup::GetColumnStatistics(const S
 	if (!SupportsExactMinMaxBounds(type)) {
 		return nullptr;
 	}
+	//! Materialize only when column bounds are actually needed (not for COUNT(*)).
+	EnsureDataFilesMaterialized();
 	if (data_files.empty()) {
 		return nullptr;
 	}
@@ -685,25 +694,28 @@ void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) co
 		count += manifest.added_rows_count;
 	}
 
-	//! Materialize data-file entries so column bounds are available for MIN/MAX.
+	PartitionStatistics partition_stats;
+	partition_stats.count = count;
+	partition_stats.count_type = CountType::COUNT_EXACT;
+	//! Lazy IcebergPartitionRowGroup: data-file bounds are materialized only when
+	//! GetColumnStatistics runs (MIN/MAX). COUNT(*) uses count alone.
+	partition_stats.partition_row_group = make_shared_ptr<IcebergPartitionRowGroup>(*this);
+	result.push_back(std::move(partition_stats));
+}
+
+void IcebergMultiFileList::EnsureDataFilesMaterialized(vector<reference<const IcebergDataFile>> &result) const {
+	lock_guard<mutex> guard(shared_state->lock);
+	InitializeFiles(guard);
+
 	idx_t materialized = 0;
 	while (GetDataFile(materialized, guard)) {
 		materialized++;
 	}
-	vector<reference<const IcebergDataFile>> data_files;
-	data_files.reserve(data_manifest_entries.size());
+	result.clear();
+	result.reserve(data_manifest_entries.size());
 	for (auto &entry : data_manifest_entries) {
-		data_files.push_back(entry.entry.data_file);
+		result.push_back(entry.entry.data_file);
 	}
-
-	PartitionStatistics partition_stats;
-	partition_stats.count = count;
-	partition_stats.count_type = CountType::COUNT_EXACT;
-	//! Manifest column bounds (not Iceberg partition-statistics files) — those
-	//! files have no per-column min/max.
-	partition_stats.partition_row_group =
-	    make_shared_ptr<IcebergPartitionRowGroup>(GetSchema().columns, std::move(data_files));
-	result.push_back(std::move(partition_stats));
 }
 
 void IcebergPredicateStats::SetLowerBound(const Value &new_lower_bound) {

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -406,6 +406,13 @@ IcebergPartitionRowGroup::IcebergPartitionRowGroup(const vector<unique_ptr<Icebe
 }
 
 bool IcebergPartitionRowGroup::SupportsExactMinMaxBounds(const LogicalType &type) {
+	//! Nested types (STRUCT/LIST/MAP/ARRAY/UNION) have no single composite bound in
+	//! the Iceberg manifest (bounds are keyed per primitive field id), so there is
+	//! nothing to fold into an exact table-level MIN/MAX. Excluding them here also
+	//! guards against a nested float/truncated leaf slipping past the checks below.
+	if (type.IsNested()) {
+		return false;
+	}
 	//! FLOAT/DOUBLE are excluded because of the Iceberg spec (not a DuckDB limit):
 	//! the spec defines float/double manifest lower_bounds/upper_bounds to *exclude*
 	//! NaN (tracked separately via nan_value_counts) and to treat -0.0 == +0.0.

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -6,6 +6,8 @@
 #include "duckdb/function/partition_stats.hpp"
 #include "duckdb/optimizer/filter_combiner.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/function/scalar/struct_utils.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
 #include "duckdb/storage/table/row_group_reorderer.hpp"
 
 #include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
@@ -398,6 +400,112 @@ const IcebergManifestFile &IcebergMultiFileList::GetManifestFileForEntry(const B
 	}
 }
 
+IcebergPartitionRowGroup::IcebergPartitionRowGroup(const vector<unique_ptr<IcebergColumnDefinition>> &schema_p,
+                                                   vector<reference<const IcebergDataFile>> data_files_p)
+    : schema(schema_p), data_files(std::move(data_files_p)) {
+}
+
+bool IcebergPartitionRowGroup::SupportsExactMinMaxBounds(const LogicalType &type) {
+	//! FLOAT/DOUBLE are excluded because of the Iceberg spec (not a DuckDB limit):
+	//! the spec defines float/double manifest lower_bounds/upper_bounds to *exclude*
+	//! NaN (tracked separately via nan_value_counts) and to treat -0.0 == +0.0.
+	//! SQL MIN/MAX in DuckDB orders NaN as the largest value, so a file containing
+	//! NaN would have an upper_bound that disagrees with the true MAX. The manifest
+	//! bounds are therefore not a safe source of truth for exact float/double
+	//! MIN/MAX, so we fall back to scanning for those types.
+	//! See https://iceberg.apache.org/spec/#appendix-d-single-value-serialization
+	if (type.id() == LogicalTypeId::FLOAT || type.id() == LogicalTypeId::DOUBLE) {
+		return false;
+	}
+	//! VARCHAR/BLOB are implicitly excluded here as well: the spec permits writers
+	//! to store *truncated* string/binary bounds (lower rounded down, upper rounded
+	//! up), which bound the true value but are not exact enough to fold MIN/MAX.
+	return type.IsNumeric() || type.IsTemporal();
+}
+
+unique_ptr<BaseStatistics> IcebergPartitionRowGroup::GetColumnStatistics(const StorageIndex &storage_index) {
+	//! Build exact table-level min/max for one column from Iceberg manifest bounds.
+	//! Returning nullptr tells StatisticsPropagator::TryExecuteAggregates to fall
+	//! back to a normal scan for MIN/MAX on this column.
+	//!
+	//! storage_index is the logical column position in the Iceberg schema (same
+	//! mapping LogicalGet uses for path-based iceberg_scan). Nested paths are
+	//! not supported — only top-level columns.
+
+	if (storage_index.HasChildren()) {
+		return nullptr;
+	}
+	auto col_idx = storage_index.GetPrimaryIndex();
+	if (col_idx >= schema.size()) {
+		return nullptr;
+	}
+	auto &column = *schema[col_idx];
+	auto &type = column.type;
+	//! Skip types whose written bounds are not exact (truncated strings, floats
+	//! with NaN). See SupportsExactMinMaxBounds.
+	if (!SupportsExactMinMaxBounds(type)) {
+		return nullptr;
+	}
+	if (data_files.empty()) {
+		return nullptr;
+	}
+
+	//! Iceberg keys bounds by field id (stable across renames), not by name/index.
+	const auto field_id = column.id;
+	//! Reduce per-file [lower, upper] into a single table-wide [min, max].
+	//! Each file's lower_bound is the exact min of that file (for allowlisted
+	//! types), so min(lower across files) is the exact table MIN — same for MAX.
+	optional<Value> global_min;
+	optional<Value> global_max;
+	for (auto &file_ref : data_files) {
+		auto &data_file = file_ref.get();
+		auto lower_it = data_file.lower_bounds.find(field_id);
+		auto upper_it = data_file.upper_bounds.find(field_id);
+		//! Bounds are optional in the spec (e.g. all-null columns, metrics=none).
+		//! If any file lacks them we cannot prove an exact global min/max.
+		if (lower_it == data_file.lower_bounds.end() || upper_it == data_file.upper_bounds.end()) {
+			return nullptr;
+		}
+		//! Manifest stores bounds as Iceberg binary blobs; decode to typed Values.
+		IcebergPredicateStats pred_stats;
+		try {
+			pred_stats =
+			    IcebergPredicateStats::DeserializeBounds(lower_it->second, upper_it->second, column.name, type);
+		} catch (...) {
+			//! Corrupt / unexpected encoding — be conservative and skip the fold.
+			return nullptr;
+		}
+		//! Null decoded bounds (e.g. all-null file) are not usable for MIN/MAX.
+		if (!pred_stats.lower_bound || !pred_stats.upper_bound || pred_stats.lower_bound->IsNull() ||
+		    pred_stats.upper_bound->IsNull()) {
+			return nullptr;
+		}
+		if (!global_min || *pred_stats.lower_bound < *global_min) {
+			global_min = *pred_stats.lower_bound;
+		}
+		if (!global_max || *pred_stats.upper_bound > *global_max) {
+			global_max = *pred_stats.upper_bound;
+		}
+	}
+	D_ASSERT(global_min && global_max);
+
+	//! Package as DuckDB NumericStats so TryExecuteAggregates / MinMaxIsExact
+	//! can fold SELECT MIN/MAX into a constant without scanning data files.
+	auto stats = NumericStats::CreateEmpty(type);
+	NumericStats::SetMin(stats, *global_min);
+	NumericStats::SetMax(stats, *global_max);
+	return stats.ToUnique();
+}
+
+bool IcebergPartitionRowGroup::MinMaxIsExact(const BaseStatistics &stats, const StorageIndex &storage_index) {
+	//! GetColumnStatistics only returns stats for exact-capable types when every
+	//! data file has usable (non-truncated) lower and upper bounds, so those
+	//! values are exact table min/max.
+	(void)stats;
+	(void)storage_index;
+	return true;
+}
+
 void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) const {
 	if (GetMetadata().iceberg_version == 1) {
 		//! We collect no statistics information from manifests for V1 tables.
@@ -406,9 +514,13 @@ void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) co
 	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	InitializeView(guard);
 
+	lock_guard<mutex> guard(shared_state->lock);
+	InitializeFiles(guard);
+
 	for (idx_t i = 0; i < delete_manifests.size(); i++) {
 		if (delete_manifest_matches[i]) {
-			//! if a matching delete manifest exists, return;
+			//! Matching delete manifests can invalidate data-file bounds / counts;
+			//! omit partition stats so MIN/MAX/COUNT(*) fall back to a scan.
 			return;
 		}
 	}
@@ -426,10 +538,25 @@ void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) co
 		count += *manifest.counts->added_rows_count;
 	}
 
+	//! Materialize data-file entries so column bounds are available for MIN/MAX.
+	idx_t materialized = 0;
+	while (GetDataFile(materialized, guard)) {
+		materialized++;
+	}
+	vector<reference<const IcebergDataFile>> data_files;
+	data_files.reserve(data_manifest_entries.size());
+	for (auto &entry : data_manifest_entries) {
+		data_files.push_back(entry.entry.data_file);
+	}
+
 	PartitionStatistics partition_stats;
 	partition_stats.count = count;
 	partition_stats.count_type = CountType::COUNT_EXACT;
-	result.push_back(partition_stats);
+	//! Manifest column bounds (not Iceberg partition-statistics files) — those
+	//! files have no per-column min/max.
+	partition_stats.partition_row_group =
+	    make_shared_ptr<IcebergPartitionRowGroup>(GetSchema().columns, std::move(data_files));
+	result.push_back(std::move(partition_stats));
 }
 
 bool IcebergMultiFileList::TryGetNextBatch(annotated_lock_guard<annotated_mutex> &guard) const {

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -400,9 +400,15 @@ const IcebergManifestFile &IcebergMultiFileList::GetManifestFileForEntry(const B
 	}
 }
 
-IcebergPartitionRowGroup::IcebergPartitionRowGroup(const vector<unique_ptr<IcebergColumnDefinition>> &schema_p,
-                                                   vector<reference<const IcebergDataFile>> data_files_p)
-    : schema(schema_p), data_files(std::move(data_files_p)) {
+IcebergPartitionRowGroup::IcebergPartitionRowGroup(const IcebergMultiFileList &file_list_p) : file_list(file_list_p) {
+}
+
+void IcebergPartitionRowGroup::EnsureDataFilesMaterialized() {
+	if (data_files_materialized) {
+		return;
+	}
+	data_files_materialized = true;
+	file_list.EnsureDataFilesMaterialized(data_files);
 }
 
 bool IcebergPartitionRowGroup::SupportsExactMinMaxBounds(const LogicalType &type) {
@@ -442,6 +448,7 @@ unique_ptr<BaseStatistics> IcebergPartitionRowGroup::GetColumnStatistics(const S
 	if (storage_index.HasChildren()) {
 		return nullptr;
 	}
+	auto &schema = file_list.GetSchema().columns;
 	auto col_idx = storage_index.GetPrimaryIndex();
 	if (col_idx >= schema.size()) {
 		return nullptr;
@@ -453,6 +460,8 @@ unique_ptr<BaseStatistics> IcebergPartitionRowGroup::GetColumnStatistics(const S
 	if (!SupportsExactMinMaxBounds(type)) {
 		return nullptr;
 	}
+	//! Materialize only when column bounds are actually needed (not for COUNT(*)).
+	EnsureDataFilesMaterialized();
 	if (data_files.empty()) {
 		return nullptr;
 	}
@@ -504,13 +513,16 @@ unique_ptr<BaseStatistics> IcebergPartitionRowGroup::GetColumnStatistics(const S
 	return stats.ToUnique();
 }
 
-bool IcebergPartitionRowGroup::MinMaxIsExact(const BaseStatistics &stats, const StorageIndex &storage_index) {
+bool IcebergPartitionRowGroup::MinMaxIsExact(const StorageIndex &storage_index) {
 	//! GetColumnStatistics only returns stats for exact-capable types when every
 	//! data file has usable (non-truncated) lower and upper bounds, so those
 	//! values are exact table min/max.
-	(void)stats;
 	(void)storage_index;
 	return true;
+}
+
+bool IcebergPartitionRowGroup::HasPendingWrites() {
+	return false;
 }
 
 void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) const {
@@ -520,9 +532,6 @@ void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) co
 	}
 	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	InitializeView(guard);
-
-	lock_guard<mutex> guard(shared_state->lock);
-	InitializeFiles(guard);
 
 	for (idx_t i = 0; i < delete_manifests.size(); i++) {
 		if (delete_manifest_matches[i]) {
@@ -545,25 +554,29 @@ void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) co
 		count += *manifest.counts->added_rows_count;
 	}
 
-	//! Materialize data-file entries so column bounds are available for MIN/MAX.
+	PartitionStatistics partition_stats;
+	partition_stats.count = count;
+	partition_stats.count_type = CountType::COUNT_EXACT;
+	//! Lazy IcebergPartitionRowGroup: data-file bounds are materialized only when
+	//! GetColumnStatistics runs (MIN/MAX). COUNT(*) uses count alone.
+	partition_stats.partition_row_group = make_shared_ptr<IcebergPartitionRowGroup>(*this);
+	result.push_back(std::move(partition_stats));
+}
+
+void IcebergMultiFileList::EnsureDataFilesMaterialized(vector<reference<const IcebergDataFile>> &result) const {
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	InitializeView(guard);
+	StartDataManifestScan(guard);
+
 	idx_t materialized = 0;
 	while (GetDataFile(materialized, guard)) {
 		materialized++;
 	}
-	vector<reference<const IcebergDataFile>> data_files;
-	data_files.reserve(data_manifest_entries.size());
+	result.clear();
+	result.reserve(data_manifest_entries.size());
 	for (auto &entry : data_manifest_entries) {
-		data_files.push_back(entry.entry.data_file);
+		result.push_back(entry.entry.data_file);
 	}
-
-	PartitionStatistics partition_stats;
-	partition_stats.count = count;
-	partition_stats.count_type = CountType::COUNT_EXACT;
-	//! Manifest column bounds (not Iceberg partition-statistics files) — those
-	//! files have no per-column min/max.
-	partition_stats.partition_row_group =
-	    make_shared_ptr<IcebergPartitionRowGroup>(GetSchema().columns, std::move(data_files));
-	result.push_back(std::move(partition_stats));
 }
 
 bool IcebergMultiFileList::TryGetNextBatch(annotated_lock_guard<annotated_mutex> &guard) const {

--- a/test/sql/local/iceberg_scans/aggregate_min_max_metadata.test
+++ b/test/sql/local/iceberg_scans/aggregate_min_max_metadata.test
@@ -103,6 +103,36 @@ SELECT min(f), max(f) FROM iceberg_scan('{TEST_DIR}/agg_minmax_float');
 ----
 0.0	999.0
 
+# Nested types have no single composite bound in the manifest (bounds are keyed per
+# primitive field id), so MIN/MAX must fall back to a scan even when the leaves would
+# otherwise be exact. A STRUCT wrapping a FLOAT also guards against a nested float leaf.
+statement ok
+COPY (select {'f': range::FLOAT} as s from range(1000)) TO '{TEST_DIR}/agg_minmax_struct_float' (FORMAT ICEBERG);
+
+query II
+EXPLAIN SELECT min(s), max(s) FROM iceberg_scan('{TEST_DIR}/agg_minmax_struct_float');
+----
+physical_plan	<REGEX>:.*(ICEBERG_SCAN|AGGREGATE).*
+
+query II
+SELECT min(s), max(s) FROM iceberg_scan('{TEST_DIR}/agg_minmax_struct_float');
+----
+{'f': 0.0}	{'f': 999.0}
+
+# A LIST of an otherwise-exact type is still nested — no composite bound to fold.
+statement ok
+COPY (select [range] as l from range(1000)) TO '{TEST_DIR}/agg_minmax_list_int' (FORMAT ICEBERG);
+
+query II
+EXPLAIN SELECT min(l), max(l) FROM iceberg_scan('{TEST_DIR}/agg_minmax_list_int');
+----
+physical_plan	<REGEX>:.*(ICEBERG_SCAN|AGGREGATE).*
+
+query II
+SELECT min(l), max(l) FROM iceberg_scan('{TEST_DIR}/agg_minmax_list_int');
+----
+[0]	[999]
+
 # Filtered MIN/MAX is not fully answered from whole-table metadata alone.
 query II
 EXPLAIN SELECT min(id), max(id)

--- a/test/sql/local/iceberg_scans/aggregate_min_max_metadata.test
+++ b/test/sql/local/iceberg_scans/aggregate_min_max_metadata.test
@@ -46,6 +46,12 @@ EXPLAIN SELECT min(id), max(id) FROM iceberg_scan('{WORKING_DIRECTORY}/data/pers
 ----
 physical_plan	<REGEX>:.*COLUMN_DATA_SCAN.*
 
+# COUNT(*) folds from manifest row counts alone (no data-file bound materialization).
+query II
+EXPLAIN SELECT count(*) FROM iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null');
+----
+physical_plan	<REGEX>:.*COLUMN_DATA_SCAN.*
+
 # Multi-file timestamp table: insert enough rows for multiple data files.
 statement ok
 COPY (

--- a/test/sql/local/iceberg_scans/aggregate_min_max_metadata.test
+++ b/test/sql/local/iceberg_scans/aggregate_min_max_metadata.test
@@ -1,0 +1,119 @@
+# name: test/sql/local/iceberg_scans/aggregate_min_max_metadata.test
+# description: Metadata-only MIN/MAX via manifest lower_bounds/upper_bounds (not Iceberg partition-statistics files)
+# group: [iceberg_scans]
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+require avro
+
+require parquet
+
+require iceberg
+
+# is_null_is_not_null has 3 data files with non-overlapping id bounds covering [1,8].
+
+# Ground truth with statistics propagation disabled (no metadata aggregate fold).
+statement ok
+PRAGMA disabled_optimizers='statistics_propagation';
+
+statement ok
+create table oracle_id as
+select min(id) as min_id, max(id) as max_id
+from iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null');
+
+statement ok
+PRAGMA disabled_optimizers='';
+
+query II
+select min(id), max(id) from iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null');
+----
+1	8
+
+query I
+select count(*) from (
+  (select min(id) as min_id, max(id) as max_id
+   from iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null'))
+  except
+  (select * from oracle_id)
+);
+----
+0
+
+# Folded from manifest column bounds — no Iceberg scan / aggregate over data files.
+query II
+EXPLAIN SELECT min(id), max(id) FROM iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null');
+----
+physical_plan	<REGEX>:.*COLUMN_DATA_SCAN.*
+
+# Multi-file timestamp table: insert enough rows for multiple data files.
+statement ok
+COPY (
+  select TIMESTAMP '2020-01-01' + INTERVAL (range) HOUR as ts
+  from range(3000000)
+) TO '{TEST_DIR}/agg_minmax_ts' (FORMAT ICEBERG);
+
+query I
+SELECT count(*) > 1 FROM iceberg_metadata('{TEST_DIR}/agg_minmax_ts');
+----
+true
+
+statement ok
+PRAGMA disabled_optimizers='statistics_propagation';
+
+statement ok
+create table oracle_ts as
+select min(ts) as min_ts, max(ts) as max_ts
+from iceberg_scan('{TEST_DIR}/agg_minmax_ts');
+
+statement ok
+PRAGMA disabled_optimizers='';
+
+query I
+select count(*) from (
+  (select min(ts) as min_ts, max(ts) as max_ts from iceberg_scan('{TEST_DIR}/agg_minmax_ts'))
+  except
+  (select * from oracle_ts)
+);
+----
+0
+
+query II
+EXPLAIN SELECT min(ts), max(ts) FROM iceberg_scan('{TEST_DIR}/agg_minmax_ts');
+----
+physical_plan	<REGEX>:.*COLUMN_DATA_SCAN.*
+
+# VARCHAR bounds may be truncated — do not fold MIN/MAX from metadata.
+query II
+EXPLAIN SELECT min(value), max(value) FROM iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null');
+----
+physical_plan	<REGEX>:.*(ICEBERG_SCAN|AGGREGATE).*
+
+# FLOAT is excluded (NaN semantics) — fall back to a scan.
+statement ok
+COPY (select range::FLOAT as f from range(1000)) TO '{TEST_DIR}/agg_minmax_float' (FORMAT ICEBERG);
+
+query II
+EXPLAIN SELECT min(f), max(f) FROM iceberg_scan('{TEST_DIR}/agg_minmax_float');
+----
+physical_plan	<REGEX>:.*(ICEBERG_SCAN|AGGREGATE).*
+
+query II
+SELECT min(f), max(f) FROM iceberg_scan('{TEST_DIR}/agg_minmax_float');
+----
+0.0	999.0
+
+# Filtered MIN/MAX is not fully answered from whole-table metadata alone.
+query II
+EXPLAIN SELECT min(id), max(id)
+FROM iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null')
+WHERE id > 3;
+----
+physical_plan	<REGEX>:.*(ICEBERG_SCAN|AGGREGATE).*
+
+query II
+SELECT min(id), max(id)
+FROM iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null')
+WHERE id > 3;
+----
+4	8

--- a/test/sql/local/iceberg_scans/aggregate_min_max_metadata.test
+++ b/test/sql/local/iceberg_scans/aggregate_min_max_metadata.test
@@ -46,12 +46,18 @@ EXPLAIN SELECT min(id), max(id) FROM iceberg_scan('{WORKING_DIRECTORY}/data/pers
 ----
 physical_plan	<REGEX>:.*COLUMN_DATA_SCAN.*
 
-# Multi-file timestamp table: insert enough rows for multiple data files.
+# COUNT(*) folds from manifest row counts alone (no data-file bound materialization).
+query II
+EXPLAIN SELECT count(*) FROM iceberg_scan('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null');
+----
+physical_plan	<REGEX>:.*COLUMN_DATA_SCAN.*
+
+# Multi-file timestamp table: pin target file size so COPY rotates (default 512MB would be one file).
 statement ok
 COPY (
   select TIMESTAMP '2020-01-01' + INTERVAL (range) HOUR as ts
   from range(3000000)
-) TO '{TEST_DIR}/agg_minmax_ts' (FORMAT ICEBERG);
+) TO '{TEST_DIR}/agg_minmax_ts' (FORMAT ICEBERG, "write.target-file-size-bytes" '8MB', "write.parquet.row-group-size" 100000);
 
 query I
 SELECT count(*) > 1 FROM iceberg_metadata('{TEST_DIR}/agg_minmax_ts');


### PR DESCRIPTION
## Summary
- Wire `get_partition_stats` to expose per-column min/max from manifest `data_file.lower_bounds` / `upper_bounds` via a new `IcebergPartitionRowGroup`, so DuckDB's `StatisticsPropagator::TryExecuteAggregates` can fold `SELECT MIN(col)` / `SELECT MAX(col)` into constants without scanning Parquet.
- Exact fold for numeric/temporal types only (not `FLOAT`/`DOUBLE`/`VARCHAR`); bail out when any file lacks usable bounds or matching delete manifests are present.
- Uses **manifest column bounds**, not [Iceberg partition-statistics files](https://iceberg.apache.org/spec/#partition-statistics) (those carry counts/sizes only, no per-column min/max). Independent of #1023 (copies a leaner `IcebergPartitionRowGroup` focused on min/max; reconcile if both land).

## Test plan
- [x] `test/sql/local/iceberg_scans/aggregate_min_max_metadata.test` — correctness vs oracle, `EXPLAIN` shows `COLUMN_DATA_SCAN` for bigint/timestamp folds, fallbacks for varchar/float/`WHERE`; verify nested type behavior
- [x] `test/sql/local/iceberg_scans/scan_order_limit_pruning.test` still passes