### PR TITLE
[Dev] Add new catalog for `fixture-latest`, using the latest version of the docker image

### DIFF
--- a/.github/workflows/BuildIceberg.yml
+++ b/.github/workflows/BuildIceberg.yml
@@ -122,6 +122,13 @@ jobs:
       artifact-name: duckdb-iceberg
       build-path: build/relassert
 
+  test-fixture-latest:
+    name: Test against latest fixture catalog
+    needs: build_iceberg
+    uses: ./.github/workflows/test-fixture-latest-catalog.yml
+    with:
+      artifact-name: duckdb-iceberg
+
   #test-fixture-no-link:
   #  name: Test against fixture catalog no link
   #  needs: build_iceberg

--- a/.github/workflows/test-fixture-latest-catalog.yml
+++ b/.github/workflows/test-fixture-latest-catalog.yml
@@ -1,0 +1,94 @@
+name: Test Latest Fixture Catalog
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: "Name of the DuckDB-Iceberg artifact to download"
+        required: true
+        type: string
+
+jobs:
+  test-fixture-latest:
+    name: Test against latest fixture catalog
+    runs-on: ubuntu-latest
+    env:
+      ASAN_SYMBOLIZER_PATH: "/usr/bin/llvm-symbolizer"
+      ASAN_OPTIONS: "detect_leaks=1:halt_on_error=1:abort_on_error=0:external_symbolizer_path=/usr/bin/llvm-symbolizer"
+      LSAN_OPTIONS: "suppressions=${{ github.workspace }}/.combined-sanitizer-leak-suppressions.txt"
+      UBSAN_OPTIONS: "halt_on_error=1:print_stacktrace=1"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+
+      - name: Download DuckDB-Iceberg artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: build
+
+      - name: Extract relassert build artifact
+        run: |
+          rm -rf build/relassert
+          tar -xzf build/relassert-artifact.tar.gz -C build
+          ls -lh build/relassert/test/unittest
+
+      - name: Prepare leak suppressions
+        run: |
+          cp duckdb/.sanitizer-leak-suppressions.txt .combined-sanitizer-leak-suppressions.txt
+          printf '\n' >> .combined-sanitizer-leak-suppressions.txt
+          cat .sanitizer-leak-suppressions.txt >> .combined-sanitizer-leak-suppressions.txt
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
+      - name: Install fixture catalog dependencies
+        run: |
+          sudo apt update -y -qq
+          sudo apt install -y -qq python3-venv llvm
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Generate data with the latest fixture
+        run: make fixture-latest-data
+
+      - name: Run generic catalog tests
+        env:
+          FIXTURE_SERVER_AVAILABLE: 1
+        run: |
+          ./build/relassert/test/unittest --order lex "$PWD/test/sql/local/catalog_test_config_setup/*" --list-test-names-only || true
+          ./build/relassert/test/unittest --order lex "$PWD/test/sql/local/catalog_test_config_setup/*" --test-config test/configs/fixture-latest.json
+
+      - name: Test reads with PyIceberg and Spark
+        env:
+          FIXTURE_SERVER_AVAILABLE: 1
+        run: |
+          source .venv-spark4/bin/activate
+          python3 -m pytest -vv test/python --unittest-binary ./build/relassert/test/unittest --test-python-verbosity verbose
+
+      - name: Capture fixture logs
+        if: always()
+        run: docker compose -f scripts/docker-compose.yml logs --no-color > fixture-latest-compose.log
+
+      - name: Upload fixture logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fixture-latest-server-logs
+          path: fixture-latest-compose.log
+          if-no-files-found: ignore
+
+      - name: Stop latest fixture
+        if: always()
+        run: make fixture-latest-stop

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fixture gravitino lakekeeper polaris nessie
+.PHONY: fixture fixture-latest gravitino lakekeeper polaris nessie
 
 PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The catalog targets start local services, generate compatible Iceberg test data,
 | Catalog | Start services | Start and generate data | Notes |
 | --- | --- | --- | --- |
 | Apache Iceberg REST fixture | `make fixture` | `make fixture-data` | Uses the Compose setup in `scripts/` |
+| Apache Iceberg REST fixture (latest) | `make fixture-latest` | `make fixture-latest-data` | Tracks `apache/iceberg-rest-fixture:latest` in a separate compatibility lane |
 | Apache Gravitino | `make gravitino` | `make gravitino-data` | Uses the standalone Gravitino REST server and MinIO Compose setup in `scripts/gravitino/` |
 | Lakekeeper | `make lakekeeper` | `make lakekeeper-data` | Clones a pinned revision, applies the repository patch, and may add `minio` to `/etc/hosts` with `sudo` |
 | Nessie | `make nessie` | `make nessie-data` | Uses Nessie's `catalog-auth-s3` Compose setup |
