### PR TITLE
Metadata-only delete when a DELETE removes every live row of a data file

### DIFF
--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -174,7 +174,8 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 	const auto sequence_number = commit_state.next_sequence_number++;
 	auto uncommitted_manifest_files =
 	    CreateCommitManifestFiles(manifest_files, commit_state.table_info, commit_state, sequence_number);
-	D_ASSERT(!uncommitted_manifest_files.empty());
+	//! manifest_files is empty for a metadata-only delete (only altered_manifests is set).
+	D_ASSERT(!uncommitted_manifest_files.empty() || !altered_manifests.IsEmpty());
 
 	auto &fs = FileSystem::GetFileSystem(context);
 	auto manifest_list_uuid = UUID::ToString(UUID::GenerateRandomUUID());

--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -66,6 +66,11 @@ static optional<IcebergManifestListEntry> RewriteManifestFile(const IcebergManif
 		if (manifest_entry.status != IcebergManifestEntryStatusType::DELETED &&
 		    deletes.IsInvalidated(manifest_entry.data_file.file_path)) {
 			snapshot_metrics.RemoveFileSize(manifest_entry.data_file.file_size_in_bytes);
+			if (list_entry.file.content == IcebergManifestContentType::DELETE) {
+				snapshot_metrics.RemoveDeleteFile(manifest_entry.data_file.record_count);
+			} else {
+				snapshot_metrics.RemoveDataFile(manifest_entry.data_file.record_count);
+			}
 			manifest_entry.status = IcebergManifestEntryStatusType::DELETED;
 			removed_any_entries = true;
 		}

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -212,20 +212,27 @@ void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&de
 	const auto sequence_number = last_sequence_number + alters.size() + 1;
 
 	auto &fs = FileSystem::GetFileSystem(context);
-	auto delete_manifest_metadata =
-	    IcebergManifestMetadata::FromTableMetadata(table_metadata, IcebergManifestContentType::DELETE);
-	auto data_manifest_metadata =
-	    IcebergManifestMetadata::FromTableMetadata(table_metadata, IcebergManifestContentType::DATA);
-
-	auto delete_manifest_file = IcebergManifestListEntry::CreateFromEntries(
-	    fs, sequence_number, table_metadata, delete_manifest_metadata, std::move(delete_files), next_row_id);
-	// Add a manifest_file for the new insert data
-	auto data_manifest_file = IcebergManifestListEntry::CreateFromEntries(
-	    fs, sequence_number, table_metadata, data_manifest_metadata, std::move(data_files), next_row_id);
 
 	auto add_snapshot = make_uniq<IcebergAddSnapshot>(table_info);
-	add_snapshot->AddManifestFile(std::move(delete_manifest_file));
-	add_snapshot->AddManifestFile(std::move(data_manifest_file));
+
+	//! The delete side of an UPDATE can be a metadata-only whole-file delete, which produces no
+	//! delete-file entries (only altered_manifests). Only add a manifest file when it has entries;
+	//! an empty manifest is invalid.
+	if (!delete_files.empty()) {
+		auto delete_manifest_metadata =
+		    IcebergManifestMetadata::FromTableMetadata(table_metadata, IcebergManifestContentType::DELETE);
+		auto delete_manifest_file = IcebergManifestListEntry::CreateFromEntries(
+		    fs, sequence_number, table_metadata, delete_manifest_metadata, std::move(delete_files), next_row_id);
+		add_snapshot->AddManifestFile(std::move(delete_manifest_file));
+	}
+	// Add a manifest_file for the new insert data
+	if (!data_files.empty()) {
+		auto data_manifest_metadata =
+		    IcebergManifestMetadata::FromTableMetadata(table_metadata, IcebergManifestContentType::DATA);
+		auto data_manifest_file = IcebergManifestListEntry::CreateFromEntries(
+		    fs, sequence_number, table_metadata, data_manifest_metadata, std::move(data_files), next_row_id);
+		add_snapshot->AddManifestFile(std::move(data_manifest_file));
+	}
 	add_snapshot->altered_manifests = std::move(altered_manifests);
 
 	alters.push_back(*add_snapshot);

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -185,6 +185,9 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 		auto manifest_file = IcebergManifestListEntry::CreateFromEntries(
 		    fs, temp_sequence_number, table_metadata, manifest_metadata, std::move(data_files), next_row_id);
 		add_snapshot->AddManifestFile(std::move(manifest_file));
+	} else if (operation != IcebergSnapshotOperationType::DELETE) {
+		//! A snapshot with no new manifest entries is only valid for a metadata-only delete.
+		throw InternalException("AddSnapshot: empty data_files is only valid for a metadata-only DELETE");
 	}
 
 	// make sure we are still inserting into the current schema
@@ -225,14 +228,16 @@ void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&de
 		    fs, sequence_number, table_metadata, delete_manifest_metadata, std::move(delete_files), next_row_id);
 		add_snapshot->AddManifestFile(std::move(delete_manifest_file));
 	}
