### PR TITLE
Honor REST catalog URI overrides

### DIFF
--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -380,6 +380,11 @@ void IcebergCatalog::GetConfig(ClientContext &context, IcebergEndpointType &endp
 	auto catalog_config = IRCAPI::GetCatalogConfig(context, *this, effective_warehouse);
 	overrides = catalog_config.overrides;
 	defaults = catalog_config.defaults;
+	auto uri_override_it = overrides.find("uri");
+	if (uri_override_it != overrides.end()) {
+		uri = uri_override_it->second;
+		StringUtil::RTrim(uri, "/");
+	}
 	ParsePrefix();
 
 	if (attach_options.encode_entire_prefix) {

--- a/test/sql/local/catalog_custom_setup/nessie/test_nessie.test
+++ b/test/sql/local/catalog_custom_setup/nessie/test_nessie.test
@@ -46,20 +46,29 @@ attach '' as my_datalake (
 <REGEX>:.*Unrecognized access mode.*Supported options are 'vended_credentials' and 'none'.*
 
 statement ok
+call enable_logging(level='debug');
+
+statement ok
 attach 'warehouse' as my_datalake (
     type ICEBERG,
-    ENDPOINT 'http://127.0.0.1:19120/iceberg/',
+    ENDPOINT 'http://127.0.0.1:19120/iceberg/main',
     ACCESS_DELEGATION_MODE 'none',
     SECRET 'my_secret'
 );
 
+# make sure the branch-scoped endpoint is used to fetch the catalog config
+query I
+select request.url from duckdb_logs_parsed('HTTP') where request.url like '%/v1/config%';
+----
+http://127.0.0.1:19120/iceberg/main/v1/config?warehouse=warehouse
+
 statement ok
-call enable_logging(level='debug');
+call truncate_duckdb_logs();
 
 statement ok
 show all tables;
 
-# make sure warehouse main|warehouse is properly encoded
+# make sure the URI override becomes the base URL and main|warehouse is properly encoded
 query I
 select request.url from duckdb_logs_parsed('HTTP');
 ----


### PR DESCRIPTION
## Description

  REST catalogs can return an `overrides.uri` property from the `/v1/config`
  endpoint to replace the client-configured catalog base URI.

  DuckDB currently ignores this property. For branch-scoped Nessie endpoints
  such as `/iceberg/main`, this causes follow-up requests to be incorrectly
  constructed under `/iceberg/main/v1/...` instead of the canonical
  `/iceberg/v1/...` endpoint returned by the server.

  This change:

  - applies `overrides.uri` after loading the catalog configuration
  - removes trailing slashes before constructing subsequent REST URLs
  - keeps the server-provided prefix handling unchanged
  - extends the Nessie integration test to verify both the initial
    branch-scoped config request and the overridden follow-up request URLs

  This does not add generic branch or ref support to REST catalogs. It follows
  the standard server-provided configuration precedence.

  Fixes #1145

  ## Tests

  - `make debug`
  - Nessie integration tests: 7 test cases, 125 assertions
  - `make format-check`
  - `git diff --check`