### PR TITLE
[Dev] Add wrapper to protect both the `HTTPClient` and the container from concurrent access

### DIFF
--- a/src/catalog/rest/api/api_utils.cpp
+++ b/src/catalog/rest/api/api_utils.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/http_util.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/common/exception/http_exception.hpp"
+#include "duckdb/common/optional.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/main/database.hpp"
@@ -48,8 +49,11 @@ unique_ptr<HTTPResponse> APIUtils::Request(RequestType request_type, optional_pt
 	params = http_util.InitializeParameters(context, request_url);
 
 	unique_ptr<HTTPClient> placeholder_client;
-	auto &client =
-	    attached_db ? IcebergAuthorizationContextState::GetHTTPClient(*attached_db, context) : placeholder_client;
+	optional<IcebergHTTPClientLock> locked_client;
+	if (attached_db) {
+		locked_client.emplace(IcebergAuthorizationContextState::GetHTTPClient(*attached_db, context));
+	}
+	auto &client = locked_client ? locked_client->GetClient() : placeholder_client;
 	if (client) {
 		client->Initialize(*params);
 	}

--- a/src/catalog/rest/storage/aws.cpp
+++ b/src/catalog/rest/storage/aws.cpp
@@ -342,7 +342,8 @@ unique_ptr<HTTPResponse> AWSInput::ExecuteRequest(ClientContext &context, Aws::H
 
 	params = http_util.InitializeParameters(context, request_url);
 
-	auto &client = IcebergAuthorizationContextState::GetHTTPClient(attached_db, context);
+	auto locked_client = IcebergAuthorizationContextState::GetHTTPClient(attached_db, context);
+	auto &client = locked_client.GetClient();
 	if (client) {
 		client->Initialize(*params);
 	}

--- a/src/catalog/rest/storage/iceberg_authorization.cpp
+++ b/src/catalog/rest/storage/iceberg_authorization.cpp
@@ -8,10 +8,9 @@
 
 namespace duckdb {
 
-unique_ptr<HTTPClient> &IcebergAuthorizationContextState::GetHTTPClient(AttachedDatabase &db, ClientContext &context) {
+IcebergHTTPClientLock IcebergAuthorizationContextState::GetHTTPClient(AttachedDatabase &db, ClientContext &context) {
 	auto instance = context.registered_state->GetOrCreate<IcebergAuthorizationContextState>("iceberg_authorization");
-	auto res = instance->client_map.emplace(reinterpret_cast<uintptr_t>(&db), nullptr);
-	return res.first->second;
+	return IcebergHTTPClientLock(instance->client_lock, instance->client_map, reinterpret_cast<uintptr_t>(&db));
 }
 
 IcebergAuthorizationType IcebergAuthorization::TypeFromString(const string &type) {

--- a/src/include/catalog/rest/storage/iceberg_authorization.hpp
+++ b/src/include/catalog/rest/storage/iceberg_authorization.hpp
@@ -10,6 +10,22 @@
 
 namespace duckdb {
 
+class IcebergHTTPClientLock {
+public:
+	IcebergHTTPClientLock(mutex &client_lock, unordered_map<uintptr_t, unique_ptr<HTTPClient>> &client_map,
+	                      uintptr_t database_id)
+	    : guard(client_lock), client(client_map.emplace(database_id, nullptr).first->second) {
+	}
+
+	unique_ptr<HTTPClient> &GetClient() {
+		return client;
+	}
+
+private:
+	unique_lock<mutex> guard;
+	unique_ptr<HTTPClient> &client;
+};
+
 //! Hold the pre-initialized HTTPClient for a given connection
 struct IcebergAuthorizationContextState : public ClientContextState {
 public:
@@ -17,10 +33,11 @@ public:
 	}
 
 public:
-	static unique_ptr<HTTPClient> &GetHTTPClient(AttachedDatabase &db, ClientContext &context);
+	static IcebergHTTPClientLock GetHTTPClient(AttachedDatabase &db, ClientContext &context);
 
 public:
 	//! For this connection, a map of attached database -> http-client
+	mutex client_lock;
 	unordered_map<uintptr_t, unique_ptr<HTTPClient>> client_map;
 };
 


### PR DESCRIPTION
This fixes an issue exposed by #1204 , which is that multiple threads could be creating requests concurrently for the same connection+db combo.