-	// Add a manifest_file for the new insert data
-	if (!data_files.empty()) {
-		auto data_manifest_metadata =
-		    IcebergManifestMetadata::FromTableMetadata(table_metadata, IcebergManifestContentType::DATA);
-		auto data_manifest_file = IcebergManifestListEntry::CreateFromEntries(
-		    fs, sequence_number, table_metadata, data_manifest_metadata, std::move(data_files), next_row_id);
-		add_snapshot->AddManifestFile(std::move(data_manifest_file));
+	// Add a manifest_file for the new insert data. An UPDATE always re-inserts the updated rows, so
+	// (unlike the delete side) the data side must never be empty.
+	if (data_files.empty()) {
+		throw InternalException("AddUpdateSnapshot: an UPDATE must produce new data files");
 	}
+	auto data_manifest_metadata =
+	    IcebergManifestMetadata::FromTableMetadata(table_metadata, IcebergManifestContentType::DATA);
+	auto data_manifest_file = IcebergManifestListEntry::CreateFromEntries(
+	    fs, sequence_number, table_metadata, data_manifest_metadata, std::move(data_files), next_row_id);
+	add_snapshot->AddManifestFile(std::move(data_manifest_file));
 	add_snapshot->altered_manifests = std::move(altered_manifests);
 
 	alters.push_back(*add_snapshot);

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -159,29 +159,34 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 	auto &table_metadata = table_info.table_metadata;
 	CacheExistingManifestList(guard, table_metadata);
 
-	IcebergManifestContentType manifest_content_type;
-	switch (operation) {
-	case IcebergSnapshotOperationType::DELETE:
-		manifest_content_type = IcebergManifestContentType::DELETE;
-		break;
-	case IcebergSnapshotOperationType::APPEND:
-	case IcebergSnapshotOperationType::REPLACE:
-		//! This helper currently writes DATA manifest entries; REPLACE itself is not limited to data files.
-		manifest_content_type = IcebergManifestContentType::DATA;
-		break;
-	default:
-		throw NotImplementedException("Cannot have use snapshot operation type OVERWRITE here");
-	};
-
-	auto temp_sequence_number = table_metadata.last_sequence_number + alters.size() + 1;
-
-	auto &fs = FileSystem::GetFileSystem(context);
-	auto manifest_metadata = IcebergManifestMetadata::FromTableMetadata(table_metadata, manifest_content_type);
-	auto manifest_file = IcebergManifestListEntry::CreateFromEntries(
-	    fs, temp_sequence_number, table_metadata, manifest_metadata, std::move(data_files), next_row_id);
-
 	auto add_snapshot = make_uniq<IcebergAddSnapshot>(table_info, operation);
-	add_snapshot->AddManifestFile(std::move(manifest_file));
+
+	//! A metadata-only delete has no new entries (only altered_manifests); add no manifest file
+	//! rather than an empty one.
+	if (!data_files.empty()) {
+		IcebergManifestContentType manifest_content_type;
+		switch (operation) {
+		case IcebergSnapshotOperationType::DELETE:
+			manifest_content_type = IcebergManifestContentType::DELETE;
+			break;
+		case IcebergSnapshotOperationType::APPEND:
+		case IcebergSnapshotOperationType::REPLACE:
+			//! This helper currently writes DATA manifest entries; REPLACE itself is not limited to data files.
+			manifest_content_type = IcebergManifestContentType::DATA;
+			break;
+		default:
+			throw NotImplementedException("Cannot have use snapshot operation type OVERWRITE here");
+		};
+
+		auto temp_sequence_number = table_metadata.last_sequence_number + alters.size() + 1;
+
+		auto &fs = FileSystem::GetFileSystem(context);
+		auto manifest_metadata = IcebergManifestMetadata::FromTableMetadata(table_metadata, manifest_content_type);
+		auto manifest_file = IcebergManifestListEntry::CreateFromEntries(
+		    fs, temp_sequence_number, table_metadata, manifest_metadata, std::move(data_files), next_row_id);
+		add_snapshot->AddManifestFile(std::move(manifest_file));
+	}
+
 	// make sure we are still inserting into the current schema
 	if (table_metadata.current_snapshot_id) {
 		TableAddAssertCurrentSchemaId();

--- a/src/core/metadata/snapshot/iceberg_snapshot.cpp
+++ b/src/core/metadata/snapshot/iceberg_snapshot.cpp
@@ -177,6 +177,35 @@ void IcebergSnapshotMetrics::RemoveFileSize(int64_t file_size_in_bytes) {
 	UpdateTotalFilesSize(0, file_size_in_bytes);
 }
 
+void IcebergSnapshotMetrics::DecrementTotal(IcebergSnapshotMetricType type, int64_t value) {
+	auto it = metrics.find(type);
+	if (it == metrics.end()) {
+		return;
+	}
+	int64_t updated = it->second - value;
+	if (updated >= 0) {
+		it->second = updated;
+	}
+}
+
+void IcebergSnapshotMetrics::RemoveDataFile(int64_t record_count) {
+	metrics.emplace(IcebergSnapshotMetricType::DELETED_DATA_FILES, 0).first->second += 1;
+	metrics.emplace(IcebergSnapshotMetricType::DELETED_RECORDS, 0).first->second += record_count;
+	DecrementTotal(IcebergSnapshotMetricType::TOTAL_DATA_FILES, 1);
+	DecrementTotal(IcebergSnapshotMetricType::TOTAL_RECORDS, record_count);
+}
+
+void IcebergSnapshotMetrics::RemoveDeleteFile(int64_t record_count) {
+	metrics.emplace(IcebergSnapshotMetricType::REMOVED_DELETE_FILES, 0).first->second += 1;
+	DecrementTotal(IcebergSnapshotMetricType::TOTAL_DELETE_FILES, 1);
+#ifndef ICEBERG_ENABLE_EQUALITY_DELETE_WRITES
+	//! Without equality-delete writes every delete file is a positional delete file (mirrors
+	//! AddManifestListEntry's guarded accounting).
+	metrics.emplace(IcebergSnapshotMetricType::REMOVED_POSITION_DELETE_FILES, 0).first->second += 1;
+	DecrementTotal(IcebergSnapshotMetricType::TOTAL_POSITION_DELETES, record_count);
+#endif
+}
+
 bool IcebergSnapshotMetrics::HasTotalFilesSize() const {
 	return metrics.count(IcebergSnapshotMetricType::TOTAL_FILES_SIZE) != 0;
 }

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -307,9 +307,36 @@ void IcebergDelete::FlushDeletes(IcebergTransaction &transaction, ClientContext 
 			throw NotImplementedException("The same row was updated multiple times - this is not (yet) supported in "
 			                              "Iceberg. Eliminate duplicate matches prior to running the UPDATE");
 		}
+
+		auto existing_delete = multi_file_list->GetExistingPositionalDeleteData(filename);
+
+		//! When the pre-existing and new deletes together cover every row of the file, drop the whole
+		//! data file with a metadata-only manifest edit instead of writing a delete file. Positions are
+		//! 0-based ordinals, so the union equals record_count exactly when no live row survives.
+		set<idx_t> all_deletes = sorted_deletes;
+		if (existing_delete) {
+			existing_delete->ToSet(all_deletes);
+		}
+		auto record_count = multi_file_list->GetRecordCountForDataFile(filename);
+		if (record_count >= 0 && all_deletes.size() == static_cast<idx_t>(record_count)) {
+			global_state.altered_manifests.InvalidateFile(filename);
+			//! Drop delete files scoped to only this data file (referenced_data_file set): v3 deletion
+			//! vectors and DuckDB's file-scoped positional deletes. Multi-file deletes from other
+			//! engines still apply elsewhere, so leave them.
+			if (existing_delete) {
+				for (auto &bound_entry : existing_delete->entries) {
+					auto &delete_data_file = bound_entry.entry.data_file;
+					if (delete_data_file.referenced_data_file &&
+					    *delete_data_file.referenced_data_file == filename) {
+						global_state.altered_manifests.InvalidateFile(delete_data_file.file_path);
+					}
+				}
+			}
+			continue;
+		}
+
 		if (write_deletion_vector) {
 			//! Addd the existing delete we're replacing
-			auto existing_delete = multi_file_list->GetExistingPositionalDeleteData(filename);
 			if (existing_delete) {
 				auto &delete_data = *existing_delete;
 				PopulateAlteredManifests(*multi_file_list, global_state.altered_manifests, delete_data);
@@ -436,7 +463,8 @@ SinkFinalizeType IcebergDelete::Finalize(Pipeline &pipeline, Event &event, Clien
 	auto &table_info = irc_table.table_info;
 	auto iceberg_delete_files = GenerateDeleteManifestEntries(global_state);
 
-	if (!global_state.written_files.empty()) {
+	//! Also commit when the delete only dropped whole files (no written_files, but altered_manifests).
+	if (!global_state.written_files.empty() || !global_state.altered_manifests.IsEmpty()) {
 		ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
 			auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
 			transaction_data.AddSnapshot(IcebergSnapshotOperationType::DELETE, std::move(iceberg_delete_files),

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -319,7 +319,7 @@ void IcebergDelete::FlushDeletes(IcebergTransaction &transaction, ClientContext 
 		}
 		auto record_count = multi_file_list->GetRecordCountForDataFile(filename);
 		if (record_count >= 0 && all_deletes.size() == static_cast<idx_t>(record_count)) {
-			global_state.altered_manifests.InvalidateFile(filename);
+			global_state.altered_manifests.InvalidateFile(filename, sorted_deletes.size());
 			//! Drop delete files scoped to only this data file (referenced_data_file set): v3 deletion
 			//! vectors and DuckDB's file-scoped positional deletes. Multi-file deletes from other
 			//! engines still apply elsewhere, so leave them.

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -326,8 +326,7 @@ void IcebergDelete::FlushDeletes(IcebergTransaction &transaction, ClientContext 
 			if (existing_delete) {
 				for (auto &bound_entry : existing_delete->entries) {
 					auto &delete_data_file = bound_entry.entry.data_file;
-					if (delete_data_file.referenced_data_file &&
-					    *delete_data_file.referenced_data_file == filename) {
+					if (delete_data_file.referenced_data_file && *delete_data_file.referenced_data_file == filename) {
 						global_state.altered_manifests.InvalidateFile(delete_data_file.file_path);
 					}
 				}

--- a/src/include/catalog/rest/transaction/iceberg_transaction_metadata.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_metadata.hpp
@@ -10,6 +10,11 @@ public:
 	void InvalidateFile(const string &file_path) {
 		data_files.insert(file_path);
 	}
+	//! Records how many still-live rows a metadata-only DELETE removed from this data file
+	void InvalidateFile(const string &file_path, idx_t live_rows_removed) {
+		data_files.insert(file_path);
+		data_file_live_rows[file_path] = live_rows_removed;
+	}
 	bool IsInvalidated(const string &file_path) const {
 		return data_files.count(file_path);
 	}
@@ -19,10 +24,15 @@ public:
 	const unordered_set<string> &InvalidatedFiles() const {
 		return data_files;
 	}
+	const case_insensitive_map_t<idx_t> &InvalidatedDataFileLiveRows() const {
+		return data_file_live_rows;
+	}
 
 private:
 	//! The 'data_file.file_path' of invalidated data files
 	unordered_set<string> data_files;
+	//! Live rows removed per invalidated data file, for the subset with a known count (see InvalidateFile)
+	case_insensitive_map_t<idx_t> data_file_live_rows;
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/transaction/iceberg_transaction_metadata.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_metadata.hpp
@@ -16,6 +16,9 @@ public:
 	bool IsEmpty() const {
 		return data_files.empty();
 	}
+	const unordered_set<string> &InvalidatedFiles() const {
+		return data_files;
+	}
 
 private:
 	//! The 'data_file.file_path' of invalidated data files

--- a/src/include/core/metadata/snapshot/iceberg_snapshot.hpp
+++ b/src/include/core/metadata/snapshot/iceberg_snapshot.hpp
@@ -39,12 +39,15 @@ public:
 public:
 	void AddManifestListEntry(const IcebergManifestListEntry &manifest_list_entry);
 	void RemoveFileSize(int64_t file_size_in_bytes);
+	void RemoveDataFile(int64_t record_count);
+	void RemoveDeleteFile(int64_t record_count);
 	bool HasTotalFilesSize() const;
 	void SetTotalFilesSize(int64_t total_files_size);
 
 private:
 	void AddSizeMetric(IcebergSnapshotMetricType type, int64_t value);
 	void UpdateTotalFilesSize(int64_t added, int64_t removed);
+	void DecrementTotal(IcebergSnapshotMetricType type, int64_t value);
 
 public:
 	map<IcebergSnapshotMetricType, int64_t> metrics;

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -141,6 +141,9 @@ private:
 	//! Committed data files dropped by a metadata-only delete earlier in this transaction. Their
 	//! manifest rewrite only lands at commit, so transaction-local reads must hide them here.
 	mutable unordered_set<string> transaction_invalidated_files;
+	//! Live rows removed per data file dropped by a metadata-only DELETE (keyed by file_path). Absent
+	//! for wholesale invalidations (e.g. compaction), which fall back to the full record count.
+	mutable case_insensitive_map_t<idx_t> transaction_invalidated_live_rows;
 };
 
 struct IcebergDataViewCursor {

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -221,6 +221,9 @@ protected:
 	//! NOTE: this requires the lock because it modifies the 'data_files' vector, potentially invalidating references
 	optional_ptr<const BoundIcebergManifestEntry> GetDataFile(idx_t file_id, lock_guard<mutex> &guard) const;
 
+	//! Total rows in data files dropped by an in-transaction metadata-only delete.
+	idx_t GetTransactionInvalidatedRowCount() const;
+
 	unique_ptr<ExpressionFilter> GetFilterForColumnIndex(const IcebergTableFilters &filter_set,
 	                                                     const ColumnIndex &column_index) const;
 

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/multi_file/multi_file_data.hpp"
 #include "duckdb/common/list.hpp"
 #include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
@@ -137,6 +138,9 @@ private:
 	//! Physical row count per data file (file_path -> record_count), used by DELETE to detect
 	//! whole-file deletes.
 	mutable case_insensitive_map_t<int64_t> data_file_record_count;
+	//! Committed data files dropped by a metadata-only delete earlier in this transaction. Their
+	//! manifest rewrite only lands at commit, so transaction-local reads must hide them here.
+	mutable unordered_set<string> transaction_invalidated_files;
 };
 
 struct IcebergDataViewCursor {

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -134,6 +134,9 @@ private:
 
 	//! Populated as parsed data-file entries become visible to any filtered view.
 	mutable case_insensitive_map_t<vector<IcebergPartitionInfo>> data_file_partition_info;
+	//! Physical row count per data file (file_path -> record_count), used by DELETE to detect
+	//! whole-file deletes.
+	mutable case_insensitive_map_t<int64_t> data_file_record_count;
 };
 
 struct IcebergDataViewCursor {
@@ -174,6 +177,7 @@ public:
 	void GetStatistics(vector<PartitionStatistics> &result) const;
 	BoundIcebergManifestEntry GetManifestEntry(idx_t file_id) const;
 	vector<IcebergPartitionInfo> GetPartitionInfoForDataFile(const string &file_path) const;
+	int64_t GetRecordCountForDataFile(const string &file_path) const;
 	const IcebergManifestFile &GetManifestFileForEntry(const BoundIcebergManifestEntry &entry,
 	                                                   IcebergManifestContentType type) const;
 	vector<BoundIcebergManifestEntry> GetDeleteManifestEntries() const;

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -522,6 +522,15 @@ vector<IcebergPartitionInfo> IcebergMultiFileList::GetPartitionInfoForDataFile(c
 	throw InternalException("Could not find data file '%s' in manifest entries", file_path);
 }
 
+int64_t IcebergMultiFileList::GetRecordCountForDataFile(const string &file_path) const {
+	lock_guard<mutex> guard(shared_state->lock);
+	auto entry = shared_state->data_file_record_count.find(file_path);
+	if (entry != shared_state->data_file_record_count.end()) {
+		return entry->second;
+	}
+	throw InternalException("Could not find data file '%s' in manifest entries", file_path);
+}
+
 const IcebergManifestFile &IcebergMultiFileList::GetManifestFileForEntry(const BoundIcebergManifestEntry &entry,
                                                                          IcebergManifestContentType type) const {
 	if (type == IcebergManifestContentType::DATA) {
@@ -960,6 +969,8 @@ optional_ptr<const BoundIcebergManifestEntry> IcebergMultiFileList::GetDataFile(
 			}
 			shared_state->data_file_partition_info[entry_path] = data_file.partition_info;
 			shared_state->data_file_partition_info[data_file.file_path] = data_file.partition_info;
+			shared_state->data_file_record_count[entry_path] = data_file.record_count;
+			shared_state->data_file_record_count[data_file.file_path] = data_file.record_count;
 
 			if (manifest_entry.status == IcebergManifestEntryStatusType::DELETED) {
 				continue;

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -978,9 +978,10 @@ optional_ptr<const BoundIcebergManifestEntry> IcebergMultiFileList::GetDataFile(
 
 			//! Skip committed data files dropped by a metadata-only delete earlier in this
 			//! transaction (the manifest rewrite only lands at commit).
-			if (!shared_state->transaction_invalidated_files.empty() &&
-			    (shared_state->transaction_invalidated_files.count(entry_path) ||
-			     shared_state->transaction_invalidated_files.count(data_file.file_path))) {
+			if (shared_state->transaction_invalidated_files.count(entry_path)) {
+				continue;
+			}
+			if (shared_state->transaction_invalidated_files.count(data_file.file_path)) {
 				continue;
 			}
 

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -976,6 +976,14 @@ optional_ptr<const BoundIcebergManifestEntry> IcebergMultiFileList::GetDataFile(
 				continue;
 			}
 
+			//! Skip committed data files dropped by a metadata-only delete earlier in this
+			//! transaction (the manifest rewrite only lands at commit).
+			if (!shared_state->transaction_invalidated_files.empty() &&
+			    (shared_state->transaction_invalidated_files.count(entry_path) ||
+			     shared_state->transaction_invalidated_files.count(data_file.file_path))) {
+				continue;
+			}
+
 			// Check whether current data file is filtered out.
 			if (table_filters.HasFilters() &&
 			    !FileMatchesFilter(manifest_file, manifest_entry, IcebergManifestContentType::DATA)) {
@@ -1371,6 +1379,11 @@ void IcebergMultiFileList::LoadManifestList(lock_guard<mutex> &guard) const {
 		auto &transaction_data = GetTransactionData();
 		for (auto &alter_p : transaction_data.alters) {
 			auto &alter = alter_p.get();
+			//! Data files dropped by a metadata-only delete earlier in this transaction are only
+			//! removed from the manifests at commit, so hide them from transaction-local reads.
+			for (auto &invalidated : alter.altered_manifests.InvalidatedFiles()) {
+				shared_state->transaction_invalidated_files.insert(invalidated);
+			}
 			const auto &manifest_list_entries = alter.GetManifestFiles();
 			for (auto &manifest_list_entry : manifest_list_entries) {
 				auto &manifest = manifest_list_entry.file;

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -514,6 +514,15 @@ unique_ptr<NodeStatistics> IcebergMultiFileList::GetCardinality(ClientContext &c
 idx_t IcebergMultiFileList::GetTransactionInvalidatedRowCount() const {
 	idx_t invalidated_rows = 0;
 	for (auto &invalidated : shared_state->transaction_invalidated_files) {
+		//! A metadata-only DELETE records its live-row count; rows already covered by delete files
+		//! are discounted by the delete-manifest totals, so only the live rows are subtracted here.
+		auto live_entry = shared_state->transaction_invalidated_live_rows.find(invalidated);
+		if (live_entry != shared_state->transaction_invalidated_live_rows.end()) {
+			invalidated_rows += live_entry->second;
+			continue;
+		}
+		//! Wholesale invalidations (e.g. compaction) carry no live-row count; the file is replaced
+		//! entirely, so subtract its full record count.
 		auto entry = shared_state->data_file_record_count.find(invalidated);
 		if (entry != shared_state->data_file_record_count.end()) {
 			invalidated_rows += static_cast<idx_t>(entry->second);
@@ -1407,6 +1416,9 @@ void IcebergMultiFileList::LoadManifestList(lock_guard<mutex> &guard) const {
 			//! removed from the manifests at commit, so hide them from transaction-local reads.
 			for (auto &invalidated : alter.altered_manifests.InvalidatedFiles()) {
 				shared_state->transaction_invalidated_files.insert(invalidated);
+			}
+			for (auto &live_rows : alter.altered_manifests.InvalidatedDataFileLiveRows()) {
+				shared_state->transaction_invalidated_live_rows[live_rows.first] = live_rows.second;
 			}
 			const auto &manifest_list_entries = alter.GetManifestFiles();
 			for (auto &manifest_list_entry : manifest_list_entries) {

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -505,7 +505,21 @@ unique_ptr<NodeStatistics> IcebergMultiFileList::GetCardinality(ClientContext &c
 		}
 		cardinality -= manifest.added_rows_count;
 	}
+	//! Subtract pending metadata-only deletes, still included in the manifest totals until commit.
+	auto invalidated_rows = GetTransactionInvalidatedRowCount();
+	cardinality -= invalidated_rows <= cardinality ? invalidated_rows : cardinality;
 	return make_uniq<NodeStatistics>(cardinality, cardinality);
+}
+
+idx_t IcebergMultiFileList::GetTransactionInvalidatedRowCount() const {
+	idx_t invalidated_rows = 0;
+	for (auto &invalidated : shared_state->transaction_invalidated_files) {
+		auto entry = shared_state->data_file_record_count.find(invalidated);
+		if (entry != shared_state->data_file_record_count.end()) {
+			invalidated_rows += static_cast<idx_t>(entry->second);
+		}
+	}
+	return invalidated_rows;
 }
 
 BoundIcebergManifestEntry IcebergMultiFileList::GetManifestEntry(idx_t file_id) const {
@@ -555,6 +569,12 @@ void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) co
 		}
 	}
 
+	//! Pending metadata-only deletes are still in the manifest totals until commit. Their per-file
+	//! record counts only exist once files are enumerated, so force that before discounting them.
+	if (!shared_state->transaction_invalidated_files.empty()) {
+		(void)GetTotalFileCount();
+	}
+
 	idx_t count = 0;
 	for (idx_t i = 0; i < data_manifests.size(); i++) {
 		auto &manifest = data_manifests[i].entry.file;
@@ -564,6 +584,9 @@ void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) co
 		count += manifest.existing_rows_count;
 		count += manifest.added_rows_count;
 	}
+	//! Subtract pending metadata-only deletes, still included in the manifest totals until commit.
+	auto invalidated_rows = GetTransactionInvalidatedRowCount();
+	count -= invalidated_rows <= count ? invalidated_rows : count;
 
 	PartitionStatistics partition_stats;
 	partition_stats.count = count;

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -578,10 +578,13 @@ void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) co
 		}
 	}
 
-	//! Pending metadata-only deletes are still in the manifest totals until commit. Their per-file
-	//! record counts only exist once files are enumerated, so force that before discounting them.
+	//! Enumerate files to populate per-file record counts before discounting pending metadata-only
+	//! deletes. Use the guard we already hold; GetTotalFileCount() re-locks and would self-deadlock.
 	if (!shared_state->transaction_invalidated_files.empty()) {
-		(void)GetTotalFileCount();
+		idx_t enumerated = data_manifest_entries.size();
+		while (!GetFileInternal(enumerated, guard).path.empty()) {
+			enumerated++;
+		}
 	}
 
 	idx_t count = 0;

--- a/test/configs/nessie.json
+++ b/test/configs/nessie.json
@@ -132,7 +132,8 @@
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_into_sorted_table.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/update/partitions/test_update_into_partitioned_sorted_table.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_snapshot_operation_in_transaction.test",
-        "test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_snapshot_summary_delete_metrics.test"
+        "test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_snapshot_summary_delete_metrics.test",
+        "test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_snapshot_summary_metadata_only_delete_metrics.test"
       ]
     },
     {

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/partitions/test_delete_manifest_partitions.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/partitions/test_delete_manifest_partitions.test
@@ -32,36 +32,48 @@ CREATE TABLE my_datalake.default.test_delete_manifest_partitions (id INT, catego
 statement ok
 INSERT INTO my_datalake.default.test_delete_manifest_partitions VALUES
     (1, 'A'),
-    (2, 'B'),
-    (3, 'C'),
-    (4, 'D'),
-    (5, 'E'),
-    (6, NULL);
+    (2, 'A'),
+    (3, 'B'),
+    (4, 'C'),
+    (5, 'D'),
+    (6, 'D'),
+    (7, 'E'),
+    (8, NULL),
+    (9, NULL);
 
 query II
 SELECT id, category FROM my_datalake.default.test_delete_manifest_partitions ORDER BY id;
 ----
 1	A
-2	B
-3	C
-4	D
-5	E
-6	NULL
+2	A
+3	B
+4	C
+5	D
+6	D
+7	E
+8	NULL
+9	NULL
 
 query I
 SELECT COUNT(*) FROM my_datalake.default.test_delete_manifest_partitions WHERE category IN ('A', 'D') or category is null;
 ----
-3
+6
 
+# Delete one row from each of partitions A, D and NULL, leaving each partition non-empty. That keeps
+# the delete a per-file positional delete (not a metadata-only whole-file drop) so it still produces
+# the partition-tagged delete manifest entries this test asserts on.
 statement ok
-DELETE FROM my_datalake.default.test_delete_manifest_partitions WHERE category IN ('A', 'D') or category is NULL;
+DELETE FROM my_datalake.default.test_delete_manifest_partitions WHERE id IN (1, 5, 8);
 
 query II
 SELECT id, category FROM my_datalake.default.test_delete_manifest_partitions ORDER BY id;
 ----
-2	B
-3	C
-5	E
+2	A
+3	B
+4	C
+6	D
+7	E
+9	NULL
 
 statement ok
 set variable man_list_path = (select manifest_list from iceberg_snapshots(my_datalake.default.test_delete_manifest_partitions) order by timestamp_ms desc limit 1);
@@ -72,7 +84,7 @@ set variable manifest_path = (select manifest_path from read_avro(getvariable('m
 statement ok
 select * from read_avro(getvariable('manifest_path'));
 
-# manifest path should have 2 entries since entries in 2 partitions were deleted
+# the delete manifest should have 3 entries: one positional delete per touched partition (A, D, NULL)
 query I
 select count(*) from read_avro(getvariable('manifest_path'));
 ----

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_metadata_only_full_file_delete.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_metadata_only_full_file_delete.test
@@ -1,0 +1,117 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_metadata_only_full_file_delete.test
+# description: A DELETE that removes every live row of a data file drops the file with a metadata-only manifest edit (no positional delete file / deletion vector). A partial delete still writes one. Partitioned tables (one data file per partition).
+# group: [delete]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# ------------------------------------------------------------------
+# v2: positional deletes
+# ------------------------------------------------------------------
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.metadata_only_partitioned_v2;
+
+statement ok
+CREATE TABLE my_datalake.default.metadata_only_partitioned_v2 (id INT, val VARCHAR) PARTITIONED BY (id) WITH ('format-version'=2);
+
+statement ok
+INSERT INTO my_datalake.default.metadata_only_partitioned_v2 VALUES (1, 'a'), (1, 'b'), (2, 'c'), (2, 'd'), (3, 'e');
+
+# (1) whole partition delete removes every row of the id=1 data file
+query I
+DELETE FROM my_datalake.default.metadata_only_partitioned_v2 WHERE id = 1;
+----
+2
+
+# (1b) read back: the partition is gone
+query II
+SELECT * FROM my_datalake.default.metadata_only_partitioned_v2 ORDER BY id, val;
+----
+2	c
+2	d
+3	e
+
+# (1a) it was metadata-only: no live positional delete file exists
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_partitioned_v2) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+0
+
+# (2) partial partition delete removes one of the two rows in the id=2 file
+query I
+DELETE FROM my_datalake.default.metadata_only_partitioned_v2 WHERE val = 'c';
+----
+1
+
+# (2b) read back
+query II
+SELECT * FROM my_datalake.default.metadata_only_partitioned_v2 ORDER BY id, val;
+----
+2	d
+3	e
+
+# (2a) a positional delete file was written (merge-on-read)
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_partitioned_v2) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+1
+
+statement ok
+DROP TABLE my_datalake.default.metadata_only_partitioned_v2;
+
+# ------------------------------------------------------------------
+# v3: deletion vectors
+# ------------------------------------------------------------------
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.metadata_only_partitioned_v3;
+
+statement ok
+CREATE TABLE my_datalake.default.metadata_only_partitioned_v3 (id INT, val VARCHAR) PARTITIONED BY (id) WITH ('format-version'=3);
+
+statement ok
+INSERT INTO my_datalake.default.metadata_only_partitioned_v3 VALUES (1, 'a'), (1, 'b'), (2, 'c'), (2, 'd'), (3, 'e');
+
+# whole partition delete -> metadata-only, no deletion vector written
+query I
+DELETE FROM my_datalake.default.metadata_only_partitioned_v3 WHERE id = 1;
+----
+2
+
+query II
+SELECT * FROM my_datalake.default.metadata_only_partitioned_v3 ORDER BY id, val;
+----
+2	c
+2	d
+3	e
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_partitioned_v3) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+0
+
+# partial delete -> a deletion vector is written
+query I
+DELETE FROM my_datalake.default.metadata_only_partitioned_v3 WHERE val = 'c';
+----
+1
+
+query II
+SELECT * FROM my_datalake.default.metadata_only_partitioned_v3 ORDER BY id, val;
+----
+2	d
+3	e
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_partitioned_v3) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+1
+
+statement ok
+DROP TABLE my_datalake.default.metadata_only_partitioned_v3;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_metadata_only_unpartitioned.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_metadata_only_unpartitioned.test
@@ -1,0 +1,201 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_metadata_only_unpartitioned.test
+# description: Metadata-only whole-file delete on unpartitioned tables: single/multiple data files, whole vs partial, and a file emptied across two deletes (existing positional deletes + new deletes == record_count) which also drops the now-dangling file-scoped delete file.
+# group: [delete]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# ------------------------------------------------------------------
+# v2, multiple data files (one INSERT == one data file)
+# ------------------------------------------------------------------
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.metadata_only_unpart_v2;
+
+statement ok
+CREATE TABLE my_datalake.default.metadata_only_unpart_v2 (a INTEGER) WITH ('format-version'=2);
+
+statement ok
+INSERT INTO my_datalake.default.metadata_only_unpart_v2 SELECT i FROM range(0, 5) t(i);
+
+statement ok
+INSERT INTO my_datalake.default.metadata_only_unpart_v2 SELECT i FROM range(5, 10) t(i);
+
+# two live data files
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_unpart_v2) WHERE content = 'DATA' AND status != 'DELETED';
+----
+2
+
+# whole-file delete: the predicate covers exactly the first file's rows
+query I
+DELETE FROM my_datalake.default.metadata_only_unpart_v2 WHERE a < 5;
+----
+5
+
+query I
+SELECT a FROM my_datalake.default.metadata_only_unpart_v2 ORDER BY a;
+----
+5
+6
+7
+8
+9
+
+# metadata-only: no delete file, and one fewer live data file
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_unpart_v2) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+0
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_unpart_v2) WHERE content = 'DATA' AND status != 'DELETED';
+----
+1
+
+# partial delete of the surviving file -> merge-on-read delete file
+query I
+DELETE FROM my_datalake.default.metadata_only_unpart_v2 WHERE a = 5;
+----
+1
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_unpart_v2) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+1
+
+# now delete the file's remaining rows. Together with the existing positional delete this covers
+# every row of the file, so it becomes a metadata-only drop that also invalidates the now-dangling
+# file-scoped delete file.
+query I
+DELETE FROM my_datalake.default.metadata_only_unpart_v2 WHERE a >= 6;
+----
+4
+
+query I
+SELECT count(*) FROM my_datalake.default.metadata_only_unpart_v2;
+----
+0
+
+# both data files dropped, and the file-scoped delete file was invalidated too
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_unpart_v2) WHERE content = 'DATA' AND status != 'DELETED';
+----
+0
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_unpart_v2) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+0
+
+statement ok
+DROP TABLE my_datalake.default.metadata_only_unpart_v2;
+
+# ------------------------------------------------------------------
+# v2, single data file fully deleted
+# ------------------------------------------------------------------
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.metadata_only_single_v2;
+
+statement ok
+CREATE TABLE my_datalake.default.metadata_only_single_v2 (a INTEGER) WITH ('format-version'=2);
+
+statement ok
+INSERT INTO my_datalake.default.metadata_only_single_v2 SELECT i FROM range(0, 5) t(i);
+
+query I
+DELETE FROM my_datalake.default.metadata_only_single_v2 WHERE a >= 0;
+----
+5
+
+query I
+SELECT count(*) FROM my_datalake.default.metadata_only_single_v2;
+----
+0
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_single_v2) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+0
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_single_v2) WHERE content = 'DATA' AND status != 'DELETED';
+----
+0
+
+statement ok
+DROP TABLE my_datalake.default.metadata_only_single_v2;
+
+# ------------------------------------------------------------------
+# v3 (deletion vectors), multiple data files, same whole vs partial behaviour
+# ------------------------------------------------------------------
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.metadata_only_unpart_v3;
+
+statement ok
+CREATE TABLE my_datalake.default.metadata_only_unpart_v3 (a INTEGER) WITH ('format-version'=3);
+
+statement ok
+INSERT INTO my_datalake.default.metadata_only_unpart_v3 SELECT i FROM range(0, 5) t(i);
+
+statement ok
+INSERT INTO my_datalake.default.metadata_only_unpart_v3 SELECT i FROM range(5, 10) t(i);
+
+query I
+DELETE FROM my_datalake.default.metadata_only_unpart_v3 WHERE a < 5;
+----
+5
+
+query I
+SELECT a FROM my_datalake.default.metadata_only_unpart_v3 ORDER BY a;
+----
+5
+6
+7
+8
+9
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_unpart_v3) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+0
+
+# partial -> deletion vector, then empty the file (existing DV + new deletes == record_count) -> drop
+query I
+DELETE FROM my_datalake.default.metadata_only_unpart_v3 WHERE a = 5;
+----
+1
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_unpart_v3) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+1
+
+query I
+DELETE FROM my_datalake.default.metadata_only_unpart_v3 WHERE a >= 6;
+----
+4
+
+query I
+SELECT count(*) FROM my_datalake.default.metadata_only_unpart_v3;
+----
+0
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_unpart_v3) WHERE content = 'DATA' AND status != 'DELETED';
+----
+0
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_unpart_v3) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+0
+
+statement ok
+DROP TABLE my_datalake.default.metadata_only_unpart_v3;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_metadata_only_unpartitioned.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_metadata_only_unpartitioned.test
@@ -199,3 +199,63 @@ SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_unpart_v
 
 statement ok
 DROP TABLE my_datalake.default.metadata_only_unpart_v3;
+
+# ------------------------------------------------------------------
+# Transaction-local cardinality: a metadata-only drop of a file that already had a positional delete
+# must discount only the file's LIVE rows, not its full record count. The delete-manifest totals
+# already account for the pre-existing delete, so subtracting the whole record count double-counts
+# the already-deleted rows. A second live file keeps the zero-floor clamp from masking it.
+# ------------------------------------------------------------------
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.metadata_only_card_v2;
+
+statement ok
+CREATE TABLE my_datalake.default.metadata_only_card_v2 (a INTEGER) WITH ('format-version'=2);
+
+# File A: 2 rows.
+statement ok
+INSERT INTO my_datalake.default.metadata_only_card_v2 SELECT i FROM range(0, 2) t(i);
+
+# File B: 3 rows (separate data file).
+statement ok
+INSERT INTO my_datalake.default.metadata_only_card_v2 SELECT i FROM range(10, 13) t(i);
+
+# Partial delete of A -> positional delete file (1 of A's 2 rows).
+statement ok
+DELETE FROM my_datalake.default.metadata_only_card_v2 WHERE a = 0;
+
+# 4 live rows (A: 1, B: 3); the estimate discounts the positional delete.
+query II
+EXPLAIN SELECT * FROM my_datalake.default.metadata_only_card_v2;
+----
+physical_plan	<REGEX>:.*ICEBERG_SCAN.*~4 rows.*
+
+statement ok
+BEGIN;
+
+# Delete A's remaining live row: existing positional delete + this delete cover all of A, so A becomes
+# a metadata-only drop. B is untouched.
+statement ok
+DELETE FROM my_datalake.default.metadata_only_card_v2 WHERE a = 1;
+
+# Transaction-local estimate must be 3 (A gone, B=3). The double-count bug produced ~2.
+query II
+EXPLAIN SELECT * FROM my_datalake.default.metadata_only_card_v2;
+----
+physical_plan	<REGEX>:.*ICEBERG_SCAN.*~3 rows.*
+
+query I
+SELECT count(*) FROM my_datalake.default.metadata_only_card_v2;
+----
+3
+
+statement ok
+COMMIT;
+
+query I
+SELECT count(*) FROM my_datalake.default.metadata_only_card_v2;
+----
+3
+
+statement ok
+DROP TABLE my_datalake.default.metadata_only_card_v2;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_metadata_only_with_equality_deletes.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_metadata_only_with_equality_deletes.test
@@ -1,0 +1,71 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_metadata_only_with_equality_deletes.test
+# description: Safety: when a data file already has equality deletes, a later delete of the remaining live rows must NOT be mis-detected as a whole-file delete. The positional union never reaches record_count (equality-deleted rows are not positional), so it falls back to merge-on-read and reads stay correct.
+# group: [delete]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require-env EQUALITY_DELETE_WRITES_ENABLED 1
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+statement ok
+set unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes=true;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.metadata_only_equality;
+
+# equality-delete writes are only supported on unpartitioned v2 tables
+statement ok
+CREATE TABLE my_datalake.default.metadata_only_equality (a INTEGER, b INTEGER) WITH ('format-version'=2);
+
+# one data file, 5 physical rows
+statement ok
+INSERT INTO my_datalake.default.metadata_only_equality VALUES (1, 1), (2, 1), (3, 2), (4, 2), (5, 2);
+
+# pure equality predicate -> equality delete file (removes the two b=1 rows)
+statement ok
+DELETE FROM my_datalake.default.metadata_only_equality WHERE b = 1;
+
+query II
+SELECT * FROM my_datalake.default.metadata_only_equality ORDER BY a;
+----
+3	2
+4	2
+5	2
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_equality) WHERE content = 'EQUALITY_DELETES' AND status != 'DELETED';
+----
+1
+
+# delete the remaining live rows. The three live positions do not add up to the file's physical
+# record_count (5), because the equality-deleted rows are not part of the positional set, so this
+# is NOT a whole-file drop: it falls back to a positional delete file.
+statement ok
+DELETE FROM my_datalake.default.metadata_only_equality WHERE a >= 3;
+
+# reads are correct: the table is logically empty
+query I
+SELECT count(*) FROM my_datalake.default.metadata_only_equality;
+----
+0
+
+# the data file was NOT metadata-dropped (still live), and a positional delete file was written
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_equality) WHERE content = 'DATA' AND status != 'DELETED';
+----
+1
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.metadata_only_equality) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+1
+
+statement ok
+DROP TABLE my_datalake.default.metadata_only_equality;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_snapshot_summary_metadata_only_delete_metrics.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_snapshot_summary_metadata_only_delete_metrics.test
@@ -1,0 +1,127 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_snapshot_summary_metadata_only_delete_metrics.test
+# description: A metadata-only whole-file delete (no delete file written) must still populate the snapshot-summary deleted-data-files / deleted-records metrics and decrement the totals, even though the drop happens via a manifest rewrite rather than a newly added manifest.
+# group: [delete]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require json
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.test_snapshot_summary_metadata_only;
+
+statement ok
+CREATE TABLE my_datalake.default.test_snapshot_summary_metadata_only (id INTEGER, data VARCHAR);
+
+# Single INSERT -> one data file -> one 'append' snapshot (5 records).
+statement ok
+INSERT INTO my_datalake.default.test_snapshot_summary_metadata_only VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+
+# Delete every row of the single data file -> metadata-only drop (no delete file written).
+statement ok
+DELETE FROM my_datalake.default.test_snapshot_summary_metadata_only WHERE id >= 1;
+
+query I
+SELECT count(*) FROM my_datalake.default.test_snapshot_summary_metadata_only;
+----
+0
+
+# No delete file was written (the drop is a metadata-only manifest edit).
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.test_snapshot_summary_metadata_only) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+0
+
+# The append snapshot seeds the totals.
+query III
+WITH snaps AS (
+    SELECT unnest(json_extract(metadata::JSON, '$.snapshots[*]')) AS snap
+    FROM iceberg_load_table_response(my_datalake.default.test_snapshot_summary_metadata_only)
+)
+SELECT json_extract_string(snap, '$.summary.operation'),
+       json_extract_string(snap, '$.summary."total-data-files"'),
+       json_extract_string(snap, '$.summary."total-records"')
+FROM snaps
+WHERE json_extract_string(snap, '$.summary.operation') = 'append';
+----
+append	1	5
+
+# The metadata-only delete snapshot records the dropped data file and its records, and
+# decrements the running totals to zero. Before the rewrite path fed these metrics, the
+# delete snapshot reported deleted-data-files/deleted-records of 0 and left total-data-files
+# at 1.
+query IIIII
+WITH snaps AS (
+    SELECT unnest(json_extract(metadata::JSON, '$.snapshots[*]')) AS snap
+    FROM iceberg_load_table_response(my_datalake.default.test_snapshot_summary_metadata_only)
+)
+SELECT json_extract_string(snap, '$.summary.operation'),
+       json_extract_string(snap, '$.summary."deleted-data-files"'),
+       json_extract_string(snap, '$.summary."deleted-records"'),
+       json_extract_string(snap, '$.summary."total-data-files"'),
+       json_extract_string(snap, '$.summary."total-records"')
+FROM snaps
+WHERE json_extract_string(snap, '$.summary.operation') = 'delete';
+----
+delete	1	5	0	0
+
+statement ok
+DROP TABLE my_datalake.default.test_snapshot_summary_metadata_only;
+
+# ------------------------------------------------------------------
+# Contrast: a PARTIAL delete is a merge-on-read that writes a positional delete file rather than
+# dropping the data file. It must keep reporting the delete-file metrics and leave total-data-files
+# intact — the whole-file-drop metrics from the rewrite path must NOT fire (no manifest is
+# invalidated, so RewriteManifestFile is never entered).
+# ------------------------------------------------------------------
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.test_snapshot_summary_partial;
+
+statement ok
+CREATE TABLE my_datalake.default.test_snapshot_summary_partial (id INTEGER, data VARCHAR);
+
+statement ok
+INSERT INTO my_datalake.default.test_snapshot_summary_partial VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+
+# Delete a strict subset of the file's rows -> positional delete file, not a metadata-only drop.
+statement ok
+DELETE FROM my_datalake.default.test_snapshot_summary_partial WHERE id IN (2, 4);
+
+query I
+SELECT count(*) FROM my_datalake.default.test_snapshot_summary_partial;
+----
+3
+
+# A positional delete file was written.
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.test_snapshot_summary_partial) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+1
+
+# The delete snapshot reports the delete-file metrics and leaves total-data-files at 1. The
+# whole-file-drop metric (deleted-data-files) is never emitted for a merge-on-read delete, so it is
+# absent from the summary (NULL).
+query IIIII
+WITH snaps AS (
+    SELECT unnest(json_extract(metadata::JSON, '$.snapshots[*]')) AS snap
+    FROM iceberg_load_table_response(my_datalake.default.test_snapshot_summary_partial)
+)
+SELECT json_extract_string(snap, '$.summary.operation'),
+       json_extract_string(snap, '$.summary."added-delete-files"'),
+       json_extract_string(snap, '$.summary."total-delete-files"'),
+       json_extract_string(snap, '$.summary."total-data-files"'),
+       json_extract_string(snap, '$.summary."deleted-data-files"')
+FROM snaps
+WHERE json_extract_string(snap, '$.summary.operation') = 'delete';
+----
+delete	1	1	1	NULL
+
+statement ok
+DROP TABLE my_datalake.default.test_snapshot_summary_partial;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/count_star_optimizer.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/count_star_optimizer.test
@@ -58,11 +58,12 @@ select count(*) from my_datalake.default.count_star_optimizer;
 ----
 1
 
-# contain delete file, do not use the statistics information.
+# the delete removed an entire data file with a metadata-only manifest edit (no delete file), so
+# the metadata row count stays exact and the count(*) optimizer keeps using it.
 query II
 explain SELECT count(*) FROM  my_datalake.default.count_star_optimizer;
 ----
-physical_plan	<REGEX>:.*ICEBERG_SCAN.*row.*
+physical_plan	<REGEX>:.*COLUMN_DATA_SCAN.*~1.*
 
 
 

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/count_star_optimizer.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/count_star_optimizer.test
@@ -50,20 +50,26 @@ select count(*) from my_datalake.default.count_star_optimizer;
 statement ok
 ABORT;
 
+# Insert two rows as a single data file, then delete one of them. Deleting a strict subset of a
+# file's rows is always a merge-on-read (positional) delete regardless of how the catalog laid out
+# the pre-existing rows, so this exercises the "delete file present" path deterministically (a
+# whole-file delete would instead be metadata-only and leave no delete file).
 statement ok
-delete from my_datalake.default.count_star_optimizer where id = 1;
+insert into my_datalake.default.count_star_optimizer values (10, 'j'), (11, 'k');
+
+statement ok
+delete from my_datalake.default.count_star_optimizer where id = 10;
 
 query I
 select count(*) from my_datalake.default.count_star_optimizer;
 ----
-1
+3
 
-# the delete removed an entire data file with a metadata-only manifest edit (no delete file), so
-# the metadata row count stays exact and the count(*) optimizer keeps using it.
+# a positional delete file is present, so the count(*) optimizer cannot use the metadata row count.
 query II
 explain SELECT count(*) FROM  my_datalake.default.count_star_optimizer;
 ----
-physical_plan	<REGEX>:.*COLUMN_DATA_SCAN.*~1.*
+physical_plan	<REGEX>:.*ICEBERG_SCAN.*row.*
 
 
 

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_metadata_only_full_file.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_metadata_only_full_file.test
@@ -1,0 +1,171 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_metadata_only_full_file.test
+# description: Regression test — an UPDATE/MERGE whose delete portion removes every live row of a data file must drop that file with a metadata-only manifest edit (no delete file) and still commit. Previously this produced an empty DELETE manifest in AddUpdateSnapshot and crashed.
+# group: [update]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# ------------------------------------------------------------------
+# v2 UPDATE: rewriting a whole partition (one data file) -> the delete
+# portion is metadata-only, the insert adds new data. Must commit and
+# write no positional delete file.
+# ------------------------------------------------------------------
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.update_metadata_only_v2;
+
+statement ok
+CREATE TABLE my_datalake.default.update_metadata_only_v2 (id INT, val VARCHAR) PARTITIONED BY (id) WITH ('format-version'=2);
+
+statement ok
+INSERT INTO my_datalake.default.update_metadata_only_v2 VALUES (1, 'a'), (1, 'b'), (2, 'c'), (2, 'd'), (3, 'e');
+
+# update every row of the id=1 file (regression: used to crash on an empty delete manifest)
+statement ok
+UPDATE my_datalake.default.update_metadata_only_v2 SET val = 'X' WHERE id = 1;
+
+query II
+SELECT * FROM my_datalake.default.update_metadata_only_v2 ORDER BY id, val;
+----
+1	X
+1	X
+2	c
+2	d
+3	e
+
+# delete portion was metadata-only: no positional delete file
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.update_metadata_only_v2) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+0
+
+# partial update (one of two rows in the id=2 file) still uses merge-on-read
+statement ok
+UPDATE my_datalake.default.update_metadata_only_v2 SET val = 'Y' WHERE id = 2 AND val = 'c';
+
+query II
+SELECT * FROM my_datalake.default.update_metadata_only_v2 ORDER BY id, val;
+----
+1	X
+1	X
+2	Y
+2	d
+3	e
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.update_metadata_only_v2) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+1
+
+statement ok
+DROP TABLE my_datalake.default.update_metadata_only_v2;
+
+# ------------------------------------------------------------------
+# v2 MERGE ... WHEN MATCHED THEN UPDATE, exercising the same
+# delete+insert path as UPDATE.
+# ------------------------------------------------------------------
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.merge_metadata_only_v2;
+
+statement ok
+CREATE TABLE my_datalake.default.merge_metadata_only_v2 (id INT, val VARCHAR) PARTITIONED BY (id) WITH ('format-version'=2);
+
+statement ok
+INSERT INTO my_datalake.default.merge_metadata_only_v2 VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+# match the single row of the id=3 file and update it -> metadata-only delete + new data
+statement ok
+MERGE INTO my_datalake.default.merge_metadata_only_v2
+    USING (SELECT 3 AS id, 'Z' AS val) AS src
+    ON my_datalake.default.merge_metadata_only_v2.id = src.id
+    WHEN MATCHED THEN UPDATE;
+
+query II
+SELECT * FROM my_datalake.default.merge_metadata_only_v2 ORDER BY id, val;
+----
+1	a
+2	b
+3	Z
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.merge_metadata_only_v2) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+0
+
+statement ok
+DROP TABLE my_datalake.default.merge_metadata_only_v2;
+
+# ------------------------------------------------------------------
+# Transaction-local visibility: a whole-file UPDATE inside an explicit
+# transaction must hide the metadata-only-invalidated file from reads in
+# the same transaction (regression: it used to double-count, since the
+# manifest rewrite only lands at commit).
+# ------------------------------------------------------------------
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.update_metadata_only_txn;
+
+statement ok
+CREATE TABLE my_datalake.default.update_metadata_only_txn AS SELECT 1000 + i id, i % 10 as val FROM range(1000) t(i);
+
+statement ok
+BEGIN;
+
+# updates every row of the single data file -> delete portion is metadata-only
+statement ok
+UPDATE my_datalake.default.update_metadata_only_txn SET id = id + 1;
+
+# in-transaction read must see exactly 1000 rows (not 2000)
+query III
+SELECT COUNT(*), SUM(id), SUM(val) FROM my_datalake.default.update_metadata_only_txn;
+----
+1000	1500500	4500
+
+statement ok
+ROLLBACK;
+
+# after rollback the original data is intact
+query III
+SELECT COUNT(*), SUM(id), SUM(val) FROM my_datalake.default.update_metadata_only_txn;
+----
+1000	1499500	4500
+
+statement ok
+DROP TABLE my_datalake.default.update_metadata_only_txn;
+
+# ------------------------------------------------------------------
+# v3 UPDATE: same behaviour with deletion vectors.
+# ------------------------------------------------------------------
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.update_metadata_only_v3;
+
+statement ok
+CREATE TABLE my_datalake.default.update_metadata_only_v3 (id INT, val VARCHAR) PARTITIONED BY (id) WITH ('format-version'=3);
+
+statement ok
+INSERT INTO my_datalake.default.update_metadata_only_v3 VALUES (1, 'a'), (1, 'b'), (2, 'c'), (2, 'd'), (3, 'e');
+
+statement ok
+UPDATE my_datalake.default.update_metadata_only_v3 SET val = 'X' WHERE id = 1;
+
+query II
+SELECT * FROM my_datalake.default.update_metadata_only_v3 ORDER BY id, val;
+----
+1	X
+1	X
+2	c
+2	d
+3	e
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.update_metadata_only_v3) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+0
+
+statement ok
+DROP TABLE my_datalake.default.update_metadata_only_v3;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_metadata_only_full_file.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_metadata_only_full_file.test
@@ -140,6 +140,82 @@ statement ok
 DROP TABLE my_datalake.default.merge_metadata_only_v2;
 
 # ------------------------------------------------------------------
