### PR TITLE
[Dev][Scan] Scan (parquet) delete files together, instead of 1 by 1

### DIFF
--- a/src/core/deletes/iceberg_equality_delete.cpp
+++ b/src/core/deletes/iceberg_equality_delete.cpp
@@ -13,33 +13,27 @@ static void InitializeFromOtherChunk(DataChunk &target, DataChunk &other, const 
 }
 
 static void ColumnsReferencedByEqualityIds(DataChunk &source, DataChunk &result,
-                                           const vector<MultiFileColumnDefinition> &local_columns,
-                                           const vector<string> &source_names, const vector<int32_t> &equality_ids) {
-	// The equality-delete file can physically contain more columns than the reader models for it - e.g. Spark
-	// embeds the partition columns next to the equality-key columns - and not necessarily in the same order. So
-	// resolve each equality field-id to its physical position in 'source' by name rather than by its position in
-	// 'local_columns', which only covers the modeled subset.
-	unordered_map<string, column_t> name_to_source_index;
-	for (column_t i = 0; i < source_names.size(); i++) {
-		name_to_source_index[source_names[i]] = i;
-	}
+                                           const vector<MultiFileColumnDefinition> &global_columns,
+                                           const vector<int32_t> &equality_ids) {
+	D_ASSERT(source.ColumnCount() == global_columns.size());
 
-	//! Map from equality field-id to the physical column index in 'source'.
+	//! The equality scan maps every physical file to this global schema by Iceberg field-id. Map the equality ids
+	//! for this particular delete file back to their positions in the global output chunk.
 	unordered_map<int32_t, column_t> id_to_column;
-	for (auto &col : local_columns) {
+	for (column_t column_idx = 0; column_idx < global_columns.size(); column_idx++) {
+		auto &col = global_columns[column_idx];
 		D_ASSERT(!col.identifier.IsNull());
-		auto entry = name_to_source_index.find(col.name.GetIdentifierName());
-		if (entry == name_to_source_index.end()) {
-			continue;
-		}
-		id_to_column[col.identifier.GetValue<int32_t>()] = entry->second;
+		id_to_column[col.identifier.GetValue<int32_t>()] = column_idx;
 	}
 
 	// column_ids we want to slice.
 	vector<column_t> column_ids;
 	for (auto id : equality_ids) {
-		D_ASSERT(id_to_column.count(id));
-		column_ids.push_back(id_to_column[id]);
+		auto entry = id_to_column.find(id);
+		if (entry == id_to_column.end()) {
+			throw InternalException("Equality-delete field id %d is missing from the global delete schema", id);
+		}
+		column_ids.push_back(entry->second);
 	}
 	//! Take only the relevant columns from the source (equality_delete_file)
 	InitializeFromOtherChunk(result, source, column_ids);
@@ -48,13 +42,12 @@ static void ColumnsReferencedByEqualityIds(DataChunk &source, DataChunk &result,
 
 void IcebergMultiFileList::ScanEqualityDeleteFile(const BoundIcebergManifestEntry &bound_manifest_entry,
                                                   DataChunk &source,
-                                                  const vector<MultiFileColumnDefinition> &local_columns,
-                                                  const vector<string> &source_names) const {
+                                                  const vector<MultiFileColumnDefinition> &global_columns) const {
 	auto &manifest_entry = bound_manifest_entry.entry;
 	auto &data_file = manifest_entry.data_file;
 	auto &manifest_file = GetManifestFileForEntry(bound_manifest_entry, IcebergManifestContentType::DELETE);
 	D_ASSERT(!data_file.equality_ids.empty());
-	D_ASSERT(source.ColumnCount() == source_names.size());
+	D_ASSERT(source.ColumnCount() == global_columns.size());
 
 	auto count = source.size();
 	if (count == 0) {
@@ -64,7 +57,7 @@ void IcebergMultiFileList::ScanEqualityDeleteFile(const BoundIcebergManifestEntr
 	// make result only reference the columns from source (equality delete file) that have equality_ids
 	// mentioned in the manifest file
 	DataChunk result;
-	ColumnsReferencedByEqualityIds(source, result, local_columns, source_names, data_file.equality_ids);
+	ColumnsReferencedByEqualityIds(source, result, global_columns, data_file.equality_ids);
 
 	const auto sequence_number = manifest_entry.GetSequenceNumber(manifest_file);
 	//! Get or create the equality delete data for this sequence number

--- a/src/core/deletes/iceberg_equality_delete.cpp
+++ b/src/core/deletes/iceberg_equality_delete.cpp
@@ -40,11 +40,12 @@ static void ColumnsReferencedByEqualityIds(DataChunk &source, DataChunk &result,
 	result.ReferenceColumns(source, column_ids);
 }
 
-static IcebergEqualityDeleteFile &GetOrCreateEqualityDeleteFile(vector<IcebergEqualityDeleteFile> &deletes,
-                                                                const IcebergDataFile &data_file,
-                                                                const IcebergManifestFile &manifest_file,
+static IcebergEqualityDeleteFile &GetOrCreateEqualityDeleteFile(vector<unique_ptr<IcebergEqualityDeleteFile>> &deletes,
+                                                                idx_t manifest_entry_index,
+                                                                const BoundIcebergManifestEntry &manifest_entry,
                                                                 sequence_number_t sequence_number,
                                                                 equality_delete_file_index_map_t &file_indexes) {
+	auto &data_file = manifest_entry.entry.data_file;
 	auto &sequence_indexes = file_indexes[sequence_number];
 	auto index_entry = sequence_indexes.find(data_file.file_path);
 	if (index_entry != sequence_indexes.end()) {
@@ -52,18 +53,18 @@ static IcebergEqualityDeleteFile &GetOrCreateEqualityDeleteFile(vector<IcebergEq
 			throw InternalException("Equality-delete file index %llu is out of bounds for sequence number %lld",
 			                        index_entry->second, sequence_number);
 		}
-		auto &delete_file = deletes[index_entry->second];
-		D_ASSERT(delete_file.partition_spec_id == manifest_file.partition_spec_id);
+		auto &delete_file = *deletes[index_entry->second];
 		return delete_file;
 	}
 
 	auto delete_index = deletes.size();
-	deletes.emplace_back(data_file.partition_info, manifest_file.partition_spec_id, data_file.file_path);
+	deletes.push_back(make_uniq<IcebergEqualityDeleteFile>(manifest_entry_index));
 	sequence_indexes.emplace(data_file.file_path, delete_index);
-	return deletes.back();
+	return *deletes.back();
 }
 
-void IcebergMultiFileList::ScanEqualityDeleteFile(const BoundIcebergManifestEntry &bound_manifest_entry,
+void IcebergMultiFileList::ScanEqualityDeleteFile(idx_t manifest_entry_index,
+                                                  const BoundIcebergManifestEntry &bound_manifest_entry,
                                                   DataChunk &source,
                                                   const vector<MultiFileColumnDefinition> &global_columns,
                                                   equality_delete_file_index_map_t &file_indexes) const {
@@ -88,19 +89,35 @@ void IcebergMultiFileList::ScanEqualityDeleteFile(const BoundIcebergManifestEntr
 	auto &equality_delete_data = GetEqualityDeleteData();
 	auto &deletes = equality_delete_data[sequence_number];
 
-	auto &delete_file = GetOrCreateEqualityDeleteFile(deletes, data_file, manifest_file, sequence_number, file_indexes);
+	auto &delete_file = GetOrCreateEqualityDeleteFile(deletes, manifest_entry_index, bound_manifest_entry,
+	                                                  sequence_number, file_indexes);
 	auto &equality_values = delete_file.equality_values;
 	D_ASSERT(result.ColumnCount() == data_file.equality_ids.size());
-
-	for (idx_t col_idx = 0; col_idx < result.ColumnCount(); col_idx++) {
-		auto &field_id = data_file.equality_ids[col_idx];
-		auto &vec = result.data[col_idx];
-		auto &values = equality_values[field_id];
-		values.reserve(values.size() + count);
-		for (idx_t i = 0; i < count; i++) {
-			values.push_back(vec.GetValue(i));
+	if (data_file.record_count < 0) {
+		throw InvalidConfigurationException("Equality delete file '%s' has a negative record count",
+		                                    data_file.file_path);
+	}
+	auto expected_row_count = NumericCast<idx_t>(data_file.record_count);
+	if (equality_values.size() > expected_row_count || count > expected_row_count - equality_values.size()) {
+		throw InvalidConfigurationException(
+		    "Equality delete file '%s' contains more rows than its record count of %llu", data_file.file_path,
+		    expected_row_count);
+	}
+	if (equality_values.ColumnCount() == 0) {
+		equality_values.Initialize(context, result.GetTypes(), expected_row_count);
+	} else {
+		if (equality_values.ColumnCount() != result.ColumnCount()) {
+			throw InvalidConfigurationException("Equality delete file '%s' produced chunks with differing schemas",
+			                                    data_file.file_path);
+		}
+		for (idx_t column_idx = 0; column_idx < result.ColumnCount(); column_idx++) {
+			if (equality_values.data[column_idx].GetType() != result.data[column_idx].GetType()) {
+				throw InvalidConfigurationException("Equality delete file '%s' produced chunks with differing schemas",
+				                                    data_file.file_path);
+			}
 		}
 	}
+	equality_values.Append(result, VectorAppendMode::ERROR_ON_NO_SPACE);
 }
 
 } // namespace duckdb

--- a/src/core/deletes/iceberg_equality_delete.cpp
+++ b/src/core/deletes/iceberg_equality_delete.cpp
@@ -40,9 +40,33 @@ static void ColumnsReferencedByEqualityIds(DataChunk &source, DataChunk &result,
 	result.ReferenceColumns(source, column_ids);
 }
 
+static IcebergEqualityDeleteFile &GetOrCreateEqualityDeleteFile(vector<IcebergEqualityDeleteFile> &deletes,
+                                                                const IcebergDataFile &data_file,
+                                                                const IcebergManifestFile &manifest_file,
+                                                                sequence_number_t sequence_number,
+                                                                equality_delete_file_index_map_t &file_indexes) {
+	auto &sequence_indexes = file_indexes[sequence_number];
+	auto index_entry = sequence_indexes.find(data_file.file_path);
+	if (index_entry != sequence_indexes.end()) {
+		if (index_entry->second >= deletes.size()) {
+			throw InternalException("Equality-delete file index %llu is out of bounds for sequence number %lld",
+			                        index_entry->second, sequence_number);
+		}
+		auto &delete_file = deletes[index_entry->second];
+		D_ASSERT(delete_file.partition_spec_id == manifest_file.partition_spec_id);
+		return delete_file;
+	}
+
+	auto delete_index = deletes.size();
+	deletes.emplace_back(data_file.partition_info, manifest_file.partition_spec_id, data_file.file_path);
+	sequence_indexes.emplace(data_file.file_path, delete_index);
+	return deletes.back();
+}
+
 void IcebergMultiFileList::ScanEqualityDeleteFile(const BoundIcebergManifestEntry &bound_manifest_entry,
                                                   DataChunk &source,
-                                                  const vector<MultiFileColumnDefinition> &global_columns) const {
+                                                  const vector<MultiFileColumnDefinition> &global_columns,
+                                                  equality_delete_file_index_map_t &file_indexes) const {
 	auto &manifest_entry = bound_manifest_entry.entry;
 	auto &data_file = manifest_entry.data_file;
 	auto &manifest_file = GetManifestFileForEntry(bound_manifest_entry, IcebergManifestContentType::DELETE);
@@ -64,15 +88,15 @@ void IcebergMultiFileList::ScanEqualityDeleteFile(const BoundIcebergManifestEntr
 	auto &equality_delete_data = GetEqualityDeleteData();
 	auto &deletes = equality_delete_data[sequence_number];
 
-	deletes.emplace_back(data_file.partition_info, manifest_file.partition_spec_id, data_file.file_path);
-	auto &equality_values = deletes.back().equality_values;
+	auto &delete_file = GetOrCreateEqualityDeleteFile(deletes, data_file, manifest_file, sequence_number, file_indexes);
+	auto &equality_values = delete_file.equality_values;
 	D_ASSERT(result.ColumnCount() == data_file.equality_ids.size());
 
 	for (idx_t col_idx = 0; col_idx < result.ColumnCount(); col_idx++) {
 		auto &field_id = data_file.equality_ids[col_idx];
 		auto &vec = result.data[col_idx];
 		auto &values = equality_values[field_id];
-		values.reserve(count);
+		values.reserve(values.size() + count);
 		for (idx_t i = 0; i < count; i++) {
 			values.push_back(vec.GetValue(i));
 		}

--- a/src/include/core/deletes/iceberg_equality_delete.hpp
+++ b/src/include/core/deletes/iceberg_equality_delete.hpp
@@ -1,10 +1,7 @@
 #pragma once
 
-#include "duckdb/common/unordered_map.hpp"
-#include "duckdb/common/vector.hpp"
-#include "duckdb/common/types/value.hpp"
 #include "duckdb/common/typedefs.hpp"
-#include "core/metadata/manifest/iceberg_manifest.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
 
 namespace duckdb {
 
@@ -12,25 +9,17 @@ using sequence_number_t = int64_t;
 
 struct IcebergEqualityDeleteFile {
 public:
-	IcebergEqualityDeleteFile(vector<IcebergPartitionInfo> partition_info_p, int32_t partition_spec_id,
-	                          string source_file_path_p = string())
-	    : partition_info(std::move(partition_info_p)), partition_spec_id(partition_spec_id),
-	      source_file_path(std::move(source_file_path_p)) {
+	explicit IcebergEqualityDeleteFile(idx_t manifest_entry_index_p) : manifest_entry_index(manifest_entry_index_p) {
 	}
 	IcebergEqualityDeleteFile(const IcebergEqualityDeleteFile &) = delete;
 	IcebergEqualityDeleteFile &operator=(const IcebergEqualityDeleteFile &) = delete;
-	IcebergEqualityDeleteFile(IcebergEqualityDeleteFile &&) = default;
-	IcebergEqualityDeleteFile &operator=(IcebergEqualityDeleteFile &&) = default;
 
 public:
-	//! The partition info if the equality delete has partition information
-	vector<IcebergPartitionInfo> partition_info;
-	int32_t partition_spec_id;
-	//! Delete file that produced these values; used for explicit REST task references.
-	string source_file_path;
-	//! Raw equality delete values, keyed by Iceberg field-id. These are converted to bound expressions once the
-	//! scan output projection is known.
-	unordered_map<int32_t, vector<Value>> equality_values;
+	//! Index in IcebergScanPlanProvider::DeleteManifestEntries(). Unlike a reference, this remains stable when lazy
+	//! manifest enumeration grows the provider's vector.
+	idx_t manifest_entry_index;
+	//! Columns follow the referenced manifest entry's data_file.equality_ids order.
+	DataChunk equality_values;
 };
 
 } // namespace duckdb

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -251,7 +251,8 @@ private:
 	void ProcessDeletesInternal(const vector<idx_t> &manifest_indexes) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
 	void ScanDeleteFiles() const DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
-	void ScanDeleteFile(const BoundIcebergManifestEntry &entry) const
+	void ScanParquetDeleteFiles(const vector<reference<const BoundIcebergManifestEntry>> &entries,
+	                            IcebergManifestEntryContentType content) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
 	void ScanPositionalDeleteFile(const BoundIcebergManifestEntry &manifest_entry, DataChunk &result) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -34,7 +34,7 @@
 
 namespace duckdb {
 
-using equality_delete_map_t = map<sequence_number_t, vector<IcebergEqualityDeleteFile>>;
+using equality_delete_map_t = map<sequence_number_t, vector<unique_ptr<IcebergEqualityDeleteFile>>>;
 using equality_delete_file_index_map_t = unordered_map<sequence_number_t, unordered_map<string, idx_t>>;
 using position_delete_map_t = unordered_map<string, shared_ptr<IcebergDeleteData>>;
 
@@ -209,6 +209,7 @@ private:
 	OpenFileInfo GetFileInternal(idx_t i, annotated_lock_guard<annotated_mutex> &guard) const
 	    DUCKDB_REQUIRES(shared_state->lock);
 	BoundIcebergManifestEntry GetManifestEntry(idx_t file_id) const;
+	BoundIcebergManifestEntry GetDeleteManifestEntry(idx_t manifest_entry_index) const;
 	IcebergManifestFile GetManifestFileForDataFile(idx_t file_id) const;
 	const IcebergManifestFile &GetManifestFileForEntry(const BoundIcebergManifestEntry &entry,
 	                                                   IcebergManifestContentType type) const
@@ -252,13 +253,13 @@ private:
 	void ProcessDeletesInternal(const vector<idx_t> &manifest_indexes) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
 	void ScanDeleteFiles() const DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
-	void ScanParquetDeleteFiles(const vector<reference<const BoundIcebergManifestEntry>> &entries,
+	void ScanParquetDeleteFiles(const vector<idx_t> &manifest_entry_indexes,
 	                            IcebergManifestEntryContentType content) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
 	void ScanPositionalDeleteFile(const BoundIcebergManifestEntry &manifest_entry, DataChunk &result) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
-	void ScanEqualityDeleteFile(const BoundIcebergManifestEntry &manifest_entry, DataChunk &result,
-	                            const vector<MultiFileColumnDefinition> &columns,
+	void ScanEqualityDeleteFile(idx_t manifest_entry_index, const BoundIcebergManifestEntry &manifest_entry,
+	                            DataChunk &result, const vector<MultiFileColumnDefinition> &columns,
 	                            equality_delete_file_index_map_t &file_indexes) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
 	void ScanPuffinFile(const BoundIcebergManifestEntry &entry) const

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -35,6 +35,7 @@
 namespace duckdb {
 
 using equality_delete_map_t = map<sequence_number_t, vector<IcebergEqualityDeleteFile>>;
+using equality_delete_file_index_map_t = unordered_map<sequence_number_t, unordered_map<string, idx_t>>;
 using position_delete_map_t = unordered_map<string, shared_ptr<IcebergDeleteData>>;
 
 struct IcebergTableFilters {
@@ -257,7 +258,8 @@ private:
 	void ScanPositionalDeleteFile(const BoundIcebergManifestEntry &manifest_entry, DataChunk &result) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
 	void ScanEqualityDeleteFile(const BoundIcebergManifestEntry &manifest_entry, DataChunk &result,
-	                            const vector<MultiFileColumnDefinition> &columns) const
+	                            const vector<MultiFileColumnDefinition> &columns,
+	                            equality_delete_file_index_map_t &file_indexes) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
 	void ScanPuffinFile(const BoundIcebergManifestEntry &entry) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -257,8 +257,7 @@ private:
 	void ScanPositionalDeleteFile(const BoundIcebergManifestEntry &manifest_entry, DataChunk &result) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
 	void ScanEqualityDeleteFile(const BoundIcebergManifestEntry &manifest_entry, DataChunk &result,
-	                            const vector<MultiFileColumnDefinition> &columns,
-	                            const vector<string> &source_names) const
+	                            const vector<MultiFileColumnDefinition> &columns) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
 	void ScanPuffinFile(const BoundIcebergManifestEntry &entry) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);

--- a/src/include/planning/metadata_io/deletes/iceberg_deletes_file_reader.hpp
+++ b/src/include/planning/metadata_io/deletes/iceberg_deletes_file_reader.hpp
@@ -15,11 +15,14 @@ namespace duckdb {
 // Pass the already resolved open-file information to the delete scan.
 struct IcebergDeleteScanInfo : public TableFunctionInfo {
 public:
-	IcebergDeleteScanInfo(vector<OpenFileInfo> file_infos) : file_infos(std::move(file_infos)) {
+	IcebergDeleteScanInfo(vector<OpenFileInfo> file_infos, vector<MultiFileColumnDefinition> schema)
+	    : file_infos(std::move(file_infos)), schema(std::move(schema)) {
 	}
 
 public:
 	vector<OpenFileInfo> file_infos;
+	//! Global schema shared by every Parquet file in this positional or equality delete batch.
+	vector<MultiFileColumnDefinition> schema;
 };
 
 struct IcebergDeleteFileReader : public MultiFileReader {
@@ -27,6 +30,8 @@ struct IcebergDeleteFileReader : public MultiFileReader {
 
 	shared_ptr<MultiFileList> CreateFileList(ClientContext &context, const vector<string> &paths,
 	                                         const FileGlobInput &glob_input) override;
+	bool Bind(MultiFileOptions &options, MultiFileList &files, vector<LogicalType> &return_types,
+	          vector<Identifier> &names, MultiFileReaderBindData &bind_data) override;
 
 	static unique_ptr<MultiFileReader> CreateInstance(const TableFunction &table);
 

--- a/src/include/planning/metadata_io/deletes/iceberg_deletes_file_reader.hpp
+++ b/src/include/planning/metadata_io/deletes/iceberg_deletes_file_reader.hpp
@@ -12,14 +12,14 @@
 
 namespace duckdb {
 
-// pass a open file info to the delete scan
+// Pass the already resolved open-file information to the delete scan.
 struct IcebergDeleteScanInfo : public TableFunctionInfo {
 public:
-	IcebergDeleteScanInfo(OpenFileInfo file_info) : file_info(file_info) {
+	IcebergDeleteScanInfo(vector<OpenFileInfo> file_infos) : file_infos(std::move(file_infos)) {
 	}
 
 public:
-	OpenFileInfo file_info;
+	vector<OpenFileInfo> file_infos;
 };
 
 struct IcebergDeleteFileReader : public MultiFileReader {

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -1505,6 +1505,8 @@ void IcebergMultiFileList::ScanDeleteFiles() const {
 	auto &provider = GetScanPlanProvider();
 	auto &next_entry = provider.NextDeleteEntryToProcess();
 	auto &delete_entries = provider.DeleteManifestEntries();
+	vector<reference<const BoundIcebergManifestEntry>> positional_delete_entries;
+	vector<reference<const BoundIcebergManifestEntry>> equality_delete_entries;
 	for (; next_entry < delete_entries.size(); next_entry++) {
 		auto &bound_manifest_entry = delete_entries[next_entry];
 		if (!DeleteEntryMatchesFilters(bound_manifest_entry)) {
@@ -1513,7 +1515,17 @@ void IcebergMultiFileList::ScanDeleteFiles() const {
 		auto &manifest_entry = bound_manifest_entry.entry;
 		auto &data_file = manifest_entry.data_file;
 		if (StringUtil::CIEquals(data_file.file_format, "parquet")) {
-			ScanDeleteFile(bound_manifest_entry);
+			switch (data_file.content) {
+			case IcebergManifestEntryContentType::POSITION_DELETES:
+				positional_delete_entries.emplace_back(bound_manifest_entry);
+				break;
+			case IcebergManifestEntryContentType::EQUALITY_DELETES:
+				equality_delete_entries.emplace_back(bound_manifest_entry);
+				break;
+			default:
+				throw InvalidConfigurationException("Delete manifest references Parquet file '%s' with content type %d",
+				                                    data_file.file_path, static_cast<uint8_t>(data_file.content));
+			}
 		} else if (StringUtil::CIEquals(data_file.file_format, "puffin")) {
 			ScanPuffinFile(bound_manifest_entry);
 		} else {
@@ -1522,6 +1534,8 @@ void IcebergMultiFileList::ScanDeleteFiles() const {
 			    data_file.file_format);
 		}
 	}
+	ScanParquetDeleteFiles(positional_delete_entries, IcebergManifestEntryContentType::POSITION_DELETES);
+	ScanParquetDeleteFiles(equality_delete_entries, IcebergManifestEntryContentType::EQUALITY_DELETES);
 }
 
 void IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_manifest_entry) const {
@@ -1554,38 +1568,55 @@ void IcebergMultiFileList::ProcessDeletesInternal(const vector<idx_t> &manifest_
 	ScanDeleteFiles();
 }
 
-void IcebergMultiFileList::ScanDeleteFile(const BoundIcebergManifestEntry &bound_manifest_entry) const {
-	auto &manifest_entry = bound_manifest_entry.entry;
-	auto &data_file = manifest_entry.data_file;
-	auto delete_file_path = data_file.file_path;
-	auto iceberg_deletes_scan = IcebergFunctions::GetIcebergDeletesScanFunction(context);
-	auto &delete_scan_function = iceberg_deletes_scan.functions[0];
-
-	if (options.allow_moved_paths) {
-		auto iceberg_path = GetPath();
-		auto &fs = FileSystem::GetFileSystem(context);
-		delete_file_path = IcebergUtils::GetFullPath(iceberg_path, delete_file_path, fs);
+void IcebergMultiFileList::ScanParquetDeleteFiles(const vector<reference<const BoundIcebergManifestEntry>> &entries,
+                                                  IcebergManifestEntryContentType content) const {
+	if (entries.empty()) {
+		return;
 	}
+
+	vector<Value> delete_file_paths;
+	vector<OpenFileInfo> delete_file_infos;
+	delete_file_paths.reserve(entries.size());
+	delete_file_infos.reserve(entries.size());
+	for (auto &entry_ref : entries) {
+		auto &data_file = entry_ref.get().entry.data_file;
+		D_ASSERT(data_file.content == content);
+		auto delete_file_path = data_file.file_path;
+		if (options.allow_moved_paths) {
+			auto iceberg_path = GetPath();
+			auto &fs = FileSystem::GetFileSystem(context);
+			delete_file_path = IcebergUtils::GetFullPath(iceberg_path, delete_file_path, fs);
+		}
+
+		delete_file_paths.emplace_back(delete_file_path);
+		delete_file_infos.emplace_back(delete_file_path);
+		auto &file_info = delete_file_infos.back();
+		file_info.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+		file_info.extended_info->options["file_size"] = Value::UBIGINT(data_file.file_size_in_bytes);
+		// Files managed by Iceberg are immutable, so they can remain cached.
+		file_info.extended_info->options["validate_external_file_cache"] = Value::BOOLEAN(false);
+		file_info.extended_info->options["etag"] = Value("");
+		file_info.extended_info->options["last_modified"] = Value::TIMESTAMP(timestamp_t(0));
+	}
+
+	auto iceberg_deletes_scan = IcebergFunctions::GetIcebergDeletesScanFunction(context);
+	auto delete_scan_function =
+	    iceberg_deletes_scan.GetFunctionByArguments(context, {LogicalType::LIST(LogicalType::VARCHAR)});
 	// Prepare the inputs for the bind
 	vector<Value> children;
 	children.reserve(1);
-	children.push_back(Value(delete_file_path));
+	children.push_back(Value::LIST(LogicalType::VARCHAR, std::move(delete_file_paths)));
 	named_parameter_map_t named_params;
+	if (content == IcebergManifestEntryContentType::EQUALITY_DELETES) {
+		// Equality-delete files can contain different key columns. Merge their physical schemas while keeping this
+		// batch separate from the fixed positional-delete schema.
+		named_params[Identifier("union_by_name")] = Value::BOOLEAN(true);
+	}
 	vector<LogicalType> input_types;
 	vector<Identifier> input_names;
 
 	TableFunctionRef empty;
-	OpenFileInfo res(delete_file_path);
-	// create function info for the iceberg delete scan.
-	auto extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
-	extended_info->options["file_size"] = Value::UBIGINT(data_file.file_size_in_bytes);
-	// files managed by Iceberg are never modified - we can keep them cached
-	extended_info->options["validate_external_file_cache"] = Value::BOOLEAN(false);
-	// etag / last modified time can be set to dummy values
-	extended_info->options["etag"] = Value("");
-	extended_info->options["last_modified"] = Value::TIMESTAMP(timestamp_t(0));
-	res.extended_info = extended_info;
-	auto delete_info = make_shared_ptr<IcebergDeleteScanInfo>(res);
+	auto delete_info = make_shared_ptr<IcebergDeleteScanInfo>(std::move(delete_file_infos));
 	delete_scan_function.function_info = delete_info;
 
 	TableFunctionBindInput bind_input(children, named_params, input_types, input_names, nullptr, nullptr,
@@ -1611,24 +1642,29 @@ void IcebergMultiFileList::ScanDeleteFile(const BoundIcebergManifestEntry &bound
 
 	auto &multi_file_local_state = local_state->Cast<MultiFileLocalState>();
 
-	if (data_file.content == IcebergManifestEntryContentType::POSITION_DELETES) {
-		do {
-			TableFunctionInput function_input(bind_data.get(), local_state.get(), global_state.get());
-			result.Reset();
-			delete_scan_function.function(context, function_input, result);
-			result.Flatten();
+	do {
+		TableFunctionInput function_input(bind_data.get(), local_state.get(), global_state.get());
+		result.Reset();
+		delete_scan_function.function(context, function_input, result);
+		if (result.size() == 0) {
+			break;
+		}
+		result.Flatten();
+
+		auto &reader = *multi_file_local_state.job.reader;
+		auto file_idx = reader.file_list_idx.GetIndex();
+		if (file_idx >= entries.size()) {
+			throw InternalException("Delete batch reader index %llu is out of bounds for %llu files", file_idx,
+			                        entries.size());
+		}
+		auto &bound_manifest_entry = entries[file_idx].get();
+		if (content == IcebergManifestEntryContentType::POSITION_DELETES) {
 			ScanPositionalDeleteFile(bound_manifest_entry, result);
-		} while (result.size() != 0);
-	} else if (data_file.content == IcebergManifestEntryContentType::EQUALITY_DELETES) {
-		do {
-			TableFunctionInput function_input(bind_data.get(), local_state.get(), global_state.get());
-			result.Reset();
-			delete_scan_function.function(context, function_input, result);
-			result.Flatten();
-			ScanEqualityDeleteFile(bound_manifest_entry, result, multi_file_local_state.job.reader->columns,
-			                       return_names);
-		} while (result.size() != 0);
-	}
+		} else {
+			D_ASSERT(content == IcebergManifestEntryContentType::EQUALITY_DELETES);
+			ScanEqualityDeleteFile(bound_manifest_entry, result, reader.columns, return_names);
+		}
+	} while (true);
 }
 
 unique_ptr<DeleteFilter> IcebergMultiFileList::GetPositionalDeletesForFile(const string &file_path) const {

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -1568,6 +1568,50 @@ void IcebergMultiFileList::ProcessDeletesInternal(const vector<idx_t> &manifest_
 	ScanDeleteFiles();
 }
 
+static vector<MultiFileColumnDefinition>
+BuildEqualityDeleteSchema(const IcebergTableMetadata &metadata,
+                          const vector<reference<const BoundIcebergManifestEntry>> &entries) {
+	vector<MultiFileColumnDefinition> schema;
+	unordered_set<int32_t> field_ids;
+	for (auto &entry_ref : entries) {
+		auto &data_file = entry_ref.get().entry.data_file;
+		for (auto field_id : data_file.equality_ids) {
+			if (!field_ids.insert(field_id).second) {
+				continue;
+			}
+			auto column = metadata.FindColumnByFieldId(field_id);
+			if (!column) {
+				throw InvalidConfigurationException(
+				    "Equality-delete file '%s' references field id %d, but no table schema contains that field",
+				    data_file.file_path, field_id);
+			}
+			auto schema_column = column->GetMultiFileColumnDefinition();
+			// These names are internal. Use the stable field id so renames and duplicate nested leaf names cannot make
+			// two distinct Iceberg fields collide in the global schema.
+			schema_column.name = Identifier(StringUtil::Format("r%d", field_id));
+			// Columns absent from a particular equality-delete file must be NULL, not the table column's initial
+			// default.
+			schema_column.default_expression = make_uniq<ConstantExpression>(Value(schema_column.type));
+			schema.push_back(std::move(schema_column));
+		}
+	}
+	return schema;
+}
+
+static vector<MultiFileColumnDefinition> BuildPositionalDeleteSchema() {
+	vector<MultiFileColumnDefinition> schema;
+
+	MultiFileColumnDefinition file_path("file_path", LogicalType::VARCHAR);
+	file_path.identifier = Value::INTEGER(MultiFileReader::DELETE_FILE_PATH_FIELD_ID);
+	schema.push_back(std::move(file_path));
+
+	MultiFileColumnDefinition pos("pos", LogicalType::BIGINT);
+	pos.identifier = Value::INTEGER(MultiFileReader::DELETE_POS_FIELD_ID);
+	schema.push_back(std::move(pos));
+
+	return schema;
+}
+
 void IcebergMultiFileList::ScanParquetDeleteFiles(const vector<reference<const BoundIcebergManifestEntry>> &entries,
                                                   IcebergManifestEntryContentType content) const {
 	if (entries.empty()) {
@@ -1602,21 +1646,23 @@ void IcebergMultiFileList::ScanParquetDeleteFiles(const vector<reference<const B
 	auto iceberg_deletes_scan = IcebergFunctions::GetIcebergDeletesScanFunction(context);
 	auto delete_scan_function =
 	    iceberg_deletes_scan.GetFunctionByArguments(context, {LogicalType::LIST(LogicalType::VARCHAR)});
+	vector<MultiFileColumnDefinition> delete_schema;
+	if (content == IcebergManifestEntryContentType::POSITION_DELETES) {
+		delete_schema = BuildPositionalDeleteSchema();
+	} else {
+		D_ASSERT(content == IcebergManifestEntryContentType::EQUALITY_DELETES);
+		delete_schema = BuildEqualityDeleteSchema(GetMetadata(), entries);
+	}
 	// Prepare the inputs for the bind
 	vector<Value> children;
 	children.reserve(1);
 	children.push_back(Value::LIST(LogicalType::VARCHAR, std::move(delete_file_paths)));
 	named_parameter_map_t named_params;
-	if (content == IcebergManifestEntryContentType::EQUALITY_DELETES) {
-		// Equality-delete files can contain different key columns. Merge their physical schemas while keeping this
-		// batch separate from the fixed positional-delete schema.
-		named_params[Identifier("union_by_name")] = Value::BOOLEAN(true);
-	}
 	vector<LogicalType> input_types;
 	vector<Identifier> input_names;
 
 	TableFunctionRef empty;
-	auto delete_info = make_shared_ptr<IcebergDeleteScanInfo>(std::move(delete_file_infos));
+	auto delete_info = make_shared_ptr<IcebergDeleteScanInfo>(std::move(delete_file_infos), std::move(delete_schema));
 	delete_scan_function.function_info = delete_info;
 
 	TableFunctionBindInput bind_input(children, named_params, input_types, input_names, nullptr, nullptr,
@@ -1624,6 +1670,7 @@ void IcebergMultiFileList::ScanParquetDeleteFiles(const vector<reference<const B
 	vector<LogicalType> return_types;
 	vector<string> return_names;
 	auto bind_data = delete_scan_function.bind(context, bind_input, return_types, return_names);
+	auto &multi_file_bind_data = bind_data->Cast<MultiFileBindData>();
 
 	DataChunk result;
 	// Reserve for STANDARD_VECTOR_SIZE instead of count, in case the returned table contains too many tuples
@@ -1662,7 +1709,7 @@ void IcebergMultiFileList::ScanParquetDeleteFiles(const vector<reference<const B
 			ScanPositionalDeleteFile(bound_manifest_entry, result);
 		} else {
 			D_ASSERT(content == IcebergManifestEntryContentType::EQUALITY_DELETES);
-			ScanEqualityDeleteFile(bound_manifest_entry, result, reader.columns, return_names);
+			ScanEqualityDeleteFile(bound_manifest_entry, result, multi_file_bind_data.reader_bind.schema);
 		}
 	} while (true);
 }

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -1688,6 +1688,19 @@ void IcebergMultiFileList::ScanParquetDeleteFiles(const vector<reference<const B
 	auto local_state = delete_scan_function.init_local(execution_context, input, global_state.get());
 
 	auto &multi_file_local_state = local_state->Cast<MultiFileLocalState>();
+	equality_delete_file_index_map_t equality_delete_file_indexes;
+	if (content == IcebergManifestEntryContentType::EQUALITY_DELETES) {
+		for (auto &sequence_entry : GetEqualityDeleteData()) {
+			auto &sequence_indexes = equality_delete_file_indexes[sequence_entry.first];
+			auto &delete_files = sequence_entry.second;
+			for (idx_t delete_index = 0; delete_index < delete_files.size(); delete_index++) {
+				auto &file_path = delete_files[delete_index].source_file_path;
+				if (!file_path.empty()) {
+					sequence_indexes.emplace(file_path, delete_index);
+				}
+			}
+		}
+	}
 
 	do {
 		TableFunctionInput function_input(bind_data.get(), local_state.get(), global_state.get());
@@ -1709,7 +1722,8 @@ void IcebergMultiFileList::ScanParquetDeleteFiles(const vector<reference<const B
 			ScanPositionalDeleteFile(bound_manifest_entry, result);
 		} else {
 			D_ASSERT(content == IcebergManifestEntryContentType::EQUALITY_DELETES);
-			ScanEqualityDeleteFile(bound_manifest_entry, result, multi_file_bind_data.reader_bind.schema);
+			ScanEqualityDeleteFile(bound_manifest_entry, result, multi_file_bind_data.reader_bind.schema,
+			                       equality_delete_file_indexes);
 		}
 	} while (true);
 }

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -506,6 +506,17 @@ BoundIcebergManifestEntry IcebergMultiFileList::GetManifestEntry(idx_t file_id) 
 	return data_manifest_entries[file_id];
 }
 
+BoundIcebergManifestEntry IcebergMultiFileList::GetDeleteManifestEntry(idx_t manifest_entry_index) const {
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
+	auto &entries = GetScanPlanProvider().DeleteManifestEntries();
+	if (manifest_entry_index >= entries.size()) {
+		throw InternalException("Delete manifest entry index %llu is out of bounds for %llu entries",
+		                        manifest_entry_index, entries.size());
+	}
+	return entries[manifest_entry_index];
+}
+
 IcebergManifestFile IcebergMultiFileList::GetManifestFileForDataFile(idx_t file_id) const {
 	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	auto manifest_file_idx = data_manifest_entries[file_id].manifest_file_idx;
@@ -1291,25 +1302,38 @@ IcebergMultiFileList::GetEqualityDeletesForFile(const BoundIcebergManifestEntry 
 	auto &manifest_file = data_manifests[bound_manifest_entry.manifest_file_idx].entry.file;
 	auto &data_file = manifest_entry.data_file;
 	auto &metadata = GetMetadata();
+	auto &provider = GetScanPlanProvider();
+	auto &delete_entries = provider.DeleteManifestEntries();
 	auto &equality_delete_data = GetEqualityDeleteData();
 	auto it = equality_delete_data.upper_bound(manifest_entry.GetSequenceNumber(manifest_file));
 	for (; it != equality_delete_data.end(); it++) {
 		auto &delete_files = it->second;
-		for (auto &delete_file : delete_files) {
-			if (!GetScanPlanProvider().DeleteFileAppliesToDataFile(data_file.file_path, delete_file.source_file_path)) {
+		for (auto &delete_file_ptr : delete_files) {
+			auto &delete_file = *delete_file_ptr;
+			auto manifest_entry_index = delete_file.manifest_entry_index;
+			if (manifest_entry_index >= delete_entries.size()) {
+				throw InternalException("Delete manifest entry index %llu is out of bounds for %llu entries",
+				                        manifest_entry_index, delete_entries.size());
+			}
+			auto &delete_manifest_entry = delete_entries[manifest_entry_index];
+			auto &delete_data_file = delete_manifest_entry.entry.data_file;
+			if (!provider.DeleteFileAppliesToDataFile(data_file.file_path, delete_data_file.file_path)) {
 				continue;
 			}
-			auto &partition_spec = metadata.partition_specs.at(delete_file.partition_spec_id);
+			auto &delete_manifest_file =
+			    GetManifestFileForEntry(delete_manifest_entry, IcebergManifestContentType::DELETE);
+			auto delete_partition_spec_id = delete_manifest_file.partition_spec_id;
+			auto &partition_spec = metadata.partition_specs.at(delete_partition_spec_id);
 			if (partition_spec.IsPartitioned()) {
-				if (delete_file.partition_spec_id != manifest_file.partition_spec_id) {
+				if (delete_partition_spec_id != manifest_file.partition_spec_id) {
 					//! Not unpartitioned and the data does not share the same partition spec as the delete, skip the
 					//! delete file.
 					continue;
 				}
-				D_ASSERT(delete_file.partition_info.size() == data_file.partition_info.size());
+				D_ASSERT(delete_data_file.partition_info.size() == data_file.partition_info.size());
 				bool partition_matches = true;
-				for (idx_t i = 0; i < delete_file.partition_info.size(); i++) {
-					if (delete_file.partition_info[i] != data_file.partition_info[i]) {
+				for (idx_t i = 0; i < delete_data_file.partition_info.size(); i++) {
+					if (delete_data_file.partition_info[i] != data_file.partition_info[i]) {
 						//! Same partition spec id, but the partitioning information doesn't match, delete file doesn't
 						//! apply.
 						partition_matches = false;
@@ -1505,8 +1529,8 @@ void IcebergMultiFileList::ScanDeleteFiles() const {
 	auto &provider = GetScanPlanProvider();
 	auto &next_entry = provider.NextDeleteEntryToProcess();
 	auto &delete_entries = provider.DeleteManifestEntries();
-	vector<reference<const BoundIcebergManifestEntry>> positional_delete_entries;
-	vector<reference<const BoundIcebergManifestEntry>> equality_delete_entries;
+	vector<idx_t> positional_delete_entries;
+	vector<idx_t> equality_delete_entries;
 	for (; next_entry < delete_entries.size(); next_entry++) {
 		auto &bound_manifest_entry = delete_entries[next_entry];
 		if (!DeleteEntryMatchesFilters(bound_manifest_entry)) {
@@ -1517,10 +1541,10 @@ void IcebergMultiFileList::ScanDeleteFiles() const {
 		if (StringUtil::CIEquals(data_file.file_format, "parquet")) {
 			switch (data_file.content) {
 			case IcebergManifestEntryContentType::POSITION_DELETES:
-				positional_delete_entries.emplace_back(bound_manifest_entry);
+				positional_delete_entries.push_back(next_entry);
 				break;
 			case IcebergManifestEntryContentType::EQUALITY_DELETES:
-				equality_delete_entries.emplace_back(bound_manifest_entry);
+				equality_delete_entries.push_back(next_entry);
 				break;
 			default:
 				throw InvalidConfigurationException("Delete manifest references Parquet file '%s' with content type %d",
@@ -1568,13 +1592,17 @@ void IcebergMultiFileList::ProcessDeletesInternal(const vector<idx_t> &manifest_
 	ScanDeleteFiles();
 }
 
-static vector<MultiFileColumnDefinition>
-BuildEqualityDeleteSchema(const IcebergTableMetadata &metadata,
-                          const vector<reference<const BoundIcebergManifestEntry>> &entries) {
+static vector<MultiFileColumnDefinition> BuildEqualityDeleteSchema(const IcebergTableMetadata &metadata,
+                                                                   const vector<BoundIcebergManifestEntry> &entries,
+                                                                   const vector<idx_t> &manifest_entry_indexes) {
 	vector<MultiFileColumnDefinition> schema;
 	unordered_set<int32_t> field_ids;
-	for (auto &entry_ref : entries) {
-		auto &data_file = entry_ref.get().entry.data_file;
+	for (auto manifest_entry_index : manifest_entry_indexes) {
+		if (manifest_entry_index >= entries.size()) {
+			throw InternalException("Delete manifest entry index %llu is out of bounds for %llu entries",
+			                        manifest_entry_index, entries.size());
+		}
+		auto &data_file = entries[manifest_entry_index].entry.data_file;
 		for (auto field_id : data_file.equality_ids) {
 			if (!field_ids.insert(field_id).second) {
 				continue;
@@ -1612,18 +1640,23 @@ static vector<MultiFileColumnDefinition> BuildPositionalDeleteSchema() {
 	return schema;
 }
 
-void IcebergMultiFileList::ScanParquetDeleteFiles(const vector<reference<const BoundIcebergManifestEntry>> &entries,
+void IcebergMultiFileList::ScanParquetDeleteFiles(const vector<idx_t> &manifest_entry_indexes,
                                                   IcebergManifestEntryContentType content) const {
-	if (entries.empty()) {
+	if (manifest_entry_indexes.empty()) {
 		return;
 	}
+	auto &entries = GetScanPlanProvider().DeleteManifestEntries();
 
 	vector<Value> delete_file_paths;
 	vector<OpenFileInfo> delete_file_infos;
-	delete_file_paths.reserve(entries.size());
-	delete_file_infos.reserve(entries.size());
-	for (auto &entry_ref : entries) {
-		auto &data_file = entry_ref.get().entry.data_file;
+	delete_file_paths.reserve(manifest_entry_indexes.size());
+	delete_file_infos.reserve(manifest_entry_indexes.size());
+	for (auto manifest_entry_index : manifest_entry_indexes) {
+		if (manifest_entry_index >= entries.size()) {
+			throw InternalException("Delete manifest entry index %llu is out of bounds for %llu entries",
+			                        manifest_entry_index, entries.size());
+		}
+		auto &data_file = entries[manifest_entry_index].entry.data_file;
 		D_ASSERT(data_file.content == content);
 		auto delete_file_path = data_file.file_path;
 		if (options.allow_moved_paths) {
@@ -1651,7 +1684,7 @@ void IcebergMultiFileList::ScanParquetDeleteFiles(const vector<reference<const B
 		delete_schema = BuildPositionalDeleteSchema();
 	} else {
 		D_ASSERT(content == IcebergManifestEntryContentType::EQUALITY_DELETES);
-		delete_schema = BuildEqualityDeleteSchema(GetMetadata(), entries);
+		delete_schema = BuildEqualityDeleteSchema(GetMetadata(), entries, manifest_entry_indexes);
 	}
 	// Prepare the inputs for the bind
 	vector<Value> children;
@@ -1694,7 +1727,12 @@ void IcebergMultiFileList::ScanParquetDeleteFiles(const vector<reference<const B
 			auto &sequence_indexes = equality_delete_file_indexes[sequence_entry.first];
 			auto &delete_files = sequence_entry.second;
 			for (idx_t delete_index = 0; delete_index < delete_files.size(); delete_index++) {
-				auto &file_path = delete_files[delete_index].source_file_path;
+				auto manifest_entry_index = delete_files[delete_index]->manifest_entry_index;
+				if (manifest_entry_index >= entries.size()) {
+					throw InternalException("Delete manifest entry index %llu is out of bounds for %llu entries",
+					                        manifest_entry_index, entries.size());
+				}
+				auto &file_path = entries[manifest_entry_index].entry.data_file.file_path;
 				if (!file_path.empty()) {
 					sequence_indexes.emplace(file_path, delete_index);
 				}
@@ -1713,17 +1751,19 @@ void IcebergMultiFileList::ScanParquetDeleteFiles(const vector<reference<const B
 
 		auto &reader = *multi_file_local_state.job.reader;
 		auto file_idx = reader.file_list_idx.GetIndex();
-		if (file_idx >= entries.size()) {
+		if (file_idx >= manifest_entry_indexes.size()) {
 			throw InternalException("Delete batch reader index %llu is out of bounds for %llu files", file_idx,
-			                        entries.size());
+			                        manifest_entry_indexes.size());
 		}
-		auto &bound_manifest_entry = entries[file_idx].get();
+		auto manifest_entry_index = manifest_entry_indexes[file_idx];
+		D_ASSERT(manifest_entry_index < entries.size());
+		auto &bound_manifest_entry = entries[manifest_entry_index];
 		if (content == IcebergManifestEntryContentType::POSITION_DELETES) {
 			ScanPositionalDeleteFile(bound_manifest_entry, result);
 		} else {
 			D_ASSERT(content == IcebergManifestEntryContentType::EQUALITY_DELETES);
-			ScanEqualityDeleteFile(bound_manifest_entry, result, multi_file_bind_data.reader_bind.schema,
-			                       equality_delete_file_indexes);
+			ScanEqualityDeleteFile(manifest_entry_index, bound_manifest_entry, result,
+			                       multi_file_bind_data.reader_bind.schema, equality_delete_file_indexes);
 		}
 	} while (true);
 }

--- a/src/planning/iceberg_multi_file_reader.cpp
+++ b/src/planning/iceberg_multi_file_reader.cpp
@@ -187,8 +187,10 @@ vector<IcebergEqualityDeleteReadColumn> IcebergMultiFileReader::AddEqualityDelet
     MultiFileReaderData &reader_data, ClientContext &context) {
 	set<int32_t> required_field_ids;
 	for (auto &delete_file_ref : multi_file_list.GetEqualityDeletesForFile(bound_manifest_entry)) {
-		for (auto &entry : delete_file_ref.get().equality_values) {
-			required_field_ids.insert(entry.first);
+		auto manifest_entry = multi_file_list.GetDeleteManifestEntry(delete_file_ref.get().manifest_entry_index);
+		auto &data_file = manifest_entry.entry.data_file;
+		for (auto field_id : data_file.equality_ids) {
+			required_field_ids.insert(field_id);
 		}
 	}
 
@@ -454,20 +456,21 @@ unique_ptr<Expression> IcebergMultiFileReader::CreateEqualityDeleteExpression(
 	vector<unique_ptr<Expression>> rows;
 	for (auto &delete_file_ref : delete_files) {
 		auto &delete_file = delete_file_ref.get();
-		if (delete_file.equality_values.empty()) {
+		auto &equality_values = delete_file.equality_values;
+		if (equality_values.size() == 0) {
 			continue;
 		}
-		auto row_count = delete_file.equality_values.begin()->second.size();
-		for (auto &entry : delete_file.equality_values) {
-			if (entry.second.size() != row_count) {
-				throw InvalidConfigurationException("Equality delete file contains columns with differing row counts");
-			}
+		auto manifest_entry = multi_file_list.GetDeleteManifestEntry(delete_file.manifest_entry_index);
+		auto &equality_ids = manifest_entry.entry.data_file.equality_ids;
+		if (equality_values.ColumnCount() != equality_ids.size()) {
+			throw InvalidConfigurationException("Equality delete file contains an unexpected number of columns");
 		}
+		auto row_count = equality_values.size();
 		for (idx_t row_index = 0; row_index < row_count; row_index++) {
 			vector<unique_ptr<Expression>> equalities;
-			for (auto &entry : delete_file.equality_values) {
-				auto field_id = entry.first;
-				auto &constant = entry.second[row_index];
+			for (idx_t column_index = 0; column_index < equality_ids.size(); column_index++) {
+				auto field_id = equality_ids[column_index];
+				auto constant = equality_values.GetValue(column_index, row_index);
 
 				if (!id_to_local_column.count(field_id)) {
 					//! A field absent from the data file is NULL for equality-delete matching,

--- a/src/planning/metadata_io/deletes/iceberg_deletes_file_reader.cpp
+++ b/src/planning/metadata_io/deletes/iceberg_deletes_file_reader.cpp
@@ -76,15 +76,15 @@ unique_ptr<MultiFileReader> IcebergDeleteFileReader::CreateInstance(const TableF
 
 shared_ptr<MultiFileList> IcebergDeleteFileReader::CreateFileList(ClientContext &context, const vector<string> &paths,
                                                                   const FileGlobInput &glob_input) {
-	D_ASSERT(paths.size() == 1);
-	vector<OpenFileInfo> open_files;
-	// in case someone calls this
 	if (!function_info) {
 		throw NotImplementedException("IcebergDeleteFileReader must be called with function info");
 	}
 	auto &iceberg_delete_function_info = function_info->Cast<IcebergDeleteScanInfo>();
-	auto &extended_delete_info = iceberg_delete_function_info.file_info;
-	open_files.emplace_back(extended_delete_info);
+	if (paths.size() != iceberg_delete_function_info.file_infos.size()) {
+		throw InternalException("Iceberg delete scan received %llu paths but %llu open-file entries", paths.size(),
+		                        iceberg_delete_function_info.file_infos.size());
+	}
+	auto open_files = iceberg_delete_function_info.file_infos;
 	auto res = make_uniq<SimpleMultiFileList>(std::move(open_files));
 	return std::move(res);
 }

--- a/src/planning/metadata_io/deletes/iceberg_deletes_file_reader.cpp
+++ b/src/planning/metadata_io/deletes/iceberg_deletes_file_reader.cpp
@@ -89,4 +89,23 @@ shared_ptr<MultiFileList> IcebergDeleteFileReader::CreateFileList(ClientContext 
 	return std::move(res);
 }
 
+bool IcebergDeleteFileReader::Bind(MultiFileOptions &options, MultiFileList &files, vector<LogicalType> &return_types,
+                                   vector<Identifier> &names, MultiFileReaderBindData &bind_data) {
+	if (!function_info) {
+		throw NotImplementedException("IcebergDeleteFileReader must be called with function info");
+	}
+	auto &scan_info = function_info->Cast<IcebergDeleteScanInfo>();
+	if (scan_info.schema.empty()) {
+		throw InternalException("Iceberg delete scan requires a global schema");
+	}
+
+	for (auto &column : scan_info.schema) {
+		return_types.push_back(column.type);
+		names.push_back(column.name);
+	}
+	bind_data.schema = scan_info.schema;
+	bind_data.mapping = MultiFileColumnMappingMode::BY_FIELD_ID;
+	return true;
+}
+
 } // namespace duckdb

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_date_to_timestamp.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_date_to_timestamp.test
@@ -1,0 +1,107 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_date_to_timestamp.test
+# description: Equality deletes remain valid when their target column evolves from DATE to TIMESTAMP
+# group: [equality_deletes]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require-env EQUALITY_DELETE_WRITES_ENABLED 1
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+use my_datalake.default;
+
+statement ok
+set unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes=true;
+
+statement ok
+drop table if exists my_datalake.default.equality_delete_evolve_date_to_timestamp;
+
+statement ok
+create table my_datalake.default.equality_delete_evolve_date_to_timestamp (
+	id integer,
+	target date,
+	marker varchar
+);
+
+statement ok
+insert into my_datalake.default.equality_delete_evolve_date_to_timestamp values
+	(1, date '2000-01-01', 'delete-before-evolution'),
+	(2, date '2000-01-02', 'delete-after-evolution-old-file'),
+	(3, date '2000-01-03', 'keep-old');
+
+# This delete file stores the target field using its original DATE type.
+# Deleting 'delete-before-evolution'
+statement ok
+delete from my_datalake.default.equality_delete_evolve_date_to_timestamp where target = date '2000-01-01';
+
+query III
+select * from my_datalake.default.equality_delete_evolve_date_to_timestamp order by all
+----
+2	2000-01-02	delete-after-evolution-old-file
+3	2000-01-03	keep-old
+
+# Now alter the table, changing the type of the column that we made an equality delete on
+statement ok
+alter table my_datalake.default.equality_delete_evolve_date_to_timestamp alter column target set type timestamp;
+
+statement ok
+insert into my_datalake.default.equality_delete_evolve_date_to_timestamp values
+	(4, timestamp '2000-01-01 00:00:00', 'old-delete-does-not-apply-to-new-file'),
+	(5, timestamp '2000-01-02 00:00:00', 'delete-after-evolution-new-file'),
+	(6, timestamp '2000-01-04 12:34:56.123456', 'delete-promoted-value'),
+	(7, timestamp '2000-01-05 01:02:03', 'keep-new');
+
+# This promoted-type delete applies to matching rows in both the old DATE file and the new TIMESTAMP file.
+statement ok
+delete from my_datalake.default.equality_delete_evolve_date_to_timestamp where target = timestamp '2000-01-02 00:00:00';
+
+# The new rows are not hit by the older delete, but the older row should be (delete-after-evolution-old-file)
+query III
+select * from my_datalake.default.equality_delete_evolve_date_to_timestamp order by all
+----
+3	2000-01-03 00:00:00	keep-old
+4	2000-01-01 00:00:00	old-delete-does-not-apply-to-new-file
+6	2000-01-04 12:34:56.123456	delete-promoted-value
+7	2000-01-05 01:02:03	keep-new
+
+statement ok
+delete from my_datalake.default.equality_delete_evolve_date_to_timestamp where target = timestamp '2000-01-04 12:34:56.123456';
+
+# Delete a row added after the ALTER was performed
+query III
+select * from my_datalake.default.equality_delete_evolve_date_to_timestamp order by all
+----
+2	2000-01-02 00:00:00	delete-after-evolution-old-file
+3	2000-01-03 00:00:00	keep-old
+4	2000-01-01 00:00:00	old-delete-does-not-apply-to-new-file
+7	2000-01-05 01:02:03	keep-new
+
+query II
+select count(*), sum(record_count)
+from iceberg_metadata(my_datalake.default.equality_delete_evolve_date_to_timestamp)
+where content = 'EQUALITY_DELETES' and status != 'DELETED';
+----
+3	3
+
+# Do not project the equality-delete target: it must be scanned privately with the promoted type.
+query II
+select id, marker
+from my_datalake.default.equality_delete_evolve_date_to_timestamp
+order by id;
+----
+3	keep-old
+4	old-delete-does-not-apply-to-new-file
+7	keep-new
+
+statement ok
+drop table my_datalake.default.equality_delete_evolve_date_to_timestamp;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_date_to_timestamp.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_date_to_timestamp.test
@@ -102,5 +102,33 @@ order by id;
 4	old-delete-does-not-apply-to-new-file
 7	keep-new
 
+# Dropping the evolved equality-delete target must not resurrect rows from older data files.
+statement ok
+alter table my_datalake.default.equality_delete_evolve_date_to_timestamp drop column target;
+
+query II
+select *
+from my_datalake.default.equality_delete_evolve_date_to_timestamp
+order by id;
+----
+3	keep-old
+4	old-delete-does-not-apply-to-new-file
+7	keep-new
+
+# New data files do not contain the dropped field and are newer than all three delete files.
+statement ok
+insert into my_datalake.default.equality_delete_evolve_date_to_timestamp values
+	(8, 'keep-after-drop');
+
+query II
+select *
+from my_datalake.default.equality_delete_evolve_date_to_timestamp
+order by id;
+----
+3	keep-old
+4	old-delete-does-not-apply-to-new-file
+7	keep-new
+8	keep-after-drop
+
 statement ok
 drop table my_datalake.default.equality_delete_evolve_date_to_timestamp;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_date_to_timestamp.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_date_to_timestamp.test
@@ -81,7 +81,6 @@ delete from my_datalake.default.equality_delete_evolve_date_to_timestamp where t
 query III
 select * from my_datalake.default.equality_delete_evolve_date_to_timestamp order by all
 ----
-2	2000-01-02 00:00:00	delete-after-evolution-old-file
 3	2000-01-03 00:00:00	keep-old
 4	2000-01-01 00:00:00	old-delete-does-not-apply-to-new-file
 7	2000-01-05 01:02:03	keep-new

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_decimal.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_decimal.test
@@ -1,0 +1,81 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_decimal.test
+# description: Equality deletes remain valid when their target column evolves from DECIMAL(9,4) to DECIMAL(13,4)
+# group: [equality_deletes]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require-env EQUALITY_DELETE_WRITES_ENABLED 1
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+use my_datalake.default;
+
+statement ok
+set unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes=true;
+
+statement ok
+drop table if exists my_datalake.default.equality_delete_evolve_decimal;
+
+statement ok
+create table my_datalake.default.equality_delete_evolve_decimal (
+	id integer,
+	target decimal(9, 4),
+	marker varchar
+);
+
+statement ok
+insert into my_datalake.default.equality_delete_evolve_decimal values
+	(1, 1.1111::decimal(9, 4), 'delete-before-evolution'),
+	(2, 2.2222::decimal(9, 4), 'delete-after-evolution-old-file'),
+	(3, 3.3333::decimal(9, 4), 'keep-old');
+
+# This delete file stores the target field using its original DECIMAL(9,4) type.
+statement ok
+delete from my_datalake.default.equality_delete_evolve_decimal where target = 1.1111::decimal(9, 4);
+
+statement ok
+alter table my_datalake.default.equality_delete_evolve_decimal alter column target set type decimal(13, 4);
+
+statement ok
+insert into my_datalake.default.equality_delete_evolve_decimal values
+	(4, 1.1111::decimal(13, 4), 'old-delete-does-not-apply-to-new-file'),
+	(5, 2.2222::decimal(13, 4), 'delete-after-evolution-new-file'),
+	(6, 123456789.1234::decimal(13, 4), 'delete-promoted-value'),
+	(7, 987654321.4321::decimal(13, 4), 'keep-new');
+
+# This promoted-type delete applies to matching rows in both the old DECIMAL(9,4) file and the new DECIMAL(13,4) file.
+statement ok
+delete from my_datalake.default.equality_delete_evolve_decimal where target = 2.2222::decimal(13, 4);
+
+statement ok
+delete from my_datalake.default.equality_delete_evolve_decimal where target = 123456789.1234::decimal(13, 4);
+
+query II
+select count(*), sum(record_count)
+from iceberg_metadata(my_datalake.default.equality_delete_evolve_decimal)
+where content = 'EQUALITY_DELETES' and status != 'DELETED';
+----
+3	3
+
+# Do not project the equality-delete target: it must be scanned privately with the promoted type.
+query II
+select id, marker
+from my_datalake.default.equality_delete_evolve_decimal
+order by id;
+----
+3	keep-old
+4	old-delete-does-not-apply-to-new-file
+7	keep-new
+
+statement ok
+drop table my_datalake.default.equality_delete_evolve_decimal;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_drop_columns.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_drop_columns.test
@@ -1,0 +1,127 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_drop_columns.test
+# description: Multi-column equality deletes remain valid after their target columns evolve and are dropped
+# group: [equality_deletes]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require-env EQUALITY_DELETE_WRITES_ENABLED 1
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+use my_datalake.default;
+
+statement ok
+set unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes=true;
+
+statement ok
+drop table if exists my_datalake.default.equality_delete_evolve_then_drop_columns;
+
+statement ok
+create table my_datalake.default.equality_delete_evolve_then_drop_columns (
+	id integer,
+	date_key date,
+	number_key integer,
+	marker varchar
+);
+
+statement ok
+insert into my_datalake.default.equality_delete_evolve_then_drop_columns values
+	(1, date '2000-01-01', 10, 'delete-before-evolution'),
+	(2, date '2000-01-01', 11, 'keep-same-date'),
+	(3, date '2000-01-02', 10, 'keep-same-number'),
+	(4, date '2000-01-02', 20, 'delete-after-evolution-old-file'),
+	(5, date '2000-01-03', 30, 'keep-old');
+
+# This delete file stores both equality fields using their original types.
+statement ok
+delete from my_datalake.default.equality_delete_evolve_then_drop_columns
+where date_key = date '2000-01-01' and number_key = 10;
+
+# Both fields are evolved before either equality-delete target is removed.
+statement ok
+alter table my_datalake.default.equality_delete_evolve_then_drop_columns alter column date_key set type timestamp;
+
+statement ok
+alter table my_datalake.default.equality_delete_evolve_then_drop_columns alter column number_key set type bigint;
+
+statement ok
+insert into my_datalake.default.equality_delete_evolve_then_drop_columns values
+	(6, timestamp '2000-01-01 00:00:00', 10, 'old-delete-does-not-apply-to-new-file'),
+	(7, timestamp '2000-01-02 00:00:00', 20, 'delete-after-evolution-new-file'),
+	(8, timestamp '2000-01-04 12:34:56.123456', 5000000000, 'delete-promoted-values'),
+	(9, timestamp '2000-01-05 01:02:03', 6000000000, 'keep-new');
+
+# This promoted-type delete applies to a matching tuple in both old and new data files.
+statement ok
+delete from my_datalake.default.equality_delete_evolve_then_drop_columns
+where date_key = timestamp '2000-01-02 00:00:00' and number_key = 20;
+
+statement ok
+delete from my_datalake.default.equality_delete_evolve_then_drop_columns
+where date_key = timestamp '2000-01-04 12:34:56.123456' and number_key = 5000000000;
+
+query II
+select count(*), sum(record_count)
+from iceberg_metadata(my_datalake.default.equality_delete_evolve_then_drop_columns)
+where content = 'EQUALITY_DELETES' and status != 'DELETED';
+----
+3	3
+
+# One equality field is now historical while the other remains in the current schema.
+statement ok
+alter table my_datalake.default.equality_delete_evolve_then_drop_columns drop column date_key;
+
+query III
+select id, number_key, marker
+from my_datalake.default.equality_delete_evolve_then_drop_columns
+order by id;
+----
+2	11	keep-same-date
+3	10	keep-same-number
+5	30	keep-old
+6	10	old-delete-does-not-apply-to-new-file
+9	6000000000	keep-new
+
+# Both equality fields are now historical and must be scanned privately by field id.
+statement ok
+alter table my_datalake.default.equality_delete_evolve_then_drop_columns drop column number_key;
+
+query II
+select *
+from my_datalake.default.equality_delete_evolve_then_drop_columns
+order by id;
+----
+2	keep-same-date
+3	keep-same-number
+5	keep-old
+6	old-delete-does-not-apply-to-new-file
+9	keep-new
+
+statement ok
+insert into my_datalake.default.equality_delete_evolve_then_drop_columns values
+	(10, 'keep-after-both-drops');
+
+query II
+select *
+from my_datalake.default.equality_delete_evolve_then_drop_columns
+order by id;
+----
+2	keep-same-date
+3	keep-same-number
+5	keep-old
+6	old-delete-does-not-apply-to-new-file
+9	keep-new
+10	keep-after-both-drops
+
+statement ok
+drop table my_datalake.default.equality_delete_evolve_then_drop_columns;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_float_to_double.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_float_to_double.test
@@ -1,0 +1,81 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_float_to_double.test
+# description: Equality deletes remain valid when their target column evolves from FLOAT to DOUBLE
+# group: [equality_deletes]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require-env EQUALITY_DELETE_WRITES_ENABLED 1
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+use my_datalake.default;
+
+statement ok
+set unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes=true;
+
+statement ok
+drop table if exists my_datalake.default.equality_delete_evolve_float_to_double;
+
+statement ok
+create table my_datalake.default.equality_delete_evolve_float_to_double (
+	id integer,
+	target float,
+	marker varchar
+);
+
+statement ok
+insert into my_datalake.default.equality_delete_evolve_float_to_double values
+	(1, 1.5::float, 'delete-before-evolution'),
+	(2, 2.5::float, 'delete-after-evolution-old-file'),
+	(3, 3.5::float, 'keep-old');
+
+# This delete file stores the target field using its original FLOAT type.
+statement ok
+delete from my_datalake.default.equality_delete_evolve_float_to_double where target = 1.5::float;
+
+statement ok
+alter table my_datalake.default.equality_delete_evolve_float_to_double alter column target set type double;
+
+statement ok
+insert into my_datalake.default.equality_delete_evolve_float_to_double values
+	(4, 1.5::double, 'old-delete-does-not-apply-to-new-file'),
+	(5, 2.5::double, 'delete-after-evolution-new-file'),
+	(6, 16777217.25::double, 'delete-promoted-value'),
+	(7, 16777219.25::double, 'keep-new');
+
+# This promoted-type delete applies to matching rows in both the old FLOAT file and the new DOUBLE file.
+statement ok
+delete from my_datalake.default.equality_delete_evolve_float_to_double where target = 2.5::double;
+
+statement ok
+delete from my_datalake.default.equality_delete_evolve_float_to_double where target = 16777217.25::double;
+
+query II
+select count(*), sum(record_count)
+from iceberg_metadata(my_datalake.default.equality_delete_evolve_float_to_double)
+where content = 'EQUALITY_DELETES' and status != 'DELETED';
+----
+3	3
+
+# Do not project the equality-delete target: it must be scanned privately with the promoted type.
+query II
+select id, marker
+from my_datalake.default.equality_delete_evolve_float_to_double
+order by id;
+----
+3	keep-old
+4	old-delete-does-not-apply-to-new-file
+7	keep-new
+
+statement ok
+drop table my_datalake.default.equality_delete_evolve_float_to_double;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_integer_to_bigint.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_integer_to_bigint.test
@@ -1,0 +1,81 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_equality_delete_schema_evolution_integer_to_bigint.test
+# description: Equality deletes remain valid when their target column evolves from INTEGER to BIGINT
+# group: [equality_deletes]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require-env EQUALITY_DELETE_WRITES_ENABLED 1
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+use my_datalake.default;
+
+statement ok
+set unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes=true;
+
+statement ok
+drop table if exists my_datalake.default.equality_delete_evolve_integer_to_bigint;
+
+statement ok
+create table my_datalake.default.equality_delete_evolve_integer_to_bigint (
+	id integer,
+	target integer,
+	marker varchar
+);
+
+statement ok
+insert into my_datalake.default.equality_delete_evolve_integer_to_bigint values
+	(1, 1, 'delete-before-evolution'),
+	(2, 2, 'delete-after-evolution-old-file'),
+	(3, 3, 'keep-old');
+
+# This delete file stores the target field using its original INTEGER type.
+statement ok
+delete from my_datalake.default.equality_delete_evolve_integer_to_bigint where target = 1;
+
+statement ok
+alter table my_datalake.default.equality_delete_evolve_integer_to_bigint alter column target set type bigint;
+
+statement ok
+insert into my_datalake.default.equality_delete_evolve_integer_to_bigint values
+	(4, 1, 'old-delete-does-not-apply-to-new-file'),
+	(5, 2, 'delete-after-evolution-new-file'),
+	(6, 5000000000, 'delete-promoted-value'),
+	(7, 6000000000, 'keep-new');
+
+# This promoted-type delete applies to matching rows in both the old INTEGER file and the new BIGINT file.
+statement ok
+delete from my_datalake.default.equality_delete_evolve_integer_to_bigint where target = 2;
+
+statement ok
+delete from my_datalake.default.equality_delete_evolve_integer_to_bigint where target = 5000000000;
+
+query II
+select count(*), sum(record_count)
+from iceberg_metadata(my_datalake.default.equality_delete_evolve_integer_to_bigint)
+where content = 'EQUALITY_DELETES' and status != 'DELETED';
+----
+3	3
+
+# Do not project the equality-delete target: it must be scanned privately with the promoted type.
+query II
+select id, marker
+from my_datalake.default.equality_delete_evolve_integer_to_bigint
+order by id;
+----
+3	keep-old
+4	old-delete-does-not-apply-to-new-file
+7	keep-new
+
+statement ok
+drop table my_datalake.default.equality_delete_evolve_integer_to_bigint;


### PR DESCRIPTION
This makes #1217 obsolete, because we define a global schema from only the referenced `equality_ids`

#### `IcebergEqualityDeleteFile`
We now create a single `IcebergEqualityDeleteFile` per equality delete file, instead of once per scanned chunk.
The struct is much leaner now, as we remove `unordered_map<int32_t, vector<Value>>` for a `DataChunk`.
Another benefit of this is that we directly size the `DataChunk` to the right size, based on the `data_file.record_count`

And we replace all the data copied from the `manifest_file`/`manifest_entry`/`data_file` with a `idx_t manifest_entry_index`, to look this information up later instead of copying it.

#### Misc

Group the positional delete files together to scan in a single MultiFileReader, and likewise group the equality delete files together.