@@ -150,7 +151,7 @@ TEST_CONFIG="$(bash -c 'source scripts/catalog_test_config.sh && active_catalog_
   test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_table.test
 ```
 
-`active_catalog_test_config` accepts `fixture`, `gravitino`, `lakekeeper`, `nessie`, or `polaris`. It reports an error for a missing, empty, local-only, or unknown active-catalog marker.
+`active_catalog_test_config` accepts `fixture`, `fixture-latest`, `gravitino`, `lakekeeper`, `nessie`, or `polaris`. It reports an error for a missing, empty, local-only, or unknown active-catalog marker.
 
 ### Catalog-backed Python tests
 

--- a/make/catalogs/fixture.mk
+++ b/make/catalogs/fixture.mk
@@ -24,6 +24,30 @@ fixture-data: fixture
 	if [ -f "$(FIXTURE_ENV_FILE)" ]; then echo "Loading env from $(FIXTURE_ENV_FILE)"; set -a; . ./$(FIXTURE_ENV_FILE); set +a; fi && \
 	python3 -m pytest scripts/data_generators/test_generate_data.py $(if $(TEST),-k $(TEST)) -vv
 
+fixture-latest-stop:
+	@echo "Stopping apache/iceberg-rest-fixture:latest catalog..."
+	(cd scripts && FIXTURE_DATA_DIR=fixture-latest docker compose down -v)
+
+fixture-latest: fixture-latest-stop
+	$(call stop_active_catalog)
+	@echo "Starting apache/iceberg-rest-fixture:latest catalog..."
+	mkdir -p data/generated/iceberg/fixture-latest
+	mkdir -p data/generated/intermediates
+	(cd scripts && ICEBERG_REST_FIXTURE_IMAGE=apache/iceberg-rest-fixture:latest FIXTURE_DATA_DIR=fixture-latest docker compose up -d)
+	$(call set_active_catalog,fixture-latest)
+
+fixture-latest-data: fixture-latest
+	@echo "Setting up venv-spark4 and generating data..."
+	mkdir -p data/generated/iceberg/fixture-latest && \
+	mkdir -p data/generated/intermediates && \
+	rm -rf data/generated/iceberg/fixture-latest/* && \
+	rm -rf data/generated/intermediates/* && \
+	python3 -m venv .venv-spark4 && \
+	. .venv-spark4/bin/activate && \
+	python3 -m pip install -r scripts/requirements.txt && \
+	if [ -f "$(FIXTURE_ENV_FILE)" ]; then echo "Loading env from $(FIXTURE_ENV_FILE)"; set -a; . ./$(FIXTURE_ENV_FILE); set +a; fi && \
+	python3 -m pytest scripts/data_generators/test_generate_data.py $(if $(TEST),-k $(TEST)) -vv
+
 fixture-data-local: fixture
 	@echo "Setting up venv-spark4 and generating data..."
 	$(call set_active_catalog,local)

--- a/make/catalogs/fixture.mk
+++ b/make/catalogs/fixture.mk
@@ -45,6 +45,7 @@ fixture-latest-data: fixture-latest
 	python3 -m venv .venv-spark4 && \
 	. .venv-spark4/bin/activate && \
 	python3 -m pip install -r scripts/requirements.txt && \
+	python3 -m pip install pyspark==4.1.0 && \
 	if [ -f "$(FIXTURE_ENV_FILE)" ]; then echo "Loading env from $(FIXTURE_ENV_FILE)"; set -a; . ./$(FIXTURE_ENV_FILE); set +a; fi && \
 	python3 -m pytest scripts/data_generators/test_generate_data.py $(if $(TEST),-k $(TEST)) -vv
 

--- a/scripts/catalog_test_config.sh
+++ b/scripts/catalog_test_config.sh
@@ -22,7 +22,7 @@ active_catalog_test_config() {
 	fi
 
 	case "$active_catalog" in
-		fixture|gravitino|lakekeeper|polaris|nessie)
+		fixture|fixture-latest|gravitino|lakekeeper|polaris|nessie)
 			config_path="$repo_root/test/configs/${active_catalog}.json"
 			;;
 		*)

--- a/scripts/data_generators/connections/spark_rest/__init__.py
+++ b/scripts/data_generators/connections/spark_rest/__init__.py
@@ -32,6 +32,7 @@ CONNECTION_KEY = "fixture"
 
 
 @IcebergConnection.register(CONNECTION_KEY)
+@IcebergConnection.register(CONNECTION_KEY + '-latest')
 class IcebergSparkRest(IcebergConnection):
     connection_key = CONNECTION_KEY
     default_endpoint = "http://127.0.0.1:8181"

--- a/scripts/data_generators/integration_config.py
+++ b/scripts/data_generators/integration_config.py
@@ -16,8 +16,8 @@ TEST_CONFIG_DIR = REPO_ROOT / "test" / "configs"
 DATA_GENERATORS_DIR = REPO_ROOT / "scripts" / "data_generators"
 ACTIVE_CATALOG_FILE = REPO_ROOT / ".catalogs" / ".active_catalog"
 
-REST_CATALOG_NAMES = ("fixture", "gravitino", "lakekeeper", "polaris", "nessie")
-GENERATOR_CATALOG_NAMES = ("fixture", "gravitino", "lakekeeper", "local", "polaris", "nessie")
+REST_CATALOG_NAMES = ("fixture", "fixture-latest", "gravitino", "lakekeeper", "polaris", "nessie")
+GENERATOR_CATALOG_NAMES = ("fixture", "fixture-latest", "gravitino", "lakekeeper", "local", "polaris", "nessie")
 
 
 @dataclass(frozen=True)
@@ -130,6 +130,27 @@ REST_CATALOG_PROFILES = {
         name="fixture",
         connection_key="fixture",
         unittest_config=TEST_CONFIG_DIR / "fixture.json",
+        pyiceberg_uri=os.getenv("ICEBERG_ENDPOINT", "http://127.0.0.1:8181"),
+        pyiceberg_warehouse=os.getenv("WAREHOUSE", ""),
+        pyiceberg_oauth_token_url=f"{os.getenv('ICEBERG_ENDPOINT', 'http://127.0.0.1:8181')}/v1/oauth/tokens",
+        pyiceberg_oauth_payload={
+            "grant_type": "client_credentials",
+            "client_id": os.getenv("ICEBERG_CLIENT_ID", "admin"),
+            "client_secret": os.getenv("ICEBERG_CLIENT_SECRET", "password"),
+            "scope": "PRINCIPAL_ROLE:ALL",
+        },
+        pyiceberg_options={
+            "s3.endpoint": os.getenv("S3_ENDPOINT", "http://127.0.0.1:9000"),
+            "s3.access-key-id": os.getenv("S3_KEY_ID", "admin"),
+            "s3.secret-access-key": os.getenv("S3_SECRET", "password"),
+            "s3.path-style-access": "true",
+            "s3.ssl.enabled": "false",
+        },
+    ),
+    "fixture-latest": CatalogProfile(
+        name="fixture-latest",
+        connection_key="fixture",
+        unittest_config=TEST_CONFIG_DIR / "fixture-latest.json",
         pyiceberg_uri=os.getenv("ICEBERG_ENDPOINT", "http://127.0.0.1:8181"),
         pyiceberg_warehouse=os.getenv("WAREHOUSE", ""),
         pyiceberg_oauth_token_url=f"{os.getenv('ICEBERG_ENDPOINT', 'http://127.0.0.1:8181')}/v1/oauth/tokens",

--- a/scripts/data_generators/integration_config.py
+++ b/scripts/data_generators/integration_config.py
@@ -122,8 +122,14 @@ SPARK_RUNTIMES = {
         iceberg_library_version="1.10.0",
         supports_v3=True,
     ),
+    "4.1": SparkRuntime(
+        name="4.1",
+        spark_version=Version("4.1"),
+        scala_binary_version="2.13",
+        iceberg_library_version="1.11.0",
+        supports_v3=True,
+    ),
 }
-
 
 REST_CATALOG_PROFILES = {
     "fixture": CatalogProfile(

--- a/scripts/data_generators/tests/default/spark_written_upper_lower_bounds/__init__.py
+++ b/scripts/data_generators/tests/default/spark_written_upper_lower_bounds/__init__.py
@@ -12,6 +12,7 @@ POLARIS_SKIP_REASON = (
 class Test(IcebergTest):
     catalog_mapping = {
         "fixture": "fixture-single-thread",
+        "fixture-latest": "fixture-single-thread",
         "gravitino": "fixture-single-thread",
         "nessie": "fixture-single-thread"
     }

--- a/scripts/data_generators/tests/default/spark_written_upper_lower_bounds_all_null/__init__.py
+++ b/scripts/data_generators/tests/default/spark_written_upper_lower_bounds_all_null/__init__.py
@@ -6,6 +6,7 @@ import pathlib
 class Test(IcebergTest):
     catalog_mapping = {
         "fixture": "fixture-single-thread",
+        "fixture-latest": "fixture-single-thread",
         "gravitino": "fixture-single-thread",
         "nessie": "fixture-single-thread"
     }

--- a/scripts/data_generators/tests/default/spark_written_upper_lower_bounds_single_value/__init__.py
+++ b/scripts/data_generators/tests/default/spark_written_upper_lower_bounds_single_value/__init__.py
@@ -6,6 +6,7 @@ import pathlib
 class Test(IcebergTest):
     catalog_mapping = {
         "fixture": "fixture-single-thread",
+        "fixture-latest": "fixture-single-thread",
         "gravitino": "fixture-single-thread",
         "nessie": "fixture-single-thread"
     }

--- a/scripts/data_generators/tests/default/spark_written_upper_lower_decimal_bounds/__init__.py
+++ b/scripts/data_generators/tests/default/spark_written_upper_lower_decimal_bounds/__init__.py
@@ -12,6 +12,7 @@ POLARIS_SKIP_REASON = (
 class Test(IcebergTest):
     catalog_mapping = {
         "fixture": "fixture-single-thread",
+        "fixture-latest": "fixture-single-thread",
         "gravitino": "fixture-single-thread",
         "nessie": "fixture-single-thread"
     }

--- a/scripts/data_generators/tests/default/spark_written_upper_lower_hugeint_bounds/__init__.py
+++ b/scripts/data_generators/tests/default/spark_written_upper_lower_hugeint_bounds/__init__.py
@@ -12,6 +12,7 @@ POLARIS_SKIP_REASON = (
 class Test(IcebergTest):
     catalog_mapping = {
         "fixture": "fixture-single-thread",
+        "fixture-latest": "fixture-single-thread",
         "gravitino": "fixture-single-thread",
         "nessie": "fixture-single-thread"
     }

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   rest:
-    image: apache/iceberg-rest-fixture:1.10.1
+    image: ${ICEBERG_REST_FIXTURE_IMAGE:-apache/iceberg-rest-fixture:1.10.1}
     container_name: iceberg-rest
     networks:
       iceberg_net:
@@ -26,7 +26,7 @@ services:
           - warehouse.minio
     volumes:
       - type: bind
-        source: ../data/generated/iceberg/fixture/
+        source: ../data/generated/iceberg/${FIXTURE_DATA_DIR:-fixture}/
         target: /data
     ports:
       - 9001:9001

--- a/test/configs/fixture-latest.json
+++ b/test/configs/fixture-latest.json
@@ -1,0 +1,18 @@
+{
+  "description": "Use apache/iceberg-rest-fixture:latest as Iceberg REST Catalog.",
+  "on_init": "CREATE SECRET (TYPE S3,KEY_ID 'admin',SECRET 'password',ENDPOINT '127.0.0.1:9000',URL_STYLE 'path',USE_SSL 0); ATTACH '' AS my_datalake (TYPE ICEBERG,CLIENT_ID 'admin',CLIENT_SECRET 'password',ENDPOINT 'http://127.0.0.1:8181'); Create schema if not exists my_datalake.default;",
+  "statically_loaded_extensions": [
+    "core_functions",
+    "parquet",
+    "avro",
+    "iceberg",
+    "httpfs",
+    "icu"
+  ],
+  "test_env": [
+    {
+      "env_name": "CATALOG_TEST_CONFIG_SETUP",
+      "env_value": "fixture"
+    }
+  ]
+}

--- a/test/python/benchmark/test_metadata_late_materialization.py
+++ b/test/python/benchmark/test_metadata_late_materialization.py
@@ -13,7 +13,10 @@ def test_setup_metadata_late_materialization_benchmark(
     unittest_test_config,
     print_unittest_stdin,
 ):
-    assert catalog_profile.name == "fixture", "The regression benchmarks read from the fixture catalog"
+    assert catalog_profile.name in (
+        "fixture",
+        "fixture-latest",
+    ), "The regression benchmarks read from a fixture catalog"
 
     with DuckDBUnittestRunner(
         unittest_binary,

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_transactional_updates_error_omits_stacktrace.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_transactional_updates_error_omits_stacktrace.test
@@ -72,7 +72,7 @@ commit;
 <REGEX>:.*Failed to commit.*
 
 query II
-select * from my_datalake.default.multi_transaction_update;
+select * from my_datalake.default.multi_transaction_update order by all;
 ----
 0	0
 2	2


### PR DESCRIPTION
The latest version has support for new functionality, such as scan planning

We can disable the github workflow once `1.11.0` gets a published release, and bump the pinned version on the `fixture` catalog.