+# v2 MERGE WHEN MATCHED THEN UPDATE that only touches a subset of a
+# data file's rows -> merge-on-read (a delete file is written), covering
+# the non-metadata-only branch of the MERGE delete+insert path.
+# ------------------------------------------------------------------
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.merge_partial_v2;
+
+# unpartitioned: a single INSERT lands all rows in one data file
+statement ok
+CREATE TABLE my_datalake.default.merge_partial_v2 (id INT, val VARCHAR) WITH ('format-version'=2);
+
+statement ok
+INSERT INTO my_datalake.default.merge_partial_v2 VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+# match only id=2 (one of three rows in the file) -> partial delete -> delete file written
+query I
+MERGE INTO my_datalake.default.merge_partial_v2 AS t
+    USING (SELECT 2 AS id, 'B' AS val) AS s ON t.id = s.id
+    WHEN MATCHED THEN UPDATE SET val = s.val;
+----
+1
+
+query II
+SELECT * FROM my_datalake.default.merge_partial_v2 ORDER BY id, val;
+----
+1	a
+2	B
+3	c
+
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.merge_partial_v2) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+1
+
+statement ok
+DROP TABLE my_datalake.default.merge_partial_v2;
+
+# ------------------------------------------------------------------
+# v3 MERGE (deletion vectors): combined WHEN MATCHED (whole-file update ->
+# metadata-only) + WHEN NOT MATCHED (insert) in a single statement.
+# ------------------------------------------------------------------
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.merge_metadata_only_v3;
+
+statement ok
+CREATE TABLE my_datalake.default.merge_metadata_only_v3 (id INT, val VARCHAR) PARTITIONED BY (id) WITH ('format-version'=3);
+
+statement ok
+INSERT INTO my_datalake.default.merge_metadata_only_v3 VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+query I
+MERGE INTO my_datalake.default.merge_metadata_only_v3 AS t
+    USING (VALUES (1, 'A'), (4, 'd')) AS s(id, val) ON t.id = s.id
+    WHEN MATCHED THEN UPDATE SET val = s.val
+    WHEN NOT MATCHED THEN INSERT VALUES (s.id, s.val);
+----
+2
+
+query II
+SELECT * FROM my_datalake.default.merge_metadata_only_v3 ORDER BY id, val;
+----
+1	A
+2	b
+3	c
+4	d
+
+# the matched UPDATE rewrote a whole partition file, so no deletion vector was written
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.merge_metadata_only_v3) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+0
+
+statement ok
+DROP TABLE my_datalake.default.merge_metadata_only_v3;
+
+# ------------------------------------------------------------------
 # Transaction-local visibility: a whole-file UPDATE inside an explicit
 # transaction must hide the metadata-only-invalidated file from reads in
 # the same transaction (regression: it used to double-count, since the

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_metadata_only_full_file.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_metadata_only_full_file.test
@@ -67,8 +67,9 @@ statement ok
 DROP TABLE my_datalake.default.update_metadata_only_v2;
 
 # ------------------------------------------------------------------
