### PR TITLE
Rework schema lifetime/ownership

### DIFF
--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -92,15 +92,16 @@ optional_ptr<CatalogEntry> IcebergCatalog::CreateSchema(CatalogTransaction trans
 			if (entry) {
 				return entry;
 			}
-			auto new_schema = make_uniq<IcebergSchemaEntry>(*this, info);
+			auto new_schema = make_shared_ptr<IcebergSchemaEntry>(*this, info);
 			schemas.AddEntry(schema_name, new_schema);
-			return &schemas.GetEntry(schema_name);
+			iceberg_transaction.schemas[schema_name] = new_schema;
+			return new_schema.get();
 		}
 		throw CatalogException("Schema with name \"%s\" already exists", info.GetQualifiedName().Schema());
 	}
 
 	// Schema does not exist - stage it locally and defer the server creation and catalog publication to commit
-	auto new_schema = make_uniq<IcebergSchemaEntry>(*this, info);
+	auto new_schema = make_shared_ptr<IcebergSchemaEntry>(*this, info);
 	auto result = new_schema.get();
 	iceberg_transaction.created_schemas.emplace(schema_name, std::move(new_schema));
 	return result;

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -72,34 +72,38 @@ optional_ptr<CatalogEntry> IcebergCatalog::CreateSchema(CatalogTransaction trans
 	}
 
 	D_ASSERT(context);
