### PR TITLE
__iceberg_unsafe_struct_null_default_interpretation should be <48 chars

### DIFF
--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -51,7 +51,7 @@ static void SetUnsafeStructNullDefaultInterpretation(ClientContext &context, Set
 	auto interpretation = parameter.GetValue<string>();
 	if (interpretation != "{}") {
 		throw InvalidConfigurationException("'%s' must be NULL or '{}', got '%s'",
-		                                    UNSAFE_STRUCT_NULL_DEFAULT_INTERPRETATION_CONFIG_VARIABLE, interpretation);
+		                                    UNSAFE_STRUCT_NULL_DEFAULT_INTERP_CONFIG_VARIABLE, interpretation);
 	}
 	value = true;
 }
@@ -113,7 +113,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    "Bodies longer than this are truncated with a trailing '... (truncated)' marker. Set to 0 to omit the body.",
 	    LogicalType::UBIGINT, Value::UBIGINT(10000));
 	config.AddExtensionOption(
-	    UNSAFE_STRUCT_NULL_DEFAULT_INTERPRETATION_CONFIG_VARIABLE,
+	    UNSAFE_STRUCT_NULL_DEFAULT_INTERP_CONFIG_VARIABLE,
 	    "DANGEROUS TESTING-ONLY SETTING: interpret a null Iceberg STRUCT default as an empty struct whose fields "
 	    "use their own defaults. The only non-null value accepted is '{}'.",
 	    LogicalType::VARCHAR, Value(LogicalType::VARCHAR), SetUnsafeStructNullDefaultInterpretation, SetScope::GLOBAL);

--- a/src/include/iceberg_options.hpp
+++ b/src/include/iceberg_options.hpp
@@ -21,8 +21,8 @@ static constexpr uint64_t DEFAULT_ICEBERG_FORMAT_VERSION = 2;
 // of a positional delete. This exists only to exercise the equality-delete read path.
 static string ENABLE_EQUALITY_DELETES_CONFIG_VARIABLE = "unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes";
 
-static constexpr const char *UNSAFE_STRUCT_NULL_DEFAULT_INTERPRETATION_CONFIG_VARIABLE =
-    "__iceberg_unsafe_struct_null_default_interpretation";
+static constexpr const char *UNSAFE_STRUCT_NULL_DEFAULT_INTERP_CONFIG_VARIABLE =
+    "__iceberg_unsafe_struct_null_default_interp";
 
 // When this is provided (and unsafe_enable_version_guessing is true)
 // we first look for DEFAULT_VERSION_HINT_FILE, if it doesn't exist we

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_default_struct.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/alter/alter_default_struct.test
@@ -16,7 +16,7 @@ set ignore_error_messages
 
 # Default value of the setting
 statement ok
-SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = NULL;
+SET GLOBAL __iceberg_unsafe_struct_null_default_interp = NULL;
 
 statement ok
 drop table if exists my_datalake.default.alter_default_struct;
@@ -112,7 +112,7 @@ drop table my_datalake.default.alter_default_struct;
 # Now test with reinterpreting struct default 'null' as {}
 
 statement ok
-SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+SET GLOBAL __iceberg_unsafe_struct_null_default_interp = '{}';
 
 statement ok
 create table my_datalake.default.alter_default_struct (
@@ -204,4 +204,4 @@ drop table my_datalake.default.alter_default_struct;
 
 # Reset the value, since it's a global static
 statement ok
-SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = NULL;
+SET GLOBAL __iceberg_unsafe_struct_null_default_interp = NULL;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/default/test_create_default_struct.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/default/test_create_default_struct.test
@@ -19,7 +19,7 @@ statement ok
 drop table if exists my_datalake.default.tbl;
 
 statement ok
-SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+SET GLOBAL __iceberg_unsafe_struct_null_default_interp = '{}';
 
 statement ok
 create table my_datalake.default.tbl(
@@ -177,7 +177,7 @@ select * from my_datalake.default.nested_tbl order by all;
 {'a': test, 'b': {'v1': 1000, 'v2': NULL, 'v3': NULL}, 'e': NULL}	24
 
 statement ok
-RESET __iceberg_unsafe_struct_null_default_interpretation;
+RESET __iceberg_unsafe_struct_null_default_interp;
 
 # In the default safe mode, DEFAULT NULL on a STRUCT remains NULL.
 

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/default/test_create_default_struct_nested.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/create/default/test_create_default_struct_nested.test
@@ -21,7 +21,7 @@ statement ok
 drop table if exists my_datalake.default.nested_nested_tbl;
 
 statement ok
-SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+SET GLOBAL __iceberg_unsafe_struct_null_default_interp = '{}';
 
 statement ok
 create table my_datalake.default.nested_nested_tbl(
@@ -155,4 +155,4 @@ select * from my_datalake.default.nested_nested_tbl order by all;
 {'a': test, 'b': {'v1': 1000, 'v2': {'f1': foo, 'f2': bar, 'f3': baz}, 'v3': -500}, 'e': NULL}	48
 
 statement ok
-RESET __iceberg_unsafe_struct_null_default_interpretation;
+RESET __iceberg_unsafe_struct_null_default_interp;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_into_default_struct.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_into_default_struct.test
@@ -31,7 +31,7 @@ statement ok
 DROP TABLE IF EXISTS my_datalake.default.tbl;
 
 statement ok
-SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+SET GLOBAL __iceberg_unsafe_struct_null_default_interp = '{}';
 
 statement ok
 CREATE TABLE my_datalake.default.tbl(
@@ -119,7 +119,7 @@ select * from my_datalake.default.tbl where id = 6;
 6	{'a': hello, 'b': 42, 'c': \xAA\xFF\xAA}	NULL
 
 statement ok
-RESET __iceberg_unsafe_struct_null_default_interpretation;
+RESET __iceberg_unsafe_struct_null_default_interp;
 
 # In the default safe mode, DEFAULT NULL on a STRUCT remains NULL.
 

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_into_default_struct_nested.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/merge/merge_into_default_struct_nested.test
@@ -31,7 +31,7 @@ statement ok
 DROP TABLE IF EXISTS my_datalake.default.nested_nested_tbl;
 
 statement ok
-SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+SET GLOBAL __iceberg_unsafe_struct_null_default_interp = '{}';
 
 statement ok
 CREATE TABLE my_datalake.default.nested_nested_tbl(
@@ -191,4 +191,4 @@ select * from my_datalake.default.nested_nested_tbl where id = 6;
 6	{'a': test, 'b': {'v1': 1000, 'v2': {'f1': foo, 'f2': bar, 'f3': baz}, 'v3': -500}, 'e': NULL}	72
 
 statement ok
-RESET __iceberg_unsafe_struct_null_default_interpretation;
+RESET __iceberg_unsafe_struct_null_default_interp;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_default_struct.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_default_struct.test
@@ -19,7 +19,7 @@ statement ok
 drop table if exists my_datalake.default.tbl;
 
 statement ok
-SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+SET GLOBAL __iceberg_unsafe_struct_null_default_interp = '{}';
 
 statement ok
 create table my_datalake.default.tbl(
@@ -92,7 +92,7 @@ select * from my_datalake.default.tbl where id = 3
 3	{'a': test, 'b': NULL, 'c': \xAA\xFF\xAA}	NULL
 
 statement ok
-RESET __iceberg_unsafe_struct_null_default_interpretation;
+RESET __iceberg_unsafe_struct_null_default_interp;
 
 # In the default safe mode, DEFAULT NULL on a STRUCT remains NULL.
 

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_default_struct_nested.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_default_struct_nested.test
@@ -21,7 +21,7 @@ statement ok
 drop table if exists my_datalake.default.nested_nested_tbl;
 
 statement ok
-SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+SET GLOBAL __iceberg_unsafe_struct_null_default_interp = '{}';
 
 statement ok
 create table my_datalake.default.nested_nested_tbl(
@@ -137,4 +137,4 @@ select * from my_datalake.default.nested_nested_tbl where id = 3;
 3	{'a': test, 'b': {'v1': 1000, 'v2': {'f1': foo, 'f2': bar, 'f3': baz}, 'v3': -500}, 'e': NULL}	36
 
 statement ok
-RESET __iceberg_unsafe_struct_null_default_interpretation;
+RESET __iceberg_unsafe_struct_null_default_interp;

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/fixture/alter/alter_add_field_v3.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/fixture/alter/alter_add_field_v3.test
@@ -141,7 +141,7 @@ INSERT INTO my_datalake.default.alter_add_field_struct VALUES
 	(2, {'a': 'beta', 'nested': {'x': 'two'}});
 
 statement ok
-SET GLOBAL __iceberg_unsafe_struct_null_default_interpretation = '{}';
+SET GLOBAL __iceberg_unsafe_struct_null_default_interp = '{}';
 
 statement ok
 ALTER TABLE my_datalake.default.alter_add_field_struct ADD COLUMN payload.extra STRUCT(
@@ -184,7 +184,7 @@ select id, payload from my_datalake.default.alter_add_field_struct order by id;
 2	{'a': beta, 'nested': {'x': two}, 'extra': {'flag': true, 'inner': {'renamed_z': alpha-default}, 'flag2': NULL}}
 
 statement ok
-RESET __iceberg_unsafe_struct_null_default_interpretation;
+RESET __iceberg_unsafe_struct_null_default_interp;
 
 # Add a field of type STRUCT with DEFAULT NULL. Existing rows read it back as NULL.
 


### PR DESCRIPTION
Otherwise we cannot bump iceberg in duckdb main