-# v2 MERGE ... WHEN MATCHED THEN UPDATE, exercising the same
-# delete+insert path as UPDATE.
+# v2 MERGE INTO, covering WHEN MATCHED (UPDATE), WHEN NOT MATCHED
+# (INSERT), and both actions in a single statement. Matched UPDATEs that
+# rewrite a whole partition file exercise the metadata-only delete path.
 # ------------------------------------------------------------------
 statement ok
 DROP TABLE IF EXISTS my_datalake.default.merge_metadata_only_v2;
@@ -79,20 +80,57 @@ CREATE TABLE my_datalake.default.merge_metadata_only_v2 (id INT, val VARCHAR) PA
 statement ok
 INSERT INTO my_datalake.default.merge_metadata_only_v2 VALUES (1, 'a'), (2, 'b'), (3, 'c');
 
-# match the single row of the id=3 file and update it -> metadata-only delete + new data
-statement ok
-MERGE INTO my_datalake.default.merge_metadata_only_v2
-    USING (SELECT 3 AS id, 'Z' AS val) AS src
-    ON my_datalake.default.merge_metadata_only_v2.id = src.id
-    WHEN MATCHED THEN UPDATE;
+# WHEN MATCHED THEN UPDATE: matches the whole id=1 file -> metadata-only delete + new data
+query I
+MERGE INTO my_datalake.default.merge_metadata_only_v2 AS t
+    USING (SELECT 1 AS id, 'A' AS val) AS s ON t.id = s.id
+    WHEN MATCHED THEN UPDATE SET val = s.val;
+----
+1
 
 query II
 SELECT * FROM my_datalake.default.merge_metadata_only_v2 ORDER BY id, val;
 ----
