### PR TITLE
Add tests for Iceberg snapshot summary.operation labeling

### DIFF
--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -218,7 +218,7 @@ void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&de
 	auto data_manifest_file = IcebergManifestListEntry::CreateFromEntries(
 	    fs, sequence_number, table_metadata, data_manifest_metadata, std::move(data_files), next_row_id);
 
-	auto add_snapshot = make_uniq<IcebergAddSnapshot>(table_info);
+	auto add_snapshot = make_uniq<IcebergAddSnapshot>(table_info, IcebergSnapshotOperationType::OVERWRITE);
 	add_snapshot->AddManifestFile(std::move(delete_manifest_file));
 	add_snapshot->AddManifestFile(std::move(data_manifest_file));
 	add_snapshot->altered_manifests = std::move(altered_manifests);

--- a/test/sql/copy/basic_copy.test
+++ b/test/sql/copy/basic_copy.test
@@ -39,3 +39,8 @@ query I
 select typeof(b) from iceberg_scan('__TEST_DIR__/iceberg_table')
 ----
 VARCHAR
+
+query I
+select operation from iceberg_snapshots('__TEST_DIR__/iceberg_table')
+----
+append

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/functions/test_snapshot_operation.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/functions/test_snapshot_operation.test
@@ -1,0 +1,59 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/functions/test_snapshot_operation.test
+# description: Snapshot summary.operation is labeled append/delete/overwrite correctly
+# group: [functions]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.snapshot_operation_test;
+
+statement ok
+CREATE TABLE my_datalake.default.snapshot_operation_test AS SELECT range AS id FROM range(10);
+
+query I
+SELECT operation FROM iceberg_snapshots(my_datalake.default.snapshot_operation_test)
+ORDER BY sequence_number DESC
+LIMIT 1;
+----
+append
+
+statement ok
+INSERT INTO my_datalake.default.snapshot_operation_test SELECT range AS id FROM range(10, 20);
+
+query I
+SELECT operation FROM iceberg_snapshots(my_datalake.default.snapshot_operation_test)
+ORDER BY sequence_number DESC
+LIMIT 1;
+----
+append
+
+statement ok
+DELETE FROM my_datalake.default.snapshot_operation_test WHERE id % 2 = 0;
+
+query I
+SELECT operation FROM iceberg_snapshots(my_datalake.default.snapshot_operation_test)
+ORDER BY sequence_number DESC
+LIMIT 1;
+----
+delete
+
+statement ok
+UPDATE my_datalake.default.snapshot_operation_test SET id = id + 1000 WHERE id = 1;
+
+query I
+SELECT operation FROM iceberg_snapshots(my_datalake.default.snapshot_operation_test)
+ORDER BY sequence_number DESC
+LIMIT 1;
+----
+overwrite


### PR DESCRIPTION
## Summary
- Upstream already plumbs `summary.operation` through `IcebergAddSnapshot` (`append` / `delete` / default `overwrite`).
- Pass `OVERWRITE` explicitly for UPDATE snapshot commits.
- Add SQL coverage: `basic_copy.test` asserts `append`; catalog test covers INSERT/DELETE/UPDATE.

## Test plan
- [ ] `./build/release/test/unittest test/sql/copy/basic_copy.test`
- [ ] Run `test_snapshot_operation.test` with `CATALOG_TEST_CONFIG_SETUP`