### PR TITLE
[Struct Defaults] Correct the behavior, `null` struct default shouldn't be reinterpreted as `{}`

### DIFF
--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -664,7 +664,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 
 		IcebergDefaultBinder binder(context);
 		auto default_constant_value = binder.Evaluate(expression.get(), column.type);
-		column.write_default = make_uniq<Value>(default_constant_value);
+		column.SetWriteDefault(default_constant_value);
 
 		auto new_schema_id = new_schema->schema_id;
 

--- a/src/common/iceberg_default.cpp
+++ b/src/common/iceberg_default.cpp
@@ -8,6 +8,12 @@
 
 namespace duckdb {
 
+// This compatibility switch only exists to exercise empty STRUCT defaults in tests.
+bool &IcebergDefault::InterpretStructNullAsEmpty() {
+	static bool value = false;
+	return value;
+}
+
 IcebergDefaultBinder::IcebergDefaultBinder(ClientContext &context)
     : context(context), binder(Binder::CreateBinder(context)), constant_binder(*binder, context, "DEFAULT") {
 }

--- a/src/common/iceberg_default.cpp
+++ b/src/common/iceberg_default.cpp
@@ -75,29 +75,50 @@ static Value CreateStructMapping(const LogicalType &struct_type, const string &n
 	return Value::TUPLE({Value(name), struct_value});
 }
 
-static Value CreateStructDefault(const Value &value,
+static bool IsStructDefaultDescriptor(const Value &value) {
+	if (value.type().id() != LogicalTypeId::STRUCT) {
+		return false;
+	}
+	auto &children = StructType::GetChildTypes(value.type());
+	return children.size() == 2 && children[0].first == "struct_default" && children[1].first == "field_defaults";
+}
+
+static const Value &GetStructDefault(const Value &descriptor) {
+	D_ASSERT(IsStructDefaultDescriptor(descriptor));
+	return StructValue::GetChildren(descriptor)[0];
+}
+
+static const Value &GetStructFieldDefaults(const Value &descriptor) {
+	D_ASSERT(IsStructDefaultDescriptor(descriptor));
+	return StructValue::GetChildren(descriptor)[1];
+}
+
+static Value CreateStructDefault(const Value &descriptor,
                                  const case_insensitive_map_t<unique_ptr<StructFieldMapping>> &mapping = {}) {
+	D_ASSERT(IsStructDefaultDescriptor(descriptor));
 	child_list_t<Value> field_defaults;
-	auto &field_values = StructValue::GetChildren(value);
-	auto &struct_children = StructType::GetChildTypes(value.type());
+	auto &field_defaults_value = GetStructFieldDefaults(descriptor);
+	auto &field_values = StructValue::GetChildren(field_defaults_value);
+	auto &struct_children = StructType::GetChildTypes(field_defaults_value.type());
 	for (idx_t j = 0; j < field_values.size(); j++) {
 		auto &field_name = struct_children[j].first;
-		auto &field_type = struct_children[j].second;
 		auto &field_value = field_values[j];
 
 		auto it = mapping.find(field_name.GetIdentifierName());
 		const bool is_mapped = it != mapping.end();
 
 		Value field_default;
-		if (field_type.id() == LogicalTypeId::STRUCT) {
+		if (IsStructDefaultDescriptor(field_value)) {
 			if (is_mapped) {
 				field_default = CreateStructDefault(field_value, it->second->child_mapping);
 			} else {
-				field_default = CreateStructDefault(field_value);
+				field_default = GetStructDefault(field_value);
 			}
 
 			if (field_default.IsNull()) {
-				//! All fields were skipped, no need to include this value
+				if (!is_mapped) {
+					field_defaults.emplace_back(field_name, std::move(field_default));
+				}
 				continue;
 			}
 		} else {
@@ -120,6 +141,12 @@ static Value EvaluateStructDefault(ClientContext &context, const Expression &def
 	if (!default_expr.IsFoldable()) {
 		throw BinderException("Cannot resolve partial STRUCT insert with non-constant default value");
 	}
+	if (default_expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+		auto &function_expr = default_expr.Cast<BoundFunctionExpression>();
+		if (function_expr.Function().GetName() == "constant_or_null" && function_expr.GetChildren().size() == 2) {
+			return ExpressionExecutor::EvaluateScalar(context, *function_expr.GetChildren()[1]);
+		}
+	}
 	Value default_value;
 	if (!ExpressionExecutor::TryEvaluateScalar(context, default_expr, default_value)) {
 		throw BinderException("Cannot resolve partial STRUCT insert with non-constant default value");
@@ -134,8 +161,8 @@ unique_ptr<Expression> IcebergDefaultProjectionResolver::ResolveDefault(ClientCo
                                                                         const LogicalType &result_type,
                                                                         ColumnBinding binding,
                                                                         const Expression &default_expr) {
-	auto default_value = EvaluateStructDefault(context, default_expr);
-	if (default_value.IsNull() || input_type.id() != LogicalTypeId::STRUCT ||
+	auto default_descriptor = EvaluateStructDefault(context, default_expr);
+	if (default_descriptor.IsNull() || input_type.id() != LogicalTypeId::STRUCT ||
 	    result_type.id() != LogicalTypeId::STRUCT) {
 		return make_uniq<BoundColumnRefExpression>(input_type, binding);
 	}
@@ -147,7 +174,7 @@ unique_ptr<Expression> IcebergDefaultProjectionResolver::ResolveDefault(ClientCo
 
 	case_insensitive_map_t<unique_ptr<StructFieldMapping>> mapping;
 	children.push_back(make_uniq<BoundConstantExpression>(CreateStructMapping(input_type, "", mapping)));
-	children.push_back(make_uniq<BoundConstantExpression>(CreateStructDefault(default_value, mapping)));
+	children.push_back(make_uniq<BoundConstantExpression>(CreateStructDefault(default_descriptor, mapping)));
 	return RemapStructFun::GetFunction().Bind(context, std::move(children));
 }
 

--- a/src/common/iceberg_default.cpp
+++ b/src/common/iceberg_default.cpp
@@ -1,5 +1,6 @@
 #include "common/iceberg_default.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/function/scalar/generic_common.hpp"
 #include "duckdb/function/scalar/struct_functions.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
@@ -85,6 +86,8 @@ static bool IsStructDefaultDescriptor(const Value &value) {
 	if (value.type().id() != LogicalTypeId::STRUCT) {
 		return false;
 	}
+	// Descriptors are internal typed values with two deliberately named fields. They are not valid user-facing
+	// STRUCT default syntax and are never written to Iceberg metadata.
 	auto &children = StructType::GetChildTypes(value.type());
 	return children.size() == 2 && children[0].first == "struct_default" && children[1].first == "field_defaults";
 }
@@ -116,8 +119,12 @@ static Value CreateStructDefault(const Value &descriptor,
 		Value field_default;
 		if (IsStructDefaultDescriptor(field_value)) {
 			if (is_mapped) {
+				// The nested STRUCT is present in the input. Recurse so that only its omitted children receive
+				// field defaults.
 				field_default = CreateStructDefault(field_value, it->second->child_mapping);
 			} else {
+				// The nested STRUCT itself is absent. Iceberg requires its whole-STRUCT default here; do not
+				// synthesize a value from its child defaults.
 				field_default = GetStructDefault(field_value);
 			}
 
@@ -144,19 +151,38 @@ static Value CreateStructDefault(const Value &descriptor,
 }
 
 static Value EvaluateStructDefault(ClientContext &context, const Expression &default_expr) {
+	// This is called by DuckDB's default projection hook. At this point the parsed envelope created by
+	// IcebergColumnDefinition::GetColumnDefinition has been bound by DuckDB, so generic_common.hpp can identify it
+	// from the bound function and its bind data.
 	if (!default_expr.IsFoldable()) {
 		throw BinderException("Cannot resolve partial STRUCT insert with non-constant default value");
 	}
-	if (default_expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
-		auto &function_expr = default_expr.Cast<BoundFunctionExpression>();
-		if (function_expr.Function().GetName() == "constant_or_null" && function_expr.GetChildren().size() == 2) {
-			return ExpressionExecutor::EvaluateScalar(context, *function_expr.GetChildren()[1]);
-		}
-	}
+
+	// Evaluate first because ConstantOrNull::IsConstantOrNull verifies that the function's bound constant is the
+	// value we expect. For the Iceberg envelope the descriptor (argument 2) is non-NULL, therefore normal
+	// constant_or_null semantics make this exactly the whole-STRUCT default from argument 1.
 	Value default_value;
 	if (!ExpressionExecutor::TryEvaluateScalar(context, default_expr, default_value)) {
 		throw BinderException("Cannot resolve partial STRUCT insert with non-constant default value");
 	}
+	if (default_expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+		// The catalog hook exposes the default as const, while the generic recognition helper accepts a mutable
+		// BoundFunctionExpression. Work on a normal expression copy instead of hardcoding function-name/bind-data
+		// detection here or casting away constness. Copying preserves the bound function and its bind data.
+		auto expression_copy = default_expr.Copy();
+		auto &function_expr = expression_copy->Cast<BoundFunctionExpression>();
+		if (ConstantOrNull::IsConstantOrNull(function_expr, default_value)) {
+			D_ASSERT(function_expr.GetChildren().size() == 2);
+
+			// This is the sole point where the envelope changes meaning: partial STRUCT projection needs the
+			// recursive descriptor, not the envelope's runtime value. Argument 2 is a foldable internal constant,
+			// so evaluate and return it for CreateStructDefault below.
+			return ExpressionExecutor::EvaluateScalar(context, *function_expr.GetChildren()[1]);
+		}
+	}
+
+	// Non-STRUCT Iceberg columns do not use the envelope. Return their ordinary default value; ResolveDefault's
+	// type check below will leave their input projection unchanged.
 	return default_value;
 }
 
@@ -170,10 +196,14 @@ unique_ptr<Expression> IcebergDefaultProjectionResolver::ResolveDefault(ClientCo
 	auto default_descriptor = EvaluateStructDefault(context, default_expr);
 	if (default_descriptor.IsNull() || input_type.id() != LogicalTypeId::STRUCT ||
 	    result_type.id() != LogicalTypeId::STRUCT) {
+		// Explicit input NULL is preserved by the input reference itself. Whole-column DEFAULT values never reach
+		// this remapping path: DuckDB projects the already-bound default expression directly for omitted columns.
 		return make_uniq<BoundColumnRefExpression>(input_type, binding);
 	}
 
-	// Column is of type STRUCT, create a remap that fills in omitted fields from the column default.
+	// A non-NULL STRUCT was supplied. Build a remap that preserves mapped fields and fills only omitted fields from
+	// the recursive descriptor. RemapStructFun propagates a NULL input STRUCT as NULL, so explicit NULL remains NULL
+	// even when the compatibility setting makes the whole-STRUCT default non-NULL.
 	vector<unique_ptr<Expression>> children;
 	children.push_back(make_uniq<BoundColumnRefExpression>(input_type, binding));
 	children.push_back(make_uniq<BoundConstantExpression>(Value(result_type)));

--- a/src/core/metadata/schema/iceberg_column_definition.cpp
+++ b/src/core/metadata/schema/iceberg_column_definition.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/parser/column_definition.hpp"
 #include "duckdb/common/multi_file/multi_file_data.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
+#include "duckdb/function/scalar/generic_functions.hpp"
 #include "common/iceberg_default.hpp"
 
 namespace duckdb {
@@ -333,6 +334,11 @@ Value IcebergColumnDefinition::GetWriteDefault() const {
 
 Value IcebergColumnDefinition::GetWriteDefaultDescriptor() const {
 	D_ASSERT(type.id() == LogicalTypeId::STRUCT);
+
+	// Keep the default for every direct child. For nested STRUCT children, keep another descriptor instead of
+	// eagerly materializing their children. The projection resolver can then distinguish:
+	//   * an omitted nested STRUCT, which uses that child's `struct_default`; and
+	//   * a supplied, non-NULL nested STRUCT, which recursively uses that child's `field_defaults`.
 	child_list_t<Value> field_defaults;
 	for (auto &child : children) {
 		if (child->type.id() == LogicalTypeId::STRUCT) {
@@ -352,10 +358,24 @@ ColumnDefinition IcebergColumnDefinition::GetColumnDefinition() const {
 
 	auto write_default = GetWriteDefault();
 	if (type.id() == LogicalTypeId::STRUCT) {
+		// DuckDB's default projection hook receives the bound default expression, but not the Iceberg column
+		// metadata from which it originated. Carry the recursive field defaults through that existing interface in
+		// a real `constant_or_null` expression:
+		//
+		//   constant_or_null(<whole-STRUCT default>, <non-NULL recursive descriptor>)
+		//
+		// The second argument is deliberately non-NULL, so ordinary evaluation of the expression returns the first
+		// argument unchanged. Consequently an omitted/DEFAULT whole STRUCT still observes `write_default`: normally
+		// typed NULL, or a materialized STRUCT under the test-only compatibility setting.
+		//
+		// The expression is parsed here, where no ClientContext is available. DuckDB binds the registered scalar
+		// function later. The Iceberg projection resolver recognizes that bound function through
+		// ConstantOrNull::IsConstantOrNull and extracts the second argument only when it needs to remap a supplied
+		// non-NULL STRUCT. This envelope is internal and is not serialized into Iceberg metadata.
 		vector<unique_ptr<ParsedExpression>> arguments;
 		arguments.push_back(make_uniq<ConstantExpression>(std::move(write_default)));
 		arguments.push_back(make_uniq<ConstantExpression>(GetWriteDefaultDescriptor()));
-		res.SetDefaultValue(make_uniq<FunctionExpression>(Identifier("constant_or_null"), std::move(arguments)));
+		res.SetDefaultValue(make_uniq<FunctionExpression>(Identifier(ConstantOrNullFun::Name), std::move(arguments)));
 	} else if (!write_default.IsNull()) {
 		if (type.IsNested()) {
 			throw NotImplementedException("DEFAULT values for nested types are not supported yet");

--- a/src/core/metadata/schema/iceberg_column_definition.cpp
+++ b/src/core/metadata/schema/iceberg_column_definition.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/value_operations/value_operations.hpp"
 #include "duckdb/parser/column_definition.hpp"
 #include "duckdb/common/multi_file/multi_file_data.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
+#include "iceberg_options.hpp"
 
 namespace duckdb {
 
@@ -287,28 +289,26 @@ unique_ptr<IcebergColumnDefinition> IcebergColumnDefinition::Copy() const {
 
 MultiFileColumnDefinition IcebergColumnDefinition::GetMultiFileColumnDefinition() const {
 	MultiFileColumnDefinition column(name, type);
-	if (!initial_default || initial_default->IsNull()) {
-		if (type.id() == LogicalTypeId::STRUCT) {
-			//! NOTE: spec defines {} as default value, but in practice no engine/catalog supports this
-			vector<Value> child_values;
-			for (auto &child : children) {
-				auto child_column = child->GetMultiFileColumnDefinition();
-				auto &child_default = child_column.default_expression->Cast<ConstantExpression>().GetValue();
-				child_values.emplace_back(child_default);
-			}
-			auto default_value = Value::STRUCT(type, child_values);
-			column.default_expression = make_uniq<ConstantExpression>(default_value);
-		} else {
-			column.default_expression = make_uniq<ConstantExpression>(Value(type));
-		}
-	} else {
-		column.default_expression = make_uniq<ConstantExpression>(*initial_default);
-	}
+	column.default_expression = make_uniq<ConstantExpression>(GetInitialDefault());
 	column.identifier = Value::INTEGER(id);
 	for (auto &child : children) {
 		column.children.push_back(child->GetMultiFileColumnDefinition());
 	}
 	return column;
+}
+
+Value IcebergColumnDefinition::GetInitialDefault() const {
+	Value result = initial_default ? *initial_default : Value(type);
+	if (type.id() != LogicalTypeId::STRUCT || !result.IsNull() ||
+	    !IcebergUnsafeStructNullDefaultInterpretationEnabled()) {
+		return result;
+	}
+	vector<Value> child_defaults;
+	child_defaults.reserve(children.size());
+	for (auto &child : children) {
+		child_defaults.push_back(child->GetInitialDefault());
+	}
+	return Value::STRUCT(type, std::move(child_defaults));
 }
 
 Value IcebergColumnDefinition::GetWriteDefault() const {
@@ -320,35 +320,49 @@ Value IcebergColumnDefinition::GetWriteDefault() const {
 		//! If it's not set, use the initial-default (if that *is* set)
 		default_to_use = initial_default.get();
 	}
-	auto res = ColumnDefinition(Identifier(name), type);
-	if (default_to_use) {
-		return *default_to_use;
+	Value result = default_to_use ? *default_to_use : Value(type);
+	if (type.id() != LogicalTypeId::STRUCT || !result.IsNull() ||
+	    !IcebergUnsafeStructNullDefaultInterpretationEnabled()) {
+		return result;
 	}
-	return Value(type);
+	vector<Value> child_defaults;
+	child_defaults.reserve(children.size());
+	for (auto &child : children) {
+		child_defaults.push_back(child->GetWriteDefault());
+	}
+	return Value::STRUCT(type, std::move(child_defaults));
+}
+
+Value IcebergColumnDefinition::GetWriteDefaultDescriptor() const {
+	D_ASSERT(type.id() == LogicalTypeId::STRUCT);
+	child_list_t<Value> field_defaults;
+	for (auto &child : children) {
+		if (child->type.id() == LogicalTypeId::STRUCT) {
+			field_defaults.emplace_back(child->name, child->GetWriteDefaultDescriptor());
+		} else {
+			field_defaults.emplace_back(child->name, child->GetWriteDefault());
+		}
+	}
+	child_list_t<Value> descriptor;
+	descriptor.emplace_back("struct_default", GetWriteDefault());
+	descriptor.emplace_back("field_defaults", Value::STRUCT(std::move(field_defaults)));
+	return Value::STRUCT(std::move(descriptor));
 }
 
 ColumnDefinition IcebergColumnDefinition::GetColumnDefinition() const {
 	auto res = ColumnDefinition(Identifier(name), type);
 
 	auto write_default = GetWriteDefault();
-	if (!write_default.IsNull()) {
+	if (type.id() == LogicalTypeId::STRUCT) {
+		vector<unique_ptr<ParsedExpression>> arguments;
+		arguments.push_back(make_uniq<ConstantExpression>(std::move(write_default)));
+		arguments.push_back(make_uniq<ConstantExpression>(GetWriteDefaultDescriptor()));
+		res.SetDefaultValue(make_uniq<FunctionExpression>(Identifier("constant_or_null"), std::move(arguments)));
+	} else if (!write_default.IsNull()) {
 		if (type.IsNested()) {
-			throw NotImplementedException("{} DEFAULT not supported for STRUCT yet");
+			throw NotImplementedException("DEFAULT values for nested types are not supported yet");
 		}
 		res.SetDefaultValue(make_uniq<ConstantExpression>(write_default));
-	} else if (type.id() == LogicalTypeId::STRUCT) {
-		vector<Value> child_values;
-		for (auto &child : children) {
-			auto child_column = child->GetColumnDefinition();
-			if (child_column.HasDefaultValue()) {
-				auto &child_default = child_column.DefaultValue().Cast<ConstantExpression>();
-				child_values.emplace_back(child_default.GetValue());
-			} else {
-				child_values.emplace_back(Value(child->type));
-			}
-		}
-		auto default_value = Value::STRUCT(type, child_values);
-		res.SetDefaultValue(make_uniq<ConstantExpression>(default_value));
 	}
 
 	if (doc) {
@@ -356,6 +370,19 @@ ColumnDefinition IcebergColumnDefinition::GetColumnDefinition() const {
 		res.SetComment(Value(*doc));
 	}
 	return res;
+}
+
+void IcebergColumnDefinition::SetWriteDefault(const Value &default_value) {
+	if (type.id() != LogicalTypeId::STRUCT || default_value.IsNull()) {
+		write_default = make_uniq<Value>(default_value);
+		return;
+	}
+	auto &default_children = StructValue::GetChildren(default_value);
+	D_ASSERT(default_children.size() == children.size());
+	write_default = make_uniq<Value>(Value(type));
+	for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {
+		children[child_idx]->SetWriteDefault(default_children[child_idx]);
+	}
 }
 
 static bool DefaultsAreEqual(const unique_ptr<Value> &a, const unique_ptr<Value> &b) {

--- a/src/core/metadata/schema/iceberg_column_definition.cpp
+++ b/src/core/metadata/schema/iceberg_column_definition.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/parser/column_definition.hpp"
 #include "duckdb/common/multi_file/multi_file_data.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
-#include "iceberg_options.hpp"
+#include "common/iceberg_default.hpp"
 
 namespace duckdb {
 
@@ -299,8 +299,7 @@ MultiFileColumnDefinition IcebergColumnDefinition::GetMultiFileColumnDefinition(
 
 Value IcebergColumnDefinition::GetInitialDefault() const {
 	Value result = initial_default ? *initial_default : Value(type);
-	if (type.id() != LogicalTypeId::STRUCT || !result.IsNull() ||
-	    !IcebergUnsafeStructNullDefaultInterpretationEnabled()) {
+	if (type.id() != LogicalTypeId::STRUCT || !result.IsNull() || !IcebergDefault::InterpretStructNullAsEmpty()) {
 		return result;
 	}
 	vector<Value> child_defaults;
@@ -321,8 +320,7 @@ Value IcebergColumnDefinition::GetWriteDefault() const {
 		default_to_use = initial_default.get();
 	}
 	Value result = default_to_use ? *default_to_use : Value(type);
-	if (type.id() != LogicalTypeId::STRUCT || !result.IsNull() ||
-	    !IcebergUnsafeStructNullDefaultInterpretationEnabled()) {
+	if (type.id() != LogicalTypeId::STRUCT || !result.IsNull() || !IcebergDefault::InterpretStructNullAsEmpty()) {
 		return result;
 	}
 	vector<Value> child_defaults;

--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -24,6 +24,7 @@
 #include "iceberg_logging.hpp"
 #include "iceberg_attach.hpp"
 #include "iceberg_options.hpp"
+#include "common/iceberg_default.hpp"
 #include "function/copy/iceberg_copy_function.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"
 #include "planning/iceberg_optimizer.hpp"
@@ -42,8 +43,9 @@ static void SetDefaultFormatVersion(ClientContext &context, SetScope scope, Valu
 }
 
 static void SetUnsafeStructNullDefaultInterpretation(ClientContext &context, SetScope scope, Value &parameter) {
+	auto &value = IcebergDefault::InterpretStructNullAsEmpty();
 	if (parameter.IsNull()) {
-		SetIcebergUnsafeStructNullDefaultInterpretation(false);
+		value = false;
 		return;
 	}
 	auto interpretation = parameter.GetValue<string>();
@@ -51,7 +53,7 @@ static void SetUnsafeStructNullDefaultInterpretation(ClientContext &context, Set
 		throw InvalidConfigurationException("'%s' must be NULL or '{}', got '%s'",
 		                                    UNSAFE_STRUCT_NULL_DEFAULT_INTERPRETATION_CONFIG_VARIABLE, interpretation);
 	}
-	SetIcebergUnsafeStructNullDefaultInterpretation(true);
+	value = true;
 }
 
 static unique_ptr<TransactionManager> CreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,

--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -41,6 +41,19 @@ static void SetDefaultFormatVersion(ClientContext &context, SetScope scope, Valu
 	}
 }
 
+static void SetUnsafeStructNullDefaultInterpretation(ClientContext &context, SetScope scope, Value &parameter) {
+	if (parameter.IsNull()) {
+		SetIcebergUnsafeStructNullDefaultInterpretation(false);
+		return;
+	}
+	auto interpretation = parameter.GetValue<string>();
+	if (interpretation != "{}") {
+		throw InvalidConfigurationException("'%s' must be NULL or '{}', got '%s'",
+		                                    UNSAFE_STRUCT_NULL_DEFAULT_INTERPRETATION_CONFIG_VARIABLE, interpretation);
+	}
+	SetIcebergUnsafeStructNullDefaultInterpretation(true);
+}
+
 static unique_ptr<TransactionManager> CreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,
                                                                AttachedDatabase &db, Catalog &catalog) {
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
@@ -94,6 +107,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    "Maximum number of characters of a REST catalog POST body to include in Iceberg log messages. "
 	    "Bodies longer than this are truncated with a trailing '... (truncated)' marker. Set to 0 to omit the body.",
 	    LogicalType::UBIGINT, Value::UBIGINT(10000));
+	config.AddExtensionOption(
+	    UNSAFE_STRUCT_NULL_DEFAULT_INTERPRETATION_CONFIG_VARIABLE,
+	    "DANGEROUS TESTING-ONLY SETTING: interpret a null Iceberg STRUCT default as an empty struct whose fields "
+	    "use their own defaults. The only non-null value accepted is '{}'.",
+	    LogicalType::VARCHAR, Value(LogicalType::VARCHAR), SetUnsafeStructNullDefaultInterpretation, SetScope::GLOBAL);
 #ifdef ICEBERG_ENABLE_EQUALITY_DELETE_WRITES
 	config.AddExtensionOption(
 	    ENABLE_EQUALITY_DELETES_CONFIG_VARIABLE,

--- a/src/iceberg_options.cpp
+++ b/src/iceberg_options.cpp
@@ -1,7 +1,19 @@
 #include "iceberg_options.hpp"
 #include "common/iceberg_utils.hpp"
+#include "duckdb/common/atomic.hpp"
 
 namespace duckdb {
+
+// This compatibility switch only exists to exercise empty STRUCT defaults in tests.
+static atomic<bool> unsafe_struct_null_default_interpretation(false);
+
+bool IcebergUnsafeStructNullDefaultInterpretationEnabled() {
+	return unsafe_struct_null_default_interpretation.load();
+}
+
+void SetIcebergUnsafeStructNullDefaultInterpretation(bool enabled) {
+	unsafe_struct_null_default_interpretation.store(enabled);
+}
 
 IcebergOptions::IcebergOptions() : snapshot_lookup(IcebergSnapshotLookup::FromLatest()) {
 }

--- a/src/iceberg_options.cpp
+++ b/src/iceberg_options.cpp
@@ -4,17 +4,6 @@
 
 namespace duckdb {
 
-// This compatibility switch only exists to exercise empty STRUCT defaults in tests.
-static atomic<bool> unsafe_struct_null_default_interpretation(false);
-
-bool IcebergUnsafeStructNullDefaultInterpretationEnabled() {
-	return unsafe_struct_null_default_interpretation.load();
-}
-
-void SetIcebergUnsafeStructNullDefaultInterpretation(bool enabled) {
-	unsafe_struct_null_default_interpretation.store(enabled);
-}
-
 IcebergOptions::IcebergOptions() : snapshot_lookup(IcebergSnapshotLookup::FromLatest()) {
 }
 

--- a/src/include/common/iceberg_default.hpp
+++ b/src/include/common/iceberg_default.hpp
@@ -7,6 +7,10 @@
 
 namespace duckdb {
 
+struct IcebergDefault {
+	static bool &InterpretStructNullAsEmpty();
+};
+
 class IcebergDefaultBinder {
 public:
 	IcebergDefaultBinder(ClientContext &context);

--- a/src/include/core/metadata/schema/iceberg_column_definition.hpp
+++ b/src/include/core/metadata/schema/iceberg_column_definition.hpp
@@ -44,6 +44,15 @@ public:
 private:
 	Value GetInitialDefault() const;
 	Value GetWriteDefault() const;
+	//! Returns an internal, recursive description of a STRUCT write default.
+	//!
+	//! `struct_default` is the default for the whole STRUCT. `field_defaults` contains the defaults used only after
+	//! a non-NULL STRUCT value has been supplied. Keeping these values separate is required by Iceberg: a missing
+	//! nested STRUCT field uses its whole-STRUCT default, while a present nested STRUCT has its omitted children
+	//! filled recursively.
+	//!
+	//! This descriptor is carried through DuckDB's default-expression plumbing as the second argument of a
+	//! `constant_or_null` envelope. It is internal metadata and is never serialized to Iceberg.
 	Value GetWriteDefaultDescriptor() const;
 
 public:

--- a/src/include/core/metadata/schema/iceberg_column_definition.hpp
+++ b/src/include/core/metadata/schema/iceberg_column_definition.hpp
@@ -30,6 +30,7 @@ public:
 	MultiFileColumnDefinition GetMultiFileColumnDefinition() const;
 	unique_ptr<IcebergColumnDefinition> Copy() const;
 	bool Equals(const IcebergColumnDefinition &other) const;
+	void SetWriteDefault(const Value &default_value);
 
 public:
 	void AddChild(unique_ptr<IcebergColumnDefinition> &&child);
@@ -41,7 +42,9 @@ public:
 	void RewriteType();
 
 private:
+	Value GetInitialDefault() const;
 	Value GetWriteDefault() const;
+	Value GetWriteDefaultDescriptor() const;
 
 public:
 	int32_t id;

--- a/src/include/iceberg_options.hpp
+++ b/src/include/iceberg_options.hpp
@@ -24,9 +24,6 @@ static string ENABLE_EQUALITY_DELETES_CONFIG_VARIABLE = "unsafe_and_disabled_for
 static constexpr const char *UNSAFE_STRUCT_NULL_DEFAULT_INTERPRETATION_CONFIG_VARIABLE =
     "__iceberg_unsafe_struct_null_default_interpretation";
 
-bool IcebergUnsafeStructNullDefaultInterpretationEnabled();
-void SetIcebergUnsafeStructNullDefaultInterpretation(bool enabled);
-
 // When this is provided (and unsafe_enable_version_guessing is true)
 // we first look for DEFAULT_VERSION_HINT_FILE, if it doesn't exist we
 // then search for versions matching the DEFAULT_TABLE_VERSION_FORMAT

--- a/src/include/iceberg_options.hpp
+++ b/src/include/iceberg_options.hpp
@@ -21,6 +21,12 @@ static constexpr uint64_t DEFAULT_ICEBERG_FORMAT_VERSION = 2;
 // of a positional delete. This exists only to exercise the equality-delete read path.
 static string ENABLE_EQUALITY_DELETES_CONFIG_VARIABLE = "unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes";
 
+static constexpr const char *UNSAFE_STRUCT_NULL_DEFAULT_INTERPRETATION_CONFIG_VARIABLE =
+    "__iceberg_unsafe_struct_null_default_interpretation";
+
+bool IcebergUnsafeStructNullDefaultInterpretationEnabled();
+void SetIcebergUnsafeStructNullDefaultInterpretation(bool enabled);
+
 // When this is provided (and unsafe_enable_version_guessing is true)
 // we first look for DEFAULT_VERSION_HINT_FILE, if it doesn't exist we
 // then search for versions matching the DEFAULT_TABLE_VERSION_FORMAT

--- a/test/configs/nessie.json
+++ b/test/configs/nessie.json
@@ -70,6 +70,7 @@
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/iceberg_types/test_geometry_type_nested.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_type_v3.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_type_timestamptz_ns_v3.test",
+        "test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_default_struct.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/create/default/test_create_default_struct.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/create/default/test_create_default_struct_nested.test",
         "test/sql/local/catalog_test_config_setup/catalog_agnostic/create/default/test_create_default_timestamptz_ns.test",

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/add_field.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/add_field.test
@@ -155,12 +155,10 @@ insert into my_datalake.default.add_struct_field VALUES (
 	true
 );
 
-# FIXME: 'another_struct' should be NULL, as it gets backfilled without a DEFAULT
-# but NULL is treated differently for now (hopefully we can fix this behavior later)
 query II
 select * from my_datalake.default.add_struct_field order by all;
 ----
 {'a': hello world, 'b': NULL, 'nested': {'d': 1982-02-12, 'prim': test test test}, 'c': 1934-05-21, 'another_struct': {'col': {'inception': true}}}	true
-{'a': hello world, 'b': NULL, 'nested': {'d': 1982-02-12, 'prim': this is a long string}, 'c': 1934-05-21, 'another_struct': {'col': {'inception': NULL}}}	true
-{'a': hello world, 'b': NULL, 'nested': {'d': 1982-02-12, 'prim': NULL}, 'c': 1934-05-21, 'another_struct': {'col': {'inception': NULL}}}	true
-{'a': test, 'b': false, 'nested': {'d': 2012-08-19, 'prim': NULL}, 'c': NULL, 'another_struct': {'col': {'inception': NULL}}}	false
+{'a': hello world, 'b': NULL, 'nested': {'d': 1982-02-12, 'prim': this is a long string}, 'c': 1934-05-21, 'another_struct': NULL}	true
+{'a': hello world, 'b': NULL, 'nested': {'d': 1982-02-12, 'prim': NULL}, 'c': 1934-05-21, 'another_struct': NULL}	true
+{'a': test, 'b': false, 'nested': {'d': 2012-08-19, 'prim': NULL}, 'c': NULL, 'another_struct': NULL}	false

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_default_struct.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_default_struct.test
@@ -1,0 +1,203 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_default_struct.test
+# description: ALTER SET DEFAULT recursively lowers STRUCT defaults
+# group: [alter]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+# Default value of the setting
+statement ok
+SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = NULL;
+
+statement ok
+drop table if exists my_datalake.default.alter_default_struct;
+
+statement ok
+create table my_datalake.default.alter_default_struct (
+	id INTEGER,
+	payload STRUCT(
+		a VARCHAR,
+		nested STRUCT(x INTEGER)
+	) DEFAULT NULL
+) WITH ('format-version' = 3);
+
+statement ok
+insert into my_datalake.default.alter_default_struct
+	values (
+		1,
+		{
+			'a': 'seed',
+			'nested': {
+				'x': 1
+			}
+		}
+	);
+
+# Partial struct, missing 'nested'
+statement ok
+insert into my_datalake.default.alter_default_struct
+	values (
+		10,
+		{
+			'a': 'seed2'
+		}
+	);
+
+# Entirely missing struct
+statement ok
+insert into my_datalake.default.alter_default_struct(id)
+	values (
+		11
+	);
+
+statement ok
+alter table my_datalake.default.alter_default_struct
+	alter column payload set default {
+		'a': 'altered',
+		'nested': {'x': 42}
+	};
+
+statement ok
+insert into my_datalake.default.alter_default_struct values
+	(2, DEFAULT),
+	(3, {
+		'nested': {
+			'x': 7
+		}
+	});
+
+query II
+select id, payload
+from my_datalake.default.alter_default_struct
+order by all;
+----
+1	{'a': seed, 'nested': {'x': 1}}
+2	NULL
+3	{'a': NULL, 'nested': {'x': 7}}
+10	{'a': seed2, 'nested': NULL}
+11	NULL
+
+statement ok
+alter table my_datalake.default.alter_default_struct
+	alter column payload set default NULL;
+
+statement ok
+insert into my_datalake.default.alter_default_struct values
+	(4, DEFAULT),
+	(5, NULL);
+
+query II
+select id, payload
+from my_datalake.default.alter_default_struct
+where id >= 4
+order by all;
+----
+4	NULL
+5	NULL
+10	{'a': seed2, 'nested': NULL}
+11	NULL
+
+statement ok
+drop table my_datalake.default.alter_default_struct;
+
+# Now test with reinterpreting struct default 'null' as {}
+
+statement ok
+SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+
+statement ok
+create table my_datalake.default.alter_default_struct (
+	id INTEGER,
+	payload STRUCT(
+		a VARCHAR,
+		nested STRUCT(x INTEGER)
+	) DEFAULT NULL
+) WITH ('format-version' = 3);
+
+statement ok
+insert into my_datalake.default.alter_default_struct
+	values (
+		1,
+		{
+			'a': 'seed',
+			'nested': {
+				'x': 1
+			}
+		}
+	);
+
+# Partial struct, missing 'nested'
+statement ok
+insert into my_datalake.default.alter_default_struct
+	values (
+		10,
+		{
+			'a': 'seed2'
+		}
+	);
+
+# Entirely missing struct
+statement ok
+insert into my_datalake.default.alter_default_struct(id)
+	values (
+		11
+	);
+
+statement ok
+alter table my_datalake.default.alter_default_struct
+	alter column payload set default {
+		'a': 'altered',
+		'nested': {'x': 42}
+	};
+
+statement ok
+insert into my_datalake.default.alter_default_struct values
+	(2, DEFAULT),
+	(3, {
+		'nested': {
+			'x': 7
+		}
+	});
+
+query II
+select id, payload
+from my_datalake.default.alter_default_struct
+order by all;
+----
+1	{'a': seed, 'nested': {'x': 1}}
+2	{'a': altered, 'nested': {'x': 42}}
+3	{'a': NULL, 'nested': {'x': 7}}
+10	{'a': seed2, 'nested': {'x': NULL}}
+11	{'a': NULL, 'nested': {'x': NULL}}
+
+statement ok
+alter table my_datalake.default.alter_default_struct
+	alter column payload set default NULL;
+
+statement ok
+insert into my_datalake.default.alter_default_struct values
+	(4, DEFAULT),
+	(5, NULL);
+
+query II
+select id, payload
+from my_datalake.default.alter_default_struct
+where id >= 4
+order by all;
+----
+4	{'a': altered, 'nested': {'x': 42}}
+5	NULL
+10	{'a': seed2, 'nested': {'x': NULL}}
+11	{'a': NULL, 'nested': {'x': NULL}}
+
+statement ok
+drop table my_datalake.default.alter_default_struct;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_default_struct.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_default_struct.test
@@ -201,3 +201,7 @@ order by all;
 
 statement ok
 drop table my_datalake.default.alter_default_struct;
+
+# Reset the value, since it's a global static
+statement ok
+SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = NULL;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/drop_field.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/drop_field.test
@@ -94,12 +94,10 @@ insert into my_datalake.default.drop_struct_field VALUES (
 	{'a': 'hello world', 'nested': {'d': '1982/2/12'::DATE}}, true
 )
 
-# FIXME: 'also_nested' should be NULL (in row 1), as it gets backfilled without a DEFAULT
-# but NULL is treated differently for now (hopefully we can fix this behavior later)
 query II
 select * from my_datalake.default.drop_struct_field order by all;
 ----
-{'a': hello world, 'nested': {'d': 1982-02-12}, 'also_nested': {'e': NULL, 'f': NULL}}	true
+{'a': hello world, 'nested': {'d': 1982-02-12}, 'also_nested': NULL}	true
 {'a': test, 'nested': {'d': 2012-08-19}, 'also_nested': {'e': test, 'f': 42}}	false
 
 # ---------- Drop field from nested struct ----------
@@ -129,13 +127,11 @@ insert into my_datalake.default.drop_struct_field VALUES (
 	true
 );
 
-# FIXME: 'also_nested' should be NULL, as it gets backfilled without a DEFAULT
-# but NULL is treated differently for now (hopefully we can fix this behavior later)
 query II
 select * from my_datalake.default.drop_struct_field order by all;
 ----
-{'a': hello world, 'nested': {'d': 1982-02-12}, 'also_nested': {'f': NULL}}	true
-{'a': hello world, 'nested': {'d': 1982-02-12}, 'also_nested': {'f': NULL}}	true
+{'a': hello world, 'nested': {'d': 1982-02-12}, 'also_nested': NULL}	true
+{'a': hello world, 'nested': {'d': 1982-02-12}, 'also_nested': NULL}	true
 {'a': test, 'nested': {'d': 2012-08-19}, 'also_nested': {'f': 42}}	false
 
 statement ok
@@ -154,12 +150,10 @@ insert into my_datalake.default.drop_struct_field VALUES (
 	true
 );
 
-# FIXME: 'also_nested' should be NULL, as it gets backfilled without a DEFAULT
-# but NULL is treated differently for now (hopefully we can fix this behavior later)
 query II
 select * from my_datalake.default.drop_struct_field order by all;
 ----
-{'a': hello world, 'also_nested': {'f': NULL}}	true
-{'a': hello world, 'also_nested': {'f': NULL}}	true
-{'a': hello world, 'also_nested': {'f': NULL}}	true
+{'a': hello world, 'also_nested': NULL}	true
+{'a': hello world, 'also_nested': NULL}	true
+{'a': hello world, 'also_nested': NULL}	true
 {'a': test, 'also_nested': {'f': 42}}	false

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/default/test_create_default_struct.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/default/test_create_default_struct.test
@@ -18,8 +18,9 @@ set ignore_error_messages
 statement ok
 drop table if exists my_datalake.default.tbl;
 
-# NOTE: Since no engine/catalog supports the {} default for STRUCT, we write NULL (omit the initial-default) for STRUCT instead
-# This changes the behavior matrix, and will need to be updated when support for {} is added
+statement ok
+SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+
 statement ok
 create table my_datalake.default.tbl(
 	col STRUCT(
@@ -87,8 +88,6 @@ select * from my_datalake.default.tbl order by all;
 statement ok
 drop table if exists my_datalake.default.nested_tbl;
 
-# NOTE: Since no engine/catalog supports the {} default for STRUCT, we write NULL (omit the initial-default) for STRUCT instead
-# This changes the behavior matrix, and will need to be updated when support for {} is added
 statement ok
 create table my_datalake.default.nested_tbl(
 	col STRUCT(
@@ -177,7 +176,10 @@ select * from my_datalake.default.nested_tbl order by all;
 {'a': test, 'b': {'v1': 1000, 'v2': NULL, 'v3': -500}, 'e': NULL}	12
 {'a': test, 'b': {'v1': 1000, 'v2': NULL, 'v3': NULL}, 'e': NULL}	24
 
-# DEFAULT NULL on a STRUCT currently materializes a struct whose fields are all NULL.
+statement ok
+RESET __iceberg_unsafe_struct_null_default_interpretation;
+
+# In the default safe mode, DEFAULT NULL on a STRUCT remains NULL.
 
 statement ok
 drop table if exists my_datalake.default.tbl_default_null_struct;
@@ -199,11 +201,12 @@ create table my_datalake.default.tbl_default_null_struct(
 statement ok
 insert into my_datalake.default.tbl_default_null_struct values
 	(1, DEFAULT),
-	(2, DEFAULT);
+	(2, DEFAULT),
+	(3, NULL);
 
-# FIXME: 'c' should be NULL, but this needs support for {} first
 query II
 select * from my_datalake.default.tbl_default_null_struct order by id;
 ----
-1	{'a': NULL, 'b': NULL, 'c': {'x': NULL}}
-2	{'a': NULL, 'b': NULL, 'c': {'x': NULL}}
+1	NULL
+2	NULL
+3	NULL

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/default/test_create_default_struct_nested.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/default/test_create_default_struct_nested.test
@@ -20,8 +20,9 @@ set ignore_error_messages
 statement ok
 drop table if exists my_datalake.default.nested_nested_tbl;
 
-# NOTE: Since no engine/catalog supports the {} default for STRUCT, we write NULL (omit the initial-default) for STRUCT instead
-# This changes the behavior matrix, and will need to be updated when support for {} is added
+statement ok
+SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+
 statement ok
 create table my_datalake.default.nested_nested_tbl(
 	col STRUCT(
@@ -152,3 +153,6 @@ select * from my_datalake.default.nested_nested_tbl order by all;
 {'a': test, 'b': {'v1': 1000, 'v2': {'f1': alpha, 'f2': NULL, 'f3': gamma}, 'v3': -500}, 'e': NULL}	12
 {'a': test, 'b': {'v1': 1000, 'v2': {'f1': alpha, 'f2': NULL, 'f3': NULL}, 'v3': -500}, 'e': NULL}	24
 {'a': test, 'b': {'v1': 1000, 'v2': {'f1': foo, 'f2': bar, 'f3': baz}, 'v3': -500}, 'e': NULL}	48
+
+statement ok
+RESET __iceberg_unsafe_struct_null_default_interpretation;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_into_default_struct.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_into_default_struct.test
@@ -30,8 +30,9 @@ set prefetch_all_parquet_files = false;
 statement ok
 DROP TABLE IF EXISTS my_datalake.default.tbl;
 
-# NOTE: Since no engine/catalog supports the {} default for STRUCT, we write NULL (omit the initial-default) for STRUCT instead
-# This changes the behavior matrix, and will need to be updated when support for {} is added
+statement ok
+SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+
 statement ok
 CREATE TABLE my_datalake.default.tbl(
 	id INTEGER,
@@ -117,7 +118,10 @@ select * from my_datalake.default.tbl where id = 6;
 ----
 6	{'a': hello, 'b': 42, 'c': \xAA\xFF\xAA}	NULL
 
-# DEFAULT NULL on a STRUCT currently materializes a struct whose fields are all NULL.
+statement ok
+RESET __iceberg_unsafe_struct_null_default_interpretation;
+
+# In the default safe mode, DEFAULT NULL on a STRUCT remains NULL.
 
 statement ok
 drop table if exists my_datalake.default.tbl_default_null_struct;
@@ -153,14 +157,12 @@ WHEN NOT MATCHED THEN INSERT VALUES (s.id, DEFAULT, s.col2)
 ----
 2
 
-# FIXME: 'c' should be NULL, but this needs support for {} first
 query III
 select * from my_datalake.default.tbl_default_null_struct where id = 1;
 ----
-1	{'a': NULL, 'b': NULL, 'c': {'x': NULL}}	100
+1	NULL	100
 
-# FIXME: 'c' should be NULL, but this needs support for {} first
 query III
 select * from my_datalake.default.tbl_default_null_struct where id = 3;
 ----
-3	{'a': NULL, 'b': NULL, 'c': {'x': NULL}}	300
+3	NULL	300

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_into_default_struct_nested.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_into_default_struct_nested.test
@@ -30,8 +30,9 @@ set prefetch_all_parquet_files = false;
 statement ok
 DROP TABLE IF EXISTS my_datalake.default.nested_nested_tbl;
 
-# NOTE: Since no engine/catalog supports the {} default for STRUCT, we write NULL (omit the initial-default) for STRUCT instead
-# This changes the behavior matrix, and will need to be updated when support for {} is added
+statement ok
+SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+
 statement ok
 CREATE TABLE my_datalake.default.nested_nested_tbl(
 	id INTEGER,
@@ -188,3 +189,6 @@ query III
 select * from my_datalake.default.nested_nested_tbl where id = 6;
 ----
 6	{'a': test, 'b': {'v1': 1000, 'v2': {'f1': foo, 'f2': bar, 'f3': baz}, 'v3': -500}, 'e': NULL}	72
+
+statement ok
+RESET __iceberg_unsafe_struct_null_default_interpretation;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_default_struct.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_default_struct.test
@@ -18,8 +18,9 @@ set ignore_error_messages
 statement ok
 drop table if exists my_datalake.default.tbl;
 
-# NOTE: Since no engine/catalog supports the {} default for STRUCT, we write NULL (omit the initial-default) for STRUCT instead
-# This changes the behavior matrix, and will need to be updated when support for {} is added
+statement ok
+SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+
 statement ok
 create table my_datalake.default.tbl(
 	id INTEGER,
@@ -90,7 +91,10 @@ select * from my_datalake.default.tbl where id = 3
 ----
 3	{'a': test, 'b': NULL, 'c': \xAA\xFF\xAA}	NULL
 
-# DEFAULT NULL on a STRUCT currently materializes a struct whose fields are all NULL.
+statement ok
+RESET __iceberg_unsafe_struct_null_default_interpretation;
+
+# In the default safe mode, DEFAULT NULL on a STRUCT remains NULL.
 
 statement ok
 drop table if exists my_datalake.default.tbl_default_null_struct;
@@ -121,8 +125,7 @@ update my_datalake.default.tbl_default_null_struct
 	col2 = col2 + 100
 where id = 1;
 
-# FIXME: 'c' should be NULL, but this needs support for {} first
 query III
 select * from my_datalake.default.tbl_default_null_struct where id = 1;
 ----
-1	{'a': NULL, 'b': NULL, 'c': {'x': NULL}}	110
+1	NULL	110

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_default_struct_nested.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_default_struct_nested.test
@@ -20,8 +20,9 @@ set ignore_error_messages
 statement ok
 drop table if exists my_datalake.default.nested_nested_tbl;
 
-# NOTE: Since no engine/catalog supports the {} default for STRUCT, we write NULL (omit the initial-default) for STRUCT instead
-# This changes the behavior matrix, and will need to be updated when support for {} is added
+statement ok
+SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+
 statement ok
 create table my_datalake.default.nested_nested_tbl(
 	id INTEGER,
@@ -134,3 +135,6 @@ query III
 select * from my_datalake.default.nested_nested_tbl where id = 3;
 ----
 3	{'a': test, 'b': {'v1': 1000, 'v2': {'f1': foo, 'f2': bar, 'f3': baz}, 'v3': -500}, 'e': NULL}	36
+
+statement ok
+RESET __iceberg_unsafe_struct_null_default_interpretation;

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/fixture/alter/alter_add_field_v3.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/fixture/alter/alter_add_field_v3.test
@@ -141,6 +141,9 @@ INSERT INTO my_datalake.default.alter_add_field_struct VALUES
 	(2, {'a': 'beta', 'nested': {'x': 'two'}});
 
 statement ok
+SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+
+statement ok
 ALTER TABLE my_datalake.default.alter_add_field_struct ADD COLUMN payload.extra STRUCT(
 	flag BOOLEAN,
 	"inner" STRUCT(
@@ -180,8 +183,10 @@ select id, payload from my_datalake.default.alter_add_field_struct order by id;
 1	{'a': alpha, 'nested': {'x': one}, 'extra': {'flag': true, 'inner': {'renamed_z': alpha-default}, 'flag2': NULL}}
 2	{'a': beta, 'nested': {'x': two}, 'extra': {'flag': true, 'inner': {'renamed_z': alpha-default}, 'flag2': NULL}}
 
-# Add a field of type STRUCT with DEFAULT NULL. Existing rows currently read it back
-# as a struct whose fields are all NULL rather than NULL.
+statement ok
+RESET __iceberg_unsafe_struct_null_default_interpretation;
+
+# Add a field of type STRUCT with DEFAULT NULL. Existing rows read it back as NULL.
 
 statement ok
 drop table if exists my_datalake.default.alter_add_field_struct_default_null;
@@ -213,15 +218,13 @@ ALTER TABLE my_datalake.default.alter_add_field_struct_default_null ADD COLUMN p
 	flag2 BOOLEAN
 ) DEFAULT NULL;
 
-# FIXME: 'inner' should be NULL, but this needs support for {} first
 query II
 select id, payload from my_datalake.default.alter_add_field_struct_default_null order by id;
 ----
-1	{'a': alpha, 'nested': {'x': one}, 'extra': {'flag': NULL, 'inner': {'z': NULL}, 'flag2': NULL}}
-2	{'a': beta, 'nested': {'x': two}, 'extra': {'flag': NULL, 'inner': {'z': NULL}, 'flag2': NULL}}
+1	{'a': alpha, 'nested': {'x': one}, 'extra': NULL}
+2	{'a': beta, 'nested': {'x': two}, 'extra': NULL}
 
-# Add a nested field of type STRUCT with DEFAULT NULL. Existing rows currently read it
-# back as a struct whose fields are all NULL rather than NULL.
+# Add a nested field of type STRUCT with DEFAULT NULL. Existing rows read it back as NULL.
 
 statement ok
 drop table if exists my_datalake.default.alter_add_field_nested_struct_default_null;
@@ -253,5 +256,5 @@ ALTER TABLE my_datalake.default.alter_add_field_nested_struct_default_null ADD C
 query II
 select id, payload from my_datalake.default.alter_add_field_nested_struct_default_null order by id;
 ----
-1	{'a': alpha, 'nested': {'x': one, 'extra': {'y': NULL, 'z': NULL}}}
-2	{'a': beta, 'nested': {'x': two, 'extra': {'y': NULL, 'z': NULL}}}
+1	{'a': alpha, 'nested': {'x': one, 'extra': NULL}}
+2	{'a': beta, 'nested': {'x': two, 'extra': NULL}}


### PR DESCRIPTION
Fixes an issue mentioned in #1072 