-1	a
+1	A
 2	b
-3	Z
+3	c
 
+# WHEN NOT MATCHED THEN INSERT: pure insert, no delete
+query I
+MERGE INTO my_datalake.default.merge_metadata_only_v2 AS t
+    USING (SELECT 4 AS id, 'd' AS val) AS s ON t.id = s.id
+    WHEN NOT MATCHED THEN INSERT VALUES (s.id, s.val);
+----
+1
+
+query II
+SELECT * FROM my_datalake.default.merge_metadata_only_v2 ORDER BY id, val;
+----
+1	A
+2	b
+3	c
+4	d
+
+# Both actions in one statement: matched id=2 (whole-file update -> metadata-only delete) and
+# not-matched id=5 (insert).
+query I
+MERGE INTO my_datalake.default.merge_metadata_only_v2 AS t
+    USING (VALUES (2, 'B'), (5, 'e')) AS s(id, val) ON t.id = s.id
+    WHEN MATCHED THEN UPDATE SET val = s.val
+    WHEN NOT MATCHED THEN INSERT VALUES (s.id, s.val);
+----
+2
+
+query II
+SELECT * FROM my_datalake.default.merge_metadata_only_v2 ORDER BY id, val;
+----
+1	A
+2	B
+3	c
+4	d
+5	e
+
+# every matched UPDATE rewrote a whole partition file, so all deletes were metadata-only
 query I
 SELECT count(*) FROM iceberg_metadata(my_datalake.default.merge_metadata_only_v2) WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
 ----


