### PR TITLE
[Dev][Scan] Lazy loading for delete-manifests

### DIFF
--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -81,6 +81,7 @@ private:
 class IcebergTableEntry;
 class IcebergScanPlanProvider;
 class ClientSideScanPlanProvider;
+struct IcebergDeleteManifestLoadState;
 struct IcebergMultiFileList;
 struct IcebergMultiFileReader;
 struct RowGroupOrderOptions;
@@ -129,9 +130,8 @@ private:
 	//! Scanned delete manifests and their owners.
 	mutable vector<IcebergManifestListEntry> committed_delete_manifests DUCKDB_GUARDED_BY(lock);
 	mutable vector<reference<const IcebergManifestListEntry>> transaction_delete_manifests DUCKDB_GUARDED_BY(lock);
-	mutable unique_ptr<AvroScan> delete_manifest_scan DUCKDB_GUARDED_BY(delete_lock);
-	mutable unique_ptr<manifest_file::ManifestReader> delete_manifest_reader DUCKDB_GUARDED_BY(delete_lock);
-	mutable bool delete_entries_enumerated DUCKDB_GUARDED_BY(delete_lock) = false;
+	mutable vector<shared_ptr<IcebergDeleteManifestLoadState>> delete_manifest_loads DUCKDB_GUARDED_BY(delete_lock);
+	mutable vector<bool> delete_manifest_entries_enumerated DUCKDB_GUARDED_BY(delete_lock);
 	mutable idx_t next_delete_entry_to_process DUCKDB_GUARDED_BY(delete_lock) = 0;
 	mutable vector<BoundIcebergManifestEntry> delete_manifest_entries DUCKDB_GUARDED_BY(delete_lock);
 
@@ -213,13 +213,17 @@ private:
 	                                                   IcebergManifestContentType type) const
 	    DUCKDB_REQUIRES(shared_state->lock);
 
-	void ProcessDeletes() const;
+	void ProcessDeletes(const BoundIcebergManifestEntry &data_manifest_entry) const;
 	unique_ptr<DeleteFilter> GetPositionalDeletesForFile(const string &file_path) const;
 	vector<reference<const IcebergEqualityDeleteFile>>
 	GetEqualityDeletesForFile(const BoundIcebergManifestEntry &manifest_entry) const;
-	vector<BoundIcebergManifestEntry> GetDeleteManifestEntries() const;
 
 	bool ManifestMatchesFilter(const IcebergManifestFile &manifest) const;
