### PR TITLE
Equality deletes filtering based on manifest metrics main

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -142,6 +142,7 @@ jobs:
           ENABLE_EXTENSION_AUTOLOADING: 1
           ENABLE_EXTENSION_AUTOINSTALL: 1
           BUILD_BENCHMARK: 1
+          EXT_FLAGS: -DICEBERG_ENABLE_EQUALITY_DELETE_WRITES=1
         with:
           build-type: release
           build: python3 duckdb/scripts/ci/retry.py -- make -C base release

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -85,6 +85,7 @@ jobs:
           ENABLE_EXTENSION_AUTOLOADING: 1
           ENABLE_EXTENSION_AUTOINSTALL: 1
           BUILD_BENCHMARK: 1
+          EXT_FLAGS: -DICEBERG_ENABLE_EQUALITY_DELETE_WRITES=1
         with:
           build-type: release
           build: python3 duckdb/scripts/ci/retry.py -- make release

--- a/benchmark/file_pruning_benchmarks/prune_equality_deletes.benchmark
+++ b/benchmark/file_pruning_benchmarks/prune_equality_deletes.benchmark
@@ -1,0 +1,61 @@
+# name: benchmark/file_pruning_benchmarks/prune_equality_deletes.benchmark
+# description: prune equality deletes when a given predicate would not select rows an equality delete would filter out
+# group: [file_pruning_benchmarks]
+
+name Prune positional deletes from unread partitions
+group file_pruning_benchmarks
+subgroup positional_deletes
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Build a DuckDB-written, format-version 2 table partitioned by day(event_date):
+#   * 365 day-partitions
+#   * a single merge-on-read DELETE removes id=0 from every partition, which writes one
+#     positional delete file per data file => 365 positional delete files, one per partition.
+# The timed query touches a single day-partition. Only that day's positional delete file can
+# affect the result; the other 364 reference data files in partitions the filter excludes.
+# Without metrics/partition-based delete pruning every one of the 365 delete files is opened and
+# materialized; with pruning only the one belonging to the scanned partition is read.
+load
+SET enable_external_file_cache=false;
+SET unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes=true;
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181',
+);
+CREATE SCHEMA if not exists my_datalake.default;
+DROP TABLE IF EXISTS my_datalake.default.prune_positional_deletes;
+CREATE TABLE my_datalake.default.prune_positional_deletes (
+    id BIGINT,
+    event VARCHAR,
+    event_date DATE
+);
+INSERT INTO my_datalake.default.prune_positional_deletes
+SELECT
+    range % 1000,
+    'e' || range::VARCHAR,
+    DATE '2024-01-01' + (range // 1000)::INTEGER
+FROM range(365000);
+DELETE FROM my_datalake.default.prune_positional_deletes WHERE id = 1 or id = 2 or id = 3 or id = 10 or id = 20;
+
+run
+SELECT *
+FROM my_datalake.default.prune_positional_deletes
+WHERE id = 50;
+

--- a/benchmark/file_pruning_benchmarks/prune_equality_deletes.benchmark
+++ b/benchmark/file_pruning_benchmarks/prune_equality_deletes.benchmark
@@ -51,7 +51,7 @@ SELECT
     range % 1000,
     'e' || range::VARCHAR,
     DATE '2024-01-01' + (range // 1000)::INTEGER
-FROM range(365000);
+FROM range(900000);
 DELETE FROM my_datalake.default.prune_positional_deletes WHERE id = 1 or id = 2 or id = 3 or id = 10 or id = 20;
 
 run

--- a/src/execution/helpers/equality_delete_helpers.cpp
+++ b/src/execution/helpers/equality_delete_helpers.cpp
@@ -34,20 +34,6 @@ namespace duckdb {
 //! ICEBERG_ENABLE_EQUALITY_DELETE_WRITES compile flag is on - in default builds the callers
 //! (in iceberg_delete.cpp) are #ifdef'd out, so this code is dead.
 
-static bool ExpressionContainsFunction(const Expression &expr, const char *function_name) {
-	if (expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION &&
-	    expr.Cast<BoundFunctionExpression>().Function().GetName() == function_name) {
-		return true;
-	}
-	bool found = false;
-	ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
-		if (!found && ExpressionContainsFunction(child, function_name)) {
-			found = true;
-		}
-	});
-	return found;
-}
-
 //! Whether a physical-filter expression is built purely from equality-delete forms, i.e. `col = const`,
 //! `col IN (const, ...)`, and AND/OR of those. `col IN (...)` and `col = c1 OR ...` can leave such a physical
 //! filter behind even though they also push down as a scan filter; recognizing it here keeps that delete on
@@ -91,12 +77,10 @@ static bool ExpressionIsEqualityDeleteForm(const Expression &expr) {
 static bool PlanContainsPhysicalFilter(PhysicalOperator &plan) {
 	if (plan.type == PhysicalOperatorType::FILTER) {
 		auto &filter = plan.Cast<PhysicalFilter>();
-		//! Two physical filters are compatible with writing an equality delete and must not disqualify it:
-		//!  - the 'iceberg_verify_equality_deletes' filter the read path injects to apply existing equality
-		//!    deletes (otherwise every delete after the first falls back to positional deletes), and
-		//!  - the DELETE predicate itself when it is a pure equality form (`col IN (...)` / `col = c1 OR ...`).
-		if (!ExpressionContainsFunction(*filter.expression, "iceberg_verify_equality_deletes") &&
-		    !ExpressionIsEqualityDeleteForm(*filter.expression)) {
+		//! The DELETE predicate can leave a physical filter behind even when it is a pure equality form
+		//! (`col IN (...)` / `col = c1 OR ...` also push down as a scan filter). Such a filter must not
+		//! disqualify writing an equality delete; anything else does.
+		if (!ExpressionIsEqualityDeleteForm(*filter.expression)) {
 			return true;
 		}
 	}

--- a/src/execution/helpers/equality_delete_helpers.cpp
+++ b/src/execution/helpers/equality_delete_helpers.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/common/types/uuid.hpp"
 #include "duckdb/execution/execution_context.hpp"
+#include "duckdb/execution/operator/filter/physical_filter.hpp"
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/function/copy_function.hpp"
@@ -12,12 +13,18 @@
 #include "duckdb/parallel/thread_context.hpp"
 #include "duckdb/parser/parsed_data/copy_info.hpp"
 #include "duckdb/parser/qualified_name.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
+#include "duckdb/planner/filter/table_filter_functions.hpp"
 
 #include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
 #include "common/iceberg_utils.hpp"
+#include "core/expression/iceberg_value.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "iceberg_options.hpp"
 
@@ -27,9 +34,71 @@ namespace duckdb {
 //! ICEBERG_ENABLE_EQUALITY_DELETE_WRITES compile flag is on - in default builds the callers
 //! (in iceberg_delete.cpp) are #ifdef'd out, so this code is dead.
 
+static bool ExpressionContainsFunction(const Expression &expr, const char *function_name) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION &&
+	    expr.Cast<BoundFunctionExpression>().Function().GetName() == function_name) {
+		return true;
+	}
+	bool found = false;
+	ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
+		if (!found && ExpressionContainsFunction(child, function_name)) {
+			found = true;
+		}
+	});
+	return found;
+}
+
+//! Whether a physical-filter expression is built purely from equality-delete forms, i.e. `col = const`,
+//! `col IN (const, ...)`, and AND/OR of those. `col IN (...)` and `col = c1 OR ...` can leave such a physical
+//! filter behind even though they also push down as a scan filter; recognizing it here keeps that delete on
+//! the equality-delete path. Anything else (ranges, functions, arbitrary expressions) disqualifies.
+static bool ExpressionIsEqualityDeleteForm(const Expression &expr) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION &&
+	    expr.GetExpressionType() == ExpressionType::COMPARE_EQUAL) {
+		auto &comparison = expr.Cast<BoundFunctionExpression>();
+		auto &left = BoundComparisonExpression::Left(comparison);
+		auto &right = BoundComparisonExpression::Right(comparison);
+		//! Exactly one side must be a constant (the other is the column expression).
+		return (left.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) !=
+		       (right.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT);
+	}
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR &&
+	    expr.GetExpressionType() == ExpressionType::COMPARE_IN) {
+		auto &op = expr.Cast<BoundOperatorExpression>();
+		auto &children = op.GetChildren();
+		if (children.size() < 2 || children[0]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+			return false;
+		}
+		for (idx_t i = 1; i < children.size(); i++) {
+			if (children[i]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+				return false;
+			}
+		}
+		return true;
+	}
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION) {
+		auto &conjunction = expr.Cast<BoundConjunctionExpression>();
+		for (auto &child : conjunction.GetChildren()) {
+			if (!ExpressionIsEqualityDeleteForm(*child)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	return false;
+}
+
 static bool PlanContainsPhysicalFilter(PhysicalOperator &plan) {
 	if (plan.type == PhysicalOperatorType::FILTER) {
-		return true;
+		auto &filter = plan.Cast<PhysicalFilter>();
+		//! Two physical filters are compatible with writing an equality delete and must not disqualify it:
+		//!  - the 'iceberg_verify_equality_deletes' filter the read path injects to apply existing equality
+		//!    deletes (otherwise every delete after the first falls back to positional deletes), and
+		//!  - the DELETE predicate itself when it is a pure equality form (`col IN (...)` / `col = c1 OR ...`).
+		if (!ExpressionContainsFunction(*filter.expression, "iceberg_verify_equality_deletes") &&
+		    !ExpressionIsEqualityDeleteForm(*filter.expression)) {
+			return true;
+		}
 	}
 	for (auto &child : plan.children) {
 		if (PlanContainsPhysicalFilter(child.get())) {
@@ -97,6 +166,91 @@ static bool TryGetColumnPath(const Expression &expr, vector<Identifier> &column_
 	}
 }
 
+static bool SetOrMatchColumnExpression(optional_ptr<const Expression> &column_expression, const Expression &candidate) {
+	if (!column_expression) {
+		column_expression = candidate;
+		return true;
+	}
+	//! Every disjunct of an OR must reference the same column.
+	return Expression::Equals(*column_expression, candidate);
+}
+
+//! Extract the (single) column expression a filter targets and the set of values it deletes, for the
+//! supported forms: `col = c`, `col IN (c1, ...)`, and `col = c1 OR col = c2 OR ...` (which may nest IN).
+//! NULL constants are dropped - they can never match an equality. Returns false for any other shape.
+static bool TryGetEqualityDeleteValuesFromExpression(const Expression &expr,
+                                                     optional_ptr<const Expression> &column_expression,
+                                                     vector<Value> &values) {
+	//! `col IN (...)` / `col = c1 OR ...` push down as an optional scan filter, wrapped in an
+	//! optional-filter scalar function whose real predicate lives in the bind info. Unwrap it.
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+		auto &func = expr.Cast<BoundFunctionExpression>();
+		if (func.Function().GetName() == OptionalFilterScalarFun::NAME && func.BindInfo()) {
+			auto &data = func.BindInfo()->Cast<OptionalFilterFunctionData>();
+			return data.child_filter_expr &&
+			       TryGetEqualityDeleteValuesFromExpression(*data.child_filter_expr, column_expression, values);
+		}
+		if (func.Function().GetName() == SelectivityOptionalFilterScalarFun::NAME && func.BindInfo()) {
+			auto &data = func.BindInfo()->Cast<SelectivityOptionalFilterFunctionData>();
+			return data.child_filter_expr &&
+			       TryGetEqualityDeleteValuesFromExpression(*data.child_filter_expr, column_expression, values);
+		}
+	}
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION &&
+	    expr.GetExpressionType() == ExpressionType::COMPARE_EQUAL) {
+		auto &compare_expr = expr.Cast<BoundFunctionExpression>();
+		auto &left = BoundComparisonExpression::Left(compare_expr);
+		auto &right = BoundComparisonExpression::Right(compare_expr);
+		optional_ptr<const Expression> column;
+		optional_ptr<const Value> constant;
+		if (right.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+			column = left;
+			constant = right.Cast<BoundConstantExpression>().GetValue();
+		} else if (left.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+			column = right;
+			constant = left.Cast<BoundConstantExpression>().GetValue();
+		} else {
+			return false;
+		}
+		if (!SetOrMatchColumnExpression(column_expression, *column)) {
+			return false;
+		}
+		if (!constant->IsNull()) {
+			values.push_back(*constant);
+		}
+		return true;
+	}
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR &&
+	    expr.GetExpressionType() == ExpressionType::COMPARE_IN) {
+		auto &op = expr.Cast<BoundOperatorExpression>();
+		auto &children = op.GetChildren();
+		if (children.size() < 2 || !SetOrMatchColumnExpression(column_expression, *children[0])) {
+			return false;
+		}
+		for (idx_t i = 1; i < children.size(); i++) {
+			if (children[i]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+				return false;
+			}
+			auto &value = children[i]->Cast<BoundConstantExpression>().GetValue();
+			if (!value.IsNull()) {
+				values.push_back(value);
+			}
+		}
+		return true;
+	}
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION &&
+	    expr.GetExpressionType() == ExpressionType::CONJUNCTION_OR) {
+		auto &conjunction = expr.Cast<BoundConjunctionExpression>();
+		for (auto &child : conjunction.GetChildren()) {
+			if (!TryGetEqualityDeleteValuesFromExpression(*child, column_expression, values)) {
+				return false;
+			}
+		}
+		return !conjunction.GetChildren().empty();
+	}
+	return false;
+}
+
 } // namespace
 
 bool IcebergDelete::TryGetEqualityDeletePredicates(ClientContext &context, IcebergTableEntry &table,
@@ -139,27 +293,14 @@ bool IcebergDelete::TryGetEqualityDeletePredicates(ClientContext &context, Icebe
 		auto &table_filter = filter_entry.Filter().Cast<ExpressionFilter>();
 		auto &expr = *table_filter.expr;
 
-		//! Only a plain `column = constant` qualifies (rejects IN, OR/AND conjunctions, IS NULL, ...).
-
-		if (expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
-			return false;
-		}
-		if (expr.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
-			return false;
-		}
-		auto &compare_expr = expr.Cast<BoundFunctionExpression>();
-		auto &left = BoundComparisonExpression::Left(compare_expr);
-		auto &right = BoundComparisonExpression::Right(compare_expr);
-
-		optional_ptr<const Value> constant_value;
+		//! Accept `col = c`, `col IN (...)`, or `col = c1 OR col = c2 OR ...`; reject anything else.
 		optional_ptr<const Expression> column_expression;
-		if (right.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
-			column_expression = left;
-			constant_value = right.Cast<BoundConstantExpression>().GetValue();
-		} else if (left.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
-			column_expression = right;
-			constant_value = left.Cast<BoundConstantExpression>().GetValue();
-		} else {
+		vector<Value> raw_values;
+		if (!TryGetEqualityDeleteValuesFromExpression(expr, column_expression, raw_values)) {
+			return false;
+		}
+		if (!column_expression || raw_values.empty()) {
+			//! e.g. `col IN (NULL)` - nothing to delete via equality; fall back to positional.
 			return false;
 		}
 		vector<Identifier> column_path;
@@ -191,19 +332,35 @@ bool IcebergDelete::TryGetEqualityDeletePredicates(ClientContext &context, Icebe
 				return false;
 			}
 		}
-		Value delete_value;
-		string error_message;
-		if (!constant_value->DefaultTryCastAs(column_definition->type, delete_value, &error_message, true)) {
-			return false;
-		}
 		IcebergEqualityDeletePredicate predicate;
 		predicate.field_id = column_definition->id;
 		predicate.column_name = column_definition->name;
 		predicate.type = column_definition->type;
-		predicate.value = std::move(delete_value);
+		for (auto &raw_value : raw_values) {
+			Value delete_value;
+			string error_message;
+			if (!raw_value.DefaultTryCastAs(column_definition->type, delete_value, &error_message, true)) {
+				return false;
+			}
+			predicate.values.push_back(std::move(delete_value));
+		}
 		equality_predicates.push_back(std::move(predicate));
 	}
-	return !equality_predicates.empty();
+
+	if (equality_predicates.empty()) {
+		return false;
+	}
+	//! The equality-delete file materializes the cross product of every column's value set. Cap it so a
+	//! very large delete falls back to positional deletes instead of writing a huge equality-delete file.
+	static constexpr idx_t MAX_EQUALITY_DELETE_ROWS = 4096;
+	idx_t total_rows = 1;
+	for (auto &predicate : equality_predicates) {
+		total_rows *= predicate.values.size();
+		if (total_rows > MAX_EQUALITY_DELETE_ROWS) {
+			return false;
+		}
+	}
+	return true;
 }
 
 void IcebergDelete::WriteEqualityDeleteFile(ClientContext &context, IcebergDeleteGlobalState &global_state) const {
@@ -249,15 +406,39 @@ void IcebergDelete::WriteEqualityDeleteFile(ClientContext &context, IcebergDelet
 	CopyFunctionFileStatistics stats;
 	copy_fun.function.copy_to_get_written_statistics(context, *function_data, *copy_global_state, stats);
 
-	// Write a single row containing the equality-delete tuple (one value per equality column).
-	DataChunk write_chunk;
-	write_chunk.Initialize(context, types_to_write);
-	for (idx_t col_idx = 0; col_idx < equality_predicates.size(); col_idx++) {
-		write_chunk.data[col_idx].SetValue(0, equality_predicates[col_idx].value);
+	// Materialize the equality-delete rows: the cross product of every column's value set. Within a row
+	// the columns are AND-ed and rows are OR-ed, encoding `(col0 IN vals0) AND (col1 IN vals1) AND ...`.
+	vector<vector<Value>> rows;
+	rows.emplace_back();
+	for (auto &predicate : equality_predicates) {
+		vector<vector<Value>> expanded;
+		for (auto &existing_row : rows) {
+			for (auto &value : predicate.values) {
+				auto new_row = existing_row;
+				new_row.push_back(value);
+				expanded.push_back(std::move(new_row));
+			}
+		}
+		rows = std::move(expanded);
 	}
-	write_chunk.SetChildCardinality(1);
-	copy_fun.function.copy_to_sink(execution_context, *function_data, *copy_global_state, *copy_local_state,
-	                               write_chunk);
+
+	// Write the delete tuples (one per row), chunking at STANDARD_VECTOR_SIZE.
+	idx_t rows_written = 0;
+	while (rows_written < rows.size()) {
+		idx_t chunk_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, rows.size() - rows_written);
+		DataChunk write_chunk;
+		write_chunk.Initialize(context, types_to_write);
+		for (idx_t row_idx = 0; row_idx < chunk_count; row_idx++) {
+			auto &row = rows[rows_written + row_idx];
+			for (idx_t col_idx = 0; col_idx < row.size(); col_idx++) {
+				write_chunk.data[col_idx].SetValue(row_idx, row[col_idx]);
+			}
+		}
+		write_chunk.SetChildCardinality(chunk_count);
+		copy_fun.function.copy_to_sink(execution_context, *function_data, *copy_global_state, *copy_local_state,
+		                               write_chunk);
+		rows_written += chunk_count;
+	}
 
 	copy_fun.function.copy_to_combine(execution_context, *function_data, *copy_global_state, *copy_local_state);
 	copy_fun.function.copy_to_finalize(context, *function_data, *copy_global_state);
@@ -265,9 +446,38 @@ void IcebergDelete::WriteEqualityDeleteFile(ClientContext &context, IcebergDelet
 	IcebergDeleteFileInfo delete_file;
 	delete_file.file_name = delete_file_path;
 	delete_file.file_format = "parquet";
-	delete_file.delete_count = 1;
+	delete_file.delete_count = rows.size();
 	delete_file.file_size_bytes = stats.file_size_bytes;
 	delete_file.equality_ids = std::move(equality_ids);
+
+	// Record per-field metrics for the equality-delete values so scans can prune this delete file when its
+	// equality-field range is disjoint from the scan predicate / a data file's bounds. Each field's bound
+	// spans the min/max of its value set.
+	for (auto &predicate : equality_predicates) {
+		Value min_value = predicate.values[0];
+		Value max_value = predicate.values[0];
+		for (auto &value : predicate.values) {
+			if (value < min_value) {
+				min_value = value;
+			}
+			if (value > max_value) {
+				max_value = value;
+			}
+		}
+		auto lower = IcebergValue::SerializeValue(min_value, predicate.type, SerializeBound::LOWER_BOUND);
+		if (lower.HasError()) {
+			throw InvalidConfigurationException(lower.GetError());
+		} else if (lower.HasValue()) {
+			delete_file.lower_bounds[predicate.field_id] = lower.GetValue();
+		}
+		auto upper = IcebergValue::SerializeValue(max_value, predicate.type, SerializeBound::UPPER_BOUND);
+		if (upper.HasError()) {
+			throw InvalidConfigurationException(upper.GetError());
+		} else if (upper.HasValue()) {
+			delete_file.upper_bounds[predicate.field_id] = upper.GetValue();
+		}
+	}
+
 	global_state.written_files.emplace(delete_file_path, std::move(delete_file));
 }
 

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -397,6 +397,9 @@ vector<IcebergManifestEntry> IcebergDelete::GenerateDeleteManifestEntries(Iceber
 			data_file.record_count = delete_file.delete_count;
 			data_file.file_size_in_bytes = delete_file.file_size_bytes;
 			data_file.equality_ids = delete_file.equality_ids;
+			//! Record the equality-delete value bounds so the file can be pruned on metrics.
+			data_file.lower_bounds = delete_file.lower_bounds;
+			data_file.upper_bounds = delete_file.upper_bounds;
 			iceberg_delete_files.push_back(manifest_entry);
 			continue;
 		}

--- a/src/include/execution/operator/iceberg_delete.hpp
+++ b/src/include/execution/operator/iceberg_delete.hpp
@@ -39,8 +39,10 @@ struct IcebergEqualityDeletePredicate {
 	string column_name;
 	//! The column type
 	LogicalType type;
-	//! The constant value to delete (cast to `type`)
-	Value value;
+	//! The set of values to delete for this column (cast to `type`). A single value for `col = c`,
+	//! multiple for `col IN (c1, c2, ...)` or `col = c1 OR col = c2 OR ...`. The equality-delete rows
+	//! are the cross product of every predicate's value set.
+	vector<Value> values;
 };
 
 class IcebergDeleteLocalState : public LocalSinkState {
@@ -63,6 +65,9 @@ struct IcebergDeleteFileInfo {
 	vector<IcebergPartitionInfo> partition_info;
 	//! When non-empty, this is an equality-delete file; holds the field-ids it applies to
 	vector<int32_t> equality_ids;
+	//! Per-field serialized lower/upper bounds of the equality-delete values (field-id -> bound blob).
+	unordered_map<int32_t, Value> lower_bounds;
+	unordered_map<int32_t, Value> upper_bounds;
 };
 
 class IcebergDeleteGlobalState : public GlobalSinkState {

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -744,10 +744,14 @@ bool IcebergMultiFileList::FileMatchesFilter(const IcebergManifestFile &manifest
 		if (!FilePartitionMatchesFilter(data_file, manifest_file, metadata, schema)) {
 			return false;
 		}
+		// Equality-delete files carry per-column value bounds, so a predicate on an equality column that
+		// is disjoint from those bounds means the file cannot delete any row the scan returns - prune it.
+		// Positional-delete files only carry file_path bounds and remain filtered on partitions only.
+		bool is_equality_delete = data_file.content == IcebergManifestEntryContentType::EQUALITY_DELETES;
 		if (data_file.lower_bounds.empty() || data_file.upper_bounds.empty() ||
-		    file_type == IcebergManifestContentType::DELETE) {
+		    (file_type == IcebergManifestContentType::DELETE && !is_equality_delete)) {
 			// There are no bounds statistics for the file, can't filter,
-			// or it is a delete file, which should only be filtered on partitions
+			// or it is a positional delete file, which should only be filtered on partitions
 			continue;
 		}
 

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -1,5 +1,6 @@
 #include "planning/iceberg_multi_file_list.hpp"
 
+#include "core/metadata/manifest/iceberg_manifest_list.hpp"
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
 #include "duckdb/function/partition_stats.hpp"
 #include "duckdb/logging/logger.hpp"
@@ -744,12 +745,9 @@ bool IcebergMultiFileList::FileMatchesFilter(const IcebergManifestFile &manifest
 		if (!FilePartitionMatchesFilter(data_file, manifest_file, metadata, schema)) {
 			return false;
 		}
-		// Equality-delete files carry per-column value bounds, so a predicate on an equality column that
-		// is disjoint from those bounds means the file cannot delete any row the scan returns - prune it.
-		// Positional-delete files only carry file_path bounds and remain filtered on partitions only.
-		bool is_equality_delete = data_file.content == IcebergManifestEntryContentType::EQUALITY_DELETES;
+
 		if (data_file.lower_bounds.empty() || data_file.upper_bounds.empty() ||
-		    (file_type == IcebergManifestContentType::DELETE && !is_equality_delete)) {
+		    data_file.content == IcebergManifestEntryContentType::POSITION_DELETES) {
 			// There are no bounds statistics for the file, can't filter,
 			// or it is a positional delete file, which should only be filtered on partitions
 			continue;

--- a/src/storage/statistics/iceberg_variant_statistics.cpp
+++ b/src/storage/statistics/iceberg_variant_statistics.cpp
@@ -356,7 +356,7 @@ bool IcebergVariantBoundsReader::RekeyBoundsVariant(const Value &bounds_variant,
 		// keys (the flat JSON paths "$['person']['address']['zip']", ...), with the leaf bounds as typed scalars.
 		Vector tmp(bounds_variant, count_t(1));
 		RecursiveUnifiedVectorFormat format;
-		Vector::RecursiveToUnifiedFormat(tmp, 1, format);
+		Vector::RecursiveToUnifiedFormat(tmp, format);
 		UnifiedVariantVectorData variant_data(format);
 		struct_value = VariantUtils::ConvertVariantToValue(variant_data, 0, 0);
 	} catch (...) {

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_do_not_read_equality_deletes.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_do_not_read_equality_deletes.test
@@ -1,0 +1,117 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_do_not_read_equality_deletes.test
+# description: Test iceberg deletes
+# group: [equality_deletes]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require-env EQUALITY_DELETE_WRITES_ENABLED 1
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+set unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes=true;
+
+# help when inspecting explain statements
+# disable join order to disable requests to data files during GetCardinality
+statement ok
+set disabled_optimizers='column_lifetime,statistics_propagation,join_order';
+
+statement ok
+set enable_external_file_cache=false;
+
+statement ok
+drop table if exists my_datalake.default.equality_delete_table_filter_pruning_test;
+
+statement ok
+create table my_datalake.default.equality_delete_table_filter_pruning_test as select range a, range % 50 b from range(10000);
+
+statement ok
+delete from my_datalake.default.equality_delete_table_filter_pruning_test where b = 1;
+
+statement ok
+delete from my_datalake.default.equality_delete_table_filter_pruning_test where b = 2;
+
+statement ok
+delete from my_datalake.default.equality_delete_table_filter_pruning_test where b = 3;
+
+statement ok
+delete from my_datalake.default.equality_delete_table_filter_pruning_test where b = 4;
+
+statement ok
+call enable_logging('HTTP');
+
+statement ok
+EXPLAIN select count(*) from my_datalake.default.equality_delete_table_filter_pruning_test group by all;
+
+# equality delete file is not scanned.
+query I
+select count(*) from duckdb_logs_parsed('http') where request.url like '%-deletes.parquet' and request.type = 'GET';
+----
+0
+
+# 4 different equality delete files
+query I
+select count(*) from iceberg_metadata(my_datalake.default.equality_delete_table_filter_pruning_test) where content like '%EQUALITY_DELETES%';
+----
+4
+
+# equality deletes are written with upper and lower bounds
+query II
+select upper_bound, lower_bound from iceberg_column_stats(my_datalake.default.equality_delete_table_filter_pruning_test) where file_path like '%equality-deletes.parquet' and column_name = 'b';
+----
+1	1
+2	2
+3	3
+4	4
+
+statement ok
+call truncate_duckdb_logs();
+
+query II
+select a, b from my_datalake.default.equality_delete_table_filter_pruning_test where b = 20 order by a limit 1;
+----
+20	20
+
+
+# TODO figure out why equality delete files are requested twice.
+# statement ok
+# select request.url, request.headers['Range'] from duckdb_logs_parsed('http') where request.url like '%deletes.parquet';
+
+# 0 equality delete files selected since we know from bounds pruning they cannot be selected.
+query I
+select count(*) from duckdb_logs_parsed('http') where request.url like '%equality-deletes.parquet';
+----
+0
+
+statement ok
+call truncate_duckdb_logs();
+
+# should request 2 equality delete files
+query I
+select count(*) from duckdb_logs_parsed('http') where request.url like '%equality-deletes.parquet';
+----
+0
+
+
+query II
+select a, b from my_datalake.default.equality_delete_table_filter_pruning_test where b >= 2 and b <= 10 order by a limit 1;
+----
+5	5	
+
+# should request 3 equality delete files (2, 3, 4)
+query I
+select count(distinct(request.url)) from duckdb_logs_parsed('http') where request.url like '%equality-deletes.parquet' ;
+----
+3
+
+
+

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_in_and_or.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_in_and_or.test
@@ -1,0 +1,93 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_in_and_or.test
+# description: DELETE with a single-column IN filter or an OR-conjunction of equalities writes an equality delete file
+# group: [equality_deletes]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require-env EQUALITY_DELETE_WRITES_ENABLED 1
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+set unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes=true;
+
+statement ok
+set disabled_optimizers='column_lifetime,statistics_propagation,join_order';
+
+statement ok
+set enable_external_file_cache=false;
+
+statement ok
+drop table if exists my_datalake.default.eq_delete_in_or;
+
+statement ok
+create table my_datalake.default.eq_delete_in_or as select range a, range % 50 b from range(1000);
+
+# --- single-column IN filter => one equality delete file with one row per value ---
+statement ok
+delete from my_datalake.default.eq_delete_in_or where a in (1, 5, 7, 9);
+
+# an EQUALITY_DELETES file with 4 rows (one per IN value) was written, no positional delete files.
+query II
+SELECT content, sum(record_count)
+FROM iceberg_metadata(my_datalake.default.eq_delete_in_or)
+WHERE content IN ('EQUALITY_DELETES', 'POSITION_DELETES') AND status != 'DELETED'
+GROUP BY content ORDER BY content;
+----
+EQUALITY_DELETES	4
+
+# the four rows are gone, others remain
+query I
+select count(*) from my_datalake.default.eq_delete_in_or where a in (1, 5, 7, 9);
+----
+0
+
+query I
+select count(*) from my_datalake.default.eq_delete_in_or;
+----
+996
+
+# --- single-column OR-of-equals => equality delete file ---
+statement ok
+delete from my_datalake.default.eq_delete_in_or where a = 100 or a = 200 or a = 300 or a = 400;
+
+query I
+SELECT sum(record_count)
+FROM iceberg_metadata(my_datalake.default.eq_delete_in_or)
+WHERE content = 'EQUALITY_DELETES' AND status != 'DELETED';
+----
+8
+
+query I
+select count(*) from my_datalake.default.eq_delete_in_or where a in (100, 200, 300, 400);
+----
+0
+
+query I
+select count(*) from my_datalake.default.eq_delete_in_or;
+----
+992
+
+# --- bounds pruning still applies: a predicate disjoint from every equality-delete range reads no delete file ---
+statement ok
+call enable_logging('HTTP');
+
+statement ok
+select a from my_datalake.default.eq_delete_in_or where a = 900 order by a;
+
+# a=900 is disjoint from [1,9] and [100,400], so no equality delete file is fetched.
+query I
+select count(*) from duckdb_logs_parsed('http') where request.url like '%equality-deletes.parquet' and request.type = 'GET';
+----
+0
+
+statement ok
+drop table my_datalake.default.eq_delete_in_or;


### PR DESCRIPTION
Do not read equality delete files if a query predicate would not never match what the equality delete filters out. I.e

```sql
Create table t1 as select range%100 a from range(1000);
-- create equality delete file with the following IN values
delete from t1 where a in (5, 10, 15, 20, 30);
-- select tuples(s) that are not even in the equality delete
Select * from t1 where a = 50;
```

This required some updates to the equality delete helper file, but those changes are not shipped in releases, since we do not want to support equality deletes