### PR DESCRIPTION
## What / why

I hit this building a delete + insert incremental event-stream pipeline (repeatedly deleting a partition and re-inserting it). Every `DELETE` writes merge-on-read delete files/DVs even when the predicate removes every live row of a data file, so the dead files pile up and every later `scan` / `MERGE` / `DELETE` still has to read them plus their delete files. When a delete fully empties a file, I'd rather drop it via metadata.

This is **Phase 1** and I'd like a sanity check on direction before going further.

## Phase 1 (this PR) — drop fully-deleted files at flush time

We already scan every matching row, so at flush we know the exact deleted positions per file. When `existing + new deleted positions == record_count` (positions are 0-based ordinals, so this holds exactly when no live row survives), invalidate the data file instead of writing a delete file; otherwise fall back to the current path.

- Exact check (no stats/null/NaN edge cases), and naturally covers whole-partition deletes.
- Reuses the existing `IcebergManifestDeletes` -> `RewriteManifestFile` commit path (the one `iceberg_rewrite_data_files` uses).
- Adds an invalidate-only `AddSnapshot` path for when a delete only drops whole files (no new manifest entries).
- Also invalidates delete files provably scoped to the dropped data file (v3 deletion vectors, and DuckDB's file-scoped positional deletes via `referenced_data_file`). Multi-file positional delete files written by other engines still apply to surviving files, so they're left for that engine's maintenance to reclaim once dangling.

## Phase 2 (follow-up) — skip the scan via strict metrics

On top of Phase 1, add a strict metrics evaluator (the strict dual of the inclusive `IcebergPredicate::MatchBounds`) to check per-file stats against the predicate *before* scanning, so provably-fully-covered files skip the scan entirely; partial files keep the MOR path. Best-effort with a safe fallback.

## Tests

Fixture tests under `.../catalog_agnostic/delete/`:
- `test_metadata_only_full_file_delete.test` — partitioned v2 (positional) + v3 (DV): whole-partition delete writes no delete file; partial delete does.
- `test_metadata_only_unpartitioned.test` — multiple/single data files, whole vs partial, and a file emptied across two deletes (existing deletes + new == record_count) which also drops the dangling file-scoped delete file.
- `test_metadata_only_with_equality_deletes.test` (gated on `EQUALITY_DELETE_WRITES_ENABLED`) — safety: with equality deletes present, deleting the remaining live rows is not mis-detected as a whole-file drop; it falls back to MOR and reads stay correct.

## Known limitations (deliberate for this phase)

- Snapshot summary counts (`deleted-data-files` / `deleted-records`) are not decremented for the metadata drop (pre-existing accounting gap); reads/cardinality are correct.
- No write-isolation conflict detection (same as today's deletes).

## Questions

1. Does this direction fit what you had in mind for #620 / #826?
2. Prefer keeping it transparent inside the `DELETE` plan (Phase 1 at flush, Phase 2 at plan time), or opt-in?
3. Anything on summary correctness or write isolation you'd want handled here vs. deferred?