+	bool DeleteManifestMatchesDataFile(const IcebergManifestFile &delete_manifest,
+	                                   const BoundIcebergManifestEntry &data_manifest_entry) const
+	    DUCKDB_REQUIRES(shared_state->lock);
+	vector<idx_t> GetDeleteManifestsForDataFile(const BoundIcebergManifestEntry &data_manifest_entry) const
+	    DUCKDB_REQUIRES(shared_state->lock);
 	bool FilePartitionMatchesFilter(const IcebergDataFile &data_file, const IcebergManifestFile &manifest_file,
 	                                const IcebergTableMetadata &metadata, const IcebergTableSchema &schema) const;
 	bool FileMatchesFilter(const IcebergManifestFile &manifest_file, const IcebergManifestEntry &manifest_entry,
@@ -242,8 +246,10 @@ private:
 	void LoadManifestList(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
 	void InitializeScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);
 	void StartDataManifestScan(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
-	void EnumerateDeleteManifestEntriesInternal() const DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
-	void ProcessDeletesInternal() const DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
+	void EnumerateDeleteManifestEntriesInternal(const vector<idx_t> &manifest_indexes) const
+	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
+	void ProcessDeletesInternal(const vector<idx_t> &manifest_indexes) const
+	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
 	void ScanDeleteFiles() const DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
 	void ScanDeleteFile(const BoundIcebergManifestEntry &entry) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -287,6 +287,8 @@ private:
 	//! Combination of committed + transaction delete manifests
 	mutable vector<BoundIcebergManifestListEntry> delete_manifests DUCKDB_GUARDED_BY(shared_state->lock);
 	mutable vector<bool> delete_manifest_matches DUCKDB_GUARDED_BY(shared_state->lock);
+	//! Conservative until InitializeView determines whether this filtered view has any matching delete manifests.
+	mutable atomic<bool> has_matching_delete_manifests {true};
 
 	mutable IcebergDataViewCursor data_view_cursor DUCKDB_GUARDED_BY(shared_state->lock);
 	//! References to items inside the 'manifest_entries' of the list entries in the 'data_manifests'

--- a/src/include/planning/iceberg_scan_plan_provider.hpp
+++ b/src/include/planning/iceberg_scan_plan_provider.hpp
@@ -10,12 +10,12 @@ public:
 	virtual ~IcebergScanPlanProvider() = default;
 
 	virtual void LoadManifestList(const IcebergMultiFileList &file_list) = 0;
-	virtual void StartDeleteManifestScan(const IcebergMultiFileList &file_list) = 0;
 	virtual void StartDataManifestScan(const IcebergMultiFileList &file_list) = 0;
-	virtual void EnumerateDeleteManifestEntries(const IcebergMultiFileList &file_list) = 0;
+	virtual void ReadDeleteManifests(const IcebergMultiFileList &file_list, const vector<idx_t> &manifest_indexes) = 0;
+	virtual void EnumerateDeleteManifestEntries(const IcebergMultiFileList &file_list,
+	                                            const vector<idx_t> &manifest_indexes) = 0;
 	virtual bool TryGetNextBatch(IcebergDataViewCursor &cursor) = 0;
 	virtual void FinishScanTasks() = 0;
-	virtual bool FinishedScanningDeletes() const = 0;
 	virtual bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const = 0;
 	virtual vector<IcebergManifestListEntry> &DataManifests() = 0;
 	virtual vector<IcebergManifestListEntry> &DeleteManifests() = 0;
@@ -30,15 +30,14 @@ public:
 	explicit ClientSideScanPlanProvider(IcebergMultiFileListSharedState &shared_state);
 
 	void LoadManifestList(const IcebergMultiFileList &file_list) override DUCKDB_REQUIRES(shared_state.lock);
-	void StartDeleteManifestScan(const IcebergMultiFileList &file_list) override
-	    DUCKDB_REQUIRES(shared_state.lock, shared_state.delete_lock);
 	void StartDataManifestScan(const IcebergMultiFileList &file_list) override
 	    DUCKDB_REQUIRES(shared_state.lock, file_list.shared_state->lock);
-	void EnumerateDeleteManifestEntries(const IcebergMultiFileList &file_list) override
+	void ReadDeleteManifests(const IcebergMultiFileList &file_list, const vector<idx_t> &manifest_indexes) override;
+	void EnumerateDeleteManifestEntries(const IcebergMultiFileList &file_list,
+	                                    const vector<idx_t> &manifest_indexes) override
 	    DUCKDB_REQUIRES(shared_state.lock, shared_state.delete_lock);
 	bool TryGetNextBatch(IcebergDataViewCursor &cursor) override DUCKDB_REQUIRES(shared_state.lock);
 	void FinishScanTasks() override DUCKDB_REQUIRES(shared_state.lock);
-	bool FinishedScanningDeletes() const override DUCKDB_REQUIRES(shared_state.delete_lock);
 	bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const override;
 	vector<IcebergManifestListEntry> &DataManifests() override DUCKDB_REQUIRES(shared_state.lock);
 	vector<IcebergManifestListEntry> &DeleteManifests() override DUCKDB_REQUIRES(shared_state.lock);
@@ -56,12 +55,12 @@ public:
 	explicit ServerSideScanPlanProvider(IcebergServerSideScanPlan plan);
 
 	void LoadManifestList(const IcebergMultiFileList &file_list) override;
-	void StartDeleteManifestScan(const IcebergMultiFileList &file_list) override;
 	void StartDataManifestScan(const IcebergMultiFileList &file_list) override;
-	void EnumerateDeleteManifestEntries(const IcebergMultiFileList &file_list) override;
+	void ReadDeleteManifests(const IcebergMultiFileList &file_list, const vector<idx_t> &manifest_indexes) override;
+	void EnumerateDeleteManifestEntries(const IcebergMultiFileList &file_list,
+	                                    const vector<idx_t> &manifest_indexes) override;
 	bool TryGetNextBatch(IcebergDataViewCursor &cursor) override;
 	void FinishScanTasks() override;
-	bool FinishedScanningDeletes() const override;
 	bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const override;
 	vector<IcebergManifestListEntry> &DataManifests() override;
 	vector<IcebergManifestListEntry> &DeleteManifests() override;
@@ -75,7 +74,7 @@ private:
 	IcebergServerSideScanPlan plan;
 	ManifestEntryReadState read_state;
 	bool data_manifest_scan_started = false;
-	bool delete_entries_enumerated = false;
+	vector<bool> delete_manifest_entries_enumerated;
 	idx_t next_delete_entry_to_process = 0;
 	vector<BoundIcebergManifestEntry> delete_manifest_entries;
 	position_delete_map_t positional_delete_data;

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -1349,14 +1349,20 @@ void IcebergMultiFileList::InitializeView(annotated_lock_guard<annotated_mutex> 
 	auto &transaction_delete_manifests = shared_state->transaction_delete_manifests;
 	delete_manifests.reserve(committed_delete_manifests.size() + transaction_delete_manifests.size());
 	delete_manifest_matches.reserve(committed_delete_manifests.size() + transaction_delete_manifests.size());
+	bool view_has_matching_delete_manifests = false;
 	for (auto &manifest : committed_delete_manifests) {
 		delete_manifests.emplace_back(delete_manifests.size(), manifest);
-		delete_manifest_matches.push_back(ManifestMatchesFilter(manifest.file));
+		auto matches = ManifestMatchesFilter(manifest.file);
+		delete_manifest_matches.push_back(matches);
+		view_has_matching_delete_manifests |= matches;
 	}
 	for (auto &manifest : transaction_delete_manifests) {
 		delete_manifests.emplace_back(delete_manifests.size(), manifest);
-		delete_manifest_matches.push_back(ManifestMatchesFilter(manifest.get().file));
+		auto matches = ManifestMatchesFilter(manifest.get().file);
+		delete_manifest_matches.push_back(matches);
+		view_has_matching_delete_manifests |= matches;
 	}
+	has_matching_delete_manifests.store(view_has_matching_delete_manifests);
 }
 
 namespace {
@@ -1519,6 +1525,10 @@ void IcebergMultiFileList::ScanDeleteFiles() const {
 }
 
 void IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_manifest_entry) const {
+	if (!has_matching_delete_manifests.load()) {
+		return;
+	}
+
 	vector<idx_t> manifest_indexes;
 	optional_ptr<IcebergScanPlanProvider> provider;
 	{
@@ -1526,6 +1536,9 @@ void IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_
 		InitializeView(guard);
 		manifest_indexes = GetDeleteManifestsForDataFile(data_manifest_entry);
 		provider = scan_plan_provider.get();
+	}
+	if (manifest_indexes.empty()) {
+		return;
 	}
 
 	D_ASSERT(provider);

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -1184,6 +1184,102 @@ bool IcebergMultiFileList::ManifestMatchesFilter(const IcebergManifestFile &mani
 	return true;
 }
 
+bool IcebergMultiFileList::DeleteManifestMatchesDataFile(const IcebergManifestFile &delete_manifest,
+                                                         const BoundIcebergManifestEntry &data_manifest_entry) const {
+	auto &metadata = GetMetadata();
+	auto partition_spec_it = metadata.partition_specs.find(delete_manifest.partition_spec_id);
+	if (partition_spec_it == metadata.partition_specs.end()) {
+		throw InvalidInputException("Delete manifest %s references partition_spec_id %d which doesn't exist",
+		                            delete_manifest.manifest_path, delete_manifest.partition_spec_id);
+	}
+	auto &delete_partition_spec = partition_spec_it->second;
+	if (delete_partition_spec.IsUnpartitioned()) {
+		//! An unpartitioned manifest can contain global equality deletes.
+		return true;
+	}
+
+	auto &data_manifest = data_manifests[data_manifest_entry.manifest_file_idx].entry.file;
+	if (delete_manifest.partition_spec_id != data_manifest.partition_spec_id) {
+		return false;
+	}
+	if (!delete_manifest.partitions.has_partitions) {
+		return true;
+	}
+
+	auto &field_summaries = delete_manifest.partitions.field_summary;
+	if (delete_partition_spec.fields.size() != field_summaries.size()) {
+		throw InvalidInputException("Delete manifest has %d partition summaries but partition spec %d has %d fields",
+		                            field_summaries.size(), delete_manifest.partition_spec_id,
+		                            delete_partition_spec.fields.size());
+	}
+
+	auto &data_file = data_manifest_entry.entry.data_file;
+	unordered_map<uint64_t, reference<const Value>> partition_values;
+	for (auto &partition : data_file.partition_info) {
+		partition_values.emplace(partition.field_id, partition.value);
+	}
+
+	for (idx_t field_idx = 0; field_idx < delete_partition_spec.fields.size(); field_idx++) {
+		auto &field = delete_partition_spec.fields[field_idx];
+		auto partition_value_it = partition_values.find(field.partition_field_id);
+		if (partition_value_it == partition_values.end()) {
+			//! Missing partition information cannot safely exclude the manifest.
+			return true;
+		}
+		auto &partition_value = partition_value_it->second.get();
+		auto &field_summary = field_summaries[field_idx];
+		if (partition_value.IsNull()) {
+			if (!field_summary.contains_null) {
+				return false;
+			}
+			continue;
+		}
+
+		auto source_column = metadata.FindColumnByFieldId(NumericCast<int32_t>(field.source_id));
+		if (!source_column) {
+			//! Schema evolution can make the source column unavailable; keep the manifest conservatively.
+			return true;
+		}
+		auto partition_type = field.transform.GetSerializedType(source_column->type);
+		auto stats = IcebergPredicateStats::DeserializeBounds(field_summary.lower_bound, field_summary.upper_bound,
+		                                                      source_column->name, partition_type);
+		auto typed_partition_value = partition_value.DefaultCastAs(partition_type);
+		if (stats.lower_bound && typed_partition_value < *stats.lower_bound) {
+			return false;
+		}
+		if (stats.upper_bound && typed_partition_value > *stats.upper_bound) {
+			return false;
+		}
+	}
+	return true;
+}
+
+vector<idx_t>
+IcebergMultiFileList::GetDeleteManifestsForDataFile(const BoundIcebergManifestEntry &data_manifest_entry) const {
+	vector<idx_t> result;
+	auto &data_manifest = data_manifests[data_manifest_entry.manifest_file_idx].entry.file;
+	auto data_sequence_number = data_manifest_entry.entry.GetSequenceNumber(data_manifest);
+	for (idx_t manifest_idx = 0; manifest_idx < delete_manifests.size(); manifest_idx++) {
+		if (!delete_manifest_matches[manifest_idx]) {
+			continue;
+		}
+		auto &delete_manifest = delete_manifests[manifest_idx].entry.file;
+		if (!delete_manifest.sequence_number) {
+			throw InvalidConfigurationException("Delete manifest %s does not have a sequence number",
+			                                    delete_manifest.manifest_path);
+		}
+		//! Position deletes can apply at an equal sequence number; equality deletes are filtered exactly after loading.
+		if (*delete_manifest.sequence_number < data_sequence_number) {
+			continue;
+		}
+		if (!DeleteManifestMatchesDataFile(delete_manifest, data_manifest_entry)) {
+			continue;
+		}
+		result.push_back(manifest_idx);
+	}
+	return result;
+}
+
 vector<reference<const IcebergEqualityDeleteFile>>
 IcebergMultiFileList::GetEqualityDeletesForFile(const BoundIcebergManifestEntry &bound_manifest_entry) const {
 	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
@@ -1382,8 +1478,8 @@ void IcebergMultiFileList::StartDataManifestScan(annotated_lock_guard<annotated_
 	GetScanPlanProvider().StartDataManifestScan(*this);
 }
 
-void IcebergMultiFileList::EnumerateDeleteManifestEntriesInternal() const {
-	GetScanPlanProvider().EnumerateDeleteManifestEntries(*this);
+void IcebergMultiFileList::EnumerateDeleteManifestEntriesInternal(const vector<idx_t> &manifest_indexes) const {
+	GetScanPlanProvider().EnumerateDeleteManifestEntries(*this, manifest_indexes);
 }
 
 bool IcebergMultiFileList::DeleteEntryMatchesFilters(const BoundIcebergManifestEntry &bound_manifest_entry) const {
@@ -1422,44 +1518,27 @@ void IcebergMultiFileList::ScanDeleteFiles() const {
 	}
 }
 
-void IcebergMultiFileList::ProcessDeletes() const {
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	InitializeView(guard);
-	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
-	ProcessDeletesInternal();
-}
-
-void IcebergMultiFileList::ProcessDeletesInternal() const {
-	//! Enumerate the delete manifest entries, then read the delete files they reference.
-	//! Delete enumeration is idempotent, so this is safe if the entries were already enumerated.
-	EnumerateDeleteManifestEntriesInternal();
-	ScanDeleteFiles();
-}
-
-vector<BoundIcebergManifestEntry> IcebergMultiFileList::GetDeleteManifestEntries() const {
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	InitializeView(guard);
-	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
-	EnumerateDeleteManifestEntriesInternal();
-	vector<BoundIcebergManifestEntry> result;
-	auto &delete_entries = GetScanPlanProvider().DeleteManifestEntries();
-	for (auto &entry : delete_entries) {
-		if (!DeleteEntryMatchesFilters(entry)) {
-			continue;
-		}
-		auto manifest_idx = entry.manifest_file_idx;
-		auto &manifest = delete_manifests[manifest_idx];
-		auto &manifest_file = manifest.entry.file;
-		if (!delete_manifest_matches[manifest_idx]) {
-			continue;
-		}
-		if (table_filters.HasFilters() &&
-		    !FileMatchesFilter(manifest_file, entry.entry, IcebergManifestContentType::DELETE)) {
-			continue;
-		}
-		result.push_back(entry);
+void IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_manifest_entry) const {
+	vector<idx_t> manifest_indexes;
+	optional_ptr<IcebergScanPlanProvider> provider;
+	{
+		annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+		InitializeView(guard);
+		manifest_indexes = GetDeleteManifestsForDataFile(data_manifest_entry);
+		provider = scan_plan_provider.get();
 	}
-	return result;
+
+	D_ASSERT(provider);
+	provider->ReadDeleteManifests(*this, manifest_indexes);
+
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
+	ProcessDeletesInternal(manifest_indexes);
+}
+
+void IcebergMultiFileList::ProcessDeletesInternal(const vector<idx_t> &manifest_indexes) const {
+	EnumerateDeleteManifestEntriesInternal(manifest_indexes);
+	ScanDeleteFiles();
 }
 
 void IcebergMultiFileList::ScanDeleteFile(const BoundIcebergManifestEntry &bound_manifest_entry) const {

--- a/src/planning/iceberg_multi_file_reader.cpp
+++ b/src/planning/iceberg_multi_file_reader.cpp
@@ -388,7 +388,7 @@ ReaderInitializeType IcebergMultiFileReader::InitializeReader(MultiFileReaderDat
 	const auto &multi_file_list = dynamic_cast<const IcebergMultiFileList &>(*iceberg_state.file_list);
 	auto file_id = reader_data.reader->file_list_idx.GetIndex();
 	auto bound_manifest_entry = multi_file_list.GetManifestEntry(file_id);
-	multi_file_list.ProcessDeletes();
+	multi_file_list.ProcessDeletes(bound_manifest_entry);
 
 	//! Make a copy of the global columns+column_ids, if we have equality deletes we will add columns to this
 	//! This is done so CreateMapping treats these columns as required for the current file,

--- a/src/planning/iceberg_scan_plan_provider.cpp
+++ b/src/planning/iceberg_scan_plan_provider.cpp
@@ -10,7 +10,19 @@
 #include "planning/metadata_io/manifest_list/bound_iceberg_manifest_list_entry.hpp"
 #include "planning/metadata_io/manifest_list/iceberg_manifest_list_reader.hpp"
 
+#include <condition_variable>
+
 namespace duckdb {
+
+struct IcebergDeleteManifestLoadState {
+	mutex lock;
+	std::condition_variable cv;
+	bool complete = false;
+	ErrorData error;
+	vector<idx_t> manifest_indexes;
+	vector<IcebergManifestListEntry> manifests;
+	shared_ptr<IcebergManifestScanningState> scan_state;
+};
 
 namespace {
 
@@ -145,21 +157,18 @@ void ClientSideScanPlanProvider::LoadManifestList(const IcebergMultiFileList &fi
 		}
 	}
 
+	{
+		annotated_lock_guard<annotated_mutex> delete_guard(shared_state.delete_lock);
+		shared_state.delete_manifest_loads.resize(DeleteManifests().size());
+		shared_state.delete_manifest_entries_enumerated.resize(
+		    DeleteManifests().size() + shared_state.transaction_delete_manifests.size(), false);
+	}
+
 	shared_state.manifest_list_loaded = true;
 	DUCKDB_LOG(shared_state.context, IcebergLogType,
 	           "Iceberg metadata phase=manifest_list_loaded data_manifests=%llu delete_manifests=%llu",
 	           DataManifests().size() + shared_state.transaction_data_manifests.size(),
 	           DeleteManifests().size() + shared_state.transaction_delete_manifests.size());
-}
-
-void ClientSideScanPlanProvider::StartDeleteManifestScan(const IcebergMultiFileList &file_list) {
-	if (shared_state.delete_manifest_scan || DeleteManifests().empty()) {
-		return;
-	}
-	shared_state.delete_manifest_scan =
-	    AvroScan::ScanManifest(file_list.GetSnapshot(), DeleteManifests(), file_list.options, shared_state.fs,
-	                           file_list.GetPath(), file_list.GetMetadata(), shared_state.context);
-	shared_state.delete_manifest_reader = make_uniq<manifest_file::ManifestReader>(*shared_state.delete_manifest_scan);
 }
 
 void ClientSideScanPlanProvider::StartDataManifestScan(const IcebergMultiFileList &file_list) {
@@ -212,56 +221,171 @@ void ClientSideScanPlanProvider::StartDataManifestScan(const IcebergMultiFileLis
 	           selected_manifest_count, file_list.data_manifest_matches.size(), file_list.table_filters.FilterCount());
 }
 
-void ClientSideScanPlanProvider::EnumerateDeleteManifestEntries(const IcebergMultiFileList &file_list) {
-	if (shared_state.delete_entries_enumerated) {
-		return;
+void ClientSideScanPlanProvider::ReadDeleteManifests(const IcebergMultiFileList &file_list,
+                                                     const vector<idx_t> &manifest_indexes) {
+	shared_ptr<IcebergDeleteManifestLoadState> new_load;
+	vector<shared_ptr<IcebergDeleteManifestLoadState>> required_loads;
+	idx_t committed_manifest_count;
+	{
+		annotated_lock_guard<annotated_mutex> guard(shared_state.lock);
+		annotated_lock_guard<annotated_mutex> delete_guard(shared_state.delete_lock);
+		committed_manifest_count = shared_state.committed_delete_manifests.size();
+		auto total_manifest_count = committed_manifest_count + shared_state.transaction_delete_manifests.size();
+		for (auto manifest_idx : manifest_indexes) {
+			if (manifest_idx >= total_manifest_count) {
+				throw InternalException("Selected delete manifest index %llu is out of bounds", manifest_idx);
+			}
+			if (manifest_idx >= committed_manifest_count) {
+				continue;
+			}
+			auto &manifest = shared_state.committed_delete_manifests[manifest_idx];
+			if (manifest.HasManifestEntries()) {
+				//! Scan for this manifest is already completed
+				continue;
+			}
+			auto &load = shared_state.delete_manifest_loads[manifest_idx];
+			if (!load) {
+				//! No load for this manifest exists yet
+				if (!new_load) {
+					//! We haven't created a load yet, initialize it here
+					new_load = make_shared_ptr<IcebergDeleteManifestLoadState>();
+					required_loads.push_back(new_load);
+				}
+				//! Set the load for this manifest to indicate it's being loaded
+				load = new_load;
+				new_load->manifest_indexes.push_back(manifest_idx);
+				new_load->manifests.push_back(manifest);
+			} else {
+				//! A load already exists for this manifest
+				bool already_required = false;
+				for (auto &required_load : required_loads) {
+					if (required_load.get() == load.get()) {
+						//! We've already registered a previous manifest that is part of the same load
+						already_required = true;
+						break;
+					}
+				}
+				if (!already_required) {
+					//! We haven't seen this load yet, add it to our required loads
+					required_loads.push_back(load);
+				}
+			}
+		}
 	}
-	StartDeleteManifestScan(file_list);
 
+	if (new_load) {
+		//! At least one of the manifests we need aren't referenced yet, need to start a scan for it/them
+		ErrorData load_error;
+		try {
+			auto scan =
+			    AvroScan::ScanManifest(file_list.GetSnapshot(), new_load->manifests, file_list.options, shared_state.fs,
+			                           file_list.GetPath(), file_list.GetMetadata(), shared_state.context);
+			new_load->scan_state = make_shared_ptr<IcebergManifestScanningState>(shared_state.context, std::move(scan),
+			                                                                     new_load->manifests);
+
+			auto &executor = new_load->scan_state->executor;
+			auto &scheduler = TaskScheduler::GetScheduler(shared_state.context);
+			auto num_threads = MinValue<idx_t>(scheduler.NumberOfThreads(), new_load->manifest_indexes.size());
+			new_load->scan_state->in_progress_tasks = num_threads;
+			for (idx_t i = 0; i < num_threads; i++) {
+				executor.ScheduleTask(make_uniq<ManifestReadTask>(*new_load->scan_state));
+			}
+
+			DUCKDB_LOG(shared_state.context, IcebergLogType,
+			           "Iceberg metadata phase=delete_manifest_scan_started selected_delete_manifests=%llu "
+			           "total_delete_manifests=%llu filters=%llu",
+			           new_load->manifest_indexes.size(), committed_manifest_count,
+			           file_list.table_filters.FilterCount());
+			executor.WorkOnTasks();
+
+			annotated_lock_guard<annotated_mutex> guard(shared_state.lock);
+			for (idx_t load_idx = 0; load_idx < new_load->manifest_indexes.size(); load_idx++) {
+				auto manifest_idx = new_load->manifest_indexes[load_idx];
+				auto &target = shared_state.committed_delete_manifests[manifest_idx];
+				auto &source = new_load->manifests[load_idx];
+				D_ASSERT(!target.HasManifestEntries());
+				target.manifest_entries = std::move(source.manifest_entries);
+			}
+		} catch (std::exception &ex) {
+			load_error = ErrorData(ex);
+		} catch (...) { // LCOV_EXCL_START
+			load_error = ErrorData("Unknown exception while reading Iceberg delete manifests");
+		} // LCOV_EXCL_STOP
+
+		{
+			lock_guard<mutex> guard(new_load->lock);
+			new_load->error = std::move(load_error);
+			new_load->complete = true;
+		}
+		new_load->cv.notify_all();
+	}
+
+	for (auto &load : required_loads) {
+		unique_lock<mutex> guard(load->lock);
+		load->cv.wait(guard, [&load] { return load->complete; });
+		if (load->error.HasError()) {
+			load->error.Throw();
+		}
+	}
+}
+
+void ClientSideScanPlanProvider::EnumerateDeleteManifestEntries(const IcebergMultiFileList &file_list,
+                                                                const vector<idx_t> &manifest_indexes) {
 	optional_ptr<const case_insensitive_map_t<string>> transactional_delete_files;
 	if (file_list.HasTransactionData()) {
 		transactional_delete_files = file_list.GetTransactionData().transactional_delete_files;
 	}
-	while (!FinishedScanningDeletes()) {
-		shared_state.delete_manifest_reader->Read();
-	}
-
-	for (idx_t i = 0; i < DeleteManifests().size(); i++) {
-		auto &manifest_list_entry = DeleteManifests()[i];
-		auto manifest = BoundIcebergManifestListEntry(i, manifest_list_entry);
-		for (auto &manifest_entry : manifest_list_entry.GetManifestEntries()) {
-			if (manifest_entry.status == IcebergManifestEntryStatusType::DELETED) {
-				continue;
-			}
-			auto &referenced_data_file = manifest_entry.data_file.referenced_data_file;
-			if (referenced_data_file && transactional_delete_files &&
-			    transactional_delete_files->count(*referenced_data_file)) {
-				continue;
-			}
-			shared_state.delete_manifest_entries.push_back(manifest.BindEntry(manifest_entry));
+	auto committed_manifest_count = DeleteManifests().size();
+	auto total_manifest_count = committed_manifest_count + shared_state.transaction_delete_manifests.size();
+	for (auto manifest_idx : manifest_indexes) {
+		if (manifest_idx >= total_manifest_count) {
+			throw InternalException("Selected delete manifest index %llu is out of bounds", manifest_idx);
 		}
-	}
+		if (shared_state.delete_manifest_entries_enumerated[manifest_idx]) {
+			continue;
+		}
 
-	auto offset = DeleteManifests().size();
-	for (idx_t transaction_idx = 0; transaction_idx < shared_state.transaction_delete_manifests.size();
-	     transaction_idx++) {
-		auto &manifest_list_entry = shared_state.transaction_delete_manifests[transaction_idx].get();
-		auto manifest = BoundIcebergManifestListEntry(offset + transaction_idx, manifest_list_entry);
-		for (auto &manifest_entry : manifest_list_entry.GetManifestEntries()) {
-			auto &data_file = manifest_entry.data_file;
-			auto &referenced_data_file = data_file.referenced_data_file;
-			if (referenced_data_file && transactional_delete_files) {
-				auto it = transactional_delete_files->find(*referenced_data_file);
-				if (it != transactional_delete_files->end() && it->second != data_file.file_path) {
+		vector<BoundIcebergManifestEntry> bound_entries;
+		if (manifest_idx < committed_manifest_count) {
+			auto &manifest_list_entry = DeleteManifests()[manifest_idx];
+			if (!manifest_list_entry.HasManifestEntries()) {
+				throw InternalException("Selected delete manifest %llu was not loaded", manifest_idx);
+			}
+			auto manifest = BoundIcebergManifestListEntry(manifest_idx, manifest_list_entry);
+			for (auto &manifest_entry : manifest_list_entry.GetManifestEntries()) {
+				if (manifest_entry.status == IcebergManifestEntryStatusType::DELETED) {
 					continue;
 				}
+				auto &referenced_data_file = manifest_entry.data_file.referenced_data_file;
+				if (referenced_data_file && transactional_delete_files &&
+				    transactional_delete_files->count(*referenced_data_file)) {
+					continue;
+				}
+				bound_entries.push_back(manifest.BindEntry(manifest_entry));
 			}
-			shared_state.delete_manifest_entries.push_back(manifest.BindEntry(manifest_entry));
+		} else {
+			auto transaction_idx = manifest_idx - committed_manifest_count;
+			auto &manifest_list_entry = shared_state.transaction_delete_manifests[transaction_idx].get();
+			auto manifest = BoundIcebergManifestListEntry(manifest_idx, manifest_list_entry);
+			for (auto &manifest_entry : manifest_list_entry.GetManifestEntries()) {
+				auto &data_file = manifest_entry.data_file;
+				auto &referenced_data_file = data_file.referenced_data_file;
+				if (referenced_data_file && transactional_delete_files) {
+					auto it = transactional_delete_files->find(*referenced_data_file);
+					if (it != transactional_delete_files->end() && it->second != data_file.file_path) {
+						continue;
+					}
+				}
+				bound_entries.push_back(manifest.BindEntry(manifest_entry));
+			}
 		}
+		shared_state.delete_manifest_entries.reserve(shared_state.delete_manifest_entries.size() +
+		                                             bound_entries.size());
+		for (auto &bound_entry : bound_entries) {
+			shared_state.delete_manifest_entries.push_back(std::move(bound_entry));
+		}
+		shared_state.delete_manifest_entries_enumerated[manifest_idx] = true;
 	}
-
-	shared_state.delete_entries_enumerated = true;
-	D_ASSERT(FinishedScanningDeletes());
 }
 
 bool ClientSideScanPlanProvider::TryGetNextBatch(IcebergDataViewCursor &cursor) {
@@ -298,10 +422,6 @@ void ClientSideScanPlanProvider::FinishScanTasks() {
 	}
 }
 
-bool ClientSideScanPlanProvider::FinishedScanningDeletes() const {
-	return !shared_state.delete_manifest_reader || shared_state.delete_manifest_reader->Finished();
-}
-
 bool ClientSideScanPlanProvider::DeleteFileAppliesToDataFile(const string &data_file_path,
                                                              const string &delete_file_path) const {
 	return true;
@@ -332,12 +452,14 @@ equality_delete_map_t &ClientSideScanPlanProvider::EqualityDeleteData() {
 }
 
 ServerSideScanPlanProvider::ServerSideScanPlanProvider(IcebergServerSideScanPlan plan_p) : plan(std::move(plan_p)) {
+	delete_manifest_entries_enumerated.resize(plan.delete_manifests.size(), false);
 }
 
 void ServerSideScanPlanProvider::LoadManifestList(const IcebergMultiFileList &file_list) {
 }
 
-void ServerSideScanPlanProvider::StartDeleteManifestScan(const IcebergMultiFileList &file_list) {
+void ServerSideScanPlanProvider::ReadDeleteManifests(const IcebergMultiFileList &file_list,
+                                                     const vector<idx_t> &manifest_indexes) {
 }
 
 void ServerSideScanPlanProvider::StartDataManifestScan(const IcebergMultiFileList &file_list) {
@@ -350,20 +472,24 @@ void ServerSideScanPlanProvider::StartDataManifestScan(const IcebergMultiFileLis
 	}
 }
 
-void ServerSideScanPlanProvider::EnumerateDeleteManifestEntries(const IcebergMultiFileList &file_list) {
-	if (delete_entries_enumerated) {
-		return;
-	}
-	for (idx_t i = 0; i < plan.delete_manifests.size(); i++) {
-		auto &manifest_list_entry = plan.delete_manifests[i];
-		auto manifest = BoundIcebergManifestListEntry(i, manifest_list_entry);
+void ServerSideScanPlanProvider::EnumerateDeleteManifestEntries(const IcebergMultiFileList &file_list,
+                                                                const vector<idx_t> &manifest_indexes) {
+	for (auto manifest_idx : manifest_indexes) {
+		if (manifest_idx >= plan.delete_manifests.size()) {
+			throw InternalException("Selected server-side delete manifest index %llu is out of bounds", manifest_idx);
+		}
+		if (delete_manifest_entries_enumerated[manifest_idx]) {
+			continue;
+		}
+		auto &manifest_list_entry = plan.delete_manifests[manifest_idx];
+		auto manifest = BoundIcebergManifestListEntry(manifest_idx, manifest_list_entry);
 		for (auto &manifest_entry : manifest_list_entry.GetManifestEntries()) {
 			if (manifest_entry.status != IcebergManifestEntryStatusType::DELETED) {
 				delete_manifest_entries.push_back(manifest.BindEntry(manifest_entry));
 			}
 		}
+		delete_manifest_entries_enumerated[manifest_idx] = true;
 	}
-	delete_entries_enumerated = true;
 }
 
 bool ServerSideScanPlanProvider::TryGetNextBatch(IcebergDataViewCursor &cursor) {
@@ -371,10 +497,6 @@ bool ServerSideScanPlanProvider::TryGetNextBatch(IcebergDataViewCursor &cursor) 
 }
 
 void ServerSideScanPlanProvider::FinishScanTasks() {
-}
-
-bool ServerSideScanPlanProvider::FinishedScanningDeletes() const {
-	return true;
 }
 
 bool ServerSideScanPlanProvider::DeleteFileAppliesToDataFile(const string &data_file_path,

--- a/test/configs/fixture-latest.json
+++ b/test/configs/fixture-latest.json
@@ -41,6 +41,7 @@
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/test_filtering_geometry_predicates.test",
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/test_data_manifest_late_materialization.test",
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/should_do_filter_pruning_on_expressionless_string_filters.test",
+				"test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/test_delete_manifest_filter_pushdown.test",
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/partitioning/struct_filter_issue.test",
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/logging/test_reads_on_bounds.test"
 			]

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/test_delete_manifest_filter_pushdown.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/test_delete_manifest_filter_pushdown.test
@@ -1,0 +1,140 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/test_delete_manifest_filter_pushdown.test
+# description: Delete manifests and entries are pruned using filters pushed into the Iceberg file list
+# group: [filtering]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+set threads=1;
+
+statement ok
+set enable_external_file_cache=false;
+
+statement ok
+drop table if exists my_datalake.default.delete_manifest_filter_pushdown;
+
+statement ok
+create table my_datalake.default.delete_manifest_filter_pushdown (
+	part integer,
+	payload integer
+) partitioned by (part) with (
+	'format-version' = 3,
+	'commit.manifest-merge.enabled' = 'false'
+);
+
+statement ok
+insert into my_datalake.default.delete_manifest_filter_pushdown select 1, range from range(10, 14);
+
+statement ok
+insert into my_datalake.default.delete_manifest_filter_pushdown select 2, range from range(20, 24);
+
+statement ok
+insert into my_datalake.default.delete_manifest_filter_pushdown select 3, range from range(30, 34);
+
+statement ok
+delete from my_datalake.default.delete_manifest_filter_pushdown where part = 1 and payload = 10;
+
+statement ok
+delete from my_datalake.default.delete_manifest_filter_pushdown where part = 2 and payload = 20;
+
+statement ok
+delete from my_datalake.default.delete_manifest_filter_pushdown where part = 3 and payload = 30;
+
+query II
+select manifest_content, count(distinct manifest_path)
+from iceberg_metadata(my_datalake.default.delete_manifest_filter_pushdown)
+where status <> 'DELETED'
+group by manifest_content
+order by manifest_content;
+----
+DATA	3
+DELETE	3
+
+statement ok
+call enable_logging(['Iceberg', 'HTTP'], storage='memory');
+
+statement ok
+set logging_level='debug';
+
+# A partition predicate selects the matching data and delete manifests.
+statement ok
+call truncate_duckdb_logs();
+
+query I
+select sum(payload) from my_datalake.default.delete_manifest_filter_pushdown where part = 2;
+----
+66
+
+query I
+select count(*) from duckdb_logs()
+where type = 'Iceberg'
+  and message.contains('phase=delete_manifest_scan_started selected_delete_manifests=1 total_delete_manifests=3 filters=1');
+----
+1
+
+query I
+select count(distinct request.url) from duckdb_logs_parsed('HTTP') where request.url like '%.avro';
+----
+3
+
+# An impossible partition predicate opens neither data nor delete manifests.
+statement ok
+call truncate_duckdb_logs();
+
+query I
+select count(*) from my_datalake.default.delete_manifest_filter_pushdown where part = 99;
+----
+0
+
+query I
+select count(*) from duckdb_logs()
+where type = 'Iceberg'
+  and message.contains('phase=delete_manifest_scan_started');
+----
+0
+
+query I
+select count(distinct request.url) from duckdb_logs_parsed('HTTP') where request.url like '%.avro';
+----
+1
+
+# Without filter pushdown, all delete manifests are enumerated and the logical filter remains correct.
+statement ok
+set disabled_optimizers='filter_pushdown';
+
+statement ok
+call truncate_duckdb_logs();
+
+query I
+select sum(payload) from my_datalake.default.delete_manifest_filter_pushdown where part = 2;
+----
+66
+
+# 3 data manifests, all selecting 1 delete manifest to scan
+query I
+select count(*) from duckdb_logs()
+where type = 'Iceberg'
+  and message.contains('phase=delete_manifest_scan_started selected_delete_manifests=1 total_delete_manifests=3 filters=0');
+----
+3
+
+query I
+select count(distinct request.url) from duckdb_logs_parsed('HTTP') where request.url like '%.avro';
+----
+7
+
+statement ok
+set disabled_optimizers='';
+
+statement ok
+drop table my_datalake.default.delete_manifest_filter_pushdown;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/test_delete_manifest_late_materialization.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/test_delete_manifest_late_materialization.test
@@ -1,0 +1,112 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/test_delete_manifest_late_materialization.test
+# description: Delete manifests are loaded only when their sequence and partition can apply to an initialized data file
+# group: [filtering]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+set iceberg_use_server_side_scan_planning=false;
+
+statement ok
+set enable_external_file_cache=false;
+
+statement ok
+drop table if exists my_datalake.default.delete_manifest_late_materialization;
+
+statement ok
+create table my_datalake.default.delete_manifest_late_materialization (
+	part integer,
+	payload integer
+) partitioned by (part) with (
+	'format-version' = 3,
+	'commit.manifest-merge.enabled' = 'false'
+);
+
+# Both of these data files precede the delete manifest.
+statement ok
+insert into my_datalake.default.delete_manifest_late_materialization select 1, range from range(10, 14);
+
+statement ok
+insert into my_datalake.default.delete_manifest_late_materialization select 2, range from range(20, 24);
+
+statement ok
+delete from my_datalake.default.delete_manifest_late_materialization where part = 1 and payload = 10;
+
+# This data file has a sequence number newer than the delete manifest.
+statement ok
+insert into my_datalake.default.delete_manifest_late_materialization select 3, range from range(30, 34);
+
+query II
+select manifest_content, count(distinct manifest_path)
+from iceberg_metadata(my_datalake.default.delete_manifest_late_materialization)
+where status <> 'DELETED'
+group by manifest_content
+order by manifest_content;
+----
+DATA	3
+DELETE	1
+
+statement ok
+call enable_logging('Iceberg', storage='memory');
+
+statement ok
+set logging_level='debug';
+
+# The delete manifest has a different partition from this older data file.
+statement ok
+call truncate_duckdb_logs();
+
+query I
+select sum(payload) from my_datalake.default.delete_manifest_late_materialization where part = 2;
+----
+86
+
+query I
+select count(*) from duckdb_logs()
+where type = 'Iceberg' and message.contains('phase=delete_manifest_scan_started');
+----
+0
+
+# The delete manifest is older than this data file.
+statement ok
+call truncate_duckdb_logs();
+
+query I
+select sum(payload) from my_datalake.default.delete_manifest_late_materialization where part = 3;
+----
+126
+
+query I
+select count(*) from duckdb_logs()
+where type = 'Iceberg' and message.contains('phase=delete_manifest_scan_started');
+----
+0
+
+# The matching older data file causes the one applicable delete manifest to be loaded.
+statement ok
+call truncate_duckdb_logs();
+
+query I
+select sum(payload) from my_datalake.default.delete_manifest_late_materialization where part = 1;
+----
+36
+
+query I
+select count(*) from duckdb_logs()
+where type = 'Iceberg'
+  and message.contains('phase=delete_manifest_scan_started selected_delete_manifests=1 total_delete_manifests=1');
+----
+1
+
+statement ok
+drop table my_datalake.default.delete_manifest_late_materialization;


### PR DESCRIPTION
This PR fixes #1243 

`ProcessDeletes` now takes `BoundIcebergManifestEntry &data_manifest_entry` and uses the sequence number, as well as the partitions and the pushed down filters to select only the delete manifests that *could* contain deletes relevant to the data file.

With this list of manifest indexes it creates a scan for just those delete manifests, and waits until those delete manifests are finished scanning. (In the future this should block, freeing up the worker to do other things while the delete manifests are scanned)