### PR TITLE
[Dev] Fix possible case-sensitivity problem, add annotation for locks

### DIFF
--- a/src/core/deletes/iceberg_positional_delete.cpp
+++ b/src/core/deletes/iceberg_positional_delete.cpp
@@ -14,8 +14,7 @@ void IcebergPositionalDeleteData::ToSet(set<idx_t> &out) const {
 }
 
 static optional_ptr<IcebergPositionalDeleteData>
-TryGetOrCreate(case_insensitive_map_t<shared_ptr<IcebergDeleteData>> &deletes, const BoundIcebergManifestEntry &entry,
-               const string &file_path) {
+TryGetOrCreate(position_delete_map_t &deletes, const BoundIcebergManifestEntry &entry, const string &file_path) {
 	auto it = deletes.find(file_path);
 	if (it == deletes.end()) {
 		it = deletes.emplace(file_path, make_shared_ptr<IcebergPositionalDeleteData>(entry)).first;

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/multi_file/multi_file_list.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types/batched_data_collection.hpp"
 #include "duckdb/common/multi_file/multi_file_data.hpp"
 #include "duckdb/common/list.hpp"
@@ -115,35 +116,35 @@ private:
 	optional_ptr<IcebergTableEntry> table;
 	IcebergOptions options;
 
-	mutable mutex lock;
-	mutable mutex delete_lock;
+	mutable annotated_mutex lock;
+	mutable annotated_mutex delete_lock DUCKDB_ACQUIRED_AFTER(lock);
 	mutable ManifestEntryReadState read_state;
 
-	mutable bool server_side_planning_enabled = true;
+	mutable bool server_side_planning_enabled DUCKDB_GUARDED_BY(lock) = true;
 
-	mutable bool manifest_list_loaded = false;
-	mutable bool data_manifest_scan_started = false;
+	mutable bool manifest_list_loaded DUCKDB_GUARDED_BY(lock) = false;
+	mutable bool data_manifest_scan_started DUCKDB_GUARDED_BY(lock) = false;
 
 	//! Scanned delete manifests and their owners.
-	mutable vector<IcebergManifestListEntry> committed_delete_manifests;
-	mutable vector<reference<const IcebergManifestListEntry>> transaction_delete_manifests;
-	mutable unique_ptr<AvroScan> delete_manifest_scan;
-	mutable unique_ptr<manifest_file::ManifestReader> delete_manifest_reader;
-	mutable bool delete_entries_enumerated = false;
-	mutable idx_t next_delete_entry_to_process = 0;
-	mutable vector<BoundIcebergManifestEntry> delete_manifest_entries;
+	mutable vector<IcebergManifestListEntry> committed_delete_manifests DUCKDB_GUARDED_BY(lock);
+	mutable vector<reference<const IcebergManifestListEntry>> transaction_delete_manifests DUCKDB_GUARDED_BY(lock);
+	mutable unique_ptr<AvroScan> delete_manifest_scan DUCKDB_GUARDED_BY(delete_lock);
+	mutable unique_ptr<manifest_file::ManifestReader> delete_manifest_reader DUCKDB_GUARDED_BY(delete_lock);
+	mutable bool delete_entries_enumerated DUCKDB_GUARDED_BY(delete_lock) = false;
+	mutable idx_t next_delete_entry_to_process DUCKDB_GUARDED_BY(delete_lock) = 0;
+	mutable vector<BoundIcebergManifestEntry> delete_manifest_entries DUCKDB_GUARDED_BY(delete_lock);
 
 	//! Scanned data manifests and their owners.
-	mutable vector<IcebergManifestListEntry> committed_data_manifests;
-	mutable vector<reference<const IcebergManifestListEntry>> transaction_data_manifests;
-	mutable unique_ptr<IcebergManifestScanningState> data_manifest_read_state;
+	mutable vector<IcebergManifestListEntry> committed_data_manifests DUCKDB_GUARDED_BY(lock);
+	mutable vector<reference<const IcebergManifestListEntry>> transaction_data_manifests DUCKDB_GUARDED_BY(lock);
+	mutable unique_ptr<IcebergManifestScanningState> data_manifest_read_state DUCKDB_GUARDED_BY(lock);
 
 	//! Declared after the manifest owners so references in parsed delete data are destroyed first.
-	mutable position_delete_map_t positional_delete_data;
-	mutable equality_delete_map_t equality_delete_data;
+	mutable position_delete_map_t positional_delete_data DUCKDB_GUARDED_BY(delete_lock);
+	mutable equality_delete_map_t equality_delete_data DUCKDB_GUARDED_BY(delete_lock);
 
 	//! Populated as parsed data-file entries become visible to any filtered view.
-	mutable unordered_map<string, vector<IcebergPartitionInfo>> data_file_partition_info;
+	mutable unordered_map<string, vector<IcebergPartitionInfo>> data_file_partition_info DUCKDB_GUARDED_BY(lock);
 };
 
 struct IcebergDataViewCursor {
@@ -200,16 +201,19 @@ private:
 	IcebergMultiFileList(shared_ptr<IcebergMultiFileListSharedState> shared_state);
 	void GetStatistics(vector<PartitionStatistics> &result) const;
 
-	void InitializeView(lock_guard<mutex> &guard) const;
+	void InitializeView(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
 
 	bool HasTransactionData() const;
 	//! Reorder (and prune, when a LIMIT is present) the materialized data files by the
 	//! ORDER BY column's per-file min/max bounds, mirroring the native RowGroupReorderer.
-	void EnsureScanOrderApplied(lock_guard<mutex> &guard) const;
-	OpenFileInfo GetFileInternal(idx_t i, lock_guard<mutex> &guard) const;
+	void EnsureScanOrderApplied(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
+	OpenFileInfo GetFileInternal(idx_t i, annotated_lock_guard<annotated_mutex> &guard) const
+	    DUCKDB_REQUIRES(shared_state->lock);
 	BoundIcebergManifestEntry GetManifestEntry(idx_t file_id) const;
+	IcebergManifestFile GetManifestFileForDataFile(idx_t file_id) const;
 	const IcebergManifestFile &GetManifestFileForEntry(const BoundIcebergManifestEntry &entry,
-	                                                   IcebergManifestContentType type) const;
+	                                                   IcebergManifestContentType type) const
+	    DUCKDB_REQUIRES(shared_state->lock);
 
 	void ProcessDeletes() const;
 	unique_ptr<DeleteFilter> GetPositionalDeletesForFile(const string &file_path) const;
@@ -225,30 +229,38 @@ private:
 	//! Whether a delete file's manifest entry can apply to any file selected by the current scan filter.
 	//! Delete files are pruned on partition only: one whose partition is excluded by the filter cannot
 	//! delete a row from any surviving data file, so it does not need to be read.
-	bool DeleteEntryMatchesFilters(const BoundIcebergManifestEntry &bound_manifest_entry) const;
+	bool DeleteEntryMatchesFilters(const BoundIcebergManifestEntry &bound_manifest_entry) const
+	    DUCKDB_REQUIRES(shared_state->lock);
 
 	//! NOTE: this requires the lock because it modifies the 'data_files' vector, potentially invalidating references
-	optional_ptr<const BoundIcebergManifestEntry> GetDataFile(idx_t file_id, lock_guard<mutex> &guard) const;
+	optional_ptr<const BoundIcebergManifestEntry> GetDataFile(idx_t file_id,
+	                                                          annotated_lock_guard<annotated_mutex> &guard) const
+	    DUCKDB_REQUIRES(shared_state->lock);
 
 	unique_ptr<ExpressionFilter> GetFilterForColumnIndex(const ColumnIndex &column_index) const;
 
-	bool TryGetNextBatch(lock_guard<mutex> &guard) const;
-	void FinishScanTasks(lock_guard<mutex> &guard) const;
-	void LoadManifestList(lock_guard<mutex> &guard) const;
-	void InitializeScanPlanProvider() const;
-	void StartDataManifestScan(lock_guard<mutex> &guard) const;
-	void EnumerateDeleteManifestEntriesInternal() const;
-	void ProcessDeletesInternal() const;
-	void ScanDeleteFiles() const;
-	void ScanDeleteFile(const BoundIcebergManifestEntry &entry) const;
-	void ScanPositionalDeleteFile(const BoundIcebergManifestEntry &manifest_entry, DataChunk &result) const;
+	bool TryGetNextBatch(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
+	void FinishScanTasks(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
+	void LoadManifestList(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
+	void InitializeScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);
+	void StartDataManifestScan(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
+	void EnumerateDeleteManifestEntriesInternal() const DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
+	void ProcessDeletesInternal() const DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
+	void ScanDeleteFiles() const DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
+	void ScanDeleteFile(const BoundIcebergManifestEntry &entry) const
+	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
+	void ScanPositionalDeleteFile(const BoundIcebergManifestEntry &manifest_entry, DataChunk &result) const
+	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
 	void ScanEqualityDeleteFile(const BoundIcebergManifestEntry &manifest_entry, DataChunk &result,
 	                            const vector<MultiFileColumnDefinition> &columns,
-	                            const vector<string> &source_names) const;
-	void ScanPuffinFile(const BoundIcebergManifestEntry &entry) const;
-	position_delete_map_t &GetPositionalDeleteData() const;
-	equality_delete_map_t &GetEqualityDeleteData() const;
-	IcebergScanPlanProvider &GetScanPlanProvider() const;
+	                            const vector<string> &source_names) const
+	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
+	void ScanPuffinFile(const BoundIcebergManifestEntry &entry) const
+	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
+	position_delete_map_t &GetPositionalDeleteData() const
+	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
+	equality_delete_map_t &GetEqualityDeleteData() const DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
+	IcebergScanPlanProvider &GetScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);
 
 private:
 	friend class ClientSideScanPlanProvider;
@@ -266,22 +278,22 @@ private:
 
 	//! The provider is per-view. The server-side implementation owns its filter-derived plan, while the client-side
 	//! implementation delegates to the shared manifest state above.
-	mutable unique_ptr<IcebergScanPlanProvider> scan_plan_provider;
+	mutable unique_ptr<IcebergScanPlanProvider> scan_plan_provider DUCKDB_GUARDED_BY(shared_state->lock);
 
 	//! Combination of committed + transaction delete manifests
-	mutable vector<BoundIcebergManifestListEntry> delete_manifests;
-	mutable vector<bool> delete_manifest_matches;
+	mutable vector<BoundIcebergManifestListEntry> delete_manifests DUCKDB_GUARDED_BY(shared_state->lock);
+	mutable vector<bool> delete_manifest_matches DUCKDB_GUARDED_BY(shared_state->lock);
 
-	mutable IcebergDataViewCursor data_view_cursor;
+	mutable IcebergDataViewCursor data_view_cursor DUCKDB_GUARDED_BY(shared_state->lock);
 	//! References to items inside the 'manifest_entries' of the list entries in the 'data_manifests'
-	mutable vector<BoundIcebergManifestEntry> data_manifest_entries;
+	mutable vector<BoundIcebergManifestEntry> data_manifest_entries DUCKDB_GUARDED_BY(shared_state->lock);
 	//! Combination of committed + transaction data manifests
-	mutable vector<BoundIcebergManifestListEntry> data_manifests;
-	mutable vector<bool> data_manifest_matches;
+	mutable vector<BoundIcebergManifestListEntry> data_manifests DUCKDB_GUARDED_BY(shared_state->lock);
+	mutable vector<bool> data_manifest_matches DUCKDB_GUARDED_BY(shared_state->lock);
 
 	//! Set by the table function's set_scan_order callback when an ORDER BY ... LIMIT can drive scan order.
-	mutable unique_ptr<RowGroupOrderOptions> scan_order_options;
-	mutable bool scan_order_applied = false;
+	mutable unique_ptr<RowGroupOrderOptions> scan_order_options DUCKDB_GUARDED_BY(shared_state->lock);
+	mutable bool scan_order_applied DUCKDB_GUARDED_BY(shared_state->lock) = false;
 };
 
 } // namespace duckdb

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -33,6 +33,7 @@
 namespace duckdb {
 
 using equality_delete_map_t = map<sequence_number_t, vector<IcebergEqualityDeleteFile>>;
+using position_delete_map_t = unordered_map<string, shared_ptr<IcebergDeleteData>>;
 
 struct IcebergTableFilters {
 	using filter_set_t = unordered_map<idx_t, unique_ptr<ExpressionFilter>>;
@@ -138,11 +139,11 @@ private:
 	mutable unique_ptr<IcebergManifestScanningState> data_manifest_read_state;
 
 	//! Declared after the manifest owners so references in parsed delete data are destroyed first.
-	mutable case_insensitive_map_t<shared_ptr<IcebergDeleteData>> positional_delete_data;
+	mutable position_delete_map_t positional_delete_data;
 	mutable equality_delete_map_t equality_delete_data;
 
 	//! Populated as parsed data-file entries become visible to any filtered view.
-	mutable case_insensitive_map_t<vector<IcebergPartitionInfo>> data_file_partition_info;
+	mutable unordered_map<string, vector<IcebergPartitionInfo>> data_file_partition_info;
 };
 
 struct IcebergDataViewCursor {
@@ -245,7 +246,7 @@ private:
 	                            const vector<MultiFileColumnDefinition> &columns,
 	                            const vector<string> &source_names) const;
 	void ScanPuffinFile(const BoundIcebergManifestEntry &entry) const;
-	case_insensitive_map_t<shared_ptr<IcebergDeleteData>> &GetPositionalDeleteData() const;
+	position_delete_map_t &GetPositionalDeleteData() const;
 	equality_delete_map_t &GetEqualityDeleteData() const;
 	IcebergScanPlanProvider &GetScanPlanProvider() const;
 

--- a/src/include/planning/iceberg_scan_plan_provider.hpp
+++ b/src/include/planning/iceberg_scan_plan_provider.hpp
@@ -29,20 +29,23 @@ class ClientSideScanPlanProvider final : public IcebergScanPlanProvider {
 public:
 	explicit ClientSideScanPlanProvider(IcebergMultiFileListSharedState &shared_state);
 
-	void LoadManifestList(const IcebergMultiFileList &file_list) override;
-	void StartDeleteManifestScan(const IcebergMultiFileList &file_list) override;
-	void StartDataManifestScan(const IcebergMultiFileList &file_list) override;
-	void EnumerateDeleteManifestEntries(const IcebergMultiFileList &file_list) override;
-	bool TryGetNextBatch(IcebergDataViewCursor &cursor) override;
-	void FinishScanTasks() override;
-	bool FinishedScanningDeletes() const override;
+	void LoadManifestList(const IcebergMultiFileList &file_list) override DUCKDB_REQUIRES(shared_state.lock);
+	void StartDeleteManifestScan(const IcebergMultiFileList &file_list) override
+	    DUCKDB_REQUIRES(shared_state.lock, shared_state.delete_lock);
+	void StartDataManifestScan(const IcebergMultiFileList &file_list) override
+	    DUCKDB_REQUIRES(shared_state.lock, file_list.shared_state->lock);
+	void EnumerateDeleteManifestEntries(const IcebergMultiFileList &file_list) override
+	    DUCKDB_REQUIRES(shared_state.lock, shared_state.delete_lock);
+	bool TryGetNextBatch(IcebergDataViewCursor &cursor) override DUCKDB_REQUIRES(shared_state.lock);
+	void FinishScanTasks() override DUCKDB_REQUIRES(shared_state.lock);
+	bool FinishedScanningDeletes() const override DUCKDB_REQUIRES(shared_state.delete_lock);
 	bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const override;
-	vector<IcebergManifestListEntry> &DataManifests() override;
-	vector<IcebergManifestListEntry> &DeleteManifests() override;
-	idx_t &NextDeleteEntryToProcess() override;
-	vector<BoundIcebergManifestEntry> &DeleteManifestEntries() override;
-	position_delete_map_t &PositionalDeleteData() override;
-	equality_delete_map_t &EqualityDeleteData() override;
+	vector<IcebergManifestListEntry> &DataManifests() override DUCKDB_REQUIRES(shared_state.lock);
+	vector<IcebergManifestListEntry> &DeleteManifests() override DUCKDB_REQUIRES(shared_state.lock);
+	idx_t &NextDeleteEntryToProcess() override DUCKDB_REQUIRES(shared_state.delete_lock);
+	vector<BoundIcebergManifestEntry> &DeleteManifestEntries() override DUCKDB_REQUIRES(shared_state.delete_lock);
+	position_delete_map_t &PositionalDeleteData() override DUCKDB_REQUIRES(shared_state.delete_lock);
+	equality_delete_map_t &EqualityDeleteData() override DUCKDB_REQUIRES(shared_state.delete_lock);
 
 private:
 	IcebergMultiFileListSharedState &shared_state;

--- a/src/include/planning/iceberg_scan_plan_provider.hpp
+++ b/src/include/planning/iceberg_scan_plan_provider.hpp
@@ -21,7 +21,7 @@ public:
 	virtual vector<IcebergManifestListEntry> &DeleteManifests() = 0;
 	virtual idx_t &NextDeleteEntryToProcess() = 0;
 	virtual vector<BoundIcebergManifestEntry> &DeleteManifestEntries() = 0;
-	virtual case_insensitive_map_t<shared_ptr<IcebergDeleteData>> &PositionalDeleteData() = 0;
+	virtual position_delete_map_t &PositionalDeleteData() = 0;
 	virtual equality_delete_map_t &EqualityDeleteData() = 0;
 };
 
@@ -41,7 +41,7 @@ public:
 	vector<IcebergManifestListEntry> &DeleteManifests() override;
 	idx_t &NextDeleteEntryToProcess() override;
 	vector<BoundIcebergManifestEntry> &DeleteManifestEntries() override;
-	case_insensitive_map_t<shared_ptr<IcebergDeleteData>> &PositionalDeleteData() override;
+	position_delete_map_t &PositionalDeleteData() override;
 	equality_delete_map_t &EqualityDeleteData() override;
 
 private:
@@ -64,7 +64,7 @@ public:
 	vector<IcebergManifestListEntry> &DeleteManifests() override;
 	idx_t &NextDeleteEntryToProcess() override;
 	vector<BoundIcebergManifestEntry> &DeleteManifestEntries() override;
-	case_insensitive_map_t<shared_ptr<IcebergDeleteData>> &PositionalDeleteData() override;
+	position_delete_map_t &PositionalDeleteData() override;
 	equality_delete_map_t &EqualityDeleteData() override;
 
 private:
@@ -75,7 +75,7 @@ private:
 	bool delete_entries_enumerated = false;
 	idx_t next_delete_entry_to_process = 0;
 	vector<BoundIcebergManifestEntry> delete_manifest_entries;
-	case_insensitive_map_t<shared_ptr<IcebergDeleteData>> positional_delete_data;
+	position_delete_map_t positional_delete_data;
 	equality_delete_map_t equality_delete_data;
 };
 

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -126,7 +126,7 @@ IcebergScanPlanProvider &IcebergMultiFileList::GetScanPlanProvider() const {
 	return *scan_plan_provider;
 }
 
-case_insensitive_map_t<shared_ptr<IcebergDeleteData>> &IcebergMultiFileList::GetPositionalDeleteData() const {
+position_delete_map_t &IcebergMultiFileList::GetPositionalDeleteData() const {
 	return GetScanPlanProvider().PositionalDeleteData();
 }
 

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -147,13 +147,14 @@ void IcebergMultiFileList::SetOptions(const IcebergOptions &options) {
 }
 
 void IcebergMultiFileList::SetScanOrder(unique_ptr<RowGroupOrderOptions> options) {
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	scan_order_options = std::move(options);
 	//! Indicate that 'EnsureScanOrderApplied' needs to run now
 	scan_order_applied = false;
 }
 
 void IcebergMultiFileList::DisableServerSidePlanning() {
-	lock_guard<mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	if (!shared_state->manifest_list_loaded) {
 		shared_state->server_side_planning_enabled = false;
 	}
@@ -299,7 +300,7 @@ unique_ptr<ExpressionFilter> IcebergMultiFileList::GetFilterForColumnIndex(const
 }
 
 void IcebergMultiFileList::Bind(vector<LogicalType> &return_types, vector<Identifier> &names) {
-	lock_guard<mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 
 	if (have_bound) {
 		names = StringsToIdentifiers(this->names);
@@ -341,6 +342,13 @@ void IcebergMultiFileList::Bind(vector<LogicalType> &return_types, vector<Identi
 unique_ptr<IcebergMultiFileList> IcebergMultiFileList::PushdownInternal(ClientContext &context,
                                                                         TableFilterSet &new_filters,
                                                                         const vector<column_t> &column_indexes) const {
+	unique_ptr<RowGroupOrderOptions> filtered_scan_order;
+	{
+		annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+		if (scan_order_options) {
+			filtered_scan_order = make_uniq<RowGroupOrderOptions>(*scan_order_options);
+		}
+	}
 	auto filtered_list = unique_ptr<IcebergMultiFileList>(new IcebergMultiFileList(shared_state));
 
 	IcebergTableFilters result_filter_set;
@@ -359,8 +367,8 @@ unique_ptr<IcebergMultiFileList> IcebergMultiFileList::PushdownInternal(ClientCo
 	filtered_list->names = names;
 	filtered_list->types = types;
 	filtered_list->have_bound = true;
-	if (scan_order_options) {
-		filtered_list->scan_order_options = make_uniq<RowGroupOrderOptions>(*scan_order_options);
+	if (filtered_scan_order) {
+		filtered_list->SetScanOrder(std::move(filtered_scan_order));
 	}
 	return filtered_list;
 }
@@ -419,7 +427,7 @@ unique_ptr<MultiFileList> IcebergMultiFileList::ComplexFilterPushdown(ClientCont
 vector<OpenFileInfo> IcebergMultiFileList::GetAllFiles() const {
 	vector<OpenFileInfo> file_list;
 	//! Lock is required because it reads the 'manifest_entries' vector
-	lock_guard<mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	for (idx_t i = 0;; i++) {
 		auto file = GetFileInternal(i, guard);
 		if (file.path.empty()) {
@@ -432,7 +440,7 @@ vector<OpenFileInfo> IcebergMultiFileList::GetAllFiles() const {
 
 FileExpandResult IcebergMultiFileList::GetExpandResult() const {
 	// GetFileInternal(1) will ensure files with index 0 and index 1 are expanded if they are available
-	lock_guard<mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	GetFileInternal(1, guard);
 
 	// always return multiple files, In the case there is only 1 data file,
@@ -443,7 +451,7 @@ FileExpandResult IcebergMultiFileList::GetExpandResult() const {
 idx_t IcebergMultiFileList::GetTotalFileCount() const {
 	// FIXME: the 'added_files_count' + the 'existing_files_count'
 	// in the Manifest List should give us this information without scanning the manifest file(s)
-	lock_guard<mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 
 	idx_t i = data_manifest_entries.size();
 	while (!GetFileInternal(i, guard).path.empty()) {
@@ -458,7 +466,7 @@ unique_ptr<NodeStatistics> IcebergMultiFileList::GetCardinality(ClientContext &c
 		return nullptr;
 	}
 
-	lock_guard<mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	InitializeView(guard);
 
 	idx_t cardinality = 0;
@@ -481,12 +489,18 @@ unique_ptr<NodeStatistics> IcebergMultiFileList::GetCardinality(ClientContext &c
 }
 
 BoundIcebergManifestEntry IcebergMultiFileList::GetManifestEntry(idx_t file_id) const {
-	lock_guard<mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	return data_manifest_entries[file_id];
 }
 
+IcebergManifestFile IcebergMultiFileList::GetManifestFileForDataFile(idx_t file_id) const {
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	auto manifest_file_idx = data_manifest_entries[file_id].manifest_file_idx;
+	return data_manifests[manifest_file_idx].entry.file;
+}
+
 vector<IcebergPartitionInfo> IcebergMultiFileList::GetPartitionInfoForDataFile(const string &file_path) const {
-	lock_guard<mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	auto entry = shared_state->data_file_partition_info.find(file_path);
 	if (entry != shared_state->data_file_partition_info.end()) {
 		return entry->second;
@@ -508,7 +522,7 @@ void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) co
 		//! We collect no statistics information from manifests for V1 tables.
 		return;
 	}
-	lock_guard<mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	InitializeView(guard);
 
 	for (idx_t i = 0; i < delete_manifests.size(); i++) {
@@ -841,16 +855,16 @@ bool IcebergMultiFileList::FileMatchesFilter(const IcebergManifestFile &manifest
 	return true;
 }
 
-bool IcebergMultiFileList::TryGetNextBatch(lock_guard<mutex> &guard) const {
+bool IcebergMultiFileList::TryGetNextBatch(annotated_lock_guard<annotated_mutex> &guard) const {
 	return GetScanPlanProvider().TryGetNextBatch(data_view_cursor);
 }
 
-void IcebergMultiFileList::FinishScanTasks(lock_guard<mutex> &guard) const {
+void IcebergMultiFileList::FinishScanTasks(annotated_lock_guard<annotated_mutex> &guard) const {
 	GetScanPlanProvider().FinishScanTasks();
 };
 
-optional_ptr<const BoundIcebergManifestEntry> IcebergMultiFileList::GetDataFile(idx_t file_id,
-                                                                                lock_guard<mutex> &guard) const {
+optional_ptr<const BoundIcebergManifestEntry>
+IcebergMultiFileList::GetDataFile(idx_t file_id, annotated_lock_guard<annotated_mutex> &guard) const {
 	D_ASSERT(scan_plan_provider);
 	if (file_id < data_manifest_entries.size()) {
 		//! Have we already scanned this data file and returned it? If so, return it
@@ -926,7 +940,7 @@ struct IcebergOrderEntry {
 
 } // namespace
 
-void IcebergMultiFileList::EnsureScanOrderApplied(lock_guard<mutex> &guard) const {
+void IcebergMultiFileList::EnsureScanOrderApplied(annotated_lock_guard<annotated_mutex> &guard) const {
 	if (!scan_order_options || scan_order_applied) {
 		return;
 	}
@@ -1044,7 +1058,7 @@ void IcebergMultiFileList::EnsureScanOrderApplied(lock_guard<mutex> &guard) cons
 	data_manifest_entries = std::move(reordered);
 }
 
-OpenFileInfo IcebergMultiFileList::GetFileInternal(idx_t file_id, lock_guard<mutex> &guard) const {
+OpenFileInfo IcebergMultiFileList::GetFileInternal(idx_t file_id, annotated_lock_guard<annotated_mutex> &guard) const {
 	InitializeView(guard);
 	StartDataManifestScan(guard);
 	EnsureScanOrderApplied(guard);
@@ -1088,7 +1102,7 @@ OpenFileInfo IcebergMultiFileList::GetFileInternal(idx_t file_id, lock_guard<mut
 }
 
 OpenFileInfo IcebergMultiFileList::GetFile(idx_t file_id) const {
-	lock_guard<mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	return GetFileInternal(file_id, guard);
 }
 
@@ -1157,7 +1171,8 @@ bool IcebergMultiFileList::ManifestMatchesFilter(const IcebergManifestFile &mani
 
 vector<reference<const IcebergEqualityDeleteFile>>
 IcebergMultiFileList::GetEqualityDeletesForFile(const BoundIcebergManifestEntry &bound_manifest_entry) const {
-	lock_guard<mutex> guard(shared_state->delete_lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
 	vector<reference<const IcebergEqualityDeleteFile>> result;
 
 	//! Look through all the equality delete files with a *higher* sequence number
@@ -1195,7 +1210,7 @@ IcebergMultiFileList::GetEqualityDeletesForFile(const BoundIcebergManifestEntry 
 	return result;
 }
 
-void IcebergMultiFileList::InitializeView(lock_guard<mutex> &guard) const {
+void IcebergMultiFileList::InitializeView(annotated_lock_guard<annotated_mutex> &guard) const {
 	if (scan_plan_provider) {
 		return;
 	}
@@ -1335,12 +1350,12 @@ void IcebergMultiFileList::InitializeScanPlanProvider() const {
 	}
 }
 
-void IcebergMultiFileList::LoadManifestList(lock_guard<mutex> &guard) const {
+void IcebergMultiFileList::LoadManifestList(annotated_lock_guard<annotated_mutex> &guard) const {
 	InitializeScanPlanProvider();
 	GetScanPlanProvider().LoadManifestList(*this);
 }
 
-void IcebergMultiFileList::StartDataManifestScan(lock_guard<mutex> &guard) const {
+void IcebergMultiFileList::StartDataManifestScan(annotated_lock_guard<annotated_mutex> &guard) const {
 	D_ASSERT(scan_plan_provider);
 	GetScanPlanProvider().StartDataManifestScan(*this);
 }
@@ -1386,9 +1401,9 @@ void IcebergMultiFileList::ScanDeleteFiles() const {
 }
 
 void IcebergMultiFileList::ProcessDeletes() const {
-	lock_guard<mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	InitializeView(guard);
-	lock_guard<mutex> delete_guard(shared_state->delete_lock);
+	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
 	ProcessDeletesInternal();
 }
 
@@ -1400,9 +1415,9 @@ void IcebergMultiFileList::ProcessDeletesInternal() const {
 }
 
 vector<BoundIcebergManifestEntry> IcebergMultiFileList::GetDeleteManifestEntries() const {
-	lock_guard<mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	InitializeView(guard);
-	lock_guard<mutex> delete_guard(shared_state->delete_lock);
+	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
 	EnumerateDeleteManifestEntriesInternal();
 	vector<BoundIcebergManifestEntry> result;
 	auto &delete_entries = GetScanPlanProvider().DeleteManifestEntries();
@@ -1503,7 +1518,8 @@ void IcebergMultiFileList::ScanDeleteFile(const BoundIcebergManifestEntry &bound
 }
 
 unique_ptr<DeleteFilter> IcebergMultiFileList::GetPositionalDeletesForFile(const string &file_path) const {
-	lock_guard<mutex> guard(shared_state->delete_lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
 	auto &positional_delete_data = GetPositionalDeleteData();
 	auto it = positional_delete_data.find(file_path);
 	if (it != positional_delete_data.end()) {
@@ -1514,7 +1530,8 @@ unique_ptr<DeleteFilter> IcebergMultiFileList::GetPositionalDeletesForFile(const
 }
 
 shared_ptr<IcebergDeleteData> IcebergMultiFileList::GetExistingPositionalDeleteData(const string &file_path) const {
-	lock_guard<mutex> guard(shared_state->delete_lock);
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
 	auto &positional_delete_data = GetPositionalDeleteData();
 	auto it = positional_delete_data.find(file_path);
 	if (it == positional_delete_data.end()) {

--- a/src/planning/iceberg_multi_file_reader.cpp
+++ b/src/planning/iceberg_multi_file_reader.cpp
@@ -302,8 +302,7 @@ void IcebergMultiFileReader::ApplyPartitionConstants(const IcebergMultiFileList 
 	auto &reader = *reader_data.reader;
 	auto file_id = reader.file_list_idx.GetIndex();
 	auto bound_manifest_entry = multi_file_list.GetManifestEntry(file_id);
-	auto &manifest_file =
-	    multi_file_list.GetManifestFileForEntry(bound_manifest_entry, IcebergManifestContentType::DATA);
+	auto manifest_file = multi_file_list.GetManifestFileForDataFile(file_id);
 	auto &manifest_entry = bound_manifest_entry.entry;
 	auto &data_file = manifest_entry.data_file;
 

--- a/src/planning/iceberg_scan_plan_provider.cpp
+++ b/src/planning/iceberg_scan_plan_provider.cpp
@@ -323,7 +323,7 @@ vector<BoundIcebergManifestEntry> &ClientSideScanPlanProvider::DeleteManifestEnt
 	return shared_state.delete_manifest_entries;
 }
 
-case_insensitive_map_t<shared_ptr<IcebergDeleteData>> &ClientSideScanPlanProvider::PositionalDeleteData() {
+position_delete_map_t &ClientSideScanPlanProvider::PositionalDeleteData() {
 	return shared_state.positional_delete_data;
 }
 
@@ -399,7 +399,7 @@ vector<BoundIcebergManifestEntry> &ServerSideScanPlanProvider::DeleteManifestEnt
 	return delete_manifest_entries;
 }
 
-case_insensitive_map_t<shared_ptr<IcebergDeleteData>> &ServerSideScanPlanProvider::PositionalDeleteData() {
+position_delete_map_t &ServerSideScanPlanProvider::PositionalDeleteData() {
 	return positional_delete_data;
 }
 


### PR DESCRIPTION
We now use `annotated_mutex` and all the variables guarded by mutexes are annotated as such.

`positional_delete_data` was using a `case-insensitive-map`, but we access it with file paths, I don't think file paths are guaranteed to be case-insensitive on all file systems.
So I've changed it to be case-sensitive.