### PR TITLE
[Dev][Scan] Scan only selected delete manifest entries

### DIFF
--- a/src/include/core/deletes/iceberg_equality_delete.hpp
+++ b/src/include/core/deletes/iceberg_equality_delete.hpp
@@ -5,20 +5,16 @@
 
 namespace duckdb {
 
-using sequence_number_t = int64_t;
-
 struct IcebergEqualityDeleteFile {
 public:
-	explicit IcebergEqualityDeleteFile(idx_t manifest_entry_index_p) : manifest_entry_index(manifest_entry_index_p) {
+	explicit IcebergEqualityDeleteFile(vector<int32_t> equality_ids_p) : equality_ids(std::move(equality_ids_p)) {
 	}
 	IcebergEqualityDeleteFile(const IcebergEqualityDeleteFile &) = delete;
 	IcebergEqualityDeleteFile &operator=(const IcebergEqualityDeleteFile &) = delete;
 
 public:
-	//! Index in IcebergScanPlanProvider::DeleteManifestEntries(). Unlike a reference, this remains stable when lazy
-	//! manifest enumeration grows the provider's vector.
-	idx_t manifest_entry_index;
-	//! Columns follow the referenced manifest entry's data_file.equality_ids order.
+	//! Columns in equality_values follow this field-id order.
+	vector<int32_t> equality_ids;
 	DataChunk equality_values;
 };
 

--- a/src/include/planning/deletes/iceberg_delete_file_scanner.hpp
+++ b/src/include/planning/deletes/iceberg_delete_file_scanner.hpp
@@ -4,18 +4,31 @@
 
 namespace duckdb {
 
+struct IcebergDeleteFileLoadState;
+
 struct IcebergDeleteScanEntry {
-	IcebergDeleteScanEntry(idx_t manifest_entry_index_p, BoundIcebergManifestEntry entry_p)
-	    : manifest_entry_index(manifest_entry_index_p), entry(std::move(entry_p)) {
+	IcebergDeleteScanEntry(idx_t manifest_idx_p, idx_t entry_idx_p, const IcebergManifestListEntry &manifest_p,
+	                       shared_ptr<IcebergDeleteFileLoadState> load_p)
+	    : manifest_idx(manifest_idx_p), entry_idx(entry_idx_p), manifest(manifest_p), load(std::move(load_p)) {
 	}
 
-	idx_t manifest_entry_index;
-	BoundIcebergManifestEntry entry;
+	const IcebergManifestEntry &GetEntry() const;
+	BoundIcebergManifestEntry BindEntry() const;
+
+	idx_t manifest_idx;
+	idx_t entry_idx;
+	const IcebergManifestListEntry &manifest;
+	shared_ptr<IcebergDeleteFileLoadState> load;
+};
+
+struct IcebergEqualityDeleteScanResult {
+	shared_ptr<IcebergDeleteFileLoadState> load;
+	shared_ptr<IcebergEqualityDeleteFile> delete_file;
 };
 
 struct IcebergDeleteScanResult {
 	position_delete_map_t positional_delete_data;
-	equality_delete_map_t equality_delete_data;
+	vector<IcebergEqualityDeleteScanResult> equality_delete_data;
 };
 
 struct IcebergDeleteFileScanner {

--- a/src/include/planning/deletes/iceberg_delete_file_scanner.hpp
+++ b/src/include/planning/deletes/iceberg_delete_file_scanner.hpp
@@ -4,8 +4,23 @@
 
 namespace duckdb {
 
+struct IcebergDeleteScanEntry {
+	IcebergDeleteScanEntry(idx_t manifest_entry_index_p, BoundIcebergManifestEntry entry_p)
+	    : manifest_entry_index(manifest_entry_index_p), entry(std::move(entry_p)) {
+	}
+
+	idx_t manifest_entry_index;
+	BoundIcebergManifestEntry entry;
+};
+
+struct IcebergDeleteScanResult {
+	position_delete_map_t positional_delete_data;
+	equality_delete_map_t equality_delete_data;
+};
+
 struct IcebergDeleteFileScanner {
-	static void ScanFiles(const IcebergDeletePlanningContext &context);
+	static IcebergDeleteScanResult ScanFiles(const IcebergDeletePlanningContext &context,
+	                                         const vector<IcebergDeleteScanEntry> &entries);
 };
 
 } // namespace duckdb

--- a/src/include/planning/deletes/iceberg_delete_file_scanner.hpp
+++ b/src/include/planning/deletes/iceberg_delete_file_scanner.hpp
@@ -6,6 +6,7 @@ namespace duckdb {
 
 struct IcebergDeleteFileLoadState;
 
+//! Input to ScanFiles, so it can run without holding the (delete_)lock
 struct IcebergDeleteScanEntry {
 	IcebergDeleteScanEntry(idx_t manifest_idx_p, idx_t entry_idx_p, const IcebergManifestListEntry &manifest_p,
 	                       shared_ptr<IcebergDeleteFileLoadState> load_p)
@@ -18,14 +19,19 @@ struct IcebergDeleteScanEntry {
 	idx_t manifest_idx;
 	idx_t entry_idx;
 	const IcebergManifestListEntry &manifest;
+	//! The shared LoadState of the delete file to populate
 	shared_ptr<IcebergDeleteFileLoadState> load;
 };
 
+//! Intermediate to store the created delete file before adding it to the LoadState
 struct IcebergEqualityDeleteScanResult {
+	//! The LoadState to store the result into, after grabbing the lock
 	shared_ptr<IcebergDeleteFileLoadState> load;
+	//! The resulting equality delete data
 	shared_ptr<IcebergEqualityDeleteFile> delete_file;
 };
 
+//! Grouped result of all delete files scanned for a data file
 struct IcebergDeleteScanResult {
 	position_delete_map_t positional_delete_data;
 	vector<IcebergEqualityDeleteScanResult> equality_delete_data;

--- a/src/include/planning/deletes/iceberg_delete_planner.hpp
+++ b/src/include/planning/deletes/iceberg_delete_planner.hpp
@@ -14,8 +14,12 @@ class IcebergTableSchema;
 struct IcebergFilePruner;
 struct IcebergOptions;
 
-using equality_delete_map_t = map<sequence_number_t, vector<unique_ptr<IcebergEqualityDeleteFile>>>;
 using position_delete_map_t = unordered_map<string, shared_ptr<IcebergDeleteData>>;
+
+struct IcebergDeletePlan {
+	vector<reference<const IcebergEqualityDeleteFile>> equality_deletes;
+	unique_ptr<DeleteFilter> positional_deletes;
+};
 
 struct IcebergDeletePlanningContext {
 	ClientContext &context;
@@ -34,16 +38,11 @@ struct IcebergDeletePlanningContext {
 struct IcebergDeletePlanner {
 	static vector<idx_t> GetDeleteManifestsForDataFile(const IcebergDeletePlanningContext &context,
 	                                                   const BoundIcebergManifestEntry &data_manifest_entry);
-	static vector<reference<const IcebergEqualityDeleteFile>>
-	GetEqualityDeletesForFile(const IcebergDeletePlanningContext &context,
-	                          const BoundIcebergManifestEntry &data_manifest_entry);
-	static bool DeleteEntryMatchesFilters(const IcebergDeletePlanningContext &context,
-	                                      const BoundIcebergManifestEntry &delete_manifest_entry);
-	static bool DeleteEntryAppliesToDataFile(const IcebergDeletePlanningContext &context,
-	                                         const BoundIcebergManifestEntry &delete_manifest_entry,
+	static bool DeleteEntryMatchesFilters(const IcebergDeletePlanningContext &context, idx_t delete_manifest_idx,
+	                                      const IcebergManifestEntry &delete_manifest_entry);
+	static bool DeleteEntryAppliesToDataFile(const IcebergDeletePlanningContext &context, idx_t delete_manifest_idx,
+	                                         const IcebergManifestEntry &delete_manifest_entry,
 	                                         const BoundIcebergManifestEntry &data_manifest_entry);
-	static unique_ptr<DeleteFilter> GetPositionalDeletesForFile(const IcebergDeletePlanningContext &context,
-	                                                            const string &file_path);
 	static shared_ptr<IcebergDeleteData> GetExistingPositionalDeleteData(const IcebergDeletePlanningContext &context,
 	                                                                     const string &file_path);
 };

--- a/src/include/planning/deletes/iceberg_delete_planner.hpp
+++ b/src/include/planning/deletes/iceberg_delete_planner.hpp
@@ -39,6 +39,9 @@ struct IcebergDeletePlanner {
 	                          const BoundIcebergManifestEntry &data_manifest_entry);
 	static bool DeleteEntryMatchesFilters(const IcebergDeletePlanningContext &context,
 	                                      const BoundIcebergManifestEntry &delete_manifest_entry);
+	static bool DeleteEntryAppliesToDataFile(const IcebergDeletePlanningContext &context,
+	                                         const BoundIcebergManifestEntry &delete_manifest_entry,
+	                                         const BoundIcebergManifestEntry &data_manifest_entry);
 	static unique_ptr<DeleteFilter> GetPositionalDeletesForFile(const IcebergDeletePlanningContext &context,
 	                                                            const string &file_path);
 	static shared_ptr<IcebergDeleteData> GetExistingPositionalDeleteData(const IcebergDeletePlanningContext &context,

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -109,7 +109,7 @@ private:
 	void LoadManifestList(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
 	void InitializeScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);
 	void StartDataManifestScan(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
-	void EnumerateDeleteManifestEntriesInternal(const vector<idx_t> &manifest_indexes) const
+	vector<idx_t> EnumerateDeleteManifestEntriesInternal(const vector<idx_t> &manifest_indexes) const
 	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
 	IcebergScanPlanProvider &GetScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);
 	IcebergScanPlanContext GetScanPlanContext() const DUCKDB_REQUIRES(shared_state->lock);

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -68,12 +68,8 @@ public:
 	const IcebergTableMetadata &GetMetadata() const;
 	const IcebergTableSchema &GetSchema() const;
 	BoundIcebergManifestEntry GetManifestEntry(idx_t file_id) const;
-	BoundIcebergManifestEntry GetDeleteManifestEntry(idx_t manifest_entry_index) const;
 	IcebergManifestFile GetManifestFileForDataFile(idx_t file_id) const;
-	void ProcessDeletes(const BoundIcebergManifestEntry &data_manifest_entry) const;
-	unique_ptr<DeleteFilter> GetPositionalDeletesForFile(const string &file_path) const;
-	vector<reference<const IcebergEqualityDeleteFile>>
-	GetEqualityDeletesForFile(const BoundIcebergManifestEntry &manifest_entry) const;
+	IcebergDeletePlan ProcessDeletes(const BoundIcebergManifestEntry &data_manifest_entry) const;
 
 private:
 	const string &GetPath() const;
@@ -109,8 +105,6 @@ private:
 	void LoadManifestList(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
 	void InitializeScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);
 	void StartDataManifestScan(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
-	vector<idx_t> EnumerateDeleteManifestEntriesInternal(const vector<idx_t> &manifest_indexes) const
-	    DUCKDB_REQUIRES(shared_state->lock, shared_state->delete_lock);
 	IcebergScanPlanProvider &GetScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);
 	IcebergScanPlanContext GetScanPlanContext() const DUCKDB_REQUIRES(shared_state->lock);
 	IcebergDeletePlanningContext GetDeletePlanningContext() const DUCKDB_REQUIRES(shared_state->lock);

--- a/src/include/planning/iceberg_multi_file_reader.hpp
+++ b/src/include/planning/iceberg_multi_file_reader.hpp
@@ -120,20 +120,22 @@ public:
 	                           const LogicalType &type, MultiFileLocalIndex local_idx) override;
 
 private:
-	static unique_ptr<Expression> CreateEqualityDeleteExpression(const IcebergMultiFileList &multi_file_list,
-	                                                             const BoundIcebergManifestEntry &bound_manifest_entry,
-	                                                             const vector<MultiFileColumnDefinition> &local_columns,
-	                                                             const IcebergEqualityDeleteReadState &read_state);
+	static unique_ptr<Expression>
+	CreateEqualityDeleteExpression(const vector<reference<const IcebergEqualityDeleteFile>> &delete_files,
+	                               const vector<MultiFileColumnDefinition> &local_columns,
+	                               const IcebergEqualityDeleteReadState &read_state);
 	static vector<IcebergEqualityDeleteReadColumn>
-	AddEqualityDeleteColumns(const IcebergMultiFileList &multi_file_list,
-	                         const BoundIcebergManifestEntry &bound_manifest_entry,
+	AddEqualityDeleteColumns(const IcebergTableMetadata &metadata,
+	                         const vector<reference<const IcebergEqualityDeleteFile>> &delete_files,
 	                         vector<MultiFileColumnDefinition> &scan_columns, vector<ColumnIndex> &scan_column_ids,
 	                         MultiFileReaderData &reader_data, ClientContext &context);
 	static IcebergEqualityDeleteReadColumn
-	AddEqualityDeleteColumn(const IcebergMultiFileList &multi_file_list, int32_t field_id,
+	AddEqualityDeleteColumn(const IcebergTableMetadata &metadata, int32_t field_id,
 	                        vector<MultiFileColumnDefinition> &scan_columns, vector<ColumnIndex> &scan_column_ids,
 	                        MultiFileReaderData &reader_data, ClientContext &context);
-	static void ApplyPartitionConstants(const IcebergMultiFileList &multi_file_list, MultiFileReaderData &reader_data,
+	static void ApplyPartitionConstants(const IcebergManifestFile &manifest_file,
+	                                    const BoundIcebergManifestEntry &bound_manifest_entry,
+	                                    const IcebergTableMetadata &metadata, MultiFileReaderData &reader_data,
 	                                    const vector<MultiFileColumnDefinition> &global_columns,
 	                                    const vector<ColumnIndex> &global_column_ids, ClientContext &context);
 

--- a/src/include/planning/pruning/iceberg_file_pruner.hpp
+++ b/src/include/planning/pruning/iceberg_file_pruner.hpp
@@ -16,6 +16,13 @@ public:
 
 	bool ManifestMatchesFilter(const IcebergManifestFile &manifest) const;
 	bool FileMatchesFilter(const IcebergManifestFile &manifest_file, const IcebergManifestEntry &manifest_entry) const;
+	bool DeleteManifestMatchesDataFile(const IcebergManifestFile &delete_manifest,
+	                                   const IcebergManifestFile &data_manifest,
+	                                   const IcebergManifestEntry &data_manifest_entry) const;
+	bool DeleteFileMatchesDataFile(const IcebergManifestFile &delete_manifest,
+	                               const IcebergManifestEntry &delete_manifest_entry,
+	                               const IcebergManifestFile &data_manifest,
+	                               const IcebergManifestEntry &data_manifest_entry) const;
 
 private:
 	bool FilePartitionMatchesFilter(const IcebergDataFile &data_file, const IcebergManifestFile &manifest_file) const;

--- a/src/include/planning/scan_plan/iceberg_scan_plan_provider.hpp
+++ b/src/include/planning/scan_plan/iceberg_scan_plan_provider.hpp
@@ -38,14 +38,14 @@ public:
 	virtual void LoadManifestList() = 0;
 	virtual void StartDataManifestScan(const vector<bool> &matching_manifests, idx_t filter_count) = 0;
 	virtual void ReadDeleteManifests(const vector<idx_t> &manifest_indexes, idx_t filter_count) = 0;
-	virtual void EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) = 0;
+	virtual vector<idx_t> EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) = 0;
 	virtual bool TryGetNextBatch(IcebergDataViewCursor &cursor) = 0;
 	virtual void FinishScanTasks() = 0;
 	virtual bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const = 0;
 	virtual vector<IcebergManifestListEntry> &DataManifests() = 0;
 	virtual vector<IcebergManifestListEntry> &DeleteManifests() = 0;
-	virtual idx_t &NextDeleteEntryToProcess() = 0;
 	virtual vector<BoundIcebergManifestEntry> &DeleteManifestEntries() = 0;
+	virtual vector<shared_ptr<IcebergDeleteFileLoadState>> &DeleteFileLoads() = 0;
 	virtual position_delete_map_t &PositionalDeleteData() = 0;
 	virtual equality_delete_map_t &EqualityDeleteData() = 0;
 };
@@ -58,15 +58,16 @@ public:
 	void StartDataManifestScan(const vector<bool> &matching_manifests, idx_t filter_count) override
 	    DUCKDB_REQUIRES(shared_state.lock);
 	void ReadDeleteManifests(const vector<idx_t> &manifest_indexes, idx_t filter_count) override;
-	void EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) override
+	vector<idx_t> EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) override
 	    DUCKDB_REQUIRES(shared_state.lock, shared_state.delete_lock);
 	bool TryGetNextBatch(IcebergDataViewCursor &cursor) override DUCKDB_REQUIRES(shared_state.lock);
 	void FinishScanTasks() override DUCKDB_REQUIRES(shared_state.lock);
 	bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const override;
 	vector<IcebergManifestListEntry> &DataManifests() override DUCKDB_REQUIRES(shared_state.lock);
 	vector<IcebergManifestListEntry> &DeleteManifests() override DUCKDB_REQUIRES(shared_state.lock);
-	idx_t &NextDeleteEntryToProcess() override DUCKDB_REQUIRES(shared_state.delete_lock);
 	vector<BoundIcebergManifestEntry> &DeleteManifestEntries() override DUCKDB_REQUIRES(shared_state.delete_lock);
+	vector<shared_ptr<IcebergDeleteFileLoadState>> &DeleteFileLoads() override
+	    DUCKDB_REQUIRES(shared_state.delete_lock);
 	position_delete_map_t &PositionalDeleteData() override DUCKDB_REQUIRES(shared_state.delete_lock);
 	equality_delete_map_t &EqualityDeleteData() override DUCKDB_REQUIRES(shared_state.delete_lock);
 
@@ -82,14 +83,14 @@ public:
 	void LoadManifestList() override;
 	void StartDataManifestScan(const vector<bool> &matching_manifests, idx_t filter_count) override;
 	void ReadDeleteManifests(const vector<idx_t> &manifest_indexes, idx_t filter_count) override;
-	void EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) override;
+	vector<idx_t> EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) override;
 	bool TryGetNextBatch(IcebergDataViewCursor &cursor) override;
 	void FinishScanTasks() override;
 	bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const override;
 	vector<IcebergManifestListEntry> &DataManifests() override;
 	vector<IcebergManifestListEntry> &DeleteManifests() override;
-	idx_t &NextDeleteEntryToProcess() override;
 	vector<BoundIcebergManifestEntry> &DeleteManifestEntries() override;
+	vector<shared_ptr<IcebergDeleteFileLoadState>> &DeleteFileLoads() override;
 	position_delete_map_t &PositionalDeleteData() override;
 	equality_delete_map_t &EqualityDeleteData() override;
 
@@ -99,8 +100,9 @@ private:
 	ManifestEntryReadState read_state;
 	bool data_manifest_scan_started = false;
 	vector<bool> delete_manifest_entries_enumerated;
-	idx_t next_delete_entry_to_process = 0;
+	vector<vector<idx_t>> delete_manifest_entry_indexes;
 	vector<BoundIcebergManifestEntry> delete_manifest_entries;
+	vector<shared_ptr<IcebergDeleteFileLoadState>> delete_file_loads;
 	position_delete_map_t positional_delete_data;
 	equality_delete_map_t equality_delete_data;
 };

--- a/src/include/planning/scan_plan/iceberg_scan_plan_provider.hpp
+++ b/src/include/planning/scan_plan/iceberg_scan_plan_provider.hpp
@@ -15,6 +15,11 @@ class IcebergScanOrder;
 struct IcebergTableFilters;
 struct IcebergTransactionData;
 
+struct IcebergDeleteFileReference {
+	idx_t manifest_idx;
+	idx_t entry_idx;
+};
+
 struct IcebergScanPlanContext {
 	ClientContext &context;
 	FileSystem &fs;
@@ -38,16 +43,14 @@ public:
 	virtual void LoadManifestList() = 0;
 	virtual void StartDataManifestScan(const vector<bool> &matching_manifests, idx_t filter_count) = 0;
 	virtual void ReadDeleteManifests(const vector<idx_t> &manifest_indexes, idx_t filter_count) = 0;
-	virtual vector<idx_t> EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) = 0;
+	virtual vector<IcebergDeleteFileReference> GetDeleteFiles(const vector<idx_t> &manifest_indexes) = 0;
 	virtual bool TryGetNextBatch(IcebergDataViewCursor &cursor) = 0;
 	virtual void FinishScanTasks() = 0;
 	virtual bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const = 0;
 	virtual vector<IcebergManifestListEntry> &DataManifests() = 0;
 	virtual vector<IcebergManifestListEntry> &DeleteManifests() = 0;
-	virtual vector<BoundIcebergManifestEntry> &DeleteManifestEntries() = 0;
-	virtual vector<shared_ptr<IcebergDeleteFileLoadState>> &DeleteFileLoads() = 0;
+	virtual shared_ptr<IcebergDeleteFileLoadState> &GetDeleteFileLoad(IcebergDeleteFileReference delete_file) = 0;
 	virtual position_delete_map_t &PositionalDeleteData() = 0;
-	virtual equality_delete_map_t &EqualityDeleteData() = 0;
 };
 
 class ClientSideScanPlanProvider final : public IcebergScanPlanProvider {
@@ -58,18 +61,16 @@ public:
 	void StartDataManifestScan(const vector<bool> &matching_manifests, idx_t filter_count) override
 	    DUCKDB_REQUIRES(shared_state.lock);
 	void ReadDeleteManifests(const vector<idx_t> &manifest_indexes, idx_t filter_count) override;
-	vector<idx_t> EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) override
+	vector<IcebergDeleteFileReference> GetDeleteFiles(const vector<idx_t> &manifest_indexes) override
 	    DUCKDB_REQUIRES(shared_state.lock, shared_state.delete_lock);
 	bool TryGetNextBatch(IcebergDataViewCursor &cursor) override DUCKDB_REQUIRES(shared_state.lock);
 	void FinishScanTasks() override DUCKDB_REQUIRES(shared_state.lock);
 	bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const override;
 	vector<IcebergManifestListEntry> &DataManifests() override DUCKDB_REQUIRES(shared_state.lock);
 	vector<IcebergManifestListEntry> &DeleteManifests() override DUCKDB_REQUIRES(shared_state.lock);
-	vector<BoundIcebergManifestEntry> &DeleteManifestEntries() override DUCKDB_REQUIRES(shared_state.delete_lock);
-	vector<shared_ptr<IcebergDeleteFileLoadState>> &DeleteFileLoads() override
-	    DUCKDB_REQUIRES(shared_state.delete_lock);
+	shared_ptr<IcebergDeleteFileLoadState> &GetDeleteFileLoad(IcebergDeleteFileReference delete_file) override
+	    DUCKDB_REQUIRES(shared_state.lock, shared_state.delete_lock);
 	position_delete_map_t &PositionalDeleteData() override DUCKDB_REQUIRES(shared_state.delete_lock);
-	equality_delete_map_t &EqualityDeleteData() override DUCKDB_REQUIRES(shared_state.delete_lock);
 
 private:
 	IcebergScanPlanState &shared_state;
@@ -83,28 +84,22 @@ public:
 	void LoadManifestList() override;
 	void StartDataManifestScan(const vector<bool> &matching_manifests, idx_t filter_count) override;
 	void ReadDeleteManifests(const vector<idx_t> &manifest_indexes, idx_t filter_count) override;
-	vector<idx_t> EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) override;
+	vector<IcebergDeleteFileReference> GetDeleteFiles(const vector<idx_t> &manifest_indexes) override;
 	bool TryGetNextBatch(IcebergDataViewCursor &cursor) override;
 	void FinishScanTasks() override;
 	bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const override;
 	vector<IcebergManifestListEntry> &DataManifests() override;
 	vector<IcebergManifestListEntry> &DeleteManifests() override;
-	vector<BoundIcebergManifestEntry> &DeleteManifestEntries() override;
-	vector<shared_ptr<IcebergDeleteFileLoadState>> &DeleteFileLoads() override;
+	shared_ptr<IcebergDeleteFileLoadState> &GetDeleteFileLoad(IcebergDeleteFileReference delete_file) override;
 	position_delete_map_t &PositionalDeleteData() override;
-	equality_delete_map_t &EqualityDeleteData() override;
 
 private:
-	//! Declared before bound entries and parsed delete data so their references are destroyed first.
+	//! Declared before parsed delete data so its manifest-entry references are destroyed first.
 	IcebergServerSideScanPlan plan;
 	ManifestEntryReadState read_state;
 	bool data_manifest_scan_started = false;
-	vector<bool> delete_manifest_entries_enumerated;
-	vector<vector<idx_t>> delete_manifest_entry_indexes;
-	vector<BoundIcebergManifestEntry> delete_manifest_entries;
-	vector<shared_ptr<IcebergDeleteFileLoadState>> delete_file_loads;
+	vector<unordered_map<idx_t, shared_ptr<IcebergDeleteFileLoadState>>> delete_file_loads;
 	position_delete_map_t positional_delete_data;
-	equality_delete_map_t equality_delete_data;
 };
 
 } // namespace duckdb

--- a/src/include/planning/scan_plan/iceberg_scan_plan_state.hpp
+++ b/src/include/planning/scan_plan/iceberg_scan_plan_state.hpp
@@ -10,10 +10,19 @@
 #include "planning/metadata_io/manifest/bound_iceberg_manifest_entry.hpp"
 #include "planning/snapshot/iceberg_scan_info.hpp"
 
+#include <condition_variable>
+
 namespace duckdb {
 
 class IcebergTableEntry;
 struct IcebergDeleteManifestLoadState;
+
+struct IcebergDeleteFileLoadState {
+	mutex lock;
+	std::condition_variable cv;
+	bool complete = false;
+	ErrorData error;
+};
 
 struct IcebergManifestScanningState {
 	IcebergManifestScanningState(ClientContext &context, unique_ptr<AvroScan> scan,
@@ -61,8 +70,9 @@ struct IcebergScanPlanState {
 	mutable vector<reference<const IcebergManifestListEntry>> transaction_delete_manifests DUCKDB_GUARDED_BY(lock);
 	mutable vector<shared_ptr<IcebergDeleteManifestLoadState>> delete_manifest_loads DUCKDB_GUARDED_BY(delete_lock);
 	mutable vector<bool> delete_manifest_entries_enumerated DUCKDB_GUARDED_BY(delete_lock);
-	mutable idx_t next_delete_entry_to_process DUCKDB_GUARDED_BY(delete_lock) = 0;
+	mutable vector<vector<idx_t>> delete_manifest_entry_indexes DUCKDB_GUARDED_BY(delete_lock);
 	mutable vector<BoundIcebergManifestEntry> delete_manifest_entries DUCKDB_GUARDED_BY(delete_lock);
+	mutable vector<shared_ptr<IcebergDeleteFileLoadState>> delete_file_loads DUCKDB_GUARDED_BY(delete_lock);
 
 	mutable vector<IcebergManifestListEntry> committed_data_manifests DUCKDB_GUARDED_BY(lock);
 	mutable vector<reference<const IcebergManifestListEntry>> transaction_data_manifests DUCKDB_GUARDED_BY(lock);

--- a/src/include/planning/scan_plan/iceberg_scan_plan_state.hpp
+++ b/src/include/planning/scan_plan/iceberg_scan_plan_state.hpp
@@ -22,6 +22,7 @@ struct IcebergDeleteFileLoadState {
 	std::condition_variable cv;
 	bool complete = false;
 	ErrorData error;
+	shared_ptr<IcebergEqualityDeleteFile> equality_delete;
 };
 
 struct IcebergManifestScanningState {
@@ -69,19 +70,15 @@ struct IcebergScanPlanState {
 	mutable vector<IcebergManifestListEntry> committed_delete_manifests DUCKDB_GUARDED_BY(lock);
 	mutable vector<reference<const IcebergManifestListEntry>> transaction_delete_manifests DUCKDB_GUARDED_BY(lock);
 	mutable vector<shared_ptr<IcebergDeleteManifestLoadState>> delete_manifest_loads DUCKDB_GUARDED_BY(delete_lock);
-	mutable vector<bool> delete_manifest_entries_enumerated DUCKDB_GUARDED_BY(delete_lock);
-	mutable vector<vector<idx_t>> delete_manifest_entry_indexes DUCKDB_GUARDED_BY(delete_lock);
-	mutable vector<BoundIcebergManifestEntry> delete_manifest_entries DUCKDB_GUARDED_BY(delete_lock);
-	mutable vector<shared_ptr<IcebergDeleteFileLoadState>> delete_file_loads DUCKDB_GUARDED_BY(delete_lock);
+	mutable vector<unordered_map<idx_t, shared_ptr<IcebergDeleteFileLoadState>>>
+	    delete_file_loads DUCKDB_GUARDED_BY(delete_lock);
 
 	mutable vector<IcebergManifestListEntry> committed_data_manifests DUCKDB_GUARDED_BY(lock);
 	mutable vector<reference<const IcebergManifestListEntry>> transaction_data_manifests DUCKDB_GUARDED_BY(lock);
 	mutable unique_ptr<IcebergManifestScanningState> data_manifest_read_state DUCKDB_GUARDED_BY(lock);
 
-	//! Declared after manifest owners so references in parsed delete data are destroyed first.
+	//! Declared after manifest owners so references in parsed positional-delete data are destroyed first.
 	mutable unordered_map<string, shared_ptr<IcebergDeleteData>> positional_delete_data DUCKDB_GUARDED_BY(delete_lock);
-	mutable map<sequence_number_t, vector<unique_ptr<IcebergEqualityDeleteFile>>>
-	    equality_delete_data DUCKDB_GUARDED_BY(delete_lock);
 
 	mutable unordered_map<string, vector<IcebergPartitionInfo>> data_file_partition_info DUCKDB_GUARDED_BY(lock);
 };

--- a/src/planning/deletes/iceberg_delete_file_scanner.cpp
+++ b/src/planning/deletes/iceberg_delete_file_scanner.cpp
@@ -52,7 +52,8 @@ static PuffinDeletionVectorVerificationResult VerifyPuffinDeletionVector(FileSys
 	return std::monostate {};
 }
 
-static void ScanPuffinFile(const IcebergDeletePlanningContext &context, const BoundIcebergManifestEntry &bound_entry) {
+static void ScanPuffinFile(const IcebergDeletePlanningContext &context, const BoundIcebergManifestEntry &bound_entry,
+                           IcebergDeleteScanResult &scan_result) {
 	auto &data_file = bound_entry.entry.data_file;
 	if (context.metadata.iceberg_version < 3) {
 		throw InvalidConfigurationException("DeletionVector not supported in Iceberg V%d",
@@ -89,7 +90,7 @@ static void ScanPuffinFile(const IcebergDeletePlanningContext &context, const Bo
 		}
 	}
 
-	auto &positional_delete_data = context.provider.PositionalDeleteData();
+	auto &positional_delete_data = scan_result.positional_delete_data;
 	auto it = positional_delete_data.find(*data_file.referenced_data_file);
 	if (it != positional_delete_data.end() && it->second->type == IcebergDeleteType::DELETION_VECTOR) {
 		throw InvalidConfigurationException(
@@ -115,7 +116,8 @@ static optional_ptr<IcebergPositionalDeleteData> TryGetOrCreatePositionDeletes(p
 }
 
 static void ScanPositionalDeleteFile(const IcebergDeletePlanningContext &context,
-                                     const BoundIcebergManifestEntry &bound_entry, DataChunk &result) {
+                                     const BoundIcebergManifestEntry &bound_entry, DataChunk &result,
+                                     IcebergDeleteScanResult &scan_result) {
 	auto names = FlatVector::GetData<string_t>(result.data[0]);
 	auto row_ids = FlatVector::GetData<int64_t>(result.data[1]);
 	if (result.size() == 0) {
@@ -124,7 +126,7 @@ static void ScanPositionalDeleteFile(const IcebergDeletePlanningContext &context
 
 	reference<const string_t> current_file_path = names[0];
 	auto initial_key = current_file_path.get().GetString();
-	auto &positional_delete_data = context.provider.PositionalDeleteData();
+	auto &positional_delete_data = scan_result.positional_delete_data;
 	auto deletes = TryGetOrCreatePositionDeletes(positional_delete_data, bound_entry, initial_key);
 	DUCKDB_LOG(context.context, IcebergLogType,
 	           "Iceberg Delete Scan, read 'positional_delete_file': '%s', referencing 'data_file': '%s'",
@@ -202,7 +204,8 @@ static IcebergEqualityDeleteFile &GetOrCreateEqualityDeleteFile(vector<unique_pt
 static void ScanEqualityDeleteFile(const IcebergDeletePlanningContext &context, idx_t manifest_entry_index,
                                    const BoundIcebergManifestEntry &bound_manifest_entry, DataChunk &source,
                                    const vector<MultiFileColumnDefinition> &global_columns,
-                                   equality_delete_file_index_map_t &file_indexes) {
+                                   equality_delete_file_index_map_t &file_indexes,
+                                   IcebergDeleteScanResult &scan_result) {
 	auto &manifest_entry = bound_manifest_entry.entry;
 	auto &data_file = manifest_entry.data_file;
 	auto &manifest_file = context.delete_manifests[bound_manifest_entry.manifest_file_idx].entry.file;
@@ -215,7 +218,7 @@ static void ScanEqualityDeleteFile(const IcebergDeletePlanningContext &context, 
 	DataChunk result;
 	ColumnsReferencedByEqualityIds(source, result, global_columns, data_file.equality_ids);
 	const auto sequence_number = manifest_entry.GetSequenceNumber(manifest_file);
-	auto &deletes = context.provider.EqualityDeleteData()[sequence_number];
+	auto &deletes = scan_result.equality_delete_data[sequence_number];
 	auto &delete_file = GetOrCreateEqualityDeleteFile(deletes, manifest_entry_index, bound_manifest_entry,
 	                                                  sequence_number, file_indexes);
 	auto &equality_values = delete_file.equality_values;
@@ -246,17 +249,13 @@ static void ScanEqualityDeleteFile(const IcebergDeletePlanningContext &context, 
 	equality_values.Append(result, VectorAppendMode::ERROR_ON_NO_SPACE);
 }
 
-static vector<MultiFileColumnDefinition> BuildEqualityDeleteSchema(const IcebergTableMetadata &metadata,
-                                                                   const vector<BoundIcebergManifestEntry> &entries,
-                                                                   const vector<idx_t> &manifest_entry_indexes) {
+static vector<MultiFileColumnDefinition>
+BuildEqualityDeleteSchema(const IcebergTableMetadata &metadata,
+                          const vector<reference<const IcebergDeleteScanEntry>> &scan_entries) {
 	vector<MultiFileColumnDefinition> schema;
 	unordered_set<int32_t> field_ids;
-	for (auto manifest_entry_index : manifest_entry_indexes) {
-		if (manifest_entry_index >= entries.size()) {
-			throw InternalException("Delete manifest entry index %llu is out of bounds for %llu entries",
-			                        manifest_entry_index, entries.size());
-		}
-		auto &data_file = entries[manifest_entry_index].entry.data_file;
+	for (auto &scan_entry_ref : scan_entries) {
+		auto &data_file = scan_entry_ref.get().entry.entry.data_file;
 		for (auto field_id : data_file.equality_ids) {
 			if (!field_ids.insert(field_id).second) {
 				continue;
@@ -288,22 +287,17 @@ static vector<MultiFileColumnDefinition> BuildPositionalDeleteSchema() {
 }
 
 static void ScanParquetDeleteFiles(const IcebergDeletePlanningContext &context,
-                                   const vector<idx_t> &manifest_entry_indexes,
-                                   IcebergManifestEntryContentType content) {
-	if (manifest_entry_indexes.empty()) {
+                                   const vector<reference<const IcebergDeleteScanEntry>> &scan_entries,
+                                   IcebergManifestEntryContentType content, IcebergDeleteScanResult &scan_result) {
+	if (scan_entries.empty()) {
 		return;
 	}
-	auto &entries = context.provider.DeleteManifestEntries();
 	vector<Value> delete_file_paths;
 	vector<OpenFileInfo> delete_file_infos;
-	delete_file_paths.reserve(manifest_entry_indexes.size());
-	delete_file_infos.reserve(manifest_entry_indexes.size());
-	for (auto manifest_entry_index : manifest_entry_indexes) {
-		if (manifest_entry_index >= entries.size()) {
-			throw InternalException("Delete manifest entry index %llu is out of bounds for %llu entries",
-			                        manifest_entry_index, entries.size());
-		}
-		auto &data_file = entries[manifest_entry_index].entry.data_file;
+	delete_file_paths.reserve(scan_entries.size());
+	delete_file_infos.reserve(scan_entries.size());
+	for (auto &scan_entry_ref : scan_entries) {
+		auto &data_file = scan_entry_ref.get().entry.entry.data_file;
 		D_ASSERT(data_file.content == content);
 		auto delete_file_path = data_file.file_path;
 		if (context.options.allow_moved_paths) {
@@ -322,10 +316,9 @@ static void ScanParquetDeleteFiles(const IcebergDeletePlanningContext &context,
 	auto iceberg_deletes_scan = IcebergFunctions::GetIcebergDeletesScanFunction(context.context);
 	auto delete_scan_function =
 	    iceberg_deletes_scan.GetFunctionByArguments(context.context, {LogicalType::LIST(LogicalType::VARCHAR)});
-	vector<MultiFileColumnDefinition> delete_schema =
-	    content == IcebergManifestEntryContentType::POSITION_DELETES
-	        ? BuildPositionalDeleteSchema()
-	        : BuildEqualityDeleteSchema(context.metadata, entries, manifest_entry_indexes);
+	vector<MultiFileColumnDefinition> delete_schema = content == IcebergManifestEntryContentType::POSITION_DELETES
+	                                                      ? BuildPositionalDeleteSchema()
+	                                                      : BuildEqualityDeleteSchema(context.metadata, scan_entries);
 
 	vector<Value> children;
 	children.push_back(Value::LIST(LogicalType::VARCHAR, std::move(delete_file_paths)));
@@ -357,22 +350,6 @@ static void ScanParquetDeleteFiles(const IcebergDeletePlanningContext &context,
 	auto &multi_file_local_state = local_state->Cast<MultiFileLocalState>();
 
 	equality_delete_file_index_map_t equality_delete_file_indexes;
-	if (content == IcebergManifestEntryContentType::EQUALITY_DELETES) {
-		for (auto &sequence_entry : context.provider.EqualityDeleteData()) {
-			auto &sequence_indexes = equality_delete_file_indexes[sequence_entry.first];
-			for (idx_t delete_index = 0; delete_index < sequence_entry.second.size(); delete_index++) {
-				auto manifest_entry_index = sequence_entry.second[delete_index]->manifest_entry_index;
-				if (manifest_entry_index >= entries.size()) {
-					throw InternalException("Delete manifest entry index %llu is out of bounds for %llu entries",
-					                        manifest_entry_index, entries.size());
-				}
-				auto &file_path = entries[manifest_entry_index].entry.data_file.file_path;
-				if (!file_path.empty()) {
-					sequence_indexes.emplace(file_path, delete_index);
-				}
-			}
-		}
-	}
 
 	while (true) {
 		TableFunctionInput function_input(bind_data.get(), local_state.get(), global_state.get());
@@ -383,56 +360,55 @@ static void ScanParquetDeleteFiles(const IcebergDeletePlanningContext &context,
 		}
 		result.Flatten();
 		auto file_idx = multi_file_local_state.job.reader->file_list_idx.GetIndex();
-		if (file_idx >= manifest_entry_indexes.size()) {
+		if (file_idx >= scan_entries.size()) {
 			throw InternalException("Delete batch reader index %llu is out of bounds for %llu files", file_idx,
-			                        manifest_entry_indexes.size());
+			                        scan_entries.size());
 		}
-		auto manifest_entry_index = manifest_entry_indexes[file_idx];
-		auto &bound_manifest_entry = entries[manifest_entry_index];
+		auto &scan_entry = scan_entries[file_idx].get();
+		auto &bound_manifest_entry = scan_entry.entry;
 		if (content == IcebergManifestEntryContentType::POSITION_DELETES) {
-			ScanPositionalDeleteFile(context, bound_manifest_entry, result);
+			ScanPositionalDeleteFile(context, bound_manifest_entry, result, scan_result);
 		} else {
-			ScanEqualityDeleteFile(context, manifest_entry_index, bound_manifest_entry, result,
-			                       multi_file_bind_data.reader_bind.schema, equality_delete_file_indexes);
+			ScanEqualityDeleteFile(context, scan_entry.manifest_entry_index, bound_manifest_entry, result,
+			                       multi_file_bind_data.reader_bind.schema, equality_delete_file_indexes, scan_result);
 		}
 	}
 }
 
 } // namespace
 
-void IcebergDeleteFileScanner::ScanFiles(const IcebergDeletePlanningContext &context) {
-	auto &next_entry = context.provider.NextDeleteEntryToProcess();
-	auto &delete_entries = context.provider.DeleteManifestEntries();
-	vector<idx_t> positional_delete_entries;
-	vector<idx_t> equality_delete_entries;
-	for (; next_entry < delete_entries.size(); next_entry++) {
-		auto &bound_manifest_entry = delete_entries[next_entry];
-		if (!IcebergDeletePlanner::DeleteEntryMatchesFilters(context, bound_manifest_entry)) {
-			continue;
-		}
+IcebergDeleteScanResult IcebergDeleteFileScanner::ScanFiles(const IcebergDeletePlanningContext &context,
+                                                            const vector<IcebergDeleteScanEntry> &entries) {
+	IcebergDeleteScanResult result;
+	vector<reference<const IcebergDeleteScanEntry>> positional_delete_entries;
+	vector<reference<const IcebergDeleteScanEntry>> equality_delete_entries;
+	for (auto &scan_entry : entries) {
+		auto &bound_manifest_entry = scan_entry.entry;
 		auto &data_file = bound_manifest_entry.entry.data_file;
 		if (StringUtil::CIEquals(data_file.file_format, "parquet")) {
 			switch (data_file.content) {
 			case IcebergManifestEntryContentType::POSITION_DELETES:
-				positional_delete_entries.push_back(next_entry);
+				positional_delete_entries.emplace_back(scan_entry);
 				break;
 			case IcebergManifestEntryContentType::EQUALITY_DELETES:
-				equality_delete_entries.push_back(next_entry);
+				equality_delete_entries.emplace_back(scan_entry);
 				break;
 			default:
 				throw InvalidConfigurationException("Delete manifest references Parquet file '%s' with content type %d",
 				                                    data_file.file_path, static_cast<uint8_t>(data_file.content));
 			}
 		} else if (StringUtil::CIEquals(data_file.file_format, "puffin")) {
-			ScanPuffinFile(context, bound_manifest_entry);
+			ScanPuffinFile(context, bound_manifest_entry, result);
 		} else {
 			throw NotImplementedException(
 			    "File format '%s' not supported for deletes, only supports 'parquet' and 'puffin' currently",
 			    data_file.file_format);
 		}
 	}
-	ScanParquetDeleteFiles(context, positional_delete_entries, IcebergManifestEntryContentType::POSITION_DELETES);
-	ScanParquetDeleteFiles(context, equality_delete_entries, IcebergManifestEntryContentType::EQUALITY_DELETES);
+	ScanParquetDeleteFiles(context, positional_delete_entries, IcebergManifestEntryContentType::POSITION_DELETES,
+	                       result);
+	ScanParquetDeleteFiles(context, equality_delete_entries, IcebergManifestEntryContentType::EQUALITY_DELETES, result);
+	return result;
 }
 
 } // namespace duckdb

--- a/src/planning/deletes/iceberg_delete_file_scanner.cpp
+++ b/src/planning/deletes/iceberg_delete_file_scanner.cpp
@@ -22,7 +22,18 @@
 
 namespace duckdb {
 
-using equality_delete_file_index_map_t = unordered_map<sequence_number_t, unordered_map<string, idx_t>>;
+const IcebergManifestEntry &IcebergDeleteScanEntry::GetEntry() const {
+	auto &manifest_entries = manifest.GetManifestEntries();
+	if (entry_idx >= manifest_entries.size()) {
+		throw InternalException("Delete manifest entry index %llu is out of bounds for manifest %llu", entry_idx,
+		                        manifest_idx);
+	}
+	return manifest_entries[entry_idx];
+}
+
+BoundIcebergManifestEntry IcebergDeleteScanEntry::BindEntry() const {
+	return BoundIcebergManifestListEntry(manifest_idx, manifest).BindEntry(GetEntry());
+}
 
 namespace {
 
@@ -52,8 +63,9 @@ static PuffinDeletionVectorVerificationResult VerifyPuffinDeletionVector(FileSys
 	return std::monostate {};
 }
 
-static void ScanPuffinFile(const IcebergDeletePlanningContext &context, const BoundIcebergManifestEntry &bound_entry,
+static void ScanPuffinFile(const IcebergDeletePlanningContext &context, const IcebergDeleteScanEntry &scan_entry,
                            IcebergDeleteScanResult &scan_result) {
+	auto bound_entry = scan_entry.BindEntry();
 	auto &data_file = bound_entry.entry.data_file;
 	if (context.metadata.iceberg_version < 3) {
 		throw InvalidConfigurationException("DeletionVector not supported in Iceberg V%d",
@@ -116,8 +128,9 @@ static optional_ptr<IcebergPositionalDeleteData> TryGetOrCreatePositionDeletes(p
 }
 
 static void ScanPositionalDeleteFile(const IcebergDeletePlanningContext &context,
-                                     const BoundIcebergManifestEntry &bound_entry, DataChunk &result,
+                                     const IcebergDeleteScanEntry &scan_entry, DataChunk &result,
                                      IcebergDeleteScanResult &scan_result) {
+	auto bound_entry = scan_entry.BindEntry();
 	auto names = FlatVector::GetData<string_t>(result.data[0]);
 	auto row_ids = FlatVector::GetData<int64_t>(result.data[1]);
 	if (result.size() == 0) {
@@ -179,36 +192,11 @@ static void ColumnsReferencedByEqualityIds(DataChunk &source, DataChunk &result,
 	result.ReferenceColumns(source, column_ids);
 }
 
-static IcebergEqualityDeleteFile &GetOrCreateEqualityDeleteFile(vector<unique_ptr<IcebergEqualityDeleteFile>> &deletes,
-                                                                idx_t manifest_entry_index,
-                                                                const BoundIcebergManifestEntry &manifest_entry,
-                                                                sequence_number_t sequence_number,
-                                                                equality_delete_file_index_map_t &file_indexes) {
-	auto &data_file = manifest_entry.entry.data_file;
-	auto &sequence_indexes = file_indexes[sequence_number];
-	auto index_entry = sequence_indexes.find(data_file.file_path);
-	if (index_entry != sequence_indexes.end()) {
-		if (index_entry->second >= deletes.size()) {
-			throw InternalException("Equality-delete file index %llu is out of bounds for sequence number %lld",
-			                        index_entry->second, sequence_number);
-		}
-		return *deletes[index_entry->second];
-	}
-
-	auto delete_index = deletes.size();
-	deletes.push_back(make_uniq<IcebergEqualityDeleteFile>(manifest_entry_index));
-	sequence_indexes.emplace(data_file.file_path, delete_index);
-	return *deletes.back();
-}
-
-static void ScanEqualityDeleteFile(const IcebergDeletePlanningContext &context, idx_t manifest_entry_index,
-                                   const BoundIcebergManifestEntry &bound_manifest_entry, DataChunk &source,
-                                   const vector<MultiFileColumnDefinition> &global_columns,
-                                   equality_delete_file_index_map_t &file_indexes,
-                                   IcebergDeleteScanResult &scan_result) {
-	auto &manifest_entry = bound_manifest_entry.entry;
+static void ScanEqualityDeleteFile(const IcebergDeletePlanningContext &context,
+                                   const IcebergDeleteScanEntry &scan_entry, IcebergEqualityDeleteFile &delete_file,
+                                   DataChunk &source, const vector<MultiFileColumnDefinition> &global_columns) {
+	auto &manifest_entry = scan_entry.GetEntry();
 	auto &data_file = manifest_entry.data_file;
-	auto &manifest_file = context.delete_manifests[bound_manifest_entry.manifest_file_idx].entry.file;
 	D_ASSERT(!data_file.equality_ids.empty());
 	D_ASSERT(source.ColumnCount() == global_columns.size());
 	if (source.size() == 0) {
@@ -217,10 +205,6 @@ static void ScanEqualityDeleteFile(const IcebergDeletePlanningContext &context, 
 
 	DataChunk result;
 	ColumnsReferencedByEqualityIds(source, result, global_columns, data_file.equality_ids);
-	const auto sequence_number = manifest_entry.GetSequenceNumber(manifest_file);
-	auto &deletes = scan_result.equality_delete_data[sequence_number];
-	auto &delete_file = GetOrCreateEqualityDeleteFile(deletes, manifest_entry_index, bound_manifest_entry,
-	                                                  sequence_number, file_indexes);
 	auto &equality_values = delete_file.equality_values;
 	if (data_file.record_count < 0) {
 		throw InvalidConfigurationException("Equality delete file '%s' has a negative record count",
@@ -255,7 +239,7 @@ BuildEqualityDeleteSchema(const IcebergTableMetadata &metadata,
 	vector<MultiFileColumnDefinition> schema;
 	unordered_set<int32_t> field_ids;
 	for (auto &scan_entry_ref : scan_entries) {
-		auto &data_file = scan_entry_ref.get().entry.entry.data_file;
+		auto &data_file = scan_entry_ref.get().GetEntry().data_file;
 		for (auto field_id : data_file.equality_ids) {
 			if (!field_ids.insert(field_id).second) {
 				continue;
@@ -297,7 +281,7 @@ static void ScanParquetDeleteFiles(const IcebergDeletePlanningContext &context,
 	delete_file_paths.reserve(scan_entries.size());
 	delete_file_infos.reserve(scan_entries.size());
 	for (auto &scan_entry_ref : scan_entries) {
-		auto &data_file = scan_entry_ref.get().entry.entry.data_file;
+		auto &data_file = scan_entry_ref.get().GetEntry().data_file;
 		D_ASSERT(data_file.content == content);
 		auto delete_file_path = data_file.file_path;
 		if (context.options.allow_moved_paths) {
@@ -349,7 +333,16 @@ static void ScanParquetDeleteFiles(const IcebergDeletePlanningContext &context,
 	auto local_state = delete_scan_function.init_local(execution_context, input, global_state.get());
 	auto &multi_file_local_state = local_state->Cast<MultiFileLocalState>();
 
-	equality_delete_file_index_map_t equality_delete_file_indexes;
+	vector<reference<IcebergEqualityDeleteFile>> equality_delete_files;
+	if (content == IcebergManifestEntryContentType::EQUALITY_DELETES) {
+		for (auto &scan_entry_ref : scan_entries) {
+			auto &scan_entry = scan_entry_ref.get();
+			auto equality_delete =
+			    make_shared_ptr<IcebergEqualityDeleteFile>(scan_entry.GetEntry().data_file.equality_ids);
+			equality_delete_files.emplace_back(*equality_delete);
+			scan_result.equality_delete_data.push_back({scan_entry.load, std::move(equality_delete)});
+		}
+	}
 
 	while (true) {
 		TableFunctionInput function_input(bind_data.get(), local_state.get(), global_state.get());
@@ -365,12 +358,11 @@ static void ScanParquetDeleteFiles(const IcebergDeletePlanningContext &context,
 			                        scan_entries.size());
 		}
 		auto &scan_entry = scan_entries[file_idx].get();
-		auto &bound_manifest_entry = scan_entry.entry;
 		if (content == IcebergManifestEntryContentType::POSITION_DELETES) {
-			ScanPositionalDeleteFile(context, bound_manifest_entry, result, scan_result);
+			ScanPositionalDeleteFile(context, scan_entry, result, scan_result);
 		} else {
-			ScanEqualityDeleteFile(context, scan_entry.manifest_entry_index, bound_manifest_entry, result,
-			                       multi_file_bind_data.reader_bind.schema, equality_delete_file_indexes, scan_result);
+			ScanEqualityDeleteFile(context, scan_entry, equality_delete_files[file_idx].get(), result,
+			                       multi_file_bind_data.reader_bind.schema);
 		}
 	}
 }
@@ -383,8 +375,7 @@ IcebergDeleteScanResult IcebergDeleteFileScanner::ScanFiles(const IcebergDeleteP
 	vector<reference<const IcebergDeleteScanEntry>> positional_delete_entries;
 	vector<reference<const IcebergDeleteScanEntry>> equality_delete_entries;
 	for (auto &scan_entry : entries) {
-		auto &bound_manifest_entry = scan_entry.entry;
-		auto &data_file = bound_manifest_entry.entry.data_file;
+		auto &data_file = scan_entry.GetEntry().data_file;
 		if (StringUtil::CIEquals(data_file.file_format, "parquet")) {
 			switch (data_file.content) {
 			case IcebergManifestEntryContentType::POSITION_DELETES:
@@ -398,7 +389,7 @@ IcebergDeleteScanResult IcebergDeleteFileScanner::ScanFiles(const IcebergDeleteP
 				                                    data_file.file_path, static_cast<uint8_t>(data_file.content));
 			}
 		} else if (StringUtil::CIEquals(data_file.file_format, "puffin")) {
-			ScanPuffinFile(context, bound_manifest_entry, result);
+			ScanPuffinFile(context, scan_entry, result);
 		} else {
 			throw NotImplementedException(
 			    "File format '%s' not supported for deletes, only supports 'parquet' and 'puffin' currently",

--- a/src/planning/deletes/iceberg_delete_planner.cpp
+++ b/src/planning/deletes/iceberg_delete_planner.cpp
@@ -1,99 +1,23 @@
 #include "planning/deletes/iceberg_delete_planner.hpp"
 
-#include "core/expression/iceberg_predicate_stats.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
-#include "duckdb/common/numeric_utils.hpp"
-#include "planning/scan_plan/iceberg_scan_plan_provider.hpp"
 #include "planning/pruning/iceberg_file_pruner.hpp"
+#include "planning/scan_plan/iceberg_scan_plan_provider.hpp"
 
 namespace duckdb {
-
-static bool DeleteManifestMatchesDataFile(const IcebergDeletePlanningContext &context,
-                                          const IcebergManifestFile &delete_manifest,
-                                          const BoundIcebergManifestEntry &data_manifest_entry) {
-	auto partition_spec_it = context.metadata.partition_specs.find(delete_manifest.partition_spec_id);
-	if (partition_spec_it == context.metadata.partition_specs.end()) {
-		throw InvalidInputException("Delete manifest %s references partition_spec_id %d which doesn't exist",
-		                            delete_manifest.manifest_path, delete_manifest.partition_spec_id);
-	}
-	auto &delete_partition_spec = partition_spec_it->second;
-	if (delete_partition_spec.IsUnpartitioned()) {
-		return true;
-	}
-
-	auto &data_manifest = context.data_manifests[data_manifest_entry.manifest_file_idx].entry.file;
-	if (delete_manifest.partition_spec_id != data_manifest.partition_spec_id) {
-		return false;
-	}
-	if (!delete_manifest.partitions.has_partitions) {
-		return true;
-	}
-
-	auto &field_summaries = delete_manifest.partitions.field_summary;
-	if (delete_partition_spec.fields.size() != field_summaries.size()) {
-		throw InvalidInputException("Delete manifest has %d partition summaries but partition spec %d has %d fields",
-		                            field_summaries.size(), delete_manifest.partition_spec_id,
-		                            delete_partition_spec.fields.size());
-	}
-
-	auto &data_file = data_manifest_entry.entry.data_file;
-	unordered_map<uint64_t, reference<const Value>> partition_values;
-	for (auto &partition : data_file.partition_info) {
-		partition_values.emplace(partition.field_id, partition.value);
-	}
-
-	for (idx_t field_idx = 0; field_idx < delete_partition_spec.fields.size(); field_idx++) {
-		auto &field = delete_partition_spec.fields[field_idx];
-		auto partition_value_it = partition_values.find(field.partition_field_id);
-		if (partition_value_it == partition_values.end()) {
-			return true;
-		}
-		auto &partition_value = partition_value_it->second.get();
-		auto &field_summary = field_summaries[field_idx];
-		if (partition_value.IsNull()) {
-			if (!field_summary.contains_null) {
-				return false;
-			}
-			continue;
-		}
-
-		auto source_column = context.metadata.FindColumnByFieldId(NumericCast<int32_t>(field.source_id));
-		if (!source_column) {
-			return true;
-		}
-		auto partition_type = field.transform.GetSerializedType(source_column->type);
-		auto stats = IcebergPredicateStats::DeserializeBounds(field_summary.lower_bound, field_summary.upper_bound,
-		                                                      source_column->name, partition_type);
-		auto typed_partition_value = partition_value.DefaultCastAs(partition_type);
-		if (stats.lower_bound && typed_partition_value < *stats.lower_bound) {
-			return false;
-		}
-		if (stats.upper_bound && typed_partition_value > *stats.upper_bound) {
-			return false;
-		}
-	}
-	return true;
-}
 
 vector<idx_t>
 IcebergDeletePlanner::GetDeleteManifestsForDataFile(const IcebergDeletePlanningContext &context,
                                                     const BoundIcebergManifestEntry &data_manifest_entry) {
 	vector<idx_t> result;
 	auto &data_manifest = context.data_manifests[data_manifest_entry.manifest_file_idx].entry.file;
-	auto data_sequence_number = data_manifest_entry.entry.GetSequenceNumber(data_manifest);
+	auto file_pruner = IcebergFilePruner(context.context, context.metadata, context.schema, context.table_filters);
 	for (idx_t manifest_idx = 0; manifest_idx < context.delete_manifests.size(); manifest_idx++) {
 		if (!context.delete_manifest_matches[manifest_idx]) {
 			continue;
 		}
 		auto &delete_manifest = context.delete_manifests[manifest_idx].entry.file;
-		if (!delete_manifest.sequence_number) {
-			throw InvalidConfigurationException("Delete manifest %s does not have a sequence number",
-			                                    delete_manifest.manifest_path);
-		}
-		if (*delete_manifest.sequence_number < data_sequence_number) {
-			continue;
-		}
-		if (!DeleteManifestMatchesDataFile(context, delete_manifest, data_manifest_entry)) {
+		if (!file_pruner.DeleteManifestMatchesDataFile(delete_manifest, data_manifest, data_manifest_entry.entry)) {
 			continue;
 		}
 		result.push_back(manifest_idx);
@@ -110,6 +34,7 @@ IcebergDeletePlanner::GetEqualityDeletesForFile(const IcebergDeletePlanningConte
 	auto &data_file = manifest_entry.data_file;
 	auto &delete_entries = context.provider.DeleteManifestEntries();
 	auto &equality_delete_data = context.provider.EqualityDeleteData();
+	auto file_pruner = IcebergFilePruner(context.context, context.metadata, context.schema, context.table_filters);
 	auto it = equality_delete_data.upper_bound(manifest_entry.GetSequenceNumber(manifest_file));
 	for (; it != equality_delete_data.end(); it++) {
 		for (auto &delete_file_ptr : it->second) {
@@ -124,24 +49,10 @@ IcebergDeletePlanner::GetEqualityDeletesForFile(const IcebergDeletePlanningConte
 			if (!context.provider.DeleteFileAppliesToDataFile(data_file.file_path, delete_data_file.file_path)) {
 				continue;
 			}
-			auto &delete_manifest_file = context.delete_manifests[delete_manifest_entry.manifest_file_idx].entry.file;
-			auto delete_partition_spec_id = delete_manifest_file.partition_spec_id;
-			auto &partition_spec = context.metadata.partition_specs.at(delete_partition_spec_id);
-			if (partition_spec.IsPartitioned()) {
-				if (delete_partition_spec_id != manifest_file.partition_spec_id) {
-					continue;
-				}
-				D_ASSERT(delete_data_file.partition_info.size() == data_file.partition_info.size());
-				bool partition_matches = true;
-				for (idx_t i = 0; i < delete_data_file.partition_info.size(); i++) {
-					if (delete_data_file.partition_info[i] != data_file.partition_info[i]) {
-						partition_matches = false;
-						break;
-					}
-				}
-				if (!partition_matches) {
-					continue;
-				}
+			auto &delete_manifest = context.delete_manifests[delete_manifest_entry.manifest_file_idx].entry.file;
+			if (!file_pruner.DeleteFileMatchesDataFile(delete_manifest, delete_manifest_entry.entry, manifest_file,
+			                                           manifest_entry)) {
+				continue;
 			}
 			result.emplace_back(delete_file);
 		}
@@ -160,6 +71,22 @@ bool IcebergDeletePlanner::DeleteEntryMatchesFilters(const IcebergDeletePlanning
 	}
 	return IcebergFilePruner(context.context, context.metadata, context.schema, context.table_filters)
 	    .FileMatchesFilter(context.delete_manifests[manifest_idx].entry.file, bound_manifest_entry.entry);
+}
+
+bool IcebergDeletePlanner::DeleteEntryAppliesToDataFile(const IcebergDeletePlanningContext &context,
+                                                        const BoundIcebergManifestEntry &delete_manifest_entry,
+                                                        const BoundIcebergManifestEntry &data_manifest_entry) {
+	auto &delete_file = delete_manifest_entry.entry.data_file;
+	auto &data_file = data_manifest_entry.entry.data_file;
+	if (!context.provider.DeleteFileAppliesToDataFile(data_file.file_path, delete_file.file_path)) {
+		return false;
+	}
+
+	auto &delete_manifest = context.delete_manifests[delete_manifest_entry.manifest_file_idx].entry.file;
+	auto &data_manifest = context.data_manifests[data_manifest_entry.manifest_file_idx].entry.file;
+	return IcebergFilePruner(context.context, context.metadata, context.schema, context.table_filters)
+	    .DeleteFileMatchesDataFile(delete_manifest, delete_manifest_entry.entry, data_manifest,
+	                               data_manifest_entry.entry);
 }
 
 unique_ptr<DeleteFilter> IcebergDeletePlanner::GetPositionalDeletesForFile(const IcebergDeletePlanningContext &context,

--- a/src/planning/deletes/iceberg_delete_planner.cpp
+++ b/src/planning/deletes/iceberg_delete_planner.cpp
@@ -25,75 +25,33 @@ IcebergDeletePlanner::GetDeleteManifestsForDataFile(const IcebergDeletePlanningC
 	return result;
 }
 
-vector<reference<const IcebergEqualityDeleteFile>>
-IcebergDeletePlanner::GetEqualityDeletesForFile(const IcebergDeletePlanningContext &context,
-                                                const BoundIcebergManifestEntry &bound_manifest_entry) {
-	vector<reference<const IcebergEqualityDeleteFile>> result;
-	auto &manifest_entry = bound_manifest_entry.entry;
-	auto &manifest_file = context.data_manifests[bound_manifest_entry.manifest_file_idx].entry.file;
-	auto &data_file = manifest_entry.data_file;
-	auto &delete_entries = context.provider.DeleteManifestEntries();
-	auto &equality_delete_data = context.provider.EqualityDeleteData();
-	auto file_pruner = IcebergFilePruner(context.context, context.metadata, context.schema, context.table_filters);
-	auto it = equality_delete_data.upper_bound(manifest_entry.GetSequenceNumber(manifest_file));
-	for (; it != equality_delete_data.end(); it++) {
-		for (auto &delete_file_ptr : it->second) {
-			auto &delete_file = *delete_file_ptr;
-			auto manifest_entry_index = delete_file.manifest_entry_index;
-			if (manifest_entry_index >= delete_entries.size()) {
-				throw InternalException("Delete manifest entry index %llu is out of bounds for %llu entries",
-				                        manifest_entry_index, delete_entries.size());
-			}
-			auto &delete_manifest_entry = delete_entries[manifest_entry_index];
-			auto &delete_data_file = delete_manifest_entry.entry.data_file;
-			if (!context.provider.DeleteFileAppliesToDataFile(data_file.file_path, delete_data_file.file_path)) {
-				continue;
-			}
-			auto &delete_manifest = context.delete_manifests[delete_manifest_entry.manifest_file_idx].entry.file;
-			if (!file_pruner.DeleteFileMatchesDataFile(delete_manifest, delete_manifest_entry.entry, manifest_file,
-			                                           manifest_entry)) {
-				continue;
-			}
-			result.emplace_back(delete_file);
-		}
-	}
-	return result;
-}
-
 bool IcebergDeletePlanner::DeleteEntryMatchesFilters(const IcebergDeletePlanningContext &context,
-                                                     const BoundIcebergManifestEntry &bound_manifest_entry) {
-	auto manifest_idx = bound_manifest_entry.manifest_file_idx;
-	if (!context.delete_manifest_matches[manifest_idx]) {
+                                                     idx_t delete_manifest_idx,
+                                                     const IcebergManifestEntry &delete_manifest_entry) {
+	if (!context.delete_manifest_matches[delete_manifest_idx]) {
 		return false;
 	}
 	if (!context.table_filters.HasFilters()) {
 		return true;
 	}
 	return IcebergFilePruner(context.context, context.metadata, context.schema, context.table_filters)
-	    .FileMatchesFilter(context.delete_manifests[manifest_idx].entry.file, bound_manifest_entry.entry);
+	    .FileMatchesFilter(context.delete_manifests[delete_manifest_idx].entry.file, delete_manifest_entry);
 }
 
 bool IcebergDeletePlanner::DeleteEntryAppliesToDataFile(const IcebergDeletePlanningContext &context,
-                                                        const BoundIcebergManifestEntry &delete_manifest_entry,
+                                                        idx_t delete_manifest_idx,
+                                                        const IcebergManifestEntry &delete_manifest_entry,
                                                         const BoundIcebergManifestEntry &data_manifest_entry) {
-	auto &delete_file = delete_manifest_entry.entry.data_file;
+	auto &delete_file = delete_manifest_entry.data_file;
 	auto &data_file = data_manifest_entry.entry.data_file;
 	if (!context.provider.DeleteFileAppliesToDataFile(data_file.file_path, delete_file.file_path)) {
 		return false;
 	}
 
-	auto &delete_manifest = context.delete_manifests[delete_manifest_entry.manifest_file_idx].entry.file;
+	auto &delete_manifest = context.delete_manifests[delete_manifest_idx].entry.file;
 	auto &data_manifest = context.data_manifests[data_manifest_entry.manifest_file_idx].entry.file;
 	return IcebergFilePruner(context.context, context.metadata, context.schema, context.table_filters)
-	    .DeleteFileMatchesDataFile(delete_manifest, delete_manifest_entry.entry, data_manifest,
-	                               data_manifest_entry.entry);
-}
-
-unique_ptr<DeleteFilter> IcebergDeletePlanner::GetPositionalDeletesForFile(const IcebergDeletePlanningContext &context,
-                                                                           const string &file_path) {
-	auto &positional_delete_data = context.provider.PositionalDeleteData();
-	auto it = positional_delete_data.find(file_path);
-	return it == positional_delete_data.end() ? nullptr : it->second->ToFilter();
+	    .DeleteFileMatchesDataFile(delete_manifest, delete_manifest_entry, data_manifest, data_manifest_entry.entry);
 }
 
 shared_ptr<IcebergDeleteData>

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -21,7 +21,7 @@ namespace duckdb {
 
 namespace {
 
-static void MergeDeleteScanResult(IcebergScanPlanProvider &provider, IcebergDeleteScanResult &scan_result) {
+static void MergeDeleteScanResult(IcebergScanPlanProvider &provider, IcebergDeleteScanResult &&scan_result) {
 	auto &positional_delete_data = provider.PositionalDeleteData();
 	for (auto &entry : scan_result.positional_delete_data) {
 		auto existing = positional_delete_data.find(entry.first);
@@ -53,12 +53,12 @@ static void MergeDeleteScanResult(IcebergScanPlanProvider &provider, IcebergDele
 		                                     source_positions.invalid_rows.end());
 	}
 
-	auto &equality_delete_data = provider.EqualityDeleteData();
-	for (auto &sequence_entry : scan_result.equality_delete_data) {
-		auto &target = equality_delete_data[sequence_entry.first];
-		for (auto &delete_file : sequence_entry.second) {
-			target.push_back(std::move(delete_file));
+	for (auto &entry : scan_result.equality_delete_data) {
+		if (entry.delete_file->equality_values.size() == 0) {
+			continue;
 		}
+		lock_guard<mutex> guard(entry.load->lock);
+		entry.load->equality_delete = std::move(entry.delete_file);
 	}
 }
 
@@ -362,17 +362,6 @@ BoundIcebergManifestEntry IcebergMultiFileList::GetManifestEntry(idx_t file_id) 
 	return data_manifest_entries[file_id];
 }
 
-BoundIcebergManifestEntry IcebergMultiFileList::GetDeleteManifestEntry(idx_t manifest_entry_index) const {
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
-	auto &entries = GetScanPlanProvider().DeleteManifestEntries();
-	if (manifest_entry_index >= entries.size()) {
-		throw InternalException("Delete manifest entry index %llu is out of bounds for %llu entries",
-		                        manifest_entry_index, entries.size());
-	}
-	return entries[manifest_entry_index];
-}
-
 IcebergManifestFile IcebergMultiFileList::GetManifestFileForDataFile(idx_t file_id) const {
 	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 	auto manifest_file_idx = data_manifest_entries[file_id].manifest_file_idx;
@@ -558,13 +547,6 @@ OpenFileInfo IcebergMultiFileList::GetFile(idx_t file_id) const {
 	return GetFileInternal(file_id, guard);
 }
 
-vector<reference<const IcebergEqualityDeleteFile>>
-IcebergMultiFileList::GetEqualityDeletesForFile(const BoundIcebergManifestEntry &bound_manifest_entry) const {
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
-	return IcebergDeletePlanner::GetEqualityDeletesForFile(GetDeletePlanningContext(), bound_manifest_entry);
-}
-
 void IcebergMultiFileList::InitializeView(annotated_lock_guard<annotated_mutex> &guard) const {
 	if (scan_plan_provider) {
 		return;
@@ -623,14 +605,10 @@ void IcebergMultiFileList::StartDataManifestScan(annotated_lock_guard<annotated_
 	GetScanPlanProvider().StartDataManifestScan(data_manifest_matches, table_filters.FilterCount());
 }
 
-vector<idx_t>
-IcebergMultiFileList::EnumerateDeleteManifestEntriesInternal(const vector<idx_t> &manifest_indexes) const {
-	return GetScanPlanProvider().EnumerateDeleteManifestEntries(manifest_indexes);
-}
-
-void IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_manifest_entry) const {
+IcebergDeletePlan IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_manifest_entry) const {
+	IcebergDeletePlan result;
 	if (!has_matching_delete_manifests.load()) {
-		return;
+		return result;
 	}
 
 	vector<idx_t> manifest_indexes;
@@ -643,7 +621,7 @@ void IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_
 		provider = scan_plan_provider.get();
 	}
 	if (manifest_indexes.empty()) {
-		return;
+		return result;
 	}
 
 	D_ASSERT(provider);
@@ -656,34 +634,35 @@ void IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_
 	{
 		annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 		annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
-		auto entry_indexes = EnumerateDeleteManifestEntriesInternal(manifest_indexes);
+		auto delete_files = provider->GetDeleteFiles(manifest_indexes);
 		delete_context = make_uniq<IcebergDeletePlanningContext>(GetDeletePlanningContext());
-		auto &delete_entries = provider->DeleteManifestEntries();
-		auto &delete_file_loads = provider->DeleteFileLoads();
 		unordered_set<IcebergDeleteFileLoadState *> seen_loads;
-		for (auto entry_idx : entry_indexes) {
-			if (entry_idx >= delete_entries.size()) {
-				throw InternalException("Delete manifest entry index %llu is out of bounds for %llu entries", entry_idx,
-				                        delete_entries.size());
+		for (auto delete_file : delete_files) {
+			if (delete_file.manifest_idx >= delete_manifests.size()) {
+				throw InternalException("Delete manifest index %llu is out of bounds for %llu manifests",
+				                        delete_file.manifest_idx, delete_manifests.size());
 			}
-			auto &delete_entry = delete_entries[entry_idx];
-			if (!IcebergDeletePlanner::DeleteEntryMatchesFilters(*delete_context, delete_entry)) {
+			auto &delete_manifest = delete_manifests[delete_file.manifest_idx].entry;
+			auto &manifest_entries = delete_manifest.GetManifestEntries();
+			if (delete_file.entry_idx >= manifest_entries.size()) {
+				throw InternalException("Delete manifest entry index %llu is out of bounds for manifest %llu",
+				                        delete_file.entry_idx, delete_file.manifest_idx);
+			}
+			auto &delete_entry = manifest_entries[delete_file.entry_idx];
+			if (!IcebergDeletePlanner::DeleteEntryMatchesFilters(*delete_context, delete_file.manifest_idx,
+			                                                     delete_entry)) {
 				continue;
 			}
-			if (!IcebergDeletePlanner::DeleteEntryAppliesToDataFile(*delete_context, delete_entry,
-			                                                        data_manifest_entry)) {
+			if (!IcebergDeletePlanner::DeleteEntryAppliesToDataFile(*delete_context, delete_file.manifest_idx,
+			                                                        delete_entry, data_manifest_entry)) {
 				continue;
 			}
 
-			if (entry_idx >= delete_file_loads.size()) {
-				throw InternalException("Delete file load index %llu is out of bounds for %llu entries", entry_idx,
-				                        delete_file_loads.size());
-			}
-			auto &load = delete_file_loads[entry_idx];
+			auto &load = provider->GetDeleteFileLoad(delete_file);
 			if (!load) {
 				load = make_shared_ptr<IcebergDeleteFileLoadState>();
 				new_loads.push_back(load);
-				scan_entries.emplace_back(entry_idx, delete_entry);
+				scan_entries.emplace_back(delete_file.manifest_idx, delete_file.entry_idx, delete_manifest, load);
 			}
 			if (seen_loads.insert(load.get()).second) {
 				required_loads.push_back(load);
@@ -696,7 +675,7 @@ void IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_
 		try {
 			auto scan_result = IcebergDeleteFileScanner::ScanFiles(*delete_context, scan_entries);
 			annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
-			MergeDeleteScanResult(*provider, scan_result);
+			MergeDeleteScanResult(*provider, std::move(scan_result));
 		} catch (std::exception &ex) {
 			scan_error = ErrorData(ex);
 		} catch (...) { // LCOV_EXCL_START
@@ -711,13 +690,20 @@ void IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_
 		if (load->error.HasError()) {
 			load->error.Throw();
 		}
+		if (load->equality_delete) {
+			result.equality_deletes.emplace_back(*load->equality_delete);
+		}
 	}
-}
 
-unique_ptr<DeleteFilter> IcebergMultiFileList::GetPositionalDeletesForFile(const string &file_path) const {
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
-	return IcebergDeletePlanner::GetPositionalDeletesForFile(GetDeletePlanningContext(), file_path);
+	{
+		annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
+		auto &positional_delete_data = provider->PositionalDeleteData();
+		auto entry = positional_delete_data.find(data_manifest_entry.entry.data_file.file_path);
+		if (entry != positional_delete_data.end()) {
+			result.positional_deletes = entry->second->ToFilter();
+		}
+	}
+	return result;
 }
 
 shared_ptr<IcebergDeleteData> IcebergMultiFileList::GetExistingPositionalDeleteData(const string &file_path) const {

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -19,6 +19,63 @@
 
 namespace duckdb {
 
+namespace {
+
+static void MergeDeleteScanResult(IcebergScanPlanProvider &provider, IcebergDeleteScanResult &scan_result) {
+	auto &positional_delete_data = provider.PositionalDeleteData();
+	for (auto &entry : scan_result.positional_delete_data) {
+		auto existing = positional_delete_data.find(entry.first);
+		if (existing == positional_delete_data.end()) {
+			positional_delete_data.emplace(entry.first, std::move(entry.second));
+			continue;
+		}
+
+		auto &target = existing->second;
+		auto &source = entry.second;
+		if (target->type == IcebergDeleteType::DELETION_VECTOR) {
+			if (source->type == IcebergDeleteType::DELETION_VECTOR) {
+				throw InvalidConfigurationException(
+				    "Table is corrupt, two or more deletion vectors exist for the same referenced_data_file");
+			}
+			continue;
+		}
+		if (source->type == IcebergDeleteType::DELETION_VECTOR) {
+			target = std::move(source);
+			continue;
+		}
+
+		auto &target_positions = static_cast<IcebergPositionalDeleteData &>(*target);
+		auto &source_positions = static_cast<IcebergPositionalDeleteData &>(*source);
+		for (auto &source_entry : source_positions.entries) {
+			target_positions.entries.push_back(source_entry);
+		}
+		target_positions.invalid_rows.insert(source_positions.invalid_rows.begin(),
+		                                     source_positions.invalid_rows.end());
+	}
+
+	auto &equality_delete_data = provider.EqualityDeleteData();
+	for (auto &sequence_entry : scan_result.equality_delete_data) {
+		auto &target = equality_delete_data[sequence_entry.first];
+		for (auto &delete_file : sequence_entry.second) {
+			target.push_back(std::move(delete_file));
+		}
+	}
+}
+
+static void CompleteDeleteFileLoads(const vector<shared_ptr<IcebergDeleteFileLoadState>> &loads,
+                                    const ErrorData &error) {
+	for (auto &load : loads) {
+		{
+			lock_guard<mutex> guard(load->lock);
+			load->error = error;
+			load->complete = true;
+		}
+		load->cv.notify_all();
+	}
+}
+
+} // namespace
+
 IcebergMultiFileList::IcebergMultiFileList(ClientContext &context_p, shared_ptr<IcebergScanInfo> scan_info,
                                            const string &path, const IcebergOptions &options)
     : shared_state(make_shared_ptr<IcebergScanPlanState>(context_p, std::move(scan_info), path, options)),
@@ -566,8 +623,9 @@ void IcebergMultiFileList::StartDataManifestScan(annotated_lock_guard<annotated_
 	GetScanPlanProvider().StartDataManifestScan(data_manifest_matches, table_filters.FilterCount());
 }
 
-void IcebergMultiFileList::EnumerateDeleteManifestEntriesInternal(const vector<idx_t> &manifest_indexes) const {
-	GetScanPlanProvider().EnumerateDeleteManifestEntries(manifest_indexes);
+vector<idx_t>
+IcebergMultiFileList::EnumerateDeleteManifestEntriesInternal(const vector<idx_t> &manifest_indexes) const {
+	return GetScanPlanProvider().EnumerateDeleteManifestEntries(manifest_indexes);
 }
 
 void IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_manifest_entry) const {
@@ -591,10 +649,69 @@ void IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_
 	D_ASSERT(provider);
 	provider->ReadDeleteManifests(manifest_indexes, table_filters.FilterCount());
 
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
-	EnumerateDeleteManifestEntriesInternal(manifest_indexes);
-	IcebergDeleteFileScanner::ScanFiles(GetDeletePlanningContext());
+	vector<IcebergDeleteScanEntry> scan_entries;
+	vector<shared_ptr<IcebergDeleteFileLoadState>> required_loads;
+	vector<shared_ptr<IcebergDeleteFileLoadState>> new_loads;
+	unique_ptr<IcebergDeletePlanningContext> delete_context;
+	{
+		annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+		annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
+		auto entry_indexes = EnumerateDeleteManifestEntriesInternal(manifest_indexes);
+		delete_context = make_uniq<IcebergDeletePlanningContext>(GetDeletePlanningContext());
+		auto &delete_entries = provider->DeleteManifestEntries();
+		auto &delete_file_loads = provider->DeleteFileLoads();
+		unordered_set<IcebergDeleteFileLoadState *> seen_loads;
+		for (auto entry_idx : entry_indexes) {
+			if (entry_idx >= delete_entries.size()) {
+				throw InternalException("Delete manifest entry index %llu is out of bounds for %llu entries", entry_idx,
+				                        delete_entries.size());
+			}
+			auto &delete_entry = delete_entries[entry_idx];
+			if (!IcebergDeletePlanner::DeleteEntryMatchesFilters(*delete_context, delete_entry)) {
+				continue;
+			}
+			if (!IcebergDeletePlanner::DeleteEntryAppliesToDataFile(*delete_context, delete_entry,
+			                                                        data_manifest_entry)) {
+				continue;
+			}
+
+			if (entry_idx >= delete_file_loads.size()) {
+				throw InternalException("Delete file load index %llu is out of bounds for %llu entries", entry_idx,
+				                        delete_file_loads.size());
+			}
+			auto &load = delete_file_loads[entry_idx];
+			if (!load) {
+				load = make_shared_ptr<IcebergDeleteFileLoadState>();
+				new_loads.push_back(load);
+				scan_entries.emplace_back(entry_idx, delete_entry);
+			}
+			if (seen_loads.insert(load.get()).second) {
+				required_loads.push_back(load);
+			}
+		}
+	}
+
+	if (!scan_entries.empty()) {
+		ErrorData scan_error;
+		try {
+			auto scan_result = IcebergDeleteFileScanner::ScanFiles(*delete_context, scan_entries);
+			annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
+			MergeDeleteScanResult(*provider, scan_result);
+		} catch (std::exception &ex) {
+			scan_error = ErrorData(ex);
+		} catch (...) { // LCOV_EXCL_START
+			scan_error = ErrorData("Unknown exception while reading Iceberg delete files");
+		} // LCOV_EXCL_STOP
+		CompleteDeleteFileLoads(new_loads, scan_error);
+	}
+
+	for (auto &load : required_loads) {
+		unique_lock<mutex> guard(load->lock);
+		load->cv.wait(guard, [&load] { return load->complete; });
+		if (load->error.HasError()) {
+			load->error.Throw();
+		}
+	}
 }
 
 unique_ptr<DeleteFilter> IcebergMultiFileList::GetPositionalDeletesForFile(const string &file_path) const {

--- a/src/planning/iceberg_multi_file_reader.cpp
+++ b/src/planning/iceberg_multi_file_reader.cpp
@@ -134,13 +134,13 @@ IcebergMultiFileReader::InitializeGlobalState(ClientContext &context, const Mult
 }
 
 IcebergEqualityDeleteReadColumn IcebergMultiFileReader::AddEqualityDeleteColumn(
-    const IcebergMultiFileList &multi_file_list, int32_t field_id, vector<MultiFileColumnDefinition> &scan_columns,
+    const IcebergTableMetadata &metadata, int32_t field_id, vector<MultiFileColumnDefinition> &scan_columns,
     vector<ColumnIndex> &scan_column_ids, MultiFileReaderData &reader_data, ClientContext &context) {
 	auto field_id_to_scan_column = CreateFieldIdMap(scan_columns);
 	MultiFileColumnPath column_path;
 	auto field_entry = field_id_to_scan_column.find(field_id);
 	if (field_entry == field_id_to_scan_column.end()) {
-		auto column = multi_file_list.GetMetadata().FindColumnByFieldId(field_id);
+		auto column = metadata.FindColumnByFieldId(field_id);
 		if (!column) {
 			throw InvalidConfigurationException(
 			    "Column %d must be read to apply equality deletes, but no schema contains that field id", field_id);
@@ -182,14 +182,12 @@ IcebergEqualityDeleteReadColumn IcebergMultiFileReader::AddEqualityDeleteColumn(
 }
 
 vector<IcebergEqualityDeleteReadColumn> IcebergMultiFileReader::AddEqualityDeleteColumns(
-    const IcebergMultiFileList &multi_file_list, const BoundIcebergManifestEntry &bound_manifest_entry,
+    const IcebergTableMetadata &metadata, const vector<reference<const IcebergEqualityDeleteFile>> &delete_files,
     vector<MultiFileColumnDefinition> &scan_columns, vector<ColumnIndex> &scan_column_ids,
     MultiFileReaderData &reader_data, ClientContext &context) {
 	set<int32_t> required_field_ids;
-	for (auto &delete_file_ref : multi_file_list.GetEqualityDeletesForFile(bound_manifest_entry)) {
-		auto manifest_entry = multi_file_list.GetDeleteManifestEntry(delete_file_ref.get().manifest_entry_index);
-		auto &data_file = manifest_entry.entry.data_file;
-		for (auto field_id : data_file.equality_ids) {
+	for (auto &delete_file_ref : delete_files) {
+		for (auto field_id : delete_file_ref.get().equality_ids) {
 			required_field_ids.insert(field_id);
 		}
 	}
@@ -197,7 +195,7 @@ vector<IcebergEqualityDeleteReadColumn> IcebergMultiFileReader::AddEqualityDelet
 	vector<IcebergEqualityDeleteReadColumn> result;
 	for (auto field_id : required_field_ids) {
 		result.push_back(
-		    AddEqualityDeleteColumn(multi_file_list, field_id, scan_columns, scan_column_ids, reader_data, context));
+		    AddEqualityDeleteColumn(metadata, field_id, scan_columns, scan_column_ids, reader_data, context));
 	}
 	return result;
 }
@@ -291,21 +289,20 @@ static Value TransformPartitionValue(const Value &value, const LogicalType &type
 	}
 }
 
-void IcebergMultiFileReader::ApplyPartitionConstants(const IcebergMultiFileList &multi_file_list,
+void IcebergMultiFileReader::ApplyPartitionConstants(const IcebergManifestFile &manifest_file,
+                                                     const BoundIcebergManifestEntry &bound_manifest_entry,
+                                                     const IcebergTableMetadata &metadata,
                                                      MultiFileReaderData &reader_data,
                                                      const vector<MultiFileColumnDefinition> &global_columns,
                                                      const vector<ColumnIndex> &global_column_ids,
                                                      ClientContext &context) {
 	// Get the metadata for this file
 	auto &reader = *reader_data.reader;
-	auto file_id = reader.file_list_idx.GetIndex();
-	auto bound_manifest_entry = multi_file_list.GetManifestEntry(file_id);
-	auto manifest_file = multi_file_list.GetManifestFileForDataFile(file_id);
 	auto &manifest_entry = bound_manifest_entry.entry;
 	auto &data_file = manifest_entry.data_file;
 
 	// Get the partition spec for this file
-	auto &partition_specs = multi_file_list.GetMetadata().partition_specs;
+	auto &partition_specs = metadata.partition_specs;
 	auto spec_id = manifest_file.partition_spec_id;
 	auto partition_spec_it = partition_specs.find(spec_id);
 	if (partition_spec_it == partition_specs.end()) {
@@ -388,16 +385,18 @@ ReaderInitializeType IcebergMultiFileReader::InitializeReader(MultiFileReaderDat
                                                               ClientContext &context, MultiFileGlobalState &gstate) {
 	auto &iceberg_state = gstate.multi_file_reader_state->Cast<IcebergMultiFileReaderGlobalState>();
 	const auto &multi_file_list = dynamic_cast<const IcebergMultiFileList &>(*iceberg_state.file_list);
+	auto &metadata = multi_file_list.GetMetadata();
 	auto file_id = reader_data.reader->file_list_idx.GetIndex();
 	auto bound_manifest_entry = multi_file_list.GetManifestEntry(file_id);
-	multi_file_list.ProcessDeletes(bound_manifest_entry);
+	auto manifest_file = multi_file_list.GetManifestFileForDataFile(file_id);
+	auto delete_plan = multi_file_list.ProcessDeletes(bound_manifest_entry);
 
 	//! Make a copy of the global columns+column_ids, if we have equality deletes we will add columns to this
 	//! This is done so CreateMapping treats these columns as required for the current file,
 	//! and sets up local_column_ids+expressions for these columns.
 	auto scan_columns = global_columns;
 	auto scan_column_ids = global_column_ids;
-	auto read_columns = AddEqualityDeleteColumns(multi_file_list, bound_manifest_entry, scan_columns, scan_column_ids,
+	auto read_columns = AddEqualityDeleteColumns(metadata, delete_plan.equality_deletes, scan_columns, scan_column_ids,
 	                                             reader_data, context);
 	auto equality_delete_state = make_uniq<IcebergEqualityDeleteReadState>(std::move(read_columns));
 
@@ -405,22 +404,21 @@ ReaderInitializeType IcebergMultiFileReader::InitializeReader(MultiFileReaderDat
 	                              scan_column_ids, context, gstate.multi_file_reader_state.get());
 
 	auto &reader = *reader_data.reader;
-	const auto &file_path = bound_manifest_entry.entry.data_file.file_path;
-	reader.deletion_filter = multi_file_list.GetPositionalDeletesForFile(file_path);
+	reader.deletion_filter = std::move(delete_plan.positional_deletes);
 
 	auto &local_columns = reader_data.reader->columns;
-	auto &metadata = multi_file_list.GetMetadata();
 	auto &mappings = metadata.mappings;
-	if (!multi_file_list.GetMetadata().mappings.empty()) {
+	if (!metadata.mappings.empty()) {
 		auto &root = metadata.mappings[0];
 		for (auto &local_column : local_columns) {
 			ApplyFieldMapping(local_column, mappings, root.field_mapping_indexes, context);
 		}
 	}
-	ApplyPartitionConstants(multi_file_list, reader_data, scan_columns, scan_column_ids, context);
+	ApplyPartitionConstants(manifest_file, bound_manifest_entry, metadata, reader_data, scan_columns, scan_column_ids,
+	                        context);
 
 	equality_delete_state->expression =
-	    CreateEqualityDeleteExpression(multi_file_list, bound_manifest_entry, local_columns, *equality_delete_state);
+	    CreateEqualityDeleteExpression(delete_plan.equality_deletes, local_columns, *equality_delete_state);
 	iceberg_state.CacheEqualityDeleteReadState(file_id, std::move(equality_delete_state));
 
 	return CreateMapping(context, reader_data, scan_columns, scan_column_ids, table_filters, gstate.file_list,
@@ -436,9 +434,8 @@ void IcebergMultiFileReader::FinalizeBind(MultiFileReaderData &reader_data, cons
 }
 
 unique_ptr<Expression> IcebergMultiFileReader::CreateEqualityDeleteExpression(
-    const IcebergMultiFileList &multi_file_list, const BoundIcebergManifestEntry &bound_manifest_entry,
+    const vector<reference<const IcebergEqualityDeleteFile>> &delete_files,
     const vector<MultiFileColumnDefinition> &local_columns, const IcebergEqualityDeleteReadState &read_state) {
-	auto delete_files = multi_file_list.GetEqualityDeletesForFile(bound_manifest_entry);
 	if (delete_files.empty()) {
 		return nullptr;
 	}
@@ -460,8 +457,7 @@ unique_ptr<Expression> IcebergMultiFileReader::CreateEqualityDeleteExpression(
 		if (equality_values.size() == 0) {
 			continue;
 		}
-		auto manifest_entry = multi_file_list.GetDeleteManifestEntry(delete_file.manifest_entry_index);
-		auto &equality_ids = manifest_entry.entry.data_file.equality_ids;
+		auto &equality_ids = delete_file.equality_ids;
 		if (equality_values.ColumnCount() != equality_ids.size()) {
 			throw InvalidConfigurationException("Equality delete file contains an unexpected number of columns");
 		}

--- a/src/planning/pruning/iceberg_file_pruner.cpp
+++ b/src/planning/pruning/iceberg_file_pruner.cpp
@@ -171,6 +171,126 @@ bool IcebergFilePruner::FileMatchesFilter(const IcebergManifestFile &manifest_fi
 	return true;
 }
 
+bool IcebergFilePruner::DeleteManifestMatchesDataFile(const IcebergManifestFile &delete_manifest,
+                                                      const IcebergManifestFile &data_manifest,
+                                                      const IcebergManifestEntry &data_manifest_entry) const {
+	if (!delete_manifest.sequence_number) {
+		throw InvalidConfigurationException("Delete manifest %s does not have a sequence number",
+		                                    delete_manifest.manifest_path);
+	}
+	if (*delete_manifest.sequence_number < data_manifest_entry.GetSequenceNumber(data_manifest)) {
+		return false;
+	}
+
+	auto partition_spec_it = metadata.partition_specs.find(delete_manifest.partition_spec_id);
+	if (partition_spec_it == metadata.partition_specs.end()) {
+		throw InvalidInputException("Delete manifest %s references partition_spec_id %d which doesn't exist",
+		                            delete_manifest.manifest_path, delete_manifest.partition_spec_id);
+	}
+	auto &delete_partition_spec = partition_spec_it->second;
+	if (delete_partition_spec.IsUnpartitioned()) {
+		return true;
+	}
+	if (delete_manifest.partition_spec_id != data_manifest.partition_spec_id) {
+		return false;
+	}
+	if (!delete_manifest.partitions.has_partitions) {
+		return true;
+	}
+
+	auto &field_summaries = delete_manifest.partitions.field_summary;
+	if (delete_partition_spec.fields.size() != field_summaries.size()) {
+		throw InvalidInputException("Delete manifest has %d partition summaries but partition spec %d has %d fields",
+		                            field_summaries.size(), delete_manifest.partition_spec_id,
+		                            delete_partition_spec.fields.size());
+	}
+
+	unordered_map<uint64_t, reference<const Value>> partition_values;
+	for (auto &partition : data_manifest_entry.data_file.partition_info) {
+		partition_values.emplace(partition.field_id, partition.value);
+	}
+
+	for (idx_t field_idx = 0; field_idx < delete_partition_spec.fields.size(); field_idx++) {
+		auto &field = delete_partition_spec.fields[field_idx];
+		auto partition_value_it = partition_values.find(field.partition_field_id);
+		if (partition_value_it == partition_values.end()) {
+			return true;
+		}
+		auto &partition_value = partition_value_it->second.get();
+		auto &field_summary = field_summaries[field_idx];
+		if (partition_value.IsNull()) {
+			if (!field_summary.contains_null) {
+				return false;
+			}
+			continue;
+		}
+
+		auto source_column = metadata.FindColumnByFieldId(NumericCast<int32_t>(field.source_id));
+		if (!source_column) {
+			return true;
+		}
+		auto partition_type = field.transform.GetSerializedType(source_column->type);
+		auto stats = IcebergPredicateStats::DeserializeBounds(field_summary.lower_bound, field_summary.upper_bound,
+		                                                      source_column->name, partition_type);
+		auto typed_partition_value = partition_value.DefaultCastAs(partition_type);
+		if (stats.lower_bound && typed_partition_value < *stats.lower_bound) {
+			return false;
+		}
+		if (stats.upper_bound && typed_partition_value > *stats.upper_bound) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool IcebergFilePruner::DeleteFileMatchesDataFile(const IcebergManifestFile &delete_manifest,
+                                                  const IcebergManifestEntry &delete_manifest_entry,
+                                                  const IcebergManifestFile &data_manifest,
+                                                  const IcebergManifestEntry &data_manifest_entry) const {
+	auto &delete_file = delete_manifest_entry.data_file;
+	auto &data_file = data_manifest_entry.data_file;
+	if (delete_file.referenced_data_file && *delete_file.referenced_data_file != data_file.file_path) {
+		return false;
+	}
+
+	auto delete_sequence_number = delete_manifest_entry.GetSequenceNumber(delete_manifest);
+	auto data_sequence_number = data_manifest_entry.GetSequenceNumber(data_manifest);
+	if (delete_file.content == IcebergManifestEntryContentType::EQUALITY_DELETES) {
+		if (delete_sequence_number <= data_sequence_number) {
+			return false;
+		}
+	} else if (delete_sequence_number < data_sequence_number) {
+		return false;
+	}
+
+	auto partition_spec_it = metadata.partition_specs.find(delete_manifest.partition_spec_id);
+	if (partition_spec_it == metadata.partition_specs.end()) {
+		throw InvalidInputException("Delete manifest %s references partition_spec_id %d which doesn't exist",
+		                            delete_manifest.manifest_path, delete_manifest.partition_spec_id);
+	}
+	if (partition_spec_it->second.IsUnpartitioned()) {
+		return true;
+	}
+	if (delete_manifest.partition_spec_id != data_manifest.partition_spec_id) {
+		return false;
+	}
+
+	unordered_map<uint64_t, reference<const Value>> data_partition_values;
+	for (auto &partition : data_file.partition_info) {
+		data_partition_values.emplace(partition.field_id, partition.value);
+	}
+	for (auto &delete_partition : delete_file.partition_info) {
+		auto data_partition = data_partition_values.find(delete_partition.field_id);
+		if (data_partition == data_partition_values.end()) {
+			return true;
+		}
+		if (delete_partition.value != data_partition->second.get()) {
+			return false;
+		}
+	}
+	return true;
+}
+
 bool IcebergFilePruner::ManifestMatchesFilter(const IcebergManifestFile &manifest) const {
 	auto spec_id = manifest.partition_spec_id;
 	auto partition_spec_it = metadata.partition_specs.find(spec_id);

--- a/src/planning/pruning/iceberg_file_pruner.cpp
+++ b/src/planning/pruning/iceberg_file_pruner.cpp
@@ -257,12 +257,27 @@ bool IcebergFilePruner::DeleteFileMatchesDataFile(const IcebergManifestFile &del
 
 	auto delete_sequence_number = delete_manifest_entry.GetSequenceNumber(delete_manifest);
 	auto data_sequence_number = data_manifest_entry.GetSequenceNumber(data_manifest);
-	if (delete_file.content == IcebergManifestEntryContentType::EQUALITY_DELETES) {
+
+	switch (delete_file.content) {
+	case IcebergManifestEntryContentType::EQUALITY_DELETES: {
 		if (delete_sequence_number <= data_sequence_number) {
 			return false;
 		}
-	} else if (delete_sequence_number < data_sequence_number) {
-		return false;
+		break;
+	}
+	case IcebergManifestEntryContentType::POSITION_DELETES: {
+		if (delete_sequence_number < data_sequence_number) {
+			return false;
+		}
+		auto &referenced_data_file = delete_manifest_entry.data_file.referenced_data_file;
+		if (referenced_data_file && *referenced_data_file != data_manifest_entry.data_file.file_path) {
+			return false;
+		}
+		break;
+	}
+	default:
+		throw InternalException("Unexpected manifest entry content type: %d",
+		                        static_cast<uint8_t>(delete_file.content));
 	}
 
 	auto partition_spec_it = metadata.partition_specs.find(delete_manifest.partition_spec_id);

--- a/src/planning/pruning/iceberg_file_pruner.cpp
+++ b/src/planning/pruning/iceberg_file_pruner.cpp
@@ -269,10 +269,6 @@ bool IcebergFilePruner::DeleteFileMatchesDataFile(const IcebergManifestFile &del
 		if (delete_sequence_number < data_sequence_number) {
 			return false;
 		}
-		auto &referenced_data_file = delete_manifest_entry.data_file.referenced_data_file;
-		if (referenced_data_file && *referenced_data_file != data_manifest_entry.data_file.file_path) {
-			return false;
-		}
 		break;
 	}
 	default:

--- a/src/planning/pruning/iceberg_file_pruner.cpp
+++ b/src/planning/pruning/iceberg_file_pruner.cpp
@@ -195,6 +195,8 @@ bool IcebergFilePruner::DeleteManifestMatchesDataFile(const IcebergManifestFile 
 		return false;
 	}
 	if (!delete_manifest.partitions.has_partitions) {
+		//! NOTE: This is conservative: the manifest doesn't have partition stats, but the partition spec matches
+		//! So the manifest entries in the delete manifest might still apply
 		return true;
 	}
 

--- a/src/planning/pruning/iceberg_file_pruner.cpp
+++ b/src/planning/pruning/iceberg_file_pruner.cpp
@@ -277,16 +277,23 @@ bool IcebergFilePruner::DeleteFileMatchesDataFile(const IcebergManifestFile &del
 		return false;
 	}
 
-	unordered_map<uint64_t, reference<const Value>> data_partition_values;
-	for (auto &partition : data_file.partition_info) {
-		data_partition_values.emplace(partition.field_id, partition.value);
+	if (delete_file.partition_info.size() != data_file.partition_info.size()) {
+		throw InvalidConfigurationException(
+		    "Delete file %s has %llu partition values, but data file %s has %llu for partition spec %d",
+		    delete_file.file_path, delete_file.partition_info.size(), data_file.file_path,
+		    data_file.partition_info.size(), delete_manifest.partition_spec_id);
 	}
-	for (auto &delete_partition : delete_file.partition_info) {
-		auto data_partition = data_partition_values.find(delete_partition.field_id);
-		if (data_partition == data_partition_values.end()) {
-			return true;
+	for (idx_t partition_idx = 0; partition_idx < delete_file.partition_info.size(); partition_idx++) {
+		auto &delete_partition = delete_file.partition_info[partition_idx];
+		auto &data_partition = data_file.partition_info[partition_idx];
+		if (delete_partition.field_id != data_partition.field_id) {
+			throw InvalidConfigurationException(
+			    "Delete file %s has partition field id %llu at index %llu, but data file %s has field id %llu for "
+			    "partition spec %d",
+			    delete_file.file_path, delete_partition.field_id, partition_idx, data_file.file_path,
+			    data_partition.field_id, delete_manifest.partition_spec_id);
 		}
-		if (delete_partition.value != data_partition->second.get()) {
+		if (!Value::NotDistinctFrom(delete_partition.value, data_partition.value)) {
 			return false;
 		}
 	}

--- a/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
+++ b/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
@@ -162,6 +162,8 @@ void ClientSideScanPlanProvider::LoadManifestList() {
 		shared_state.delete_manifest_loads.resize(DeleteManifests().size());
 		shared_state.delete_manifest_entries_enumerated.resize(
 		    DeleteManifests().size() + shared_state.transaction_delete_manifests.size(), false);
+		shared_state.delete_manifest_entry_indexes.resize(DeleteManifests().size() +
+		                                                  shared_state.transaction_delete_manifests.size());
 	}
 
 	shared_state.manifest_list_loaded = true;
@@ -326,7 +328,8 @@ void ClientSideScanPlanProvider::ReadDeleteManifests(const vector<idx_t> &manife
 	}
 }
 
-void ClientSideScanPlanProvider::EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) {
+vector<idx_t> ClientSideScanPlanProvider::EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) {
+	vector<idx_t> result;
 	optional_ptr<const case_insensitive_map_t<string>> transactional_delete_files;
 	if (context.transaction_data) {
 		transactional_delete_files = context.transaction_data->transactional_delete_files;
@@ -338,6 +341,8 @@ void ClientSideScanPlanProvider::EnumerateDeleteManifestEntries(const vector<idx
 			throw InternalException("Selected delete manifest index %llu is out of bounds", manifest_idx);
 		}
 		if (shared_state.delete_manifest_entries_enumerated[manifest_idx]) {
+			result.insert(result.end(), shared_state.delete_manifest_entry_indexes[manifest_idx].begin(),
+			              shared_state.delete_manifest_entry_indexes[manifest_idx].end());
 			continue;
 		}
 
@@ -378,10 +383,15 @@ void ClientSideScanPlanProvider::EnumerateDeleteManifestEntries(const vector<idx
 		shared_state.delete_manifest_entries.reserve(shared_state.delete_manifest_entries.size() +
 		                                             bound_entries.size());
 		for (auto &bound_entry : bound_entries) {
+			auto entry_idx = shared_state.delete_manifest_entries.size();
 			shared_state.delete_manifest_entries.push_back(std::move(bound_entry));
+			shared_state.delete_file_loads.push_back(nullptr);
+			shared_state.delete_manifest_entry_indexes[manifest_idx].push_back(entry_idx);
+			result.push_back(entry_idx);
 		}
 		shared_state.delete_manifest_entries_enumerated[manifest_idx] = true;
 	}
+	return result;
 }
 
 bool ClientSideScanPlanProvider::TryGetNextBatch(IcebergDataViewCursor &cursor) {
@@ -431,12 +441,12 @@ vector<IcebergManifestListEntry> &ClientSideScanPlanProvider::DeleteManifests() 
 	return shared_state.committed_delete_manifests;
 }
 
-idx_t &ClientSideScanPlanProvider::NextDeleteEntryToProcess() {
-	return shared_state.next_delete_entry_to_process;
-}
-
 vector<BoundIcebergManifestEntry> &ClientSideScanPlanProvider::DeleteManifestEntries() {
 	return shared_state.delete_manifest_entries;
+}
+
+vector<shared_ptr<IcebergDeleteFileLoadState>> &ClientSideScanPlanProvider::DeleteFileLoads() {
+	return shared_state.delete_file_loads;
 }
 
 position_delete_map_t &ClientSideScanPlanProvider::PositionalDeleteData() {

--- a/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
+++ b/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
@@ -16,7 +16,6 @@
 #include "iceberg_logging.hpp"
 #include "planning/metadata_io/avro/avro_scan.hpp"
 #include "planning/metadata_io/manifest/iceberg_manifest_reader.hpp"
-#include "planning/metadata_io/manifest_list/bound_iceberg_manifest_list_entry.hpp"
 #include "planning/metadata_io/manifest_list/iceberg_manifest_list_reader.hpp"
 
 #include <condition_variable>
@@ -160,10 +159,8 @@ void ClientSideScanPlanProvider::LoadManifestList() {
 	{
 		annotated_lock_guard<annotated_mutex> delete_guard(shared_state.delete_lock);
 		shared_state.delete_manifest_loads.resize(DeleteManifests().size());
-		shared_state.delete_manifest_entries_enumerated.resize(
-		    DeleteManifests().size() + shared_state.transaction_delete_manifests.size(), false);
-		shared_state.delete_manifest_entry_indexes.resize(DeleteManifests().size() +
-		                                                  shared_state.transaction_delete_manifests.size());
+		shared_state.delete_file_loads.resize(DeleteManifests().size() +
+		                                      shared_state.transaction_delete_manifests.size());
 	}
 
 	shared_state.manifest_list_loaded = true;
@@ -328,8 +325,8 @@ void ClientSideScanPlanProvider::ReadDeleteManifests(const vector<idx_t> &manife
 	}
 }
 
-vector<idx_t> ClientSideScanPlanProvider::EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) {
-	vector<idx_t> result;
+vector<IcebergDeleteFileReference> ClientSideScanPlanProvider::GetDeleteFiles(const vector<idx_t> &manifest_indexes) {
+	vector<IcebergDeleteFileReference> result;
 	optional_ptr<const case_insensitive_map_t<string>> transactional_delete_files;
 	if (context.transaction_data) {
 		transactional_delete_files = context.transaction_data->transactional_delete_files;
@@ -340,20 +337,15 @@ vector<idx_t> ClientSideScanPlanProvider::EnumerateDeleteManifestEntries(const v
 		if (manifest_idx >= total_manifest_count) {
 			throw InternalException("Selected delete manifest index %llu is out of bounds", manifest_idx);
 		}
-		if (shared_state.delete_manifest_entries_enumerated[manifest_idx]) {
-			result.insert(result.end(), shared_state.delete_manifest_entry_indexes[manifest_idx].begin(),
-			              shared_state.delete_manifest_entry_indexes[manifest_idx].end());
-			continue;
-		}
 
-		vector<BoundIcebergManifestEntry> bound_entries;
 		if (manifest_idx < committed_manifest_count) {
 			auto &manifest_list_entry = DeleteManifests()[manifest_idx];
 			if (!manifest_list_entry.HasManifestEntries()) {
 				throw InternalException("Selected delete manifest %llu was not loaded", manifest_idx);
 			}
-			auto manifest = BoundIcebergManifestListEntry(manifest_idx, manifest_list_entry);
-			for (auto &manifest_entry : manifest_list_entry.GetManifestEntries()) {
+			auto &manifest_entries = manifest_list_entry.GetManifestEntries();
+			for (idx_t entry_idx = 0; entry_idx < manifest_entries.size(); entry_idx++) {
+				auto &manifest_entry = manifest_entries[entry_idx];
 				if (manifest_entry.status == IcebergManifestEntryStatusType::DELETED) {
 					continue;
 				}
@@ -362,13 +354,14 @@ vector<idx_t> ClientSideScanPlanProvider::EnumerateDeleteManifestEntries(const v
 				    transactional_delete_files->count(*referenced_data_file)) {
 					continue;
 				}
-				bound_entries.push_back(manifest.BindEntry(manifest_entry));
+				result.push_back({manifest_idx, entry_idx});
 			}
 		} else {
 			auto transaction_idx = manifest_idx - committed_manifest_count;
 			auto &manifest_list_entry = shared_state.transaction_delete_manifests[transaction_idx].get();
-			auto manifest = BoundIcebergManifestListEntry(manifest_idx, manifest_list_entry);
-			for (auto &manifest_entry : manifest_list_entry.GetManifestEntries()) {
+			auto &manifest_entries = manifest_list_entry.GetManifestEntries();
+			for (idx_t entry_idx = 0; entry_idx < manifest_entries.size(); entry_idx++) {
+				auto &manifest_entry = manifest_entries[entry_idx];
 				auto &data_file = manifest_entry.data_file;
 				auto &referenced_data_file = data_file.referenced_data_file;
 				if (referenced_data_file && transactional_delete_files) {
@@ -377,19 +370,9 @@ vector<idx_t> ClientSideScanPlanProvider::EnumerateDeleteManifestEntries(const v
 						continue;
 					}
 				}
-				bound_entries.push_back(manifest.BindEntry(manifest_entry));
+				result.push_back({manifest_idx, entry_idx});
 			}
 		}
-		shared_state.delete_manifest_entries.reserve(shared_state.delete_manifest_entries.size() +
-		                                             bound_entries.size());
-		for (auto &bound_entry : bound_entries) {
-			auto entry_idx = shared_state.delete_manifest_entries.size();
-			shared_state.delete_manifest_entries.push_back(std::move(bound_entry));
-			shared_state.delete_file_loads.push_back(nullptr);
-			shared_state.delete_manifest_entry_indexes[manifest_idx].push_back(entry_idx);
-			result.push_back(entry_idx);
-		}
-		shared_state.delete_manifest_entries_enumerated[manifest_idx] = true;
 	}
 	return result;
 }
@@ -441,20 +424,28 @@ vector<IcebergManifestListEntry> &ClientSideScanPlanProvider::DeleteManifests() 
 	return shared_state.committed_delete_manifests;
 }
 
-vector<BoundIcebergManifestEntry> &ClientSideScanPlanProvider::DeleteManifestEntries() {
-	return shared_state.delete_manifest_entries;
-}
-
-vector<shared_ptr<IcebergDeleteFileLoadState>> &ClientSideScanPlanProvider::DeleteFileLoads() {
-	return shared_state.delete_file_loads;
+shared_ptr<IcebergDeleteFileLoadState> &
+ClientSideScanPlanProvider::GetDeleteFileLoad(IcebergDeleteFileReference delete_file) {
+	auto committed_manifest_count = DeleteManifests().size();
+	auto total_manifest_count = committed_manifest_count + shared_state.transaction_delete_manifests.size();
+	if (delete_file.manifest_idx >= total_manifest_count) {
+		throw InternalException("Delete manifest index %llu is out of bounds", delete_file.manifest_idx);
+	}
+	auto &manifest =
+	    delete_file.manifest_idx < committed_manifest_count
+	        ? DeleteManifests()[delete_file.manifest_idx]
+	        : shared_state.transaction_delete_manifests[delete_file.manifest_idx - committed_manifest_count].get();
+	auto &manifest_entries = manifest.GetManifestEntries();
+	if (delete_file.entry_idx >= manifest_entries.size()) {
+		throw InternalException("Delete manifest entry index %llu is out of bounds for manifest %llu",
+		                        delete_file.entry_idx, delete_file.manifest_idx);
+	}
+	auto &loads = shared_state.delete_file_loads[delete_file.manifest_idx];
+	return loads[delete_file.entry_idx];
 }
 
 position_delete_map_t &ClientSideScanPlanProvider::PositionalDeleteData() {
 	return shared_state.positional_delete_data;
-}
-
-equality_delete_map_t &ClientSideScanPlanProvider::EqualityDeleteData() {
-	return shared_state.equality_delete_data;
 }
 
 } // namespace duckdb

--- a/src/planning/scan_plan/iceberg_server_scan_plan_provider.cpp
+++ b/src/planning/scan_plan/iceberg_server_scan_plan_provider.cpp
@@ -1,12 +1,9 @@
 #include "planning/scan_plan/iceberg_scan_plan_provider.hpp"
 
-#include "planning/metadata_io/manifest_list/bound_iceberg_manifest_list_entry.hpp"
-
 namespace duckdb {
 
 ServerSideScanPlanProvider::ServerSideScanPlanProvider(IcebergServerSideScanPlan plan_p) : plan(std::move(plan_p)) {
-	delete_manifest_entries_enumerated.resize(plan.delete_manifests.size(), false);
-	delete_manifest_entry_indexes.resize(plan.delete_manifests.size());
+	delete_file_loads.resize(plan.delete_manifests.size());
 }
 
 void ServerSideScanPlanProvider::LoadManifestList() {
@@ -25,29 +22,20 @@ void ServerSideScanPlanProvider::StartDataManifestScan(const vector<bool> &match
 	}
 }
 
-vector<idx_t> ServerSideScanPlanProvider::EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) {
-	vector<idx_t> result;
+vector<IcebergDeleteFileReference> ServerSideScanPlanProvider::GetDeleteFiles(const vector<idx_t> &manifest_indexes) {
+	vector<IcebergDeleteFileReference> result;
 	for (auto manifest_idx : manifest_indexes) {
 		if (manifest_idx >= plan.delete_manifests.size()) {
 			throw InternalException("Selected server-side delete manifest index %llu is out of bounds", manifest_idx);
 		}
-		if (delete_manifest_entries_enumerated[manifest_idx]) {
-			result.insert(result.end(), delete_manifest_entry_indexes[manifest_idx].begin(),
-			              delete_manifest_entry_indexes[manifest_idx].end());
-			continue;
-		}
 		auto &manifest_list_entry = plan.delete_manifests[manifest_idx];
-		auto manifest = BoundIcebergManifestListEntry(manifest_idx, manifest_list_entry);
-		for (auto &manifest_entry : manifest_list_entry.GetManifestEntries()) {
+		auto &manifest_entries = manifest_list_entry.GetManifestEntries();
+		for (idx_t entry_idx = 0; entry_idx < manifest_entries.size(); entry_idx++) {
+			auto &manifest_entry = manifest_entries[entry_idx];
 			if (manifest_entry.status != IcebergManifestEntryStatusType::DELETED) {
-				auto entry_idx = delete_manifest_entries.size();
-				delete_manifest_entries.push_back(manifest.BindEntry(manifest_entry));
-				delete_file_loads.push_back(nullptr);
-				delete_manifest_entry_indexes[manifest_idx].push_back(entry_idx);
-				result.push_back(entry_idx);
+				result.push_back({manifest_idx, entry_idx});
 			}
 		}
-		delete_manifest_entries_enumerated[manifest_idx] = true;
 	}
 	return result;
 }
@@ -73,20 +61,22 @@ vector<IcebergManifestListEntry> &ServerSideScanPlanProvider::DeleteManifests() 
 	return plan.delete_manifests;
 }
 
-vector<BoundIcebergManifestEntry> &ServerSideScanPlanProvider::DeleteManifestEntries() {
-	return delete_manifest_entries;
-}
-
-vector<shared_ptr<IcebergDeleteFileLoadState>> &ServerSideScanPlanProvider::DeleteFileLoads() {
-	return delete_file_loads;
+shared_ptr<IcebergDeleteFileLoadState> &
+ServerSideScanPlanProvider::GetDeleteFileLoad(IcebergDeleteFileReference delete_file) {
+	if (delete_file.manifest_idx >= plan.delete_manifests.size()) {
+		throw InternalException("Delete manifest index %llu is out of bounds", delete_file.manifest_idx);
+	}
+	auto &manifest_entries = plan.delete_manifests[delete_file.manifest_idx].GetManifestEntries();
+	if (delete_file.entry_idx >= manifest_entries.size()) {
+		throw InternalException("Delete manifest entry index %llu is out of bounds for manifest %llu",
+		                        delete_file.entry_idx, delete_file.manifest_idx);
+	}
+	auto &loads = delete_file_loads[delete_file.manifest_idx];
+	return loads[delete_file.entry_idx];
 }
 
 position_delete_map_t &ServerSideScanPlanProvider::PositionalDeleteData() {
 	return positional_delete_data;
-}
-
-equality_delete_map_t &ServerSideScanPlanProvider::EqualityDeleteData() {
-	return equality_delete_data;
 }
 
 } // namespace duckdb

--- a/src/planning/scan_plan/iceberg_server_scan_plan_provider.cpp
+++ b/src/planning/scan_plan/iceberg_server_scan_plan_provider.cpp
@@ -6,6 +6,7 @@ namespace duckdb {
 
 ServerSideScanPlanProvider::ServerSideScanPlanProvider(IcebergServerSideScanPlan plan_p) : plan(std::move(plan_p)) {
 	delete_manifest_entries_enumerated.resize(plan.delete_manifests.size(), false);
+	delete_manifest_entry_indexes.resize(plan.delete_manifests.size());
 }
 
 void ServerSideScanPlanProvider::LoadManifestList() {
@@ -24,23 +25,31 @@ void ServerSideScanPlanProvider::StartDataManifestScan(const vector<bool> &match
 	}
 }
 
-void ServerSideScanPlanProvider::EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) {
+vector<idx_t> ServerSideScanPlanProvider::EnumerateDeleteManifestEntries(const vector<idx_t> &manifest_indexes) {
+	vector<idx_t> result;
 	for (auto manifest_idx : manifest_indexes) {
 		if (manifest_idx >= plan.delete_manifests.size()) {
 			throw InternalException("Selected server-side delete manifest index %llu is out of bounds", manifest_idx);
 		}
 		if (delete_manifest_entries_enumerated[manifest_idx]) {
+			result.insert(result.end(), delete_manifest_entry_indexes[manifest_idx].begin(),
+			              delete_manifest_entry_indexes[manifest_idx].end());
 			continue;
 		}
 		auto &manifest_list_entry = plan.delete_manifests[manifest_idx];
 		auto manifest = BoundIcebergManifestListEntry(manifest_idx, manifest_list_entry);
 		for (auto &manifest_entry : manifest_list_entry.GetManifestEntries()) {
 			if (manifest_entry.status != IcebergManifestEntryStatusType::DELETED) {
+				auto entry_idx = delete_manifest_entries.size();
 				delete_manifest_entries.push_back(manifest.BindEntry(manifest_entry));
+				delete_file_loads.push_back(nullptr);
+				delete_manifest_entry_indexes[manifest_idx].push_back(entry_idx);
+				result.push_back(entry_idx);
 			}
 		}
 		delete_manifest_entries_enumerated[manifest_idx] = true;
 	}
+	return result;
 }
 
 bool ServerSideScanPlanProvider::TryGetNextBatch(IcebergDataViewCursor &cursor) {
@@ -64,12 +73,12 @@ vector<IcebergManifestListEntry> &ServerSideScanPlanProvider::DeleteManifests() 
 	return plan.delete_manifests;
 }
 
-idx_t &ServerSideScanPlanProvider::NextDeleteEntryToProcess() {
-	return next_delete_entry_to_process;
-}
-
 vector<BoundIcebergManifestEntry> &ServerSideScanPlanProvider::DeleteManifestEntries() {
 	return delete_manifest_entries;
+}
+
+vector<shared_ptr<IcebergDeleteFileLoadState>> &ServerSideScanPlanProvider::DeleteFileLoads() {
+	return delete_file_loads;
 }
 
 position_delete_map_t &ServerSideScanPlanProvider::PositionalDeleteData() {

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_do_not_read_equality_deletes.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/equality_deletes/test_do_not_read_equality_deletes.test
@@ -114,4 +114,3 @@ select count(distinct(request.url)) from duckdb_logs_parsed('http') where reques
 3
 
 
-


### PR DESCRIPTION
In #1256 we made sure only to load manifests that apply to the data file being scanned.
But the resulting scan for the delete files just looked at the **full** list of (filtered) deletes.
This means that we could be scanning a delete file from a manifest that applied to a different data file, rather than only being concerned with the set that came from manifests that we added.

This PR makes it so that the final delete file scan is also narrowed down to the files that came from manifests that were selected for this data file.

The goal is to reduce lock contention, by making it more granular and centered around the data files.
So hopefully more readers can get initialized in parallel for separate data files.

Essentially the process of `InitializeReader` is now this:
1. Grab our `BoundIcebergManifestEntry` from the `file_list_idx`
2. Find the conservative group of manifest files that could apply to the data file
3. Load those delete manifests in parallel
4. Load the delete files that *actually* apply in parallel

End result is that we have a set of equality delete files + DeleteFilter that apply to our data file, from which we can plan our data file scan.