-
-	// Verify schema existence on the server first
-	bool schema_exists =
-	    IRCAPI::VerifySchemaExistence(*context, *this, info.GetQualifiedName().Schema().GetIdentifierName());
-
-	if (schema_exists) {
+	auto &iceberg_transaction = IcebergTransaction::Get(*context, *this);
+	auto &schema_name = info.GetQualifiedName().Schema().GetIdentifierName();
+	auto created_schema = iceberg_transaction.created_schemas.find(schema_name);
+	if (created_schema != iceberg_transaction.created_schemas.end()) {
 		if (info.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
-			// Schema already exists on the server - get or create a local entry and return it
-			auto entry = schemas.GetEntry(*context, info.GetQualifiedName().Schema().GetIdentifierName(),
-			                              OnEntryNotFound::RETURN_NULL);
-			if (entry) {
-				return entry;
-			}
-			auto new_schema = make_uniq<IcebergSchemaEntry>(*this, info);
-			auto schema_name = new_schema->name;
-			schemas.AddEntry(schema_name.GetIdentifierName(), std::move(new_schema));
-			return &schemas.GetEntry(info.GetQualifiedName().Schema().GetIdentifierName());
+			return created_schema->second.get();
 		}
 		throw CatalogException("Schema with name \"%s\" already exists", info.GetQualifiedName().Schema());
 	}
 
-	// Schema does not exist - create it locally and defer the server creation to commit
-	auto &iceberg_transaction = IcebergTransaction::Get(*context, *this);
+	// Verify schema existence on the server first
+	bool schema_exists = IRCAPI::VerifySchemaExistence(*context, *this, schema_name);
+
+	if (schema_exists) {
+		if (info.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
+			// Schema already exists on the server - get or create a local entry and return it
+			auto entry = schemas.GetEntry(*context, schema_name, OnEntryNotFound::RETURN_NULL);
+			if (entry) {
+				return entry;
+			}
+			auto new_schema = make_uniq<IcebergSchemaEntry>(*this, info);
+			schemas.AddEntry(schema_name, new_schema);
+			return &schemas.GetEntry(schema_name);
+		}
+		throw CatalogException("Schema with name \"%s\" already exists", info.GetQualifiedName().Schema());
+	}
+
+	// Schema does not exist - stage it locally and defer the server creation and catalog publication to commit
 	auto new_schema = make_uniq<IcebergSchemaEntry>(*this, info);
-	auto schema_name = new_schema->name;
-	schemas.AddEntry(schema_name.GetIdentifierName(), std::move(new_schema));
-	iceberg_transaction.created_schemas.insert(info.GetQualifiedName().Schema().GetIdentifierName());
-	return &schemas.GetEntry(info.GetQualifiedName().Schema().GetIdentifierName());
+	auto result = new_schema.get();
+	iceberg_transaction.created_schemas.emplace(schema_name, std::move(new_schema));
+	return result;
 }
 
 void IcebergCatalog::DropSchema(ClientContext &context, DropInfo &info) {

--- a/src/catalog/rest/iceberg_schema_set.cpp
+++ b/src/catalog/rest/iceberg_schema_set.cpp
@@ -27,18 +27,26 @@ optional_ptr<CatalogEntry> IcebergSchemaSet::GetEntry(ClientContext &context, co
 		throw CatalogException("Schema '%s' does not exist", name);
 	}
 
-	// If the schema was created in this transaction, return the transaction-local entry directly
+	// Transaction-local creations take precedence over catalog entries with the same name.
 	auto created_schema = iceberg_transaction.created_schemas.find(name);
 	if (created_schema != iceberg_transaction.created_schemas.end()) {
-		D_ASSERT(created_schema->second);
 		return created_schema->second.get();
+	}
+
+	// Return an entry already referenced by this transaction directly.
+	auto transaction_entry = iceberg_transaction.schemas.find(name);
+	if (transaction_entry != iceberg_transaction.schemas.end()) {
+		if (transaction_entry->second->DoesExist()) {
+			return transaction_entry->second.get();
+		}
+		return nullptr;
 	}
 
 	auto verify_existence = iceberg_transaction.looked_up_entries.insert(name).second;
 	auto entry = entries.find(name);
 	if (entry != entries.end()) {
-		auto &iceberg_schema_entry = entry->second->Cast<IcebergSchemaEntry>();
-		if (iceberg_schema_entry.DoesExist()) {
+		iceberg_transaction.schemas.emplace(name, entry->second);
+		if (entry->second->DoesExist()) {
 			return entry->second.get();
 		}
 		return nullptr;
@@ -63,49 +71,55 @@ optional_ptr<CatalogEntry> IcebergSchemaSet::GetEntry(ClientContext &context, co
 		info.SetQualifiedName(
 		    QualifiedName(info.GetQualifiedName().Catalog(), Identifier(name), info.GetQualifiedName().Name()));
 		info.internal = false;
-		auto schema_entry = make_uniq<IcebergSchemaEntry>(catalog, info);
+		auto schema_entry = make_shared_ptr<IcebergSchemaEntry>(catalog, info);
 		// we will not create entries with empty names
 		if (name.empty()) {
 			return nullptr;
 		}
-		CreateEntryInternal(context, std::move(schema_entry));
-		entry = entries.find(name);
-		D_ASSERT(entry != entries.end());
+		auto inserted_entry = CreateEntryInternal(std::move(schema_entry));
+		iceberg_transaction.schemas.emplace(name, inserted_entry);
+		return inserted_entry.get();
 	}
+	iceberg_transaction.schemas.emplace(name, entry->second);
 	return entry->second.get();
 }
 
 void IcebergSchemaSet::Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback) {
+	auto schema_entries = GetEntries(context);
+	for (auto &entry : schema_entries) {
+		callback(*entry);
+	}
+}
+
+vector<shared_ptr<IcebergSchemaEntry>> IcebergSchemaSet::GetEntries(ClientContext &context) {
 	lock_guard<mutex> l(entry_lock);
 	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
-	LoadEntries(context);
+	LoadEntriesInternal(context);
+	vector<shared_ptr<IcebergSchemaEntry>> result;
+	result.reserve(entries.size() + iceberg_transaction.created_schemas.size());
 	for (auto &entry : entries) {
 		if (iceberg_transaction.deleted_schemas.count(entry.first) ||
 		    iceberg_transaction.created_schemas.count(entry.first)) {
 			continue;
 		}
-		auto &iceberg_schema_entry = entry.second->Cast<IcebergSchemaEntry>();
-		if (iceberg_schema_entry.DoesExist()) {
-			callback(*entry.second);
+		auto transaction_entry = iceberg_transaction.schemas.find(entry.first);
+		if (transaction_entry == iceberg_transaction.schemas.end()) {
+			transaction_entry = iceberg_transaction.schemas.emplace(entry.first, entry.second).first;
+		}
+		if (transaction_entry->second->DoesExist()) {
+			result.push_back(transaction_entry->second);
 		}
 	}
-	for (auto &entry : iceberg_transaction.created_schemas) {
-		D_ASSERT(entry.second);
-		callback(*entry.second);
+	for (auto &created_schema : iceberg_transaction.created_schemas) {
+		result.push_back(created_schema.second);
 	}
+	return result;
 }
 
-bool IcebergSchemaSet::AddEntry(const string &name, unique_ptr<IcebergSchemaEntry> &entry) {
+void IcebergSchemaSet::AddEntry(const string &name, shared_ptr<IcebergSchemaEntry> entry) {
 	D_ASSERT(entry);
 	lock_guard<mutex> l(entry_lock);
-	auto existing_entry = entries.find(name);
-	if (existing_entry == entries.end()) {
-		entries.emplace(name, std::move(entry));
-		return true;
-	}
-	// Preserve the identity of an existing entry because other transactions may hold references to it.
-	existing_entry->second->Cast<IcebergSchemaEntry>().MarkAsExisting();
-	return false;
+	entries[name] = std::move(entry);
 }
 
 void IcebergSchemaSet::RemoveEntry(const string &name) {
@@ -113,24 +127,16 @@ void IcebergSchemaSet::RemoveEntry(const string &name) {
 	entries.erase(name);
 }
 
-CatalogEntry &IcebergSchemaSet::GetEntry(const string &name) {
-	auto entry_it = entries.find(name);
-	if (entry_it == entries.end()) {
-		throw CatalogException("Schema '%s' does not exist", name);
-	}
-	auto &entry = entry_it->second;
-	return *entry;
-}
-
-const case_insensitive_map_t<unique_ptr<CatalogEntry>> &IcebergSchemaSet::GetEntries() {
-	return entries;
-}
-
 static string GetSchemaName(const vector<string> &items) {
 	return StringUtil::Join(items, ".");
 }
 
 void IcebergSchemaSet::LoadEntries(ClientContext &context) {
+	lock_guard<mutex> l(entry_lock);
+	LoadEntriesInternal(context);
+}
+
+void IcebergSchemaSet::LoadEntriesInternal(ClientContext &context) {
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
 	bool schema_listed = iceberg_transaction.called_list_schemas;
@@ -143,21 +149,26 @@ void IcebergSchemaSet::LoadEntries(ClientContext &context) {
 		info.SetQualifiedName(QualifiedName(info.GetQualifiedName().Catalog(), Identifier(GetSchemaName(schema.items)),
 		                                    info.GetQualifiedName().Name()));
 		info.internal = false;
-		auto schema_entry = make_uniq<IcebergSchemaEntry>(catalog, info);
+		auto schema_entry = make_shared_ptr<IcebergSchemaEntry>(catalog, info);
 		schema_entry->namespace_items = std::move(schema.items);
-		CreateEntryInternal(context, std::move(schema_entry));
+		CreateEntryInternal(std::move(schema_entry));
 	}
 	iceberg_transaction.called_list_schemas = true;
 }
 
-optional_ptr<CatalogEntry> IcebergSchemaSet::CreateEntryInternal(ClientContext &context,
-                                                                 unique_ptr<CatalogEntry> entry) {
-	auto result = entry.get();
-	if (result->name.empty()) {
+shared_ptr<IcebergSchemaEntry> IcebergSchemaSet::CreateEntryInternal(shared_ptr<IcebergSchemaEntry> entry) {
+	auto &name = entry->name.GetIdentifierName();
+	if (name.empty()) {
 		throw InternalException("IcebergSchemaSet::CreateEntry called with empty name");
 	}
-	entries.insert(make_pair(result->name, std::move(entry)));
-	return result;
+	auto existing_entry = entries.find(name);
+	if (existing_entry == entries.end()) {
+		return entries.emplace(name, std::move(entry)).first->second;
+	}
+	if (!existing_entry->second->DoesExist()) {
+		existing_entry->second = std::move(entry);
+	}
+	return existing_entry->second;
 }
 
 } // namespace duckdb

--- a/src/catalog/rest/iceberg_schema_set.cpp
+++ b/src/catalog/rest/iceberg_schema_set.cpp
@@ -27,14 +27,11 @@ optional_ptr<CatalogEntry> IcebergSchemaSet::GetEntry(ClientContext &context, co
 		throw CatalogException("Schema '%s' does not exist", name);
 	}
 
-	// If the schema was created in this transaction, return the local entry directly
-	if (iceberg_transaction.created_schemas.count(name)) {
-		auto entry = entries.find(name);
-		if (entry != entries.end()) {
-			return entry->second.get();
-		}
-		throw InternalException("Schema '%s' was created in this transaction, but was no found in the local cache",
-		                        name);
+	// If the schema was created in this transaction, return the transaction-local entry directly
+	auto created_schema = iceberg_transaction.created_schemas.find(name);
+	if (created_schema != iceberg_transaction.created_schemas.end()) {
+		D_ASSERT(created_schema->second);
+		return created_schema->second.get();
 	}
 
 	auto verify_existence = iceberg_transaction.looked_up_entries.insert(name).second;
@@ -80,17 +77,35 @@ optional_ptr<CatalogEntry> IcebergSchemaSet::GetEntry(ClientContext &context, co
 
 void IcebergSchemaSet::Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback) {
 	lock_guard<mutex> l(entry_lock);
+	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
 	LoadEntries(context);
 	for (auto &entry : entries) {
+		if (iceberg_transaction.deleted_schemas.count(entry.first) ||
+		    iceberg_transaction.created_schemas.count(entry.first)) {
+			continue;
+		}
 		auto &iceberg_schema_entry = entry.second->Cast<IcebergSchemaEntry>();
 		if (iceberg_schema_entry.DoesExist()) {
 			callback(*entry.second);
 		}
 	}
+	for (auto &entry : iceberg_transaction.created_schemas) {
+		D_ASSERT(entry.second);
+		callback(*entry.second);
+	}
 }
 
-void IcebergSchemaSet::AddEntry(const string &name, unique_ptr<IcebergSchemaEntry> entry) {
-	entries.insert(make_pair(name, std::move(entry)));
+bool IcebergSchemaSet::AddEntry(const string &name, unique_ptr<IcebergSchemaEntry> &entry) {
+	D_ASSERT(entry);
+	lock_guard<mutex> l(entry_lock);
+	auto existing_entry = entries.find(name);
+	if (existing_entry == entries.end()) {
+		entries.emplace(name, std::move(entry));
+		return true;
+	}
+	// Preserve the identity of an existing entry because other transactions may hold references to it.
+	existing_entry->second->Cast<IcebergSchemaEntry>().MarkAsExisting();
+	return false;
 }
 
 void IcebergSchemaSet::RemoveEntry(const string &name) {

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -688,25 +688,22 @@ void IcebergTransaction::DoSingleTableCommitUpdates(IcebergTransactionAlterUpdat
 void IcebergTransaction::DoTableDeletes(IcebergTransactionDeleteUpdate &delete_update, ClientContext &context) {
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	auto &table = delete_update.deleted_table.get();
-	auto schema_key = table.schema.name;
 	auto table_key = table.GetTableKey();
 	auto &table_name = table.name;
 	IRCAPI::CommitTableDelete(context, catalog, table.schema.namespace_items, table_name);
 	// remove the load table result
 	ic_catalog.table_request_cache.Expire(context, table_key);
 	// remove the table entry from the catalog
-	auto &schema_entry = ic_catalog.schemas.GetEntry(schema_key.GetIdentifierName()).Cast<IcebergSchemaEntry>();
 	DropInfo drop_info;
 	drop_info.GetQualifiedNameMutable() = Identifier(table_name);
 	drop_info.if_not_found = OnEntryNotFound::RETURN_NULL;
-	schema_entry.DropEntry(context, drop_info, true);
+	table.schema.DropEntry(context, drop_info, true);
 }
 
 void IcebergTransaction::DoSchemaCreates(ClientContext &context) {
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
-	retained_schema_entries.reserve(retained_schema_entries.size() + created_schemas.size());
-	for (auto created_schema = created_schemas.begin(); created_schema != created_schemas.end();) {
-		auto &schema_name = created_schema->first;
+	for (auto &created_schema : created_schemas) {
+		auto &schema_name = created_schema.first;
 		auto namespace_identifiers = IRCAPI::ParseSchemaName(schema_name);
 
 		rest_api_objects::CreateNamespaceRequest request;
@@ -715,11 +712,7 @@ void IcebergTransaction::DoSchemaCreates(ClientContext &context) {
 		auto create_body = RESTObjectToJSONString(request);
 
 		IRCAPI::CommitNamespaceCreate(context, ic_catalog, create_body);
-		D_ASSERT(created_schema->second);
-		if (!ic_catalog.GetSchemas().AddEntry(schema_name, created_schema->second)) {
-			retained_schema_entries.push_back(std::move(created_schema->second));
-		}
-		created_schema = created_schemas.erase(created_schema);
+		ic_catalog.GetSchemas().AddEntry(schema_name, created_schema.second);
 	}
 }
 
@@ -752,7 +745,6 @@ void IcebergTransaction::DoSchemaPropertyUpdates(ClientContext &context) {
 
 		IRCAPI::CommitNamespacePropertiesUpdate(context, ic_catalog, create_body, namespace_identifiers);
 	}
-	created_schemas.clear();
 }
 
 namespace {

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -704,7 +704,9 @@ void IcebergTransaction::DoTableDeletes(IcebergTransactionDeleteUpdate &delete_u
 
 void IcebergTransaction::DoSchemaCreates(ClientContext &context) {
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
-	for (auto &schema_name : created_schemas) {
+	retained_schema_entries.reserve(retained_schema_entries.size() + created_schemas.size());
+	for (auto created_schema = created_schemas.begin(); created_schema != created_schemas.end();) {
+		auto &schema_name = created_schema->first;
 		auto namespace_identifiers = IRCAPI::ParseSchemaName(schema_name);
 
 		rest_api_objects::CreateNamespaceRequest request;
@@ -713,8 +715,12 @@ void IcebergTransaction::DoSchemaCreates(ClientContext &context) {
 		auto create_body = RESTObjectToJSONString(request);
 
 		IRCAPI::CommitNamespaceCreate(context, ic_catalog, create_body);
+		D_ASSERT(created_schema->second);
+		if (!ic_catalog.GetSchemas().AddEntry(schema_name, created_schema->second)) {
+			retained_schema_entries.push_back(std::move(created_schema->second));
+		}
+		created_schema = created_schemas.erase(created_schema);
 	}
-	created_schemas.clear();
 }
 
 void IcebergTransaction::DoSchemaDeletes(ClientContext &context) {

--- a/src/function/ducklake/iceberg_to_ducklake.cpp
+++ b/src/function/ducklake/iceberg_to_ducklake.cpp
@@ -829,9 +829,9 @@ static unique_ptr<FunctionData> IcebergToDuckLakeBind(ClientContext &context, Ta
 		}
 	}
 
-	schema_set.LoadEntries(context);
-	for (auto &it : schema_set.GetEntries()) {
-		auto &schema_entry = it.second->Cast<IcebergSchemaEntry>();
+	auto schema_entries = schema_set.GetEntries(context);
+	for (auto &schema_entry_ptr : schema_entries) {
+		auto &schema_entry = *schema_entry_ptr;
 		auto &tables = schema_entry.tables;
 		tables.LoadEntries(context);
 		for (auto &it : tables.GetEntriesMutable()) {

--- a/src/include/catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp
+++ b/src/include/catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp
@@ -48,6 +48,9 @@ public:
 	bool DoesExist() const {
 		return exists;
 	}
+	void MarkAsExisting() {
+		exists = true;
+	}
 	string GetSchemaKey() const {
 		return this->catalog.GetName() + "." + this->name;
 	};

--- a/src/include/catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp
+++ b/src/include/catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp
@@ -48,9 +48,6 @@ public:
 	bool DoesExist() const {
 		return exists;
 	}
-	void MarkAsExisting() {
-		exists = true;
-	}
 	string GetSchemaKey() const {
 		return this->catalog.GetName() + "." + this->name;
 	};

--- a/src/include/catalog/rest/iceberg_schema_set.hpp
+++ b/src/include/catalog/rest/iceberg_schema_set.hpp
@@ -18,7 +18,9 @@ public:
 	optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const string &name, OnEntryNotFound if_not_found);
 	void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
 	const case_insensitive_map_t<unique_ptr<CatalogEntry>> &GetEntries();
-	void AddEntry(const string &name, unique_ptr<IcebergSchemaEntry> entry);
+	//! Publish the entry if absent, or revive the existing cached entry without replacing its identity. Returns true
+	//! when ownership of entry was transferred to this set.
+	bool AddEntry(const string &name, unique_ptr<IcebergSchemaEntry> &entry);
 	void RemoveEntry(const string &name);
 	CatalogEntry &GetEntry(const string &name);
 

--- a/src/include/catalog/rest/iceberg_schema_set.hpp
+++ b/src/include/catalog/rest/iceberg_schema_set.hpp
@@ -1,8 +1,9 @@
 
 #pragma once
 
+#include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/string.hpp"
-#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/vector.hpp"
 
 #include "catalog_entry/schema/iceberg_schema_entry.hpp"
 
@@ -17,21 +18,19 @@ public:
 	void LoadEntries(ClientContext &context);
 	optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const string &name, OnEntryNotFound if_not_found);
 	void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
-	const case_insensitive_map_t<unique_ptr<CatalogEntry>> &GetEntries();
-	//! Publish the entry if absent, or revive the existing cached entry without replacing its identity. Returns true
-	//! when ownership of entry was transferred to this set.
-	bool AddEntry(const string &name, unique_ptr<IcebergSchemaEntry> &entry);
+	vector<shared_ptr<IcebergSchemaEntry>> GetEntries(ClientContext &context);
+	void AddEntry(const string &name, shared_ptr<IcebergSchemaEntry> entry);
 	void RemoveEntry(const string &name);
-	CatalogEntry &GetEntry(const string &name);
 
 protected:
-	optional_ptr<CatalogEntry> CreateEntryInternal(ClientContext &context, unique_ptr<CatalogEntry> entry);
+	void LoadEntriesInternal(ClientContext &context);
+	shared_ptr<IcebergSchemaEntry> CreateEntryInternal(shared_ptr<IcebergSchemaEntry> entry);
 
 public:
 	Catalog &catalog;
 
 private:
-	case_insensitive_map_t<unique_ptr<CatalogEntry>> entries;
+	case_insensitive_map_t<shared_ptr<IcebergSchemaEntry>> entries;
 	mutex entry_lock;
 };
 

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -120,14 +120,19 @@ private:
 	AccessMode access_mode;
 
 public:
+	//! Keep transaction-local entries alive when publication revives an existing negative cache entry instead of
+	//! moving the staged entry into the shared schema set.
+	vector<unique_ptr<IcebergSchemaEntry>> retained_schema_entries;
+	//! Schema entries staged by this transaction. These are published to the catalog's shared schema set only after
+	//! the namespace create has committed to the REST catalog.
+	case_insensitive_map_t<unique_ptr<IcebergSchemaEntry>> created_schemas;
 	//! Tables referenced by this transaction that have to stay alive for the duration of the transaction.
 	case_insensitive_map_t<shared_ptr<IcebergTableInformation>> tables;
 	//! The visible state of every resolved table in this transaction.
 	case_insensitive_map_t<IcebergTransactionTableState> current_table_data;
-	//! Declared after current_table_data so update references are destroyed before the referenced table states.
+	//! Declared after the schema and table states so update references are destroyed before the referenced states.
 	IcebergTransactionUpdate transaction_update;
 
-	unordered_set<string> created_schemas;
 	unordered_set<string> deleted_schemas;
 
 	bool called_list_schemas = false;

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -120,12 +120,11 @@ private:
 	AccessMode access_mode;
 
 public:
-	//! Keep transaction-local entries alive when publication revives an existing negative cache entry instead of
-	//! moving the staged entry into the shared schema set.
-	vector<unique_ptr<IcebergSchemaEntry>> retained_schema_entries;
-	//! Schema entries staged by this transaction. These are published to the catalog's shared schema set only after
-	//! the namespace create has committed to the REST catalog.
-	case_insensitive_map_t<unique_ptr<IcebergSchemaEntry>> created_schemas;
+	//! Schemas referenced by this transaction that have to stay alive for the duration of the transaction.
+	case_insensitive_map_t<shared_ptr<IcebergSchemaEntry>> schemas;
+	//! Schemas staged by this transaction. These are separate from catalog-referenced schemas so both generations stay
+	//! alive when a transaction creates a schema after referencing a stale entry with the same name.
+	case_insensitive_map_t<shared_ptr<IcebergSchemaEntry>> created_schemas;
 	//! Tables referenced by this transaction that have to stay alive for the duration of the transaction.
 	case_insensitive_map_t<shared_ptr<IcebergTableInformation>> tables;
 	//! The visible state of every resolved table in this transaction.

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_missing_schema.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_missing_schema.test
@@ -164,3 +164,38 @@ WHERE catalog_name = 'my_datalake' AND schema_name = 'connection_schema';
 
 statement ok
 drop schema my_datalake.connection_schema;
+
+# Replacing a stale cached entry must not invalidate another transaction's
+# reference to the old generation. That transaction keeps its original view;
+# a new transaction sees the schema published at commit.
+statement ok
+drop schema if exists my_datalake.pinned_missing_schema;
+
+statement ok con1
+begin;
+
+statement ok con1
+drop table if exists my_datalake.pinned_missing_schema.target;
+
+statement ok
+create schema my_datalake.pinned_missing_schema;
+
+query I con1
+SELECT count(*)
+FROM information_schema.schemata
+WHERE catalog_name = 'my_datalake' AND schema_name = 'pinned_missing_schema';
+----
+0
+
+statement ok con1
+rollback;
+
+query I con1
+SELECT count(*)
+FROM information_schema.schemata
+WHERE catalog_name = 'my_datalake' AND schema_name = 'pinned_missing_schema';
+----
+1
+
+statement ok
+drop schema my_datalake.pinned_missing_schema;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_missing_schema.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_missing_schema.test
@@ -1,0 +1,166 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/create/test_create_missing_schema.test
+# description: test creating a schema after a missing schema has been cached
+# group: [create]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require core_functions
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+set logging_level='debug'
+
+# Make sure the schema doesn't exist
+statement ok
+drop schema if exists my_datalake.missing_schema;
+
+# Table creation fails on the missing schema
+statement error
+CREATE TABLE my_datalake.missing_schema.target (
+	id INTEGER,
+	data VARCHAR
+);
+----
+Invalid Input Error: Schema with name "missing_schema" does not exist
+
+# Create the schema
+statement ok
+CREATE SCHEMA my_datalake.missing_schema;
+
+# Verift existence
+query I
+SELECT count(*)
+FROM information_schema.schemata
+WHERE catalog_name = 'my_datalake' AND schema_name = 'missing_schema';
+----
+1
+
+# Create the table again, passes now
+statement ok
+CREATE TABLE my_datalake.missing_schema.target (
+	id INTEGER,
+	data VARCHAR
+);
+
+# Verify existence of the table
+query I
+SELECT count(*) FROM my_datalake.missing_schema.target;
+----
+0
+
+# Drop the table
+statement ok
+drop table my_datalake.missing_schema.target;
+
+# Drop the schema
+statement ok
+drop schema my_datalake.missing_schema;
+
+# A schema is visible to its creating transaction and is published to the shared
+# schema set only when that transaction commits.
+statement ok
+drop schema if exists my_datalake.committed_schema;
+
+statement ok
+begin;
+
+statement ok
+create schema my_datalake.committed_schema;
+
+query I
+SELECT count(*)
+FROM information_schema.schemata
+WHERE catalog_name = 'my_datalake' AND schema_name = 'committed_schema';
+----
+1
+
+statement ok
+commit;
+
+query I
+SELECT count(*)
+FROM information_schema.schemata
+WHERE catalog_name = 'my_datalake' AND schema_name = 'committed_schema';
+----
+1
+
+statement ok
+drop schema my_datalake.committed_schema;
+
+# Rolling back must not leave an uncommitted entry in the shared schema set.
+statement ok
+drop schema if exists my_datalake.rolled_back_schema;
+
+statement ok
+begin;
+
+statement ok
+create schema my_datalake.rolled_back_schema;
+
+query I
+SELECT count(*)
+FROM information_schema.schemata
+WHERE catalog_name = 'my_datalake' AND schema_name = 'rolled_back_schema';
+----
+1
+
+statement ok
+rollback;
+
+query I
+SELECT count(*)
+FROM information_schema.schemata
+WHERE catalog_name = 'my_datalake' AND schema_name = 'rolled_back_schema';
+----
+0
+
+# Uncommitted schemas must not leak to another connection, but the commit must
+# publish the same entry to that connection.
+statement ok
+drop schema if exists my_datalake.connection_schema;
+
+statement ok con1
+begin;
+
+statement ok con1
+create schema my_datalake.connection_schema;
+
+query I
+SELECT count(*)
+FROM information_schema.schemata
+WHERE catalog_name = 'my_datalake' AND schema_name = 'connection_schema';
+----
+0
+
+query I con1
+SELECT count(*)
+FROM information_schema.schemata
+WHERE catalog_name = 'my_datalake' AND schema_name = 'connection_schema';
+----
+1
+
+statement ok con1
+commit;
+
+query I
+SELECT count(*)
+FROM information_schema.schemata
+WHERE catalog_name = 'my_datalake' AND schema_name = 'connection_schema';
+----
+1
+
+statement ok
+drop schema my_datalake.connection_schema;


### PR DESCRIPTION
This PR fixes #1233 

Created schemas are saved in the `IcebergTransaction`, and looked up schemas are also save a copy of the shared_ptr of the `IcebergCatalog`'s `IcebergSchemaSet` in the `IcebergTransaction`, to make sure it stays alive even when its replaced/deleted by another transaction.

In the COMMIT of the transaction, the transaction-local created schema(s) are added to the `IcebergSchemaSet`