### PR TITLE
Fix cmake lists and add smoke test

### DIFF
--- a/.github/workflows/BuildIceberg.yml
+++ b/.github/workflows/BuildIceberg.yml
@@ -114,6 +114,7 @@ jobs:
           bundle: bash duckdb/scripts/prepare_build_artifact.sh release
           upload-name: duckdb-iceberg-equality-delete-support
 
+  # Fixture catalog acts as the smoke test: it must pass before we spend CI on the other catalogs.
   test-fixture:
     name: Test against fixture catalog
     needs: build_iceberg
@@ -124,7 +125,7 @@ jobs:
 
   test-fixture-duckdb-tests:
     name: Test duckdb/duckdb tests against fixture catalog
-    needs: build_iceberg
+    needs: test-fixture
     uses: ./.github/workflows/test-fixture-catalog-duckdb-tests.yml
     with:
       artifact-name: duckdb-iceberg
@@ -132,7 +133,7 @@ jobs:
 
   test-fixture-latest:
     name: Test against latest fixture catalog
-    needs: build_iceberg
+    needs: test-fixture
     uses: ./.github/workflows/test-fixture-latest-catalog.yml
     with:
       artifact-name: duckdb-iceberg
@@ -147,7 +148,7 @@ jobs:
 
   test-fixture-equality-delete:
     name: Test against fixture Equality Deletes enabled
-    needs: build_iceberg
+    needs: test-fixture
     uses: ./.github/workflows/test-fixture-catalog.yml
     with:
       artifact-name: duckdb-iceberg-equality-delete-support
@@ -156,35 +157,35 @@ jobs:
 
   test-nessie:
     name: Test against Nessie Catalog
-    needs: build_iceberg
+    needs: test-fixture
     uses: ./.github/workflows/test-nessie-catalog.yml
     with:
       artifact-name: duckdb-iceberg
 
   test-gravitino:
     name: Test against Gravitino Catalog
-    needs: build_iceberg
+    needs: test-fixture
     uses: ./.github/workflows/test-gravitino-catalog.yml
     with:
       artifact-name: duckdb-iceberg
 
   test-local:
     name: Test against local Catalog
-    needs: build_iceberg
+    needs: test-fixture
     uses: ./.github/workflows/test-local-catalog.yml
     with:
       artifact-name: duckdb-iceberg
 
   test-polaris:
     name: Test against Polaris Catalog
-    needs: build_iceberg
+    needs: test-fixture
     uses: ./.github/workflows/test-polaris-catalog.yml
     with:
       artifact-name: duckdb-iceberg
 
   test-lakekeeper:
     name: Test against Lakekeeper Catalog
-    needs: build_iceberg
+    needs: test-fixture
     uses: ./.github/workflows/test-lakekeeper-catalog.yml
     with:
       artifact-name: duckdb-iceberg

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This file applies to the repository root. `duckdb/` is an upstream submodule wit
 - `scripts/data_generators/`: pytest-driven Iceberg data generator and catalog connection profiles.
 - `make/catalogs/`: local catalog lifecycle and data-generation targets.
 - `extension_config.cmake`: DuckDB extensions included in the build.
-- `CMakeLists.txt`: explicit C++ source list and extension dependencies.
+- `CMakeLists.txt`: top-level extension dependencies and linking; per-directory `src/**/CMakeLists.txt` list the C++ sources for each directory (mirroring the DuckDB submodule layout).
 - `duckdb/` and `extension-ci-tools/`: git submodules. Do not edit or update them unless the task explicitly requires it.
 
 Keep existing user changes intact. Runtime directories such as `.catalogs/`, `.venv-spark4/`, `build/`, `data/generated/`, `.cache/`, and test temp directories are generated or ignored and should not be committed.
@@ -58,7 +58,7 @@ make format-check
 make format-fix
 ```
 
-When adding a C++ implementation file, add it to `EXTENSION_SOURCES` in `CMakeLists.txt`. Follow existing DuckDB C++ conventions and prefer the narrowest relevant build before a full rebuild.
+When adding a C++ implementation file, add it to the `OBJECT` library in the `CMakeLists.txt` of the directory the file lives in (each source directory has its own `CMakeLists.txt`, mirroring the DuckDB submodule layout). If you add a new directory, give it a `CMakeLists.txt` that appends its objects to `ALL_OBJECT_FILES` and `add_subdirectory()` it from its parent. Follow existing DuckDB C++ conventions and prefer the narrowest relevant build before a full rebuild.
 
 ## Testing expectations
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,118 +20,30 @@ if(ICEBERG_ENABLE_EQUALITY_DELETE_WRITES)
 	add_definitions(-DICEBERG_ENABLE_EQUALITY_DELETE_WRITES)
 endif()
 
+# Resolve dependencies before descending into src/ so that every per-directory OBJECT library
+# inherits the include directories it needs (these commands set directory-scoped properties that
+# are inherited by subdirectories added afterwards).
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    find_package(CURL REQUIRED)
+    find_package(AWSSDK REQUIRED COMPONENTS core sso sts)
+    include_directories(${CURL_INCLUDE_DIRS})
+    include_directories(${AWSSDK_INCLUDE_DIRS})
+endif()
 
-set(EXTENSION_SOURCES
-	src/catalog/rest/api/api_utils.cpp
-	src/catalog/rest/api/catalog_api.cpp
-	src/catalog/rest/api/catalog_utils.cpp
-	src/catalog/rest/api/iceberg_add_snapshot.cpp
-	src/catalog/rest/api/iceberg_create_table_request.cpp
-	src/catalog/rest/api/iceberg_manifest_merge.cpp
-	src/catalog/rest/api/iceberg_scan_planning.cpp
-	src/catalog/rest/api/iceberg_retry.cpp
-	src/catalog/rest/api/iceberg_table_update.cpp
-	src/catalog/rest/api/iceberg_type.cpp
-	src/catalog/rest/api/iceberg_expression.cpp
-	src/catalog/rest/api/table_update.cpp
-	src/catalog/rest/api/url_utils.cpp
-	src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
-	src/catalog/rest/catalog_entry/table/iceberg_table_entry.cpp
-	src/catalog/rest/catalog_entry/table/iceberg_table_information.cpp
-	src/catalog/rest/iceberg_catalog.cpp
-	src/catalog/rest/iceberg_schema_set.cpp
-	src/catalog/rest/iceberg_table_set.cpp
-	src/catalog/rest/storage/authorization/none.cpp
-	src/catalog/rest/storage/authorization/oauth2.cpp
-	src/catalog/rest/storage/authorization/sigv4.cpp
-	src/catalog/rest/storage/aws.cpp
-	src/catalog/rest/storage/iceberg_authorization.cpp
-	src/catalog/rest/transaction/iceberg_transaction_data.cpp
-	src/catalog/rest/transaction/iceberg_transaction_manager.cpp
-	src/catalog/rest/transaction/iceberg_transaction.cpp
-	src/catalog/rest/transaction/iceberg_transaction_update.cpp
-	src/common/iceberg_utils.cpp
-	src/common/iceberg_default.cpp
-	src/core/deletes/iceberg_deletion_vector.cpp
-	src/core/deletes/iceberg_equality_delete.cpp
-	src/core/deletes/iceberg_positional_delete.cpp
-	src/core/expression/iceberg_hash.cpp
-	src/core/expression/iceberg_metrics.cpp
-	src/core/expression/iceberg_transform.cpp
-	src/core/expression/iceberg_value.cpp
-	src/core/metadata/puffin/iceberg_puffin_metadata.cpp
-	src/core/metadata/iceberg_table_metadata.cpp
-	src/core/metadata/manifest/iceberg_manifest_list.cpp
-	src/core/metadata/manifest/iceberg_manifest.cpp
-	src/core/metadata/manifest/iceberg_avro_codec.cpp
-	src/core/metadata/partition/iceberg_partition_spec.cpp
-	src/core/metadata/schema/iceberg_column_definition.cpp
-	src/core/metadata/schema/iceberg_field_mapping.cpp
-	src/core/metadata/schema/iceberg_table_schema.cpp
-	src/core/metadata/snapshot/iceberg_snapshot.cpp
-	src/core/metadata/sort/iceberg_sort_order.cpp
-	src/execution/helpers/equality_delete_helpers.cpp
-	src/execution/operator/copy/iceberg_copy.cpp
-	src/execution/operator/iceberg_delete.cpp
-	src/execution/operator/iceberg_insert.cpp
-	src/execution/operator/iceberg_update.cpp
-	src/execution/operator/physical_iceberg_create_table.cpp
-	src/execution/operator/merge_into/iceberg_merge_into.cpp
-	src/execution/operator/merge_into/iceberg_merge_insert.cpp
-	src/execution/operator/merge_into/iceberg_merge_update.cpp
-	src/function/copy/iceberg_copy_function.cpp
-	src/function/ducklake/iceberg_to_ducklake.cpp
-	src/function/ducklake/ducklake_column.cpp
-	src/function/ducklake/ducklake_column_stats.cpp
-	src/function/ducklake/ducklake_partition.cpp
-	src/function/ducklake/ducklake_partition_column.cpp
-	src/function/ducklake/ducklake_table.cpp
-	src/function/ducklake/ducklake_snapshot.cpp
-	src/function/ducklake/ducklake_schema.cpp
-	src/function/ducklake/ducklake_data_file.cpp
-	src/function/ducklake/ducklake_delete_file.cpp
-	src/function/iceberg_functions.cpp
-	src/function/iceberg_scalar_functions.cpp
-	src/function/metadata/iceberg_column_stats.cpp
-	src/function/metadata/iceberg_load_table_response.cpp
-	src/function/metadata/iceberg_metadata.cpp
-	src/function/metadata/iceberg_partition_stats.cpp
-	src/function/metadata/iceberg_rewrite_data_files.cpp
-	src/function/metadata/iceberg_snapshots.cpp
-	src/function/metadata/iceberg_table_properties_functions.cpp
-	src/function/metadata/iceberg_schema_properties_functions.cpp
-	src/function/scan/iceberg_scan.cpp
-	src/iceberg_extension.cpp
-	src/iceberg_logging.cpp
-	src/iceberg_options.cpp
-	src/iceberg_attach.cpp
-	src/maintenance/maintenance_table_loader.cpp
-	src/maintenance/rewrite_data_files_executor.cpp
-	src/maintenance/rewrite_data_files_operator.cpp
-	src/maintenance/rewrite_data_files_planner.cpp
-	src/planning/iceberg_multi_file_list.cpp
-	src/planning/iceberg_scan_plan_provider.cpp
-	src/planning/iceberg_multi_file_reader.cpp
-	src/planning/iceberg_optimizer.cpp
-	src/planning/metadata_io/avro/avro_scan.cpp
-	src/planning/metadata_io/avro/iceberg_avro_multi_file_list.cpp
-	src/planning/metadata_io/avro/iceberg_avro_multi_file_reader.cpp
-	src/planning/metadata_io/base_manifest_reader.cpp
-	src/planning/metadata_io/deletes/iceberg_deletes_file_reader.cpp
-	src/planning/metadata_io/manifest/bound_iceberg_manifest_entry.cpp
-	src/planning/metadata_io/manifest/iceberg_manifest_reader.cpp
-	src/planning/metadata_io/manifest_list/bound_iceberg_manifest_list_entry.cpp
-	src/planning/metadata_io/manifest_list/iceberg_manifest_list_reader.cpp
-	src/planning/pruning/iceberg_predicate.cpp
-	src/planning/snapshot/iceberg_snapshot_lookup.cpp
-	src/storage/statistics/iceberg_variant_statistics.cpp
-	src/storage/statistics/iceberg_statistics.cpp
-	src/storage/statistics/iceberg_data_file_stats.cpp
-)
+# Roaring is installed via vcpkg and used here
+find_package(roaring CONFIG REQUIRED)
+# Propagate roaring's usage requirements (its headers) to every OBJECT library under src/.
+link_libraries(roaring::roaring roaring::roaring-headers roaring::roaring-headers-cpp)
 
-add_subdirectory(src/rest_catalog/objects)
+# Reset the TARGET_NAME, the AWS find_package build could bleed into our build -
+# overriding `TARGET_NAME`
+set(TARGET_NAME iceberg)
 
-add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES} ${ALL_OBJECT_FILES})
+# Each directory under src/ contributes its sources as an OBJECT library and appends them to
+# ALL_OBJECT_FILES (see the per-directory CMakeLists.txt files).
+add_subdirectory(src)
+
+add_library(${EXTENSION_NAME} STATIC ${ALL_OBJECT_FILES})
 
 set(PARAMETERS "-warnings")
 
@@ -140,20 +52,7 @@ if(EMSCRIPTEN)
 endif()
 
 
-build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES} ${ALL_OBJECT_FILES})
-
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-    find_package(CURL REQUIRED)
-    find_package(AWSSDK REQUIRED COMPONENTS core sso sts)
-    include_directories(${CURL_INCLUDE_DIRS})
-endif()
-
-# Roaring is installed via vcpkg and used here
-find_package(roaring CONFIG REQUIRED)
-
-# Reset the TARGET_NAME, the AWS find_package build could bleed into our build -
-# overriding `TARGET_NAME`
-set(TARGET_NAME iceberg)
+build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${ALL_OBJECT_FILES})
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     # AWS SDK FROM vcpkg

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_subdirectory(catalog)
+add_subdirectory(common)
+add_subdirectory(core)
+add_subdirectory(execution)
+add_subdirectory(function)
+add_subdirectory(maintenance)
+add_subdirectory(planning)
+add_subdirectory(rest_catalog)
+add_subdirectory(storage)
+
+add_library(iceberg_src OBJECT iceberg_attach.cpp iceberg_extension.cpp
+                               iceberg_logging.cpp iceberg_options.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_src>
+    PARENT_SCOPE)

--- a/src/catalog/CMakeLists.txt
+++ b/src/catalog/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_subdirectory(rest)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES}
+    PARENT_SCOPE)

--- a/src/catalog/rest/CMakeLists.txt
+++ b/src/catalog/rest/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_subdirectory(api)
+add_subdirectory(catalog_entry)
+add_subdirectory(storage)
+add_subdirectory(transaction)
+
+add_library(iceberg_catalog_rest OBJECT
+            iceberg_catalog.cpp iceberg_schema_set.cpp iceberg_table_set.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_catalog_rest>
+    PARENT_SCOPE)

--- a/src/catalog/rest/api/CMakeLists.txt
+++ b/src/catalog/rest/api/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(
+  iceberg_catalog_rest_api OBJECT
+  api_utils.cpp
+  catalog_api.cpp
+  catalog_utils.cpp
+  iceberg_add_snapshot.cpp
+  iceberg_create_table_request.cpp
+  iceberg_expression.cpp
+  iceberg_manifest_merge.cpp
+  iceberg_retry.cpp
+  iceberg_scan_planning.cpp
+  iceberg_table_update.cpp
+  iceberg_type.cpp
+  table_update.cpp
+  url_utils.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_catalog_rest_api>
+    PARENT_SCOPE)

--- a/src/catalog/rest/catalog_entry/CMakeLists.txt
+++ b/src/catalog/rest/catalog_entry/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_subdirectory(schema)
+add_subdirectory(table)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES}
+    PARENT_SCOPE)

--- a/src/catalog/rest/catalog_entry/schema/CMakeLists.txt
+++ b/src/catalog/rest/catalog_entry/schema/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(iceberg_catalog_rest_catalog_entry_schema OBJECT
+            iceberg_schema_entry.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES}
+    $<TARGET_OBJECTS:iceberg_catalog_rest_catalog_entry_schema>
+    PARENT_SCOPE)

--- a/src/catalog/rest/catalog_entry/table/CMakeLists.txt
+++ b/src/catalog/rest/catalog_entry/table/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(iceberg_catalog_rest_catalog_entry_table OBJECT
+            iceberg_table_entry.cpp iceberg_table_information.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES}
+    $<TARGET_OBJECTS:iceberg_catalog_rest_catalog_entry_table>
+    PARENT_SCOPE)

--- a/src/catalog/rest/storage/CMakeLists.txt
+++ b/src/catalog/rest/storage/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_subdirectory(authorization)
+
+add_library(iceberg_catalog_rest_storage OBJECT aws.cpp
+                                                iceberg_authorization.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_catalog_rest_storage>
+    PARENT_SCOPE)

--- a/src/catalog/rest/storage/authorization/CMakeLists.txt
+++ b/src/catalog/rest/storage/authorization/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(iceberg_catalog_rest_storage_authorization OBJECT
+            none.cpp oauth2.cpp sigv4.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES}
+    $<TARGET_OBJECTS:iceberg_catalog_rest_storage_authorization>
+    PARENT_SCOPE)

--- a/src/catalog/rest/transaction/CMakeLists.txt
+++ b/src/catalog/rest/transaction/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(
+  iceberg_catalog_rest_transaction OBJECT
+  iceberg_transaction.cpp iceberg_transaction_data.cpp
+  iceberg_transaction_manager.cpp iceberg_transaction_update.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_catalog_rest_transaction>
+    PARENT_SCOPE)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(iceberg_common OBJECT iceberg_default.cpp iceberg_utils.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_common>
+    PARENT_SCOPE)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_subdirectory(deletes)
+add_subdirectory(expression)
+add_subdirectory(metadata)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES}
+    PARENT_SCOPE)

--- a/src/core/deletes/CMakeLists.txt
+++ b/src/core/deletes/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(
+  iceberg_core_deletes OBJECT
+  iceberg_deletion_vector.cpp iceberg_equality_delete.cpp
+  iceberg_positional_delete.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_core_deletes>
+    PARENT_SCOPE)

--- a/src/core/expression/CMakeLists.txt
+++ b/src/core/expression/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(
+  iceberg_core_expression OBJECT iceberg_hash.cpp iceberg_metrics.cpp
+                                 iceberg_transform.cpp iceberg_value.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_core_expression>
+    PARENT_SCOPE)

--- a/src/core/metadata/CMakeLists.txt
+++ b/src/core/metadata/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_subdirectory(manifest)
+add_subdirectory(partition)
+add_subdirectory(puffin)
+add_subdirectory(schema)
+add_subdirectory(snapshot)
+add_subdirectory(sort)
+
+add_library(iceberg_core_metadata OBJECT iceberg_table_metadata.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_core_metadata>
+    PARENT_SCOPE)

--- a/src/core/metadata/manifest/CMakeLists.txt
+++ b/src/core/metadata/manifest/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(
+  iceberg_core_metadata_manifest OBJECT
+  iceberg_avro_codec.cpp iceberg_manifest.cpp iceberg_manifest_list.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_core_metadata_manifest>
+    PARENT_SCOPE)

--- a/src/core/metadata/partition/CMakeLists.txt
+++ b/src/core/metadata/partition/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(iceberg_core_metadata_partition OBJECT iceberg_partition_spec.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_core_metadata_partition>
+    PARENT_SCOPE)

--- a/src/core/metadata/puffin/CMakeLists.txt
+++ b/src/core/metadata/puffin/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(iceberg_core_metadata_puffin OBJECT iceberg_puffin_metadata.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_core_metadata_puffin>
+    PARENT_SCOPE)

--- a/src/core/metadata/schema/CMakeLists.txt
+++ b/src/core/metadata/schema/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(
+  iceberg_core_metadata_schema OBJECT
+  iceberg_column_definition.cpp iceberg_field_mapping.cpp
+  iceberg_table_schema.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_core_metadata_schema>
+    PARENT_SCOPE)

--- a/src/core/metadata/snapshot/CMakeLists.txt
+++ b/src/core/metadata/snapshot/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(iceberg_core_metadata_snapshot OBJECT iceberg_snapshot.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_core_metadata_snapshot>
+    PARENT_SCOPE)

--- a/src/core/metadata/sort/CMakeLists.txt
+++ b/src/core/metadata/sort/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(iceberg_core_metadata_sort OBJECT iceberg_sort_order.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_core_metadata_sort>
+    PARENT_SCOPE)

--- a/src/execution/CMakeLists.txt
+++ b/src/execution/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_subdirectory(helpers)
+add_subdirectory(operator)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES}
+    PARENT_SCOPE)

--- a/src/execution/helpers/CMakeLists.txt
+++ b/src/execution/helpers/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(iceberg_execution_helpers OBJECT equality_delete_helpers.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_execution_helpers>
+    PARENT_SCOPE)

--- a/src/execution/operator/CMakeLists.txt
+++ b/src/execution/operator/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_subdirectory(copy)
+add_subdirectory(merge_into)
+
+add_library(
+  iceberg_execution_operator OBJECT
+  iceberg_delete.cpp iceberg_insert.cpp iceberg_update.cpp
+  physical_iceberg_create_table.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_execution_operator>
+    PARENT_SCOPE)

--- a/src/execution/operator/copy/CMakeLists.txt
+++ b/src/execution/operator/copy/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(iceberg_execution_operator_copy OBJECT iceberg_copy.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_execution_operator_copy>
+    PARENT_SCOPE)

--- a/src/execution/operator/merge_into/CMakeLists.txt
+++ b/src/execution/operator/merge_into/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(
+  iceberg_execution_operator_merge_into OBJECT
+  iceberg_merge_insert.cpp iceberg_merge_into.cpp iceberg_merge_update.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_execution_operator_merge_into>
+    PARENT_SCOPE)

--- a/src/function/CMakeLists.txt
+++ b/src/function/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_subdirectory(copy)
+add_subdirectory(ducklake)
+add_subdirectory(metadata)
+add_subdirectory(scan)
+
+add_library(iceberg_function OBJECT iceberg_functions.cpp
+                                    iceberg_scalar_functions.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_function>
+    PARENT_SCOPE)

--- a/src/function/copy/CMakeLists.txt
+++ b/src/function/copy/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(iceberg_function_copy OBJECT iceberg_copy_function.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_function_copy>
+    PARENT_SCOPE)

--- a/src/function/ducklake/CMakeLists.txt
+++ b/src/function/ducklake/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(
+  iceberg_function_ducklake OBJECT
+  ducklake_column.cpp
+  ducklake_column_stats.cpp
+  ducklake_data_file.cpp
+  ducklake_delete_file.cpp
+  ducklake_partition.cpp
+  ducklake_partition_column.cpp
+  ducklake_schema.cpp
+  ducklake_snapshot.cpp
+  ducklake_table.cpp
+  iceberg_to_ducklake.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_function_ducklake>
+    PARENT_SCOPE)

--- a/src/function/metadata/CMakeLists.txt
+++ b/src/function/metadata/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(
+  iceberg_function_metadata OBJECT
+  iceberg_column_stats.cpp
+  iceberg_load_table_response.cpp
+  iceberg_metadata.cpp
+  iceberg_partition_stats.cpp
+  iceberg_rewrite_data_files.cpp
+  iceberg_schema_properties_functions.cpp
+  iceberg_snapshots.cpp
+  iceberg_table_properties_functions.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_function_metadata>
+    PARENT_SCOPE)

--- a/src/function/scan/CMakeLists.txt
+++ b/src/function/scan/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(iceberg_function_scan OBJECT iceberg_scan.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_function_scan>
+    PARENT_SCOPE)

--- a/src/maintenance/CMakeLists.txt
+++ b/src/maintenance/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(
+  iceberg_maintenance OBJECT
+  maintenance_table_loader.cpp rewrite_data_files_executor.cpp
+  rewrite_data_files_operator.cpp rewrite_data_files_planner.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_maintenance>
+    PARENT_SCOPE)

--- a/src/planning/CMakeLists.txt
+++ b/src/planning/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_subdirectory(metadata_io)
+add_subdirectory(pruning)
+add_subdirectory(snapshot)
+
+add_library(
+  iceberg_planning OBJECT
+  iceberg_multi_file_list.cpp iceberg_multi_file_reader.cpp
+  iceberg_optimizer.cpp iceberg_scan_plan_provider.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_planning>
+    PARENT_SCOPE)

--- a/src/planning/metadata_io/CMakeLists.txt
+++ b/src/planning/metadata_io/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_subdirectory(avro)
+add_subdirectory(deletes)
+add_subdirectory(manifest)
+add_subdirectory(manifest_list)
+
+add_library(iceberg_planning_metadata_io OBJECT base_manifest_reader.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_planning_metadata_io>
+    PARENT_SCOPE)

--- a/src/planning/metadata_io/avro/CMakeLists.txt
+++ b/src/planning/metadata_io/avro/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(
+  iceberg_planning_metadata_io_avro OBJECT
+  avro_scan.cpp iceberg_avro_multi_file_list.cpp
+  iceberg_avro_multi_file_reader.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_planning_metadata_io_avro>
+    PARENT_SCOPE)

--- a/src/planning/metadata_io/deletes/CMakeLists.txt
+++ b/src/planning/metadata_io/deletes/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(iceberg_planning_metadata_io_deletes OBJECT
+            iceberg_deletes_file_reader.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_planning_metadata_io_deletes>
+    PARENT_SCOPE)

--- a/src/planning/metadata_io/manifest/CMakeLists.txt
+++ b/src/planning/metadata_io/manifest/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(iceberg_planning_metadata_io_manifest OBJECT
+            bound_iceberg_manifest_entry.cpp iceberg_manifest_reader.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_planning_metadata_io_manifest>
+    PARENT_SCOPE)

--- a/src/planning/metadata_io/manifest_list/CMakeLists.txt
+++ b/src/planning/metadata_io/manifest_list/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(
+  iceberg_planning_metadata_io_manifest_list OBJECT
+  bound_iceberg_manifest_list_entry.cpp iceberg_manifest_list_reader.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES}
+    $<TARGET_OBJECTS:iceberg_planning_metadata_io_manifest_list>
+    PARENT_SCOPE)

--- a/src/planning/pruning/CMakeLists.txt
+++ b/src/planning/pruning/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(iceberg_planning_pruning OBJECT iceberg_predicate.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_planning_pruning>
+    PARENT_SCOPE)

--- a/src/planning/snapshot/CMakeLists.txt
+++ b/src/planning/snapshot/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(iceberg_planning_snapshot OBJECT iceberg_snapshot_lookup.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_planning_snapshot>
+    PARENT_SCOPE)

--- a/src/rest_catalog/CMakeLists.txt
+++ b/src/rest_catalog/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_subdirectory(objects)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES}
+    PARENT_SCOPE)

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_subdirectory(statistics)
+
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES}
+    PARENT_SCOPE)

--- a/src/storage/statistics/CMakeLists.txt
+++ b/src/storage/statistics/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(
+  iceberg_storage_statistics OBJECT
+  iceberg_data_file_stats.cpp iceberg_statistics.cpp
+  iceberg_variant_statistics.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_storage_statistics>
+    PARENT_SCOPE)


### PR DESCRIPTION
Refactor CmakeLists in the project and run fixture tests first as a sort of "smoke" test. I.e if a test fails there, we do not consume CI resources running tests on the other catalogs