### PR TITLE
[Dev] Cherry-pick Puffin metadata reading improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(EXTENSION_SOURCES
 	src/core/expression/iceberg_metrics.cpp
 	src/core/expression/iceberg_transform.cpp
 	src/core/expression/iceberg_value.cpp
+	src/core/metadata/puffin/iceberg_puffin_metadata.cpp
 	src/core/metadata/iceberg_table_metadata.cpp
 	src/core/metadata/manifest/iceberg_manifest_list.cpp
 	src/core/metadata/manifest/iceberg_manifest.cpp

--- a/src/core/deletes/iceberg_deletion_vector.cpp
+++ b/src/core/deletes/iceberg_deletion_vector.cpp
@@ -8,6 +8,7 @@
 #include "planning/iceberg_multi_file_list.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
 #include "catalog/rest/api/catalog_utils.hpp"
+#include "core/metadata/puffin/iceberg_puffin_metadata.hpp"
 
 namespace duckdb {
 
@@ -143,55 +144,24 @@ shared_ptr<IcebergDeletionVectorData> IcebergDeletionVectorData::FromBlob(const 
 //! blob's offset/length agree with the manifest content_offset/content_size_in_bytes used below.
 static void VerifyPuffinDeletionVector(FileSystem &fs, FileHandle &handle, int64_t content_offset,
                                        int64_t content_size) {
-	constexpr data_t PUFFIN_MAGIC[4] = {0x50, 0x46, 0x41, 0x31}; //! "PFA1"
-	//! Footer trailer layout: FooterPayloadSize (4) | Flags (4) | Magic (4)
-	constexpr idx_t FOOTER_TRAILER_SIZE = sizeof(int32_t) + sizeof(uint32_t) + sizeof(PUFFIN_MAGIC);
+	auto footer = IcebergPuffinReader::ReadFooter(fs, handle, handle.GetPath());
 
-	auto file_size = handle.GetFileSize();
-	if (file_size < 2 * sizeof(PUFFIN_MAGIC) + FOOTER_TRAILER_SIZE) {
-		throw InvalidConfigurationException("Deletion vector file is too small to be a valid Puffin file");
+	bool contains_blob = false;
+	for (auto &blob : footer.file_metadata.blobs) {
+		if (blob.type != "deletion-vector-v1") {
+			throw InvalidConfigurationException(
+			    "Deletion vector Puffin blob type mismatch: expected deletion-vector-v1");
+		}
+		if (blob.offset != content_offset || blob.length != content_size) {
+			continue;
+		}
+		contains_blob = true;
 	}
-
-	//! Read the footer trailer: validate the trailing magic and that the footer payload is uncompressed.
-	auto trailer_buffer = Allocator::DefaultAllocator().Allocate(file_size);
-	auto trailer = trailer_buffer.get();
-	fs.Read(handle, trailer, FOOTER_TRAILER_SIZE, file_size - FOOTER_TRAILER_SIZE);
-	if (memcmp(trailer + sizeof(int32_t) + sizeof(uint32_t), PUFFIN_MAGIC, sizeof(PUFFIN_MAGIC)) != 0) {
-		throw InvalidConfigurationException("Deletion vector file is not a valid Puffin file (bad trailing magic)");
-	}
-	//! Flags: bit 0 of the first byte set => FooterPayload is compressed (per the Puffin spec).
-	auto flags = Load<uint32_t>(trailer + sizeof(int32_t));
-	if (flags & 0x1) {
+	if (!contains_blob) {
 		throw InvalidConfigurationException(
-		    "Deletion vector Puffin footer payload is compressed; only uncompressed footers are supported");
+		    "Deletion vector blob with offset (%d) and length (%d) not found in Puffin file", content_offset,
+		    content_size);
 	}
-
-#ifdef DEBUG
-	//! Parse the full container and assert it round-trips with the manifest content_offset/size.
-	auto payload_size = Load<int32_t>(trailer);
-	D_ASSERT(payload_size > 0);
-	auto debug_buffer = Allocator::DefaultAllocator().Allocate(file_size);
-	auto data = debug_buffer.get();
-	fs.Read(handle, data, file_size, 0);
-	D_ASSERT(memcmp(data, PUFFIN_MAGIC, sizeof(PUFFIN_MAGIC)) == 0); //! leading magic
-	idx_t payload_start = file_size - FOOTER_TRAILER_SIZE - static_cast<idx_t>(payload_size);
-	D_ASSERT(payload_start >= sizeof(PUFFIN_MAGIC));
-	//! footer leading magic precedes the payload
-	D_ASSERT(memcmp(data + payload_start - sizeof(PUFFIN_MAGIC), PUFFIN_MAGIC, sizeof(PUFFIN_MAGIC)) == 0);
-	auto doc = std::unique_ptr<yyjson_doc, YyjsonDocDeleter>(
-	    yyjson_read(reinterpret_cast<const char *>(data + payload_start), static_cast<size_t>(payload_size), 0));
-	D_ASSERT(doc);
-	auto blobs = yyjson_obj_get(yyjson_doc_get_root(doc.get()), "blobs");
-	D_ASSERT(blobs && yyjson_is_arr(blobs));
-	auto blob = yyjson_arr_get_first(blobs);
-	D_ASSERT(blob);
-	D_ASSERT(yyjson_equals_str(yyjson_obj_get(blob, "type"), "deletion-vector-v1"));
-	D_ASSERT(yyjson_get_sint(yyjson_obj_get(blob, "offset")) == content_offset);
-	D_ASSERT(yyjson_get_sint(yyjson_obj_get(blob, "length")) == content_size);
-#else
-	(void)content_offset;
-	(void)content_size;
-#endif
 }
 
 void IcebergMultiFileList::ScanPuffinFile(const BoundIcebergManifestEntry &bound_entry) const {

--- a/src/core/metadata/puffin/iceberg_puffin_metadata.cpp
+++ b/src/core/metadata/puffin/iceberg_puffin_metadata.cpp
@@ -1,0 +1,210 @@
+#include "core/metadata/puffin/iceberg_puffin_metadata.hpp"
+
+#include "catalog/rest/api/catalog_utils.hpp"
+#include "duckdb/common/allocator.hpp"
+#include "duckdb/common/string_util.hpp"
+
+#include "yyjson.hpp"
+
+using namespace duckdb_yyjson;
+
+namespace duckdb {
+
+namespace {
+
+constexpr data_t PUFFIN_MAGIC[4] = {0x50, 0x46, 0x41, 0x31};
+constexpr idx_t FOOTER_TRAILER_SIZE = sizeof(int32_t) + sizeof(uint32_t) + sizeof(PUFFIN_MAGIC);
+constexpr idx_t FOOTER_FIXED_SIZE = sizeof(PUFFIN_MAGIC) + FOOTER_TRAILER_SIZE;
+
+string ParseProperties(optional<case_insensitive_map_t<string>> &target, yyjson_val *properties_val) {
+	if (!yyjson_is_obj(properties_val)) {
+		return "properties is not an object";
+	}
+	case_insensitive_map_t<string> properties;
+	size_t idx, max;
+	yyjson_val *key, *val;
+	yyjson_obj_foreach(properties_val, idx, max, key, val) {
+		if (!yyjson_is_str(val)) {
+			return StringUtil::Format("property value is not a string, found '%s' instead", yyjson_get_type_desc(val));
+		}
+		properties.emplace(yyjson_get_str(key), yyjson_get_str(val));
+	}
+	target = std::move(properties);
+	return "";
+}
+
+string ParseBlobMetadata(IcebergPuffinBlobMetadata &result, yyjson_val *obj) {
+	auto type_val = yyjson_obj_get(obj, "type");
+	if (!type_val || !yyjson_is_str(type_val)) {
+		return "Puffin blob metadata property 'type' is missing or not a string";
+	}
+	result.type = yyjson_get_str(type_val);
+
+	auto fields_val = yyjson_obj_get(obj, "fields");
+	if (!fields_val || !yyjson_is_arr(fields_val)) {
+		return "Puffin blob metadata property 'fields' is missing or not an array";
+	}
+	size_t idx, max;
+	yyjson_val *val;
+	yyjson_arr_foreach(fields_val, idx, max, val) {
+		if (!yyjson_is_int(val)) {
+			return StringUtil::Format("Puffin blob metadata field-id is not an integer, found '%s' instead",
+			                          yyjson_get_type_desc(val));
+		}
+		result.fields.emplace_back(yyjson_get_int(val));
+	}
+
+	auto parse_required_int = [&](const char *key, int64_t &target) -> string {
+		auto *int_val = yyjson_obj_get(obj, key);
+		if (!int_val) {
+			return StringUtil::Format("Puffin blob metadata property '%s' is missing", key);
+		}
+		if (yyjson_is_sint(int_val)) {
+			target = yyjson_get_sint(int_val);
+		} else if (yyjson_is_uint(int_val)) {
+			target = yyjson_get_uint(int_val);
+		} else {
+			return StringUtil::Format("Puffin blob metadata property '%s' is not an integer, found '%s' instead", key,
+			                          yyjson_get_type_desc(int_val));
+		}
+		return "";
+	};
+
+	auto error = parse_required_int("snapshot-id", result.snapshot_id);
+	if (!error.empty()) {
+		return error;
+	}
+	error = parse_required_int("sequence-number", result.sequence_number);
+	if (!error.empty()) {
+		return error;
+	}
+	error = parse_required_int("offset", result.offset);
+	if (!error.empty()) {
+		return error;
+	}
+	error = parse_required_int("length", result.length);
+	if (!error.empty()) {
+		return error;
+	}
+
+	auto compression_val = yyjson_obj_get(obj, "compression-codec");
+	if (compression_val) {
+		if (!yyjson_is_str(compression_val)) {
+			return StringUtil::Format(
+			    "Puffin blob metadata property 'compression-codec' is not a string, found '%s' instead",
+			    yyjson_get_type_desc(compression_val));
+		}
+		result.compression_codec = string(yyjson_get_str(compression_val));
+	}
+
+	auto properties_val = yyjson_obj_get(obj, "properties");
+	if (properties_val) {
+		error = ParseProperties(result.properties, properties_val);
+		if (!error.empty()) {
+			return "Puffin blob metadata " + error;
+		}
+	}
+	return "";
+}
+
+IcebergPuffinFileMetadata ParseFileMetadata(yyjson_val *root) {
+	IcebergPuffinFileMetadata result;
+	auto blobs_val = yyjson_obj_get(root, "blobs");
+	if (!blobs_val || !yyjson_is_arr(blobs_val)) {
+		throw InvalidInputException("Puffin file metadata property 'blobs' is missing or not an array");
+	}
+	size_t idx, max;
+	yyjson_val *val;
+	yyjson_arr_foreach(blobs_val, idx, max, val) {
+		IcebergPuffinBlobMetadata blob;
+		auto error = ParseBlobMetadata(blob, val);
+		if (!error.empty()) {
+			throw InvalidInputException(error);
+		}
+		result.blobs.emplace_back(std::move(blob));
+	}
+	auto properties_val = yyjson_obj_get(root, "properties");
+	if (properties_val) {
+		auto error = ParseProperties(result.properties, properties_val);
+		if (!error.empty()) {
+			throw InvalidInputException("Puffin file metadata " + error);
+		}
+	}
+	return result;
+}
+
+} // namespace
+
+IcebergPuffinFileFooter IcebergPuffinReader::ReadFooter(FileSystem &fs, FileHandle &handle, const string &path,
+                                                        optional<int64_t> expected_file_size,
+                                                        optional<int64_t> expected_footer_size) {
+	IcebergPuffinFileFooter result;
+
+	auto file_size = handle.GetFileSize();
+	if (expected_file_size && file_size != *expected_file_size) {
+		throw InvalidConfigurationException("Puffin file '%s' size mismatch: expected %lld bytes, found %lld bytes",
+		                                    path, *expected_file_size, file_size);
+	}
+	if (file_size < static_cast<int64_t>(sizeof(PUFFIN_MAGIC) + FOOTER_FIXED_SIZE)) {
+		throw InvalidConfigurationException("Puffin file '%s' is too small to be valid", path);
+	}
+
+	auto trailer_buffer = Allocator::DefaultAllocator().Allocate(FOOTER_TRAILER_SIZE);
+	auto trailer = trailer_buffer.get();
+	fs.Read(handle, trailer, FOOTER_TRAILER_SIZE, file_size - FOOTER_TRAILER_SIZE);
+	if (memcmp(trailer + sizeof(int32_t) + sizeof(uint32_t), PUFFIN_MAGIC, sizeof(PUFFIN_MAGIC)) != 0) {
+		throw InvalidConfigurationException("Puffin file '%s' has invalid trailing magic", path);
+	}
+
+	auto flags = Load<uint32_t>(trailer + sizeof(int32_t));
+	if (flags & 0x1) {
+		throw NotImplementedException("Puffin file '%s' uses a compressed footer payload, which is not supported",
+		                              path);
+	}
+
+	auto footer_payload_size = Load<int32_t>(trailer);
+	if (footer_payload_size < 0) {
+		throw InvalidConfigurationException("Puffin file '%s' has a negative footer payload size", path);
+	}
+	result.footer_payload_size = static_cast<idx_t>(footer_payload_size);
+	result.footer_size = result.footer_payload_size + FOOTER_FIXED_SIZE;
+
+	if (expected_footer_size && result.footer_size != static_cast<idx_t>(*expected_footer_size)) {
+		throw InvalidConfigurationException(
+		    "Puffin file '%s' footer size mismatch: expected %lld bytes, found %llu bytes", path, *expected_footer_size,
+		    result.footer_size);
+	}
+	if (result.footer_size > static_cast<idx_t>(file_size)) {
+		throw InvalidConfigurationException("Puffin file '%s' footer extends past the end of the file", path);
+	}
+
+	auto footer_payload_start = file_size - FOOTER_TRAILER_SIZE - result.footer_payload_size;
+	if (footer_payload_start < static_cast<int64_t>(sizeof(PUFFIN_MAGIC))) {
+		throw InvalidConfigurationException("Puffin file '%s' has an invalid footer payload offset", path);
+	}
+
+	auto footer_buffer = Allocator::DefaultAllocator().Allocate(sizeof(PUFFIN_MAGIC) + result.footer_payload_size);
+	auto footer = footer_buffer.get();
+	fs.Read(handle, footer, sizeof(PUFFIN_MAGIC) + result.footer_payload_size,
+	        footer_payload_start - static_cast<int64_t>(sizeof(PUFFIN_MAGIC)));
+	if (memcmp(footer, PUFFIN_MAGIC, sizeof(PUFFIN_MAGIC)) != 0) {
+		throw InvalidConfigurationException("Puffin file '%s' has invalid footer leading magic", path);
+	}
+
+	auto doc = std::unique_ptr<yyjson_doc, YyjsonDocDeleter>(
+	    yyjson_read(reinterpret_cast<const char *>(footer + sizeof(PUFFIN_MAGIC)), result.footer_payload_size, 0));
+	if (!doc) {
+		throw InvalidInputException("Failed to parse Puffin footer JSON from '%s'", path);
+	}
+	result.file_metadata = ParseFileMetadata(yyjson_doc_get_root(doc.get()));
+	return result;
+}
+
+IcebergPuffinFileFooter IcebergPuffinReader::ReadFooter(FileSystem &fs, const string &path,
+                                                        optional<int64_t> expected_file_size,
+                                                        optional<int64_t> expected_footer_size) {
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
+	return ReadFooter(fs, *handle, path, std::move(expected_file_size), std::move(expected_footer_size));
+}
+
+} // namespace duckdb

--- a/src/include/core/metadata/puffin/iceberg_puffin_metadata.hpp
+++ b/src/include/core/metadata/puffin/iceberg_puffin_metadata.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/optional.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
+
+namespace duckdb {
+
+struct IcebergPuffinBlobMetadata {
+public:
+	string type;
+	vector<int32_t> fields;
+	int64_t snapshot_id = 0;
+	int64_t sequence_number = 0;
+	int64_t offset = 0;
+	int64_t length = 0;
+	optional<string> compression_codec;
+	optional<case_insensitive_map_t<string>> properties;
+};
+
+struct IcebergPuffinFileMetadata {
+public:
+	vector<IcebergPuffinBlobMetadata> blobs;
+	optional<case_insensitive_map_t<string>> properties;
+};
+
+struct IcebergPuffinFileFooter {
+public:
+	IcebergPuffinFileMetadata file_metadata;
+	idx_t footer_payload_size = 0;
+	idx_t footer_size = 0;
+};
+
+class IcebergPuffinReader {
+public:
+	static IcebergPuffinFileFooter ReadFooter(FileSystem &fs, FileHandle &handle, const string &path,
+	                                          optional<int64_t> expected_file_size = optional<int64_t>(),
+	                                          optional<int64_t> expected_footer_size = optional<int64_t>());
+	static IcebergPuffinFileFooter ReadFooter(FileSystem &fs, const string &path,
+	                                          optional<int64_t> expected_file_size = optional<int64_t>(),
+	                                          optional<int64_t> expected_footer_size = optional<int64_t>());
+};
+
+} // namespace duckdb


### PR DESCRIPTION
Taken from https://github.com/duckdb/duckdb-iceberg/pull/1183

Adds dedicated classes for `IcebergPuffin` metadata.
Fixes an issue in `IcebergDeletionVector` debug verification which was expecting the file to have only 1 blob and it being the one that we're reading for that deletion vector.