### PR TITLE
[Dev] Parse the Catalog `prefix` once as a `vector<string>`, fix eviction of `LoadTableResultCache`

### DIFF
--- a/src/catalog/rest/api/catalog_api.cpp
+++ b/src/catalog/rest/api/catalog_api.cpp
@@ -165,7 +165,7 @@ bool IRCAPI::VerifySchemaExistence(ClientContext &context, IcebergCatalog &catal
 	auto namespace_items = ParseSchemaName(schema);
 
 	auto url_builder = catalog.GetBaseUrl();
-	url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+	url_builder.AddPrefixComponents(catalog.prefix);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
 	url_builder.AddPathComponent(IRCPathComponent::NamespaceComponent(namespace_items));
 	bool execute_head =
@@ -176,7 +176,7 @@ bool IRCAPI::VerifySchemaExistence(ClientContext &context, IcebergCatalog &catal
 bool IRCAPI::VerifyTableExistence(ClientContext &context, IcebergCatalog &catalog, const IcebergSchemaEntry &schema,
                                   const string &table) {
 	auto url_builder = catalog.GetBaseUrl();
-	url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+	url_builder.AddPrefixComponents(catalog.prefix);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
 	url_builder.AddPathComponent(IRCPathComponent::NamespaceComponent(schema.namespace_items));
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("tables"));
@@ -189,7 +189,7 @@ bool IRCAPI::VerifyTableExistence(ClientContext &context, IcebergCatalog &catalo
 static unique_ptr<HTTPResponse> GetTableMetadata(ClientContext &context, IcebergCatalog &catalog,
                                                  const IcebergSchemaEntry &schema, const string &table) {
 	auto url_builder = catalog.GetBaseUrl();
-	url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+	url_builder.AddPrefixComponents(catalog.prefix);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
 	url_builder.AddPathComponent(IRCPathComponent::NamespaceComponent(schema.namespace_items));
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("tables"));
@@ -234,7 +234,7 @@ IRCAPI::GetNamespace(ClientContext &context, IcebergCatalog &catalog, const Iceb
 	auto ret = APIResult<unique_ptr<const rest_api_objects::GetNamespaceResponse>>();
 
 	auto url_builder = catalog.GetBaseUrl();
-	url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+	url_builder.AddPrefixComponents(catalog.prefix);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
 	url_builder.AddPathComponent(IRCPathComponent::NamespaceComponent(schema.namespace_items));
 
@@ -268,7 +268,7 @@ vector<rest_api_objects::TableIdentifier> IRCAPI::GetTables(ClientContext &conte
 
 	do {
 		auto url_builder = catalog.GetBaseUrl();
-		url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+		url_builder.AddPrefixComponents(catalog.prefix);
 		url_builder.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
 		url_builder.AddPathComponent(IRCPathComponent::NamespaceComponent(schema.namespace_items));
 		url_builder.AddPathComponent(IRCPathComponent::RegularComponent("tables"));
@@ -325,7 +325,7 @@ vector<IRCAPISchema> IRCAPI::GetSchemas(ClientContext &context, IcebergCatalog &
 	string page_token = "";
 	do {
 		auto url_builder = catalog.GetBaseUrl();
-		url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+		url_builder.AddPrefixComponents(catalog.prefix);
 		url_builder.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
 		if (!parent.empty()) {
 			url_builder.SetParam("parent", IRCPathComponent::NamespaceComponent(parent));
@@ -412,7 +412,7 @@ static CommitResult BuildCommitResult(ClientContext &context, const unique_ptr<H
 
 CommitResult IRCAPI::CommitMultiTableUpdate(ClientContext &context, IcebergCatalog &catalog, const string &body) {
 	auto url_builder = catalog.GetBaseUrl();
-	url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+	url_builder.AddPrefixComponents(catalog.prefix);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("transactions"));
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("commit"));
 	HTTPHeaders headers(*context.db);
@@ -425,7 +425,7 @@ CommitResult IRCAPI::CommitMultiTableUpdate(ClientContext &context, IcebergCatal
 CommitResult IRCAPI::CommitTableUpdate(ClientContext &context, IcebergCatalog &catalog, const vector<string> &schema,
                                        const string &table, const string &body) {
 	auto url_builder = catalog.GetBaseUrl();
-	url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+	url_builder.AddPrefixComponents(catalog.prefix);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
 	url_builder.AddPathComponent(IRCPathComponent::NamespaceComponent(schema));
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("tables"));
@@ -440,7 +440,7 @@ CommitResult IRCAPI::CommitTableUpdate(ClientContext &context, IcebergCatalog &c
 void IRCAPI::CommitTableDelete(ClientContext &context, IcebergCatalog &catalog, const vector<string> &schema,
                                const string &table) {
 	auto url_builder = catalog.GetBaseUrl();
-	url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+	url_builder.AddPrefixComponents(catalog.prefix);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
 	url_builder.AddPathComponent(IRCPathComponent::NamespaceComponent(schema));
 
@@ -461,7 +461,7 @@ void IRCAPI::CommitTableDelete(ClientContext &context, IcebergCatalog &catalog, 
 
 void IRCAPI::CommitTableRename(ClientContext &context, IcebergCatalog &catalog, const string &body) {
 	auto url_builder = catalog.GetBaseUrl();
-	url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+	url_builder.AddPrefixComponents(catalog.prefix);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("tables"));
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("rename"));
 
@@ -479,7 +479,7 @@ void IRCAPI::CommitTableRename(ClientContext &context, IcebergCatalog &catalog, 
 
 void IRCAPI::CommitNamespaceCreate(ClientContext &context, IcebergCatalog &catalog, string body) {
 	auto url_builder = catalog.GetBaseUrl();
-	url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+	url_builder.AddPrefixComponents(catalog.prefix);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
 	HTTPHeaders headers(*context.db);
 	headers.Insert("Content-Type", "application/json");
@@ -495,7 +495,7 @@ void IRCAPI::CommitNamespaceCreate(ClientContext &context, IcebergCatalog &catal
 void IRCAPI::CommitNamespaceDrop(ClientContext &context, IcebergCatalog &catalog,
                                  const vector<string> &namespace_items) {
 	auto url_builder = catalog.GetBaseUrl();
-	url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+	url_builder.AddPrefixComponents(catalog.prefix);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
 	url_builder.AddPathComponent(IRCPathComponent::NamespaceComponent(namespace_items));
 
@@ -517,7 +517,7 @@ void IRCAPI::CommitNamespacePropertiesUpdate(ClientContext &context, IcebergCata
 		throw NotImplementedException("This Iceberg REST catalog server does not support this operation");
 	}
 	auto url_builder = catalog.GetBaseUrl();
-	url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+	url_builder.AddPrefixComponents(catalog.prefix);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
 	url_builder.AddPathComponent(IRCPathComponent::NamespaceComponent(namespace_items));
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("properties"));
@@ -536,7 +536,7 @@ rest_api_objects::LoadTableResult IRCAPI::CommitNewTable(ClientContext &context,
                                                          const vector<string> &namespace_items,
                                                          const IcebergCreateTableRequest &request) {
 	auto url_builder = catalog.GetBaseUrl();
-	url_builder.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+	url_builder.AddPrefixComponents(catalog.prefix);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
 	url_builder.AddPathComponent(IRCPathComponent::NamespaceComponent(namespace_items));
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("tables"));

--- a/src/catalog/rest/api/iceberg_scan_planning.cpp
+++ b/src/catalog/rest/api/iceberg_scan_planning.cpp
@@ -72,7 +72,7 @@ struct PlanningAccumulator {
 static IRCEndpointBuilder TableEndpoint(IcebergTableInformation &table_info) {
 	auto &catalog = table_info.catalog;
 	auto result = catalog.GetBaseUrl();
-	result.AddPrefixComponent(catalog.prefix, catalog.prefix_is_one_component);
+	result.AddPrefixComponents(catalog.prefix);
 	result.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
 	result.AddPathComponent(IRCPathComponent::NamespaceComponent(table_info.schema.namespace_items));
 	result.AddPathComponent(IRCPathComponent::RegularComponent("tables"));

--- a/src/catalog/rest/api/url_utils.cpp
+++ b/src/catalog/rest/api/url_utils.cpp
@@ -32,21 +32,8 @@ void IRCEndpointBuilder::AddPathComponent(IRCPathComponent &&component) {
 	path_components.push_back(std::move(component));
 }
 
-void IRCEndpointBuilder::AddPrefixComponent(const string &component, const bool &prefix_is_one_component) {
-	if (component.empty()) {
-		return;
-	}
-
-	// If the component contains slashes, split it into multiple segments
-	if (!prefix_is_one_component && component.find('/') != string::npos) {
-		auto segments = StringUtil::Split(component, '/');
-		for (const auto &segment : segments) {
-			if (!segment.empty()) {
-				AddPathComponent(IRCPathComponent::RegularComponent(segment));
-			}
-		}
-	} else {
-		// Single component without slashes
+void IRCEndpointBuilder::AddPrefixComponents(const vector<string> &components) {
+	for (const auto &component : components) {
 		AddPathComponent(IRCPathComponent::RegularComponent(component));
 	}
 }

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
@@ -656,16 +656,17 @@ void IcebergTableInformation::RefreshFromCatalog(ClientContext &context) {
 		                       EnumUtil::ToString(get_table_result.status_), get_table_result.error_->_error.message));
 	}
 	auto &load_table_result = *get_table_result.result_;
-	ic_catalog.table_request_cache.SetOrOverwrite(context, table_key, std::move(get_table_result.result_));
 	schema_versions.clear();
 	dummy_entry.reset();
 	InitializeFromLoadTableResult(load_table_result);
+	ic_catalog.table_request_cache.SetOrOverwrite(table_key, std::move(get_table_result.result_));
 }
 
 IcebergTableInformation IcebergTableInformation::Copy() const {
 	auto clone = IcebergTableInformation(catalog, schema, name);
 	clone.table_metadata = table_metadata.Copy();
 	clone.config = config;
+	clone.initialization_source = initialization_source;
 	for (auto &credential : storage_credentials) {
 		clone.storage_credentials.push_back(credential.Copy());
 	}
@@ -756,6 +757,7 @@ IcebergTransactionData &IcebergTableInformation::GetOrCreateTransactionData(Iceb
 
 void IcebergTableInformation::InitializeFromLoadTableResult(
     const rest_api_objects::LoadTableResult &load_table_result) {
+	initialization_source = load_table_result;
 	table_metadata = IcebergTableMetadata::FromTableMetadata(load_table_result.metadata);
 	if (auto &val = load_table_result.config) {
 		config = *val;

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -11,6 +11,7 @@
 
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
 #include "catalog/rest/api/catalog_api.hpp"
 #include "catalog/rest/api/catalog_utils.hpp"
@@ -22,6 +23,18 @@
 using namespace duckdb_yyjson;
 
 namespace duckdb {
+
+void LoadTableResultCache::EvictIfCurrent(const IcebergTableInformation &table) {
+	lock_guard<mutex> guard(lock);
+	auto it = tables.find(table.GetTableKey());
+	if (it == tables.end()) {
+		return;
+	}
+	if (it->second.load_table_result.get() != table.initialization_source.get()) {
+		return;
+	}
+	tables.erase(it);
+}
 
 IcebergCatalog::IcebergCatalog(AttachedDatabase &db_p, AccessMode access_mode,
                                unique_ptr<IcebergAuthorization> auth_handler, IcebergAttachOptions &attach_options_p,

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -338,32 +338,23 @@ void IcebergCatalog::ParsePrefix() {
 	auto default_prefix_it = defaults.find("prefix");
 	auto override_prefix_it = overrides.find("prefix");
 
-	string decoded_prefix = "";
+	const string *prefix_property = nullptr;
 	if (default_prefix_it != defaults.end()) {
-		decoded_prefix = StringUtil::URLDecode(default_prefix_it->second);
-		prefix = decoded_prefix;
-		if (!StringUtil::Equals(decoded_prefix, default_prefix_it->second)) {
-			// decoded prefix contains a slash AND is not equal to the original
-			// means prefix was encoded, and is one URL component
-			prefix_is_one_component = true;
-		} else {
-			prefix_is_one_component = false;
-		}
+		prefix_property = &default_prefix_it->second;
+	}
+	// Sometimes the prefix is in the overrides. Prefer the override prefix.
+	if (override_prefix_it != overrides.end()) {
+		prefix_property = &override_prefix_it->second;
+	}
+	if (!prefix_property) {
+		return;
 	}
 
-	// sometimes the prefix in the overrides. Prefer the override prefix
-	if (override_prefix_it != overrides.end()) {
-		decoded_prefix = StringUtil::URLDecode(override_prefix_it->second);
-		prefix = decoded_prefix;
-
-		if (!StringUtil::Equals(decoded_prefix, override_prefix_it->second)) {
-			// decoded prefix is not equal to the original
-			// means prefix was encoded, and is one URL component
-			prefix_is_one_component = true;
-		} else {
-			// decoded prefix contains a '/' or is equal
-			prefix_is_one_component = false;
-		}
+	auto decoded_prefix = StringUtil::URLDecode(*prefix_property);
+	if (attach_options.encode_entire_prefix || !StringUtil::Equals(decoded_prefix, *prefix_property)) {
+		prefix.push_back(std::move(decoded_prefix));
+	} else {
+		prefix = StringUtil::Split(decoded_prefix, '/');
 	}
 }
 
@@ -386,10 +377,6 @@ void IcebergCatalog::GetConfig(ClientContext &context, IcebergEndpointType &endp
 		StringUtil::RTrim(uri, "/");
 	}
 	ParsePrefix();
-
-	if (attach_options.encode_entire_prefix) {
-		prefix_is_one_component = true;
-	}
 
 	if (auto &endpoints = catalog_config.endpoints) {
 		for (auto &endpoint : *endpoints) {

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -68,8 +68,8 @@ bool IcebergTableSet::FillEntry(ClientContext &context, IcebergTableInformation 
 		                       EnumUtil::ToString(get_table_result.status_), get_table_result.error_->_error.message));
 	}
 	auto &load_table_result = *get_table_result.result_;
-	ic_catalog.table_request_cache.SetOrOverwrite(context, table_key, std::move(get_table_result.result_));
 	table.InitializeFromLoadTableResult(load_table_result);
+	ic_catalog.table_request_cache.SetOrOverwrite(table_key, std::move(get_table_result.result_));
 	return true;
 }
 
@@ -258,11 +258,11 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 
 	auto key = IcebergTableInformation::GetTableKey(schema.namespace_items, info.GetTableName().GetIdentifierName());
 	auto &load_table_result = *new_table_result;
-	catalog.table_request_cache.SetOrOverwrite(context, key, std::move(new_table_result));
 	auto &alter_update = iceberg_transaction.GetOrCreateAlter();
 	auto &table_info = alter_update.CreateTable(
 	    key, IcebergTableInformation(catalog, schema, info.GetTableName().GetIdentifierName()));
 	table_info.InitializeFromLoadTableResult(load_table_result);
+	catalog.table_request_cache.SetOrOverwrite(key, std::move(new_table_result));
 
 	// if we stage created the table, we add an assert create
 	auto &transaction_data = table_info.GetOrCreateTransactionData(iceberg_transaction);

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -563,7 +563,7 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	if (ic_catalog.attach_options.max_table_staleness_micros.IsValid()) {
 		for (auto &entry : alter_update.updated_tables) {
-			ic_catalog.table_request_cache.Expire(context, entry.first);
+			ic_catalog.table_request_cache.EvictIfCurrent(entry.second.get());
 		}
 	}
 }
@@ -571,11 +571,9 @@ void IcebergTransaction::DoTableUpdates(IcebergTransactionAlterUpdate &alter_upd
 void IcebergTransaction::DoTableRename(IcebergTransactionRenameUpdate &rename_update, ClientContext &context) {
 	auto &original_table = rename_update.table.get();
 	auto &schema = original_table.schema;
-	auto source_table_key = original_table.GetTableKey();
 	auto &table_name = original_table.name;
 	auto new_name = rename_update.new_name;
 	auto &new_table = rename_update.new_table.get();
-	auto destination_table_key = new_table.GetTableKey();
 
 	rest_api_objects::RenameTableRequest request;
 	request.source._namespace.value = schema.namespace_items;
@@ -587,8 +585,8 @@ void IcebergTransaction::DoTableRename(IcebergTransactionRenameUpdate &rename_up
 
 	if (catalog.attach_options.max_table_staleness_micros.IsValid()) {
 		//! The shared cache must only change once the catalog rename is durable.
-		catalog.table_request_cache.Expire(context, source_table_key);
-		catalog.table_request_cache.Expire(context, destination_table_key);
+		catalog.table_request_cache.EvictIfCurrent(original_table);
+		catalog.table_request_cache.EvictIfCurrent(new_table);
 	}
 
 	DropInfo drop_info;
@@ -689,11 +687,10 @@ void IcebergTransaction::DoTableDeletes(IcebergTransactionDeleteUpdate &delete_u
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	auto &table = delete_update.deleted_table.get();
 	auto schema_key = table.schema.name;
-	auto table_key = table.GetTableKey();
 	auto &table_name = table.name;
 	IRCAPI::CommitTableDelete(context, catalog, table.schema.namespace_items, table_name);
 	// remove the load table result
-	ic_catalog.table_request_cache.Expire(context, table_key);
+	ic_catalog.table_request_cache.EvictIfCurrent(table);
 	// remove the table entry from the catalog
 	auto &schema_entry = ic_catalog.schemas.GetEntry(schema_key.GetIdentifierName()).Cast<IcebergSchemaEntry>();
 	DropInfo drop_info;
@@ -830,17 +827,15 @@ void IcebergTransaction::EvictCachedTables() {
 	if (!catalog.attach_options.max_table_staleness_micros.IsValid()) {
 		return;
 	}
-	ScopedTransaction temp_con(db);
-	auto &temp_context = temp_con.GetContext();
 	std::visit(
 	    [&](auto &update) {
 		    using T = std::decay_t<decltype(update)>;
 		    if constexpr (std::is_same_v<T, IcebergTransactionAlterUpdate>) {
 			    for (auto &up_table : update.updated_tables) {
-				    catalog.table_request_cache.Expire(temp_context, up_table.first);
+				    catalog.table_request_cache.EvictIfCurrent(up_table.second.get());
 			    }
 		    } else if constexpr (std::is_same_v<T, IcebergTransactionDeleteUpdate>) {
-			    catalog.table_request_cache.Expire(temp_context, update.deleted_table.get().GetTableKey());
+			    catalog.table_request_cache.EvictIfCurrent(update.deleted_table.get());
 		    }
 	    },
 	    transaction_update);

--- a/src/function/metadata/iceberg_load_table_response.cpp
+++ b/src/function/metadata/iceberg_load_table_response.cpp
@@ -47,7 +47,7 @@ static unique_ptr<HTTPResponse> MakeRequest(ClientContext &context, const Iceber
 	auto &ic_table_entry = bind_data.table_entry;
 
 	auto url_builder = ic_catalog.GetBaseUrl();
-	url_builder.AddPrefixComponent(ic_catalog.prefix, ic_catalog.prefix_is_one_component);
+	url_builder.AddPrefixComponents(ic_catalog.prefix);
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("namespaces"));
 	url_builder.AddPathComponent(IRCPathComponent::NamespaceComponent(ic_schema.namespace_items));
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("tables"));

--- a/src/include/catalog/rest/api/url_utils.hpp
+++ b/src/include/catalog/rest/api/url_utils.hpp
@@ -49,7 +49,7 @@ class IRCEndpointBuilder {
 public:
 	IRCEndpointBuilder();
 	void AddPathComponent(IRCPathComponent &&component);
-	void AddPrefixComponent(const string &component, const bool &prefix_is_one_component);
+	void AddPrefixComponents(const vector<string> &components);
 
 	void SetHost(const string &host);
 	string GetHost() const;

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_information.hpp
@@ -81,6 +81,8 @@ public:
 	// dummy entry to hold existence of a table, but no schema versions
 	unique_ptr<IcebergTableEntry> dummy_entry;
 	unique_ptr<IcebergTransactionData> transaction_data;
+	//! The cached response this table was initialized from, used as an identity and never dereferenced.
+	optional_ptr<const rest_api_objects::LoadTableResult> initialization_source;
 
 private:
 	//! Unchanged by rename, used to check for a rename

--- a/src/include/catalog/rest/iceberg_catalog.hpp
+++ b/src/include/catalog/rest/iceberg_catalog.hpp
@@ -189,9 +189,8 @@ public:
 	string uri;
 	//! version
 	const string version;
-	//! optional prefix
-	string prefix;
-	bool prefix_is_one_component = true;
+	//! optional prefix path components
+	vector<string> prefix;
 	//! attach options
 	IcebergAttachOptions attach_options;
 	string default_schema;

--- a/src/include/catalog/rest/iceberg_catalog.hpp
+++ b/src/include/catalog/rest/iceberg_catalog.hpp
@@ -7,7 +7,6 @@
 #include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "duckdb/storage/storage_extension.hpp"
 #include "duckdb/common/http_util.hpp"
-#include "duckdb/transaction/meta_transaction.hpp"
 
 #include "catalog/rest/api/url_utils.hpp"
 #include "catalog/rest/iceberg_schema_set.hpp"
@@ -18,17 +17,16 @@
 namespace duckdb {
 
 class IcebergSchemaEntry;
+struct IcebergTableInformation;
 
 class MetadataCacheValue {
 public:
-	MetadataCacheValue(transaction_t creator, timestamp_ms_t expire_timestamp_ms,
+	MetadataCacheValue(timestamp_ms_t expire_timestamp_ms,
 	                   unique_ptr<const rest_api_objects::LoadTableResult> load_table_result)
-	    : creator(creator), expire_timestamp_ms(expire_timestamp_ms), load_table_result(std::move(load_table_result)) {
+	    : expire_timestamp_ms(expire_timestamp_ms), load_table_result(std::move(load_table_result)) {
 	}
 
 public:
-	//! Store the id of the transaction that added the entry
-	transaction_t creator;
 	//! The timestamp until when this entry is valid
 	timestamp_ms_t expire_timestamp_ms;
 	//! The payload of the cache entry
@@ -63,7 +61,7 @@ public:
 		}
 		return entry;
 	}
-	void SetOrOverwrite(ClientContext &context, const string &table_key,
+	void SetOrOverwrite(const string &table_key,
 	                    unique_ptr<const rest_api_objects::LoadTableResult> load_table_result) {
 		lock_guard<mutex> guard(lock);
 		// If max_table_staleness_minutes is not set, use a time in the past so cache is always expired
@@ -79,27 +77,11 @@ public:
 
 		// erase load table result if it exists.
 		tables.erase(table_key);
-		auto &meta_transaction = MetaTransaction::Get(context);
-
-		tables.emplace(table_key, MetadataCacheValue(meta_transaction.global_transaction_id, expire_timestamp_ms,
-		                                             std::move(load_table_result)));
+		tables.emplace(table_key, MetadataCacheValue(expire_timestamp_ms, std::move(load_table_result)));
 	}
 
-	void Expire(ClientContext &context, const string &table_key) {
-		lock_guard<mutex> guard(lock);
-		auto &meta_transaction = MetaTransaction::Get(context);
-		tables.erase(table_key);
-		auto it = tables.find(table_key);
-		if (it == tables.end()) {
-			//! Entry doesn't exist anymore
-			return;
-		}
-		auto &entry = it->second;
-		if (entry.creator != meta_transaction.global_transaction_id) {
-			//! The entry we made is no longer the latest version, can't expire
-			return;
-		}
-	}
+	//! Evict only if the table was initialized from the result that is still cached for its key.
+	void EvictIfCurrent(const IcebergTableInformation &table);
 
 private:
 	IcebergAttachOptions &attach_options;


### PR DESCRIPTION
This removes the need for `prefix_is_one_component` and also removes the need to reparse the prefix on every endpoint builder.

We now keep track of the initialization source of a IcebergTableInformation, and use that to make sure we only evict cache if the entry is still active in the cache