### PR TITLE
Backport #1139: Honor write.metadata.metrics.* for string bound truncation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ set(EXTENSION_SOURCES
 	src/core/deletes/iceberg_equality_delete.cpp
 	src/core/deletes/iceberg_positional_delete.cpp
 	src/core/expression/iceberg_hash.cpp
+	src/core/expression/iceberg_metrics.cpp
 	src/core/expression/iceberg_transform.cpp
 	src/core/expression/iceberg_value.cpp
 	src/core/metadata/iceberg_table_metadata.cpp

--- a/src/core/expression/iceberg_metrics.cpp
+++ b/src/core/expression/iceberg_metrics.cpp
@@ -9,20 +9,20 @@ namespace duckdb {
 IcebergMetricsConfig ParseMetricsMode(const string &raw) {
 	auto value = StringUtil::Lower(raw);
 	if (value == "none") {
-		return {IcebergMetricsMode::NONE, 0};
+		return IcebergMetricsConfig(IcebergMetricsMode::NONE, 0);
 	}
 	if (value == "counts") {
-		return {IcebergMetricsMode::COUNTS, 0};
+		return IcebergMetricsConfig(IcebergMetricsMode::COUNTS, 0);
 	}
 	if (value == "full") {
-		return {IcebergMetricsMode::FULL, DConstants::INVALID_INDEX};
+		return IcebergMetricsConfig(IcebergMetricsMode::FULL, DConstants::INVALID_INDEX);
 	}
 	if (StringUtil::StartsWith(value, "truncate(") && StringUtil::EndsWith(value, ")")) {
 		auto inner = value.substr(9, value.size() - 10);
 		try {
 			auto length = std::stoull(inner);
 			if (length > 0) {
-				return {IcebergMetricsMode::TRUNCATE, static_cast<idx_t>(length)};
+				return IcebergMetricsConfig(IcebergMetricsMode::TRUNCATE, static_cast<idx_t>(length));
 			}
 		} catch (...) {
 			// fall through to the error below

--- a/src/core/expression/iceberg_metrics.cpp
+++ b/src/core/expression/iceberg_metrics.cpp
@@ -1,0 +1,55 @@
+#include "core/expression/iceberg_metrics.hpp"
+
+#include "core/metadata/iceberg_table_metadata.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+
+namespace duckdb {
+
+IcebergMetricsConfig ParseMetricsMode(const string &raw) {
+	auto value = StringUtil::Lower(raw);
+	if (value == "none") {
+		return {IcebergMetricsMode::NONE, 0};
+	}
+	if (value == "counts") {
+		return {IcebergMetricsMode::COUNTS, 0};
+	}
+	if (value == "full") {
+		return {IcebergMetricsMode::FULL, DConstants::INVALID_INDEX};
+	}
+	if (StringUtil::StartsWith(value, "truncate(") && StringUtil::EndsWith(value, ")")) {
+		auto inner = value.substr(9, value.size() - 10);
+		try {
+			auto length = std::stoull(inner);
+			if (length > 0) {
+				return {IcebergMetricsMode::TRUNCATE, static_cast<idx_t>(length)};
+			}
+		} catch (...) {
+			// fall through to the error below
+		}
+		throw InvalidConfigurationException("Invalid metrics mode '%s': truncate length must be a positive integer",
+		                                    raw);
+	}
+	throw InvalidConfigurationException(
+	    "Invalid write.metadata.metrics mode '%s': expected 'none', 'counts', 'truncate(<n>)', or 'full'", raw);
+}
+
+IcebergMetricsConfig GetDefaultMetricsConfig(const IcebergTableMetadata &table_metadata) {
+	auto prop = table_metadata.GetTableProperty("write.metadata.metrics.default");
+	if (prop.empty()) {
+		// Iceberg's default when unset is truncate(16).
+		return IcebergMetricsConfig();
+	}
+	return ParseMetricsMode(prop);
+}
+
+IcebergMetricsConfig GetColumnMetricsConfig(const IcebergTableMetadata &table_metadata,
+                                            const IcebergMetricsConfig &default_config, const string &column_name) {
+	auto prop = table_metadata.GetTableProperty("write.metadata.metrics.column." + column_name);
+	if (prop.empty()) {
+		return default_config;
+	}
+	return ParseMetricsMode(prop);
+}
+
+} // namespace duckdb

--- a/src/core/expression/iceberg_value.cpp
+++ b/src/core/expression/iceberg_value.cpp
@@ -246,27 +246,35 @@ DeserializeResult IcebergValue::DeserializeValue(const string_t &blob, const Log
 
 const idx_t IcebergValue::MAX_STRING_UPPERBOUND_LENGTH;
 
-string IcebergValue::TruncateString(const string &input) {
-	std::vector<unsigned char> bytes(input.begin(), input.end());
-	idx_t truncated_length = std::min<idx_t>(IcebergValue::MAX_STRING_UPPERBOUND_LENGTH, bytes.size());
-	bytes.resize(truncated_length);
-	return std::string(bytes.begin(), bytes.end());
+// Largest length <= max_length that doesn't split a multi-byte UTF-8 character
+// (INVALID_INDEX = no truncation), so a truncated bound stays valid UTF-8.
+static idx_t TruncateToCodePointBoundary(const string &input, idx_t max_length) {
+	if (max_length >= input.size()) {
+		return input.size();
+	}
+	idx_t len = max_length;
+	while (len < input.size() && (static_cast<unsigned char>(input[len]) & 0xC0) == 0x80) {
+		len--;
+	}
+	return len;
 }
 
-bool IcebergValue::TruncateAndIncrementString(const string &input, string &result) {
+string IcebergValue::TruncateString(const string &input, idx_t max_length) {
+	// A prefix truncated on a code-point boundary is a valid lower bound (<= input).
+	return input.substr(0, TruncateToCodePointBoundary(input, max_length));
+}
+
+bool IcebergValue::TruncateAndIncrementString(const string &input, string &result, idx_t max_length) {
 	// If the whole value fits within the bound length it is itself a valid
 	// (exact) upper bound; nothing to truncate or increment.
-	if (input.size() <= IcebergValue::MAX_STRING_UPPERBOUND_LENGTH) {
+	if (input.size() <= max_length) {
 		result = input;
 		return true;
 	}
 
-	// Truncate to at most MAX_STRING_UPPERBOUND_LENGTH bytes, backing off so we
-	// never split a multi-byte UTF-8 character.
-	idx_t len = IcebergValue::MAX_STRING_UPPERBOUND_LENGTH;
-	while (len > 0 && (static_cast<unsigned char>(input[len]) & 0xC0) == 0x80) {
-		len--;
-	}
+	// Truncate to a code-point boundary, then round up to a valid upper bound by
+	// incrementing the last code point below.
+	idx_t len = TruncateToCodePointBoundary(input, max_length);
 
 	// Round the truncated prefix up to a valid upper bound by incrementing the
 	// last code point to the next scalar value (skipping the UTF-16 surrogate
@@ -313,7 +321,7 @@ std::vector<uint8_t> HexStringToBytes(const std::string &hex) {
 }
 
 SerializeResult IcebergValue::SerializeValue(Value input_value, const LogicalType &column_type,
-                                             SerializeBound bound_type) {
+                                             SerializeBound bound_type, const IcebergMetricsConfig &metrics_config) {
 	switch (column_type.id()) {
 	case LogicalTypeId::INTEGER: {
 		int32_t val = input_value.GetValue<int32_t>();
@@ -332,20 +340,20 @@ SerializeResult IcebergValue::SerializeValue(Value input_value, const LogicalTyp
 		return ret;
 	}
 	case LogicalTypeId::VARCHAR: {
+		auto input = input_value.GetValue<string>();
 		string val;
 		if (bound_type == SerializeBound::UPPER_BOUND) {
-			// if we are serializing upper bound, we must truncate and increment
-			if (!IcebergValue::TruncateAndIncrementString(input_value.GetValue<string>(), val)) {
+			// an upper bound must be truncated and rounded up to stay >= every value
+			if (!TruncateAndIncrementString(input, val, metrics_config.truncate_length)) {
 				// No representable upper bound could be produced; omit it (optional per spec).
 				return SerializeResult();
 			}
 		} else {
-			// for lower bound truncating is enough
-			val = IcebergValue::TruncateString(input_value.GetValue<string>());
+			// a truncated prefix is already a valid lower bound (<= every value)
+			val = TruncateString(input, metrics_config.truncate_length);
 		}
 		auto serialized_val = Value::BLOB(reinterpret_cast<const_data_ptr_t>(val.data()), val.size());
-		auto ret = SerializeResult(column_type, serialized_val);
-		return ret;
+		return SerializeResult(column_type, serialized_val);
 	}
 	case LogicalTypeId::FLOAT: {
 		float val = input_value.GetValue<float>();

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
+#include "duckdb/common/string_util.hpp"
 
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
@@ -28,6 +29,7 @@
 #include "planning/iceberg_multi_file_list.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
 #include "core/expression/iceberg_value.hpp"
+#include "core/expression/iceberg_metrics.hpp"
 #include "core/expression/iceberg_transform.hpp"
 #include "storage/statistics/iceberg_variant_statistics.hpp"
 #include "catalog/rest/api/iceberg_type.hpp"
@@ -261,6 +263,9 @@ void IcebergInsertGlobalState::AddFiles(DataChunk &chunk, const string &table_na
 		// (keyed by field id) and serialize the lower/upper bound variants once all entries are seen
 		unordered_map<int32_t, IcebergVariantBounds> variant_bounds;
 
+		// Resolve the table-level metrics mode once; per-column overrides are resolved in the loop.
+		auto default_metrics = GetDefaultMetricsConfig(table_metadata);
+
 		for (idx_t col_idx = 0; col_idx < map_children.size(); col_idx++) {
 			auto &struct_children = StructValue::GetChildren(map_children[col_idx]);
 			auto &col_name = StringValue::Get(struct_children[0]);
@@ -292,20 +297,30 @@ void IcebergInsertGlobalState::AddFiles(DataChunk &chunk, const string &table_na
 				auto normalized_col_name = StringUtil::Join(column_names, ".");
 				throw ConstraintException("NOT NULL constraint failed: %s.%s", table_name, normalized_col_name);
 			}
+			// Resolve the metrics mode for this column: per-column override -> table default ->
+			// Iceberg's truncate(16) default.
+			auto metrics = GetColumnMetricsConfig(table_metadata, default_metrics, StringUtil::Join(column_names, "."));
+			if (metrics.mode == IcebergMetricsMode::NONE) {
+				// No metrics recorded for this column.
+				continue;
+			}
+			const bool write_bounds =
+			    metrics.mode == IcebergMetricsMode::TRUNCATE || metrics.mode == IcebergMetricsMode::FULL;
+
 			// go through stats and add upper and lower bounds
 			// Do serialization of values here in case we read transaction updates
-			if (stats.has_min) {
+			if (write_bounds && stats.has_min) {
 				auto serialized_value =
-				    IcebergValue::SerializeValue(stats.min, column_info.type, SerializeBound::LOWER_BOUND);
+				    IcebergValue::SerializeValue(stats.min, column_info.type, SerializeBound::LOWER_BOUND, metrics);
 				if (serialized_value.HasError()) {
 					throw InvalidConfigurationException(serialized_value.GetError());
 				} else if (serialized_value.HasValue()) {
 					data_file.lower_bounds[column_info.id] = serialized_value.GetValue();
 				}
 			}
-			if (stats.has_max) {
+			if (write_bounds && stats.has_max) {
 				auto serialized_value =
-				    IcebergValue::SerializeValue(stats.max, column_info.type, SerializeBound::UPPER_BOUND);
+				    IcebergValue::SerializeValue(stats.max, column_info.type, SerializeBound::UPPER_BOUND, metrics);
 				if (serialized_value.HasError()) {
 					throw InvalidConfigurationException(serialized_value.GetError());
 				} else if (serialized_value.HasValue()) {
@@ -313,7 +328,7 @@ void IcebergInsertGlobalState::AddFiles(DataChunk &chunk, const string &table_na
 				}
 			}
 			// See Iceberg v3 (Appendix D) for geometry stats info
-			if (column_info.type.id() == LogicalTypeId::GEOMETRY && stats.has_bbox_xy) {
+			if (write_bounds && column_info.type.id() == LogicalTypeId::GEOMETRY && stats.has_bbox_xy) {
 				vector<double> lower {stats.bbox_xmin, stats.bbox_ymin};
 				vector<double> upper {stats.bbox_xmax, stats.bbox_ymax};
 				if (stats.has_bbox_z) {
@@ -355,6 +370,13 @@ void IcebergInsertGlobalState::AddFiles(DataChunk &chunk, const string &table_na
 
 		// serialize the accumulated variant bounds into the data file's lower/upper bounds
 		for (auto &entry : variant_bounds) {
+			// Respect the column's metrics mode; skip bounds under none/counts.
+			auto variant_metrics = GetColumnMetricsConfig(table_metadata, default_metrics,
+			                                              GetColumnNameBySourceId(ic_schema->columns, entry.first));
+			if (variant_metrics.mode != IcebergMetricsMode::TRUNCATE &&
+			    variant_metrics.mode != IcebergMetricsMode::FULL) {
+				continue;
+			}
 			bool has_lower = false;
 			bool has_upper = false;
 			string lower_blob;

--- a/src/include/core/expression/iceberg_metrics.hpp
+++ b/src/include/core/expression/iceberg_metrics.hpp
@@ -20,8 +20,7 @@ struct IcebergMetricsConfig {
 	idx_t truncate_length = DEFAULT_METRICS_TRUNCATE_LENGTH;
 
 	IcebergMetricsConfig() = default;
-	// Explicit ctor needed under C++14: brace-init of a type with default member
-	// initializers is rejected by some compilers used on v1.5-variegata.
+	// C++14: brace-init of a type with default member initializers fails on CI compilers.
 	IcebergMetricsConfig(IcebergMetricsMode mode_p, idx_t truncate_length_p)
 	    : mode(mode_p), truncate_length(truncate_length_p) {
 	}

--- a/src/include/core/expression/iceberg_metrics.hpp
+++ b/src/include/core/expression/iceberg_metrics.hpp
@@ -18,6 +18,13 @@ struct IcebergMetricsConfig {
 	IcebergMetricsMode mode = IcebergMetricsMode::TRUNCATE;
 	// Byte length for TRUNCATE; DConstants::INVALID_INDEX for FULL (no truncation).
 	idx_t truncate_length = DEFAULT_METRICS_TRUNCATE_LENGTH;
+
+	IcebergMetricsConfig() = default;
+	// Explicit ctor needed under C++14: brace-init of a type with default member
+	// initializers is rejected by some compilers used on v1.5-variegata.
+	IcebergMetricsConfig(IcebergMetricsMode mode_p, idx_t truncate_length_p)
+	    : mode(mode_p), truncate_length(truncate_length_p) {
+	}
 };
 
 // Parse a metrics mode value: none, counts, truncate(<n>), or full.

--- a/src/include/core/expression/iceberg_metrics.hpp
+++ b/src/include/core/expression/iceberg_metrics.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/string.hpp"
+
+namespace duckdb {
+
+struct IcebergTableMetadata;
+
+// Default string bound truncation length — Iceberg's truncate(16) default.
+static constexpr idx_t DEFAULT_METRICS_TRUNCATE_LENGTH = 16;
+
+// Per-column metrics collection level, from the write.metadata.metrics.* table
+// properties (https://iceberg.apache.org/docs/latest/configuration/#write-properties).
+enum class IcebergMetricsMode : uint8_t { NONE, COUNTS, TRUNCATE, FULL };
+
+struct IcebergMetricsConfig {
+	IcebergMetricsMode mode = IcebergMetricsMode::TRUNCATE;
+	// Byte length for TRUNCATE; DConstants::INVALID_INDEX for FULL (no truncation).
+	idx_t truncate_length = DEFAULT_METRICS_TRUNCATE_LENGTH;
+};
+
+// Parse a metrics mode value: none, counts, truncate(<n>), or full.
+IcebergMetricsConfig ParseMetricsMode(const string &raw);
+// Table-level default from write.metadata.metrics.default (truncate(16) when unset).
+IcebergMetricsConfig GetDefaultMetricsConfig(const IcebergTableMetadata &table_metadata);
+// Per-column config: write.metadata.metrics.column.<name> override, else default_config.
+IcebergMetricsConfig GetColumnMetricsConfig(const IcebergTableMetadata &table_metadata,
+                                            const IcebergMetricsConfig &default_config, const string &column_name);
+
+} // namespace duckdb

--- a/src/include/core/expression/iceberg_value.hpp
+++ b/src/include/core/expression/iceberg_value.hpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types.hpp"
 
+#include "core/expression/iceberg_metrics.hpp"
 #include "storage/statistics/iceberg_statistics.hpp"
 
 namespace duckdb {
@@ -77,19 +78,21 @@ public:
 
 struct IcebergValue {
 public:
-	static constexpr idx_t MAX_STRING_UPPERBOUND_LENGTH = 16;
+	static constexpr idx_t MAX_STRING_UPPERBOUND_LENGTH = DEFAULT_METRICS_TRUNCATE_LENGTH;
 	IcebergValue() = delete;
 
 public:
 	static DeserializeResult DeserializeValue(const string_t &blob, const LogicalType &target);
 	static SerializeResult SerializeValue(IcebergColumnStats &stats, const LogicalType &column_type,
 	                                      SerializeBound bound_type);
-	static SerializeResult SerializeValue(Value input_value, const LogicalType &column_type, SerializeBound bound_type);
-	static string TruncateString(const string &input);
+	static SerializeResult SerializeValue(Value input_value, const LogicalType &column_type, SerializeBound bound_type,
+	                                      const IcebergMetricsConfig &metrics_config = IcebergMetricsConfig());
+	static string TruncateString(const string &input, idx_t max_length = MAX_STRING_UPPERBOUND_LENGTH);
 	// Computes a truncated, incremented upper bound for a string. Returns false
 	// (and leaves `result` untouched) when no valid bound can be produced, so the
 	// caller can omit the optional upper bound instead of failing.
-	static bool TruncateAndIncrementString(const string &input, string &result);
+	static bool TruncateAndIncrementString(const string &input, string &result,
+	                                       idx_t max_length = MAX_STRING_UPPERBOUND_LENGTH);
 };
 
 } // namespace duckdb

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/iceberg_types/test_write_geometry_bounds.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/iceberg_types/test_write_geometry_bounds.test
@@ -188,3 +188,85 @@ query I
 select count(*) from my_datalake.default.geom_bounds_null where g is null;
 ----
 3
+
+# --- write.metadata.metrics.* gates the geometry bbox bounds -----------------
+
+# full: bbox lower/upper bounds are written (16 bytes for XY)
+statement ok
+drop table if exists my_datalake.default.mm_geom_full;
+
+statement ok
+create table my_datalake.default.mm_geom_full (g GEOMETRY)
+with ('format-version'='3', 'write.metadata.metrics.default'='full');
+
+statement ok
+insert into my_datalake.default.mm_geom_full VALUES ('POINT(1 2)'::GEOMETRY), ('POINT(5 7)'::GEOMETRY);
+
+statement ok
+set variable geom_full_mp = (select manifest_path from iceberg_metadata(my_datalake.default.mm_geom_full) order by manifest_sequence_number desc limit 1);
+
+query II
+select octet_length(map_extract(lower_bounds, 1)[1]), octet_length(map_extract(upper_bounds, 1)[1])
+from (select unnest(data_file) from read_avro(getvariable('geom_full_mp')));
+----
+16	16
+
+# truncate(16): bbox bounds are still written (truncation only affects string/binary)
+statement ok
+drop table if exists my_datalake.default.mm_geom_trunc;
+
+statement ok
+create table my_datalake.default.mm_geom_trunc (g GEOMETRY)
+with ('format-version'='3', 'write.metadata.metrics.default'='truncate(16)');
+
+statement ok
+insert into my_datalake.default.mm_geom_trunc VALUES ('POINT(1 2)'::GEOMETRY), ('POINT(5 7)'::GEOMETRY);
+
+statement ok
+set variable geom_trunc_mp = (select manifest_path from iceberg_metadata(my_datalake.default.mm_geom_trunc) order by manifest_sequence_number desc limit 1);
+
+query II
+select octet_length(map_extract(lower_bounds, 1)[1]), octet_length(map_extract(upper_bounds, 1)[1])
+from (select unnest(data_file) from read_avro(getvariable('geom_trunc_mp')));
+----
+16	16
+
+# counts: no bbox bounds, but null_value_counts still written
+statement ok
+drop table if exists my_datalake.default.mm_geom_counts;
+
+statement ok
+create table my_datalake.default.mm_geom_counts (g GEOMETRY)
+with ('format-version'='3', 'write.metadata.metrics.default'='counts');
+
+statement ok
+insert into my_datalake.default.mm_geom_counts VALUES ('POINT(1 2)'::GEOMETRY), ('POINT(5 7)'::GEOMETRY);
+
+statement ok
+set variable geom_counts_mp = (select manifest_path from iceberg_metadata(my_datalake.default.mm_geom_counts) order by manifest_sequence_number desc limit 1);
+
+query III
+select len(map_extract(lower_bounds, 1)), len(map_extract(upper_bounds, 1)), map_extract(null_value_counts, 1)[1]
+from (select unnest(data_file) from read_avro(getvariable('geom_counts_mp')));
+----
+0	0	0
+
+# none: no bbox bounds and no counts
+statement ok
+drop table if exists my_datalake.default.mm_geom_none;
+
+statement ok
+create table my_datalake.default.mm_geom_none (g GEOMETRY)
+with ('format-version'='3', 'write.metadata.metrics.default'='none');
+
+statement ok
+insert into my_datalake.default.mm_geom_none VALUES ('POINT(1 2)'::GEOMETRY), ('POINT(5 7)'::GEOMETRY);
+
+statement ok
+set variable geom_none_mp = (select manifest_path from iceberg_metadata(my_datalake.default.mm_geom_none) order by manifest_sequence_number desc limit 1);
+
+query III
+select len(map_extract(lower_bounds, 1)), len(map_extract(upper_bounds, 1)), len(map_extract(value_counts, 1))
+from (select unnest(data_file) from read_avro(getvariable('geom_none_mp')));
+----
+0	0	0

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/iceberg_types/test_write_geometry_bounds.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/iceberg_types/test_write_geometry_bounds.test
@@ -251,7 +251,7 @@ from (select unnest(data_file) from read_avro(getvariable('geom_counts_mp')));
 ----
 0	0	0
 
-# none: no bbox bounds and no counts
+# none: no bbox bounds
 statement ok
 drop table if exists my_datalake.default.mm_geom_none;
 
@@ -265,8 +265,8 @@ insert into my_datalake.default.mm_geom_none VALUES ('POINT(1 2)'::GEOMETRY), ('
 statement ok
 set variable geom_none_mp = (select manifest_path from iceberg_metadata(my_datalake.default.mm_geom_none) order by manifest_sequence_number desc limit 1);
 
-query III
-select len(map_extract(lower_bounds, 1)), len(map_extract(upper_bounds, 1)), len(map_extract(value_counts, 1))
+query II
+select len(map_extract(lower_bounds, 1)), len(map_extract(upper_bounds, 1))
 from (select unnest(data_file) from read_avro(getvariable('geom_none_mp')));
 ----
-0	0	0
+0	0

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/iceberg_types/variant/test_write_variant_bounds.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/iceberg_types/variant/test_write_variant_bounds.test
@@ -58,3 +58,80 @@ select lk, octet_length(lv) > 0, octet_length(uv) > 0 from (
 
 statement ok
 drop table if exists my_datalake.default.variant_bounds_tbl;
+
+# --- write.metadata.metrics.* gates the variant bounds -----------------------
+
+# full: the variant column (field id 1) gets lower/upper bounds
+statement ok
+drop table if exists my_datalake.default.mm_variant_full;
+
+statement ok
+create table my_datalake.default.mm_variant_full (v VARIANT)
+with ('format-version'='3', 'write.metadata.metrics.default'='full');
+
+statement ok
+insert into my_datalake.default.mm_variant_full VALUES
+    ({'age': 25, 'city': 'amsterdam'}),
+    ({'age': 30, 'city': 'berlin'}),
+    ({'age': 40, 'city': 'cairo'});
+
+statement ok
+set variable variant_full_mp = (select manifest_path from iceberg_metadata(my_datalake.default.mm_variant_full) order by manifest_sequence_number desc limit 1);
+
+query I
+select count(*) from (
+    select unnest(map_keys(lower_bounds)) lk
+    from (select unnest(data_file) from read_avro(getvariable('variant_full_mp')))
+) where lk = 1;
+----
+1
+
+# truncate(16): variant bounds are still written (truncation only affects string/binary)
+statement ok
+drop table if exists my_datalake.default.mm_variant_trunc;
+
+statement ok
+create table my_datalake.default.mm_variant_trunc (v VARIANT)
+with ('format-version'='3', 'write.metadata.metrics.default'='truncate(16)');
+
+statement ok
+insert into my_datalake.default.mm_variant_trunc VALUES
+    ({'age': 25, 'city': 'amsterdam'}),
+    ({'age': 30, 'city': 'berlin'}),
+    ({'age': 40, 'city': 'cairo'});
+
+statement ok
+set variable variant_trunc_mp = (select manifest_path from iceberg_metadata(my_datalake.default.mm_variant_trunc) order by manifest_sequence_number desc limit 1);
+
+query I
+select count(*) from (
+    select unnest(map_keys(lower_bounds)) lk
+    from (select unnest(data_file) from read_avro(getvariable('variant_trunc_mp')))
+) where lk = 1;
+----
+1
+
+# counts: no variant bounds
+statement ok
+drop table if exists my_datalake.default.mm_variant_counts;
+
+statement ok
+create table my_datalake.default.mm_variant_counts (v VARIANT)
+with ('format-version'='3', 'write.metadata.metrics.default'='counts');
+
+statement ok
+insert into my_datalake.default.mm_variant_counts VALUES
+    ({'age': 25, 'city': 'amsterdam'}),
+    ({'age': 30, 'city': 'berlin'}),
+    ({'age': 40, 'city': 'cairo'});
+
+statement ok
+set variable variant_counts_mp = (select manifest_path from iceberg_metadata(my_datalake.default.mm_variant_counts) order by manifest_sequence_number desc limit 1);
+
+query I
+select count(*) from (
+    select unnest(map_keys(lower_bounds)) lk
+    from (select unnest(data_file) from read_avro(getvariable('variant_counts_mp')))
+) where lk = 1;
+----
+0

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_metrics_mode_configuration.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_metrics_mode_configuration.test
@@ -72,7 +72,7 @@ select octet_length(ub) from (
 ----
 16
 
-# c (field 3): counts mode writes no bound...
+# c (field 3): counts mode writes no bounds.
 query I
 select count(*) from (
     select unnest(map_keys(lower_bounds)) k
@@ -81,27 +81,10 @@ select count(*) from (
 ----
 0
 
-# ...but still writes value_counts.
-query I
-select count(*) from (
-    select unnest(map_keys(value_counts)) k
-    from (select unnest(data_file) from read_avro(getvariable('mp')))
-) where k = 3;
-----
-1
-
-# d (field 4): none mode writes no bound and no counts.
+# d (field 4): none mode writes no bounds.
 query I
 select count(*) from (
     select unnest(map_keys(lower_bounds)) k
-    from (select unnest(data_file) from read_avro(getvariable('mp')))
-) where k = 4;
-----
-0
-
-query I
-select count(*) from (
-    select unnest(map_keys(value_counts)) k
     from (select unnest(data_file) from read_avro(getvariable('mp')))
 ) where k = 4;
 ----

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_metrics_mode_configuration.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_metrics_mode_configuration.test
@@ -1,0 +1,164 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_metrics_mode_configuration.test
+# description: write.metadata.metrics.default / .column.<name> control the bound truncation length and which metrics are written.
+# group: [insert]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.metrics_mode_test;
+
+# a: inherits the default truncate(8); b: full (no truncation); c: counts only
+# (no bounds); d: none (no metrics); e: per-column truncate(4) override.
+statement ok
+create table my_datalake.default.metrics_mode_test (a varchar, b varchar, c varchar, d varchar, e varchar)
+WITH (
+    'write.metadata.metrics.default'='truncate(8)',
+    'write.metadata.metrics.column.b'='full',
+    'write.metadata.metrics.column.c'='counts',
+    'write.metadata.metrics.column.d'='none',
+    'write.metadata.metrics.column.e'='truncate(4)'
+);
+
+# 16-byte ASCII value in every column.
+statement ok
+insert into my_datalake.default.metrics_mode_test values
+    ('abcdefghijklmnop', 'abcdefghijklmnop', 'abcdefghijklmnop', 'abcdefghijklmnop', 'abcdefghijklmnop');
+
+statement ok
+set variable mp = (select manifest_path from iceberg_metadata(my_datalake.default.metrics_mode_test) order by manifest_sequence_number desc limit 1);
+
+# a (field 1): lower + upper bound truncated to the configured 8 bytes.
+query I
+select octet_length(lb) from (
+    select unnest(map_keys(lower_bounds)) k, unnest(map_values(lower_bounds)) lb
+    from (select unnest(data_file) from read_avro(getvariable('mp')))
+) where k = 1;
+----
+8
+
+query I
+select octet_length(ub) from (
+    select unnest(map_keys(upper_bounds)) k, unnest(map_values(upper_bounds)) ub
+    from (select unnest(data_file) from read_avro(getvariable('mp')))
+) where k = 1;
+----
+8
+
+# b (field 2): full mode keeps the whole 16-byte value for both bounds.
+query I
+select octet_length(lb) from (
+    select unnest(map_keys(lower_bounds)) k, unnest(map_values(lower_bounds)) lb
+    from (select unnest(data_file) from read_avro(getvariable('mp')))
+) where k = 2;
+----
+16
+
+query I
+select octet_length(ub) from (
+    select unnest(map_keys(upper_bounds)) k, unnest(map_values(upper_bounds)) ub
+    from (select unnest(data_file) from read_avro(getvariable('mp')))
+) where k = 2;
+----
+16
+
+# c (field 3): counts mode writes no bound...
+query I
+select count(*) from (
+    select unnest(map_keys(lower_bounds)) k
+    from (select unnest(data_file) from read_avro(getvariable('mp')))
+) where k = 3;
+----
+0
+
+# ...but still writes value_counts.
+query I
+select count(*) from (
+    select unnest(map_keys(value_counts)) k
+    from (select unnest(data_file) from read_avro(getvariable('mp')))
+) where k = 3;
+----
+1
+
+# d (field 4): none mode writes no bound and no counts.
+query I
+select count(*) from (
+    select unnest(map_keys(lower_bounds)) k
+    from (select unnest(data_file) from read_avro(getvariable('mp')))
+) where k = 4;
+----
+0
+
+query I
+select count(*) from (
+    select unnest(map_keys(value_counts)) k
+    from (select unnest(data_file) from read_avro(getvariable('mp')))
+) where k = 4;
+----
+0
+
+# e (field 5): per-column truncate(4) overrides the truncate(8) default.
+query I
+select octet_length(lb) from (
+    select unnest(map_keys(lower_bounds)) k, unnest(map_values(lower_bounds)) lb
+    from (select unnest(data_file) from read_avro(getvariable('mp')))
+) where k = 5;
+----
+4
+
+# --- Default when the property is unset: Iceberg's truncate(16) ---
+
+statement ok
+drop table if exists my_datalake.default.metrics_default_test;
+
+statement ok
+create table my_datalake.default.metrics_default_test (s varchar);
+
+# 20-byte value; the built-in default truncates the bound to 16.
+statement ok
+insert into my_datalake.default.metrics_default_test values ('abcdefghijklmnopqrst');
+
+statement ok
+set variable mp2 = (select manifest_path from iceberg_metadata(my_datalake.default.metrics_default_test) order by manifest_sequence_number desc limit 1);
+
+query I
+select octet_length(lb) from (
+    select unnest(map_keys(lower_bounds)) k, unnest(map_values(lower_bounds)) lb
+    from (select unnest(data_file) from read_avro(getvariable('mp2')))
+) where k = 1;
+----
+16
+
+# --- Invalid metrics modes are rejected at write time ---
+
+statement ok
+drop table if exists my_datalake.default.metrics_invalid_test;
+
+statement ok
+create table my_datalake.default.metrics_invalid_test (a varchar) WITH ('write.metadata.metrics.default'='banana');
+
+statement error
+insert into my_datalake.default.metrics_invalid_test values ('x');
+----
+Invalid write.metadata.metrics mode
+
+statement ok
+drop table if exists my_datalake.default.metrics_invalid_test;
+
+statement ok
+create table my_datalake.default.metrics_invalid_test (a varchar) WITH ('write.metadata.metrics.column.a'='truncate(0)');
+
+statement error
+insert into my_datalake.default.metrics_invalid_test values ('x');
+----
+truncate length must be a positive integer

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_upper_lower_bounds_nested_types.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_upper_lower_bounds_nested_types.test
@@ -112,13 +112,6 @@ street	VARCHAR	123 Main St	123 Main St
 value	VARCHAR	gold	30
 zip	VARCHAR	12345	12345
 
-# value_counts are written to the manifest on INSERT (one row -> value_count of 1 for the top-level columns)
-query II
-select column_name, value_count from iceberg_column_stats(my_datalake.default.duckdb_nested_types) where column_name in ('id', 'name') order by column_name;
-----
-id	1
-name	1
-
 # --- write.metadata.metrics.* gates the primitive-leaf bounds ---------------
 
 # truncate(8): leaf string bounds are truncated on a code-point boundary
@@ -175,7 +168,7 @@ key	abcdefghijklmnop
 sf	abcdefghijklmnop
 value	abcdefghijklmnop
 
-# none: no leaf bounds and no value_counts for any column
+# none: no leaf bounds for any column
 statement ok
 drop table if exists my_datalake.default.mm_nested_none;
 
@@ -196,12 +189,10 @@ insert into my_datalake.default.mm_nested_none VALUES (
 statement ok
 set variable nested_none_mp = (select manifest_path from iceberg_metadata(my_datalake.default.mm_nested_none) order by manifest_sequence_number desc limit 1);
 
-query II
-select
-    (select count(*) from (select unnest(map_keys(lower_bounds)) k from (select unnest(data_file) from read_avro(getvariable('nested_none_mp'))))),
-    (select count(*) from (select unnest(map_keys(value_counts)) k from (select unnest(data_file) from read_avro(getvariable('nested_none_mp')))));
+query I
+select count(*) from (select unnest(map_keys(lower_bounds)) k from (select unnest(data_file) from read_avro(getvariable('nested_none_mp'))));
 ----
-0	0
+0
 
 # --- per-column overrides on nested leaves via the Iceberg dotted field name -----
 # Iceberg names the synthetic nested fields 'element' (list), 'key'/'value' (map),

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_upper_lower_bounds_nested_types.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_write_upper_lower_bounds_nested_types.test
@@ -111,3 +111,134 @@ phone_numbers	VARCHAR[]	NULL	NULL
 street	VARCHAR	123 Main St	123 Main St
 value	VARCHAR	gold	30
 zip	VARCHAR	12345	12345
+
+# value_counts are written to the manifest on INSERT (one row -> value_count of 1 for the top-level columns)
+query II
+select column_name, value_count from iceberg_column_stats(my_datalake.default.duckdb_nested_types) where column_name in ('id', 'name') order by column_name;
+----
+id	1
+name	1
+
+# --- write.metadata.metrics.* gates the primitive-leaf bounds ---------------
+
+# truncate(8): leaf string bounds are truncated on a code-point boundary
+statement ok
+drop table if exists my_datalake.default.mm_nested_trunc;
+
+statement ok
+create table my_datalake.default.mm_nested_trunc (
+    s STRUCT(sf VARCHAR),
+    l VARCHAR[],
+    m MAP(VARCHAR, VARCHAR)
+) WITH ('write.metadata.metrics.default'='truncate(8)');
+
+statement ok
+insert into my_datalake.default.mm_nested_trunc VALUES (
+    {'sf': 'abcdefghijklmnop'},
+    ['abcdefghijklmnop'],
+    MAP(['abcdefghijklmnop'], ['abcdefghijklmnop'])
+);
+
+query II
+select column_name, lower_bound from iceberg_column_stats(my_datalake.default.mm_nested_trunc)
+where column_name in ('sf', 'element', 'key', 'value') order by column_name;
+----
+element	abcdefgh
+key	abcdefgh
+sf	abcdefgh
+value	abcdefgh
+
+# full: leaf string bounds are written untruncated
+statement ok
+drop table if exists my_datalake.default.mm_nested_full;
+
+statement ok
+create table my_datalake.default.mm_nested_full (
+    s STRUCT(sf VARCHAR),
+    l VARCHAR[],
+    m MAP(VARCHAR, VARCHAR)
+) WITH ('write.metadata.metrics.default'='full');
+
+statement ok
+insert into my_datalake.default.mm_nested_full VALUES (
+    {'sf': 'abcdefghijklmnop'},
+    ['abcdefghijklmnop'],
+    MAP(['abcdefghijklmnop'], ['abcdefghijklmnop'])
+);
+
+query II
+select column_name, lower_bound from iceberg_column_stats(my_datalake.default.mm_nested_full)
+where column_name in ('sf', 'element', 'key', 'value') order by column_name;
+----
+element	abcdefghijklmnop
+key	abcdefghijklmnop
+sf	abcdefghijklmnop
+value	abcdefghijklmnop
+
+# none: no leaf bounds and no value_counts for any column
+statement ok
+drop table if exists my_datalake.default.mm_nested_none;
+
+statement ok
+create table my_datalake.default.mm_nested_none (
+    s STRUCT(sf VARCHAR),
+    l VARCHAR[],
+    m MAP(VARCHAR, VARCHAR)
+) WITH ('write.metadata.metrics.default'='none');
+
+statement ok
+insert into my_datalake.default.mm_nested_none VALUES (
+    {'sf': 'abcdefghijklmnop'},
+    ['abcdefghijklmnop'],
+    MAP(['abcdefghijklmnop'], ['abcdefghijklmnop'])
+);
+
+statement ok
+set variable nested_none_mp = (select manifest_path from iceberg_metadata(my_datalake.default.mm_nested_none) order by manifest_sequence_number desc limit 1);
+
+query II
+select
+    (select count(*) from (select unnest(map_keys(lower_bounds)) k from (select unnest(data_file) from read_avro(getvariable('nested_none_mp'))))),
+    (select count(*) from (select unnest(map_keys(value_counts)) k from (select unnest(data_file) from read_avro(getvariable('nested_none_mp')))));
+----
+0	0
+
+# --- per-column overrides on nested leaves via the Iceberg dotted field name -----
+# Iceberg names the synthetic nested fields 'element' (list), 'key'/'value' (map),
+# so a leaf override is keyed as write.metadata.metrics.column.<parent>.<leaf> - the
+# same path DuckDB resolves via GetFromPath. Give each leaf a different truncate
+# length and let one leaf fall through to the table default to prove each override
+# is honored independently.
+statement ok
+drop table if exists my_datalake.default.mm_nested_percol;
+
+statement ok
+create table my_datalake.default.mm_nested_percol (
+    s STRUCT(sf VARCHAR),
+    l VARCHAR[],
+    m MAP(VARCHAR, VARCHAR)
+) WITH (
+    'write.metadata.metrics.default'='truncate(16)',
+    'write.metadata.metrics.column.s.sf'='truncate(4)',
+    'write.metadata.metrics.column.l.element'='full',
+    'write.metadata.metrics.column.m.key'='truncate(8)'
+);
+
+statement ok
+insert into my_datalake.default.mm_nested_percol VALUES (
+    {'sf': 'abcdefghijklmnopqrstuvwxyz'},
+    ['abcdefghijklmnopqrstuvwxyz'],
+    MAP(['abcdefghijklmnopqrstuvwxyz'], ['abcdefghijklmnopqrstuvwxyz'])
+);
+
+# sf -> truncate(4); element -> full (untruncated); key -> truncate(8);
+# value has no override so it inherits the table default truncate(16)
+query II
+select column_name, lower_bound from iceberg_column_stats(my_datalake.default.mm_nested_percol)
+where column_name in ('sf', 'element', 'key', 'value') order by column_name;
+----
+element	abcdefghijklmnopqrstuvwxyz
+key	abcdefgh
+sf	abcd
+value	abcdefghijklmnop
+


### PR DESCRIPTION
## Summary
- Backports https://github.com/duckdb/duckdb-iceberg/pull/1139 onto `v1.5-variegata`.
- Resolves per-column `write.metadata.metrics.*` modes (`none` / `counts` / `truncate(N)` / `full`) and drives string bound serialization from them.
- Includes UTF-8 code-point-boundary truncation (from the #1138 dependency) so configurable lengths stay valid UTF-8; adapted `GetColumnNameBySourceId` for the variegata API.
    - maybe this should be a separate PR?? 

## Test plan
- [ ] `test_metrics_mode_configuration.test`
- [ ] Nested / geometry / variant metrics-mode cases in the existing per-type bound tests
- [ ] Confirm string lower/upper bounds respect `truncate(N)` and `full`