### PR TITLE
[Dev] Cache the source-id map, instead of recalculating at every call-site

### DIFF
--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -317,13 +317,12 @@ const unordered_map<int32_t, shared_ptr<IcebergTableSchema>> &IcebergTableMetada
 	return schemas;
 }
 
-// TODO: this should also recursively check struct, map, and list columns
 optional_ptr<const IcebergColumnDefinition> IcebergTableMetadata::FindColumnByFieldId(int32_t field_id) const {
 	for (auto &schema_entry : schemas) {
-		for (auto &column : schema_entry.second->columns) {
-			if (column->id == field_id) {
-				return *column;
-			}
+		auto &schema = *schema_entry.second;
+		auto column = schema.TryGetColumnByFieldId(field_id);
+		if (column) {
+			return column;
 		}
 	}
 	return nullptr;

--- a/src/core/metadata/schema/iceberg_table_schema.cpp
+++ b/src/core/metadata/schema/iceberg_table_schema.cpp
@@ -98,9 +98,17 @@ IcebergTableSchema::GetFromColumnIndex(const vector<unique_ptr<IcebergColumnDefi
 	return GetFromColumnIndex(column->GetChildren(), column_index, depth + 1);
 }
 
+const unordered_map<uint64_t, ColumnIndex> &IcebergTableSchema::GetSourceIdMap() const {
+	lock_guard<mutex> guard(source_id_map_lock);
+	if (!source_id_map_populated) {
+		PopulateSourceIdMap(source_to_column_id, columns, nullptr);
+		source_id_map_populated = true;
+	}
+	return source_to_column_id;
+}
+
 optional<ColumnIndex> IcebergTableSchema::TryGetColumnIndexByFieldId(idx_t field_id) const {
-	unordered_map<uint64_t, ColumnIndex> source_to_column_id;
-	PopulateSourceIdMap(source_to_column_id, columns, nullptr);
+	auto &source_to_column_id = GetSourceIdMap();
 	auto it = source_to_column_id.find(field_id);
 	if (it == source_to_column_id.end()) {
 		return std::nullopt;
@@ -108,12 +116,20 @@ optional<ColumnIndex> IcebergTableSchema::TryGetColumnIndexByFieldId(idx_t field
 	return it->second;
 }
 
-const IcebergColumnDefinition &IcebergTableSchema::GetColumnByFieldId(idx_t field_id) const {
+optional_ptr<const IcebergColumnDefinition> IcebergTableSchema::TryGetColumnByFieldId(idx_t field_id) const {
 	auto column_index = TryGetColumnIndexByFieldId(field_id);
 	if (!column_index) {
-		throw InvalidInputException("Field id %d does not exist in schema with id %d", field_id, schema_id);
+		return nullptr;
 	}
 	return GetFromColumnIndex(columns, *column_index, 0);
+}
+
+const IcebergColumnDefinition &IcebergTableSchema::GetColumnByFieldId(idx_t field_id) const {
+	auto column = TryGetColumnByFieldId(field_id);
+	if (!column) {
+		throw InvalidInputException("Field id %d does not exist in schema with id %d", field_id, schema_id);
+	}
+	return *column;
 }
 
 optional_ptr<const IcebergColumnDefinition>
@@ -158,8 +174,15 @@ optional_ptr<IcebergColumnDefinition> IcebergTableSchema::GetMutableFromPath(con
 	if (!res) {
 		return nullptr;
 	}
+	InvalidateSourceIdMap();
 	auto &col = *res;
 	return const_cast<IcebergColumnDefinition &>(col);
+}
+
+void IcebergTableSchema::InvalidateSourceIdMap() {
+	lock_guard<mutex> guard(source_id_map_lock);
+	source_to_column_id.clear();
+	source_id_map_populated = false;
 }
 
 shared_ptr<IcebergTableSchema> IcebergTableSchema::Copy() const {

--- a/src/function/metadata/iceberg_column_stats.cpp
+++ b/src/function/metadata/iceberg_column_stats.cpp
@@ -73,8 +73,7 @@ static unique_ptr<FunctionData> IcebergColumnStatsBind(ClientContext &context, T
 		                                               ret->snapshot_to_scan, context, options);
 		ret->schema = ret->metadata.GetSchemaFromId(ret->snapshot_to_scan.schema_id);
 
-		auto &schema = ret->schema->columns;
-		IcebergTableSchema::PopulateSourceIdMap(ret->source_to_column_id, schema, nullptr);
+		ret->source_to_column_id = ret->schema->GetSourceIdMap();
 	}
 
 	names.emplace_back("status");

--- a/src/function/metadata/iceberg_partition_stats.cpp
+++ b/src/function/metadata/iceberg_partition_stats.cpp
@@ -70,8 +70,7 @@ static unique_ptr<FunctionData> IcebergPartitionStatsBind(ClientContext &context
 		                                               ret->snapshot_to_scan, context, options);
 		ret->schema = ret->metadata.GetSchemaFromId(ret->snapshot_to_scan.schema_id);
 
-		auto &schema = ret->schema->columns;
-		IcebergTableSchema::PopulateSourceIdMap(ret->source_to_column_id, schema, nullptr);
+		ret->source_to_column_id = ret->schema->GetSourceIdMap();
 	}
 
 	names.emplace_back("manifest_path");

--- a/src/include/core/metadata/schema/iceberg_table_schema.hpp
+++ b/src/include/core/metadata/schema/iceberg_table_schema.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb/common/column_index.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/optional.hpp"
 #include "duckdb/common/types/value.hpp"
 
@@ -21,7 +22,9 @@ public:
 	                                optional_ptr<ColumnIndex> parent);
 	static const IcebergColumnDefinition &GetFromColumnIndex(const vector<unique_ptr<IcebergColumnDefinition>> &columns,
 	                                                         const ColumnIndex &column_index, idx_t depth);
+	const unordered_map<uint64_t, ColumnIndex> &GetSourceIdMap() const;
 	optional<ColumnIndex> TryGetColumnIndexByFieldId(idx_t field_id) const;
+	optional_ptr<const IcebergColumnDefinition> TryGetColumnByFieldId(idx_t field_id) const;
 	const IcebergColumnDefinition &GetColumnByFieldId(idx_t field_id) const;
 	optional_ptr<const IcebergColumnDefinition> GetFromPath(const vector<Identifier> &path,
 	                                                        optional_ptr<optional_idx> names_offset) const;
@@ -36,6 +39,14 @@ public:
 	void GetColumnNamesAndTypes(vector<string> &names, vector<LogicalType> &types) const;
 	void GetFieldIdValues(child_list_t<Value> &values) const;
 	Value GetFieldIds() const;
+
+private:
+	void InvalidateSourceIdMap();
+
+private:
+	mutable mutex source_id_map_lock;
+	mutable bool source_id_map_populated = false;
+	mutable unordered_map<uint64_t, ColumnIndex> source_to_column_id;
 
 public:
 	int32_t schema_id;


### PR DESCRIPTION
Fixes the TODO left in the code in the process