### PR TITLE
Fix false-positive detection of 'iceberg_scan' for IcebergDelete planning

### DIFF
--- a/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
@@ -123,6 +123,7 @@ virtual_column_map_t IcebergTableEntry::VirtualColumns() {
 	return result;
 }
 
+//! NOTE: IcebergDelete::FindIcebergScan needs to change in tandem with this method
 vector<column_t> IcebergTableEntry::GetRowIdColumns() const {
 	vector<column_t> result;
 	auto &table_metadata = table_info.table_metadata;

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -31,23 +31,8 @@ class IcebergDeleteLocalState;
 class IcebergDeleteGlobalState;
 class IcebergTableEntry;
 
-static bool HasProjectionIds(const PhysicalTableScan &scan) {
-	if (scan.projection_ids.empty()) {
-		return false;
-	}
-	for (idx_t i = 0; i < scan.projection_ids.size(); i++) {
-		if (scan.projection_ids[i] != i) {
-			return true;
-		}
-	}
-	return false;
-}
-
 static bool IsScanCreatedByDelete(const PhysicalTableScan &scan) {
 	if (scan.function.GetName() != "iceberg_scan") {
-		return false;
-	}
-	if (HasProjectionIds(scan)) {
 		return false;
 	}
 	if (scan.column_ids.size() < 2) {

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -31,17 +31,44 @@ class IcebergDeleteLocalState;
 class IcebergDeleteGlobalState;
 class IcebergTableEntry;
 
+static bool IsScanCreatedByDelete(const PhysicalTableScan &scan) {
+	if (scan.function.GetName() != "iceberg_scan") {
+		return false;
+	}
+	if (!scan.projection_ids.empty()) {
+		//! The scan created for the delete shouldn't have any columns that are only referenced by a filter
+		return false;
+	}
+	if (scan.column_ids.size() < 2) {
+		return false;
+	}
+
+	bool has_file_name = false;
+	bool has_file_row_number = false;
+	for (auto &column : scan.column_ids) {
+		if (!column.HasPrimaryIndex()) {
+			continue;
+		}
+		auto index = column.GetPrimaryIndex();
+		if (index == MultiFileReader::COLUMN_IDENTIFIER_FILENAME) {
+			has_file_name = true;
+		} else if (index == MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER) {
+			has_file_row_number = true;
+		}
+		if (has_file_name && has_file_row_number) {
+			return true;
+		}
+	}
+	return false;
+}
+
 optional_ptr<PhysicalTableScan> IcebergDelete::FindIcebergScan(PhysicalOperator &plan) {
 	if (plan.type == PhysicalOperatorType::TABLE_SCAN) {
 		// does this emit the virtual columns?
 		auto &scan = plan.Cast<PhysicalTableScan>();
 
-		if (scan.function.GetName() == "iceberg_scan") {
-			for (auto &col : scan.column_ids) {
-				if (col.GetPrimaryIndex() == MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER) {
-					return scan;
-				}
-			}
+		if (IsScanCreatedByDelete(scan)) {
+			return scan;
 		}
 		return nullptr;
 	}

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -31,12 +31,23 @@ class IcebergDeleteLocalState;
 class IcebergDeleteGlobalState;
 class IcebergTableEntry;
 
+static bool HasProjectionIds(const PhysicalTableScan &scan) {
+	if (scan.projection_ids.empty()) {
+		return false;
+	}
+	for (idx_t i = 0; i < scan.projection_ids.size(); i++) {
+		if (scan.projection_ids[i] != i) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static bool IsScanCreatedByDelete(const PhysicalTableScan &scan) {
 	if (scan.function.GetName() != "iceberg_scan") {
 		return false;
 	}
-	if (!scan.projection_ids.empty()) {
-		//! The scan created for the delete shouldn't have any columns that are only referenced by a filter
+	if (HasProjectionIds(scan)) {
 		return false;
 	}
 	if (scan.column_ids.size() < 2) {

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -505,7 +505,7 @@ vector<IcebergPartitionInfo> IcebergMultiFileList::GetPartitionInfoForDataFile(c
 	if (entry != shared_state->data_file_partition_info.end()) {
 		return entry->second;
 	}
-	throw InternalException("Could not find data file '%s' in manifest entries", file_path);
+	throw InvalidConfigurationException("Could not find data file '%s' in manifest entries", file_path);
 }
 
 const IcebergManifestFile &IcebergMultiFileList::GetManifestFileForEntry(const BoundIcebergManifestEntry &entry,

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/issue_1235.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/issue_1235.test
@@ -1,0 +1,83 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/issue_1235.test
+# group: [delete]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require core_functions
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.dl_target;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.dl_probe;
+
+statement ok
+CREATE TABLE my_datalake.default.dl_target (
+	id INTEGER,
+	data VARCHAR
+) WITH ('format-version' = 3);
+
+statement ok
+INSERT INTO my_datalake.default.dl_target VALUES
+	(1, 'a'),
+	(2, 'b'),
+	(3, 'c'),
+	(4, 'd'),
+	(5, 'e');
+
+statement ok
+CREATE TABLE my_datalake.default.dl_probe (
+	id INTEGER
+) WITH ('format-version' = 3);
+
+statement ok
+INSERT INTO my_datalake.default.dl_probe SELECT
+	2
+UNION ALL SELECT
+	i + 1000
+FROM range(100_000) t(i);
+
+statement ok
+DELETE FROM my_datalake.default.dl_target
+WHERE id IN (
+	SELECT
+		id
+	FROM my_datalake.default.dl_probe WHERE file_row_number < 1000000
+);
+
+query II
+select * from my_datalake.default.dl_target;
+----
+1	a
+3	c
+4	d
+5	e
+
+statement ok
+DELETE FROM my_datalake.default.dl_target
+WHERE file_row_number IN (
+	SELECT
+		3
+	FROM (
+		SELECT
+			filename,
+			file_row_number
+		FROM my_datalake.default.dl_probe
+	)
+);
+
+# id=4 was the 3rd remaining row in the table
+query II
+select * from my_datalake.default.dl_target;
+----
+1	a
+3	c
+5	e


### PR DESCRIPTION
This PR fixes #1235 

"Fix false-positive" is too strong actually, it's harder to trigger now (I tried in `issue_1235.test`, but didn't succeed), but it's likely still possible to hit a false-positive.