### PR TITLE
Optimize partitioned iceberg_rewrite_data_files via IcebergCopyOptions

### DIFF
--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -160,3 +160,8 @@ jobs:
         run: |
           ls benchmark/file_pruning_benchmarks/*.benchmark > .github/regression/file_pruning_benchmarks.csv
           python duckdb/scripts/regression/test_runner.py --old base/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/file_pruning_benchmarks.csv --verbose --threads 2 --benchmark-cache=clear
+
+      - name: Regression Test Rewrite Data Files Benchmarks
+        run: |
+          ls benchmark/rewrite_data_files/*.benchmark > .github/regression/rewrite_data_files.csv
+          python duckdb/scripts/regression/test_runner.py --old base/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/rewrite_data_files.csv --verbose --threads 2 --benchmark-cache=clear

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -160,3 +160,8 @@ jobs:
         run: |
           ls benchmark/file_pruning_benchmarks/*.benchmark > .github/regression/file_pruning_benchmarks.csv
           python duckdb/scripts/regression/test_runner.py --old base/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/file_pruning_benchmarks.csv --root-dir "$GITHUB_WORKSPACE" --verbose --threads 2 --clear-benchmark-cache
+
+      - name: Regression Test Rewrite Data Files Benchmarks
+        run: |
+          ls benchmark/rewrite_data_files/*.benchmark > .github/regression/rewrite_data_files.csv
+          python duckdb/scripts/regression/test_runner.py --old base/build/release/benchmark/benchmark_runner --new build/release/benchmark/benchmark_runner --benchmarks .github/regression/rewrite_data_files.csv --root-dir "$GITHUB_WORKSPACE" --verbose --threads 2 --clear-benchmark-cache

--- a/benchmark/rewrite_data_files/partitioned_rewrite.benchmark
+++ b/benchmark/rewrite_data_files/partitioned_rewrite.benchmark
@@ -45,46 +45,52 @@ SELECT
     range,
     chr((65 + (range % 16))::INTEGER),
     'payload-' || range::VARCHAR
-FROM range(16000);
+FROM range(1000000);
 INSERT INTO my_datalake.default.partitioned_rewrite_bench
 SELECT
     range + 16000,
     chr((65 + (range % 16))::INTEGER),
     'payload-' || (range + 16000)::VARCHAR
-FROM range(16000);
+FROM range(1000000);
 INSERT INTO my_datalake.default.partitioned_rewrite_bench
 SELECT
     range + 32000,
     chr((65 + (range % 16))::INTEGER),
     'payload-' || (range + 32000)::VARCHAR
-FROM range(16000);
+FROM range(1000000);
 INSERT INTO my_datalake.default.partitioned_rewrite_bench
 SELECT
     range + 48000,
     chr((65 + (range % 16))::INTEGER),
     'payload-' || (range + 48000)::VARCHAR
-FROM range(16000);
+FROM range(1000000);
 INSERT INTO my_datalake.default.partitioned_rewrite_bench
 SELECT
     range + 64000,
     chr((65 + (range % 16))::INTEGER),
     'payload-' || (range + 64000)::VARCHAR
-FROM range(16000);
+FROM range(1000000);
 INSERT INTO my_datalake.default.partitioned_rewrite_bench
 SELECT
     range + 80000,
     chr((65 + (range % 16))::INTEGER),
     'payload-' || (range + 80000)::VARCHAR
-FROM range(16000);
--- Snapshot tip before rewrite; cleanup rolls back here so warmup + timed runs share state.
-SET VARIABLE pre_rewrite_snapshot = (
-    SELECT snapshot_id
+FROM range(1000000);
+drop table if exists my_datalake.default.pre_rewrite_snapshot;
+create table my_datalake.default.pre_rewrite_snapshot as
+    SELECT snapshot_id::BIGINT snapshot_id
     FROM iceberg_snapshots(my_datalake.default.partitioned_rewrite_bench)
     ORDER BY sequence_number DESC
-    LIMIT 1
-);
+    LIMIT 1;
 
 run
+set enable_external_file_cache=false;
+set variable pre_rewrite_snapshot_var = (select snapshot_id from my_datalake.default.pre_rewrite_snapshot limit 1);
+SELECT *
+FROM iceberg_rollback_to_snapshot(
+    'my_datalake.default.partitioned_rewrite_bench',
+    getvariable('pre_rewrite_snapshot_var')
+);
 SELECT *
 FROM iceberg_rewrite_data_files(
     'my_datalake.default.partitioned_rewrite_bench',
@@ -92,9 +98,3 @@ FROM iceberg_rewrite_data_files(
     rewrite_all => true
 );
 
-cleanup
-SELECT *
-FROM iceberg_rollback_to_snapshot(
-    'my_datalake.default.partitioned_rewrite_bench',
-    getvariable('pre_rewrite_snapshot')
-);

--- a/benchmark/rewrite_data_files/partitioned_rewrite.benchmark
+++ b/benchmark/rewrite_data_files/partitioned_rewrite.benchmark
@@ -76,6 +76,13 @@ SELECT
     chr((65 + (range % 16))::INTEGER),
     'payload-' || (range + 80000)::VARCHAR
 FROM range(16000);
+-- Snapshot tip before rewrite; cleanup rolls back here so warmup + timed runs share state.
+SET VARIABLE pre_rewrite_snapshot = (
+    SELECT snapshot_id
+    FROM iceberg_snapshots(my_datalake.default.partitioned_rewrite_bench)
+    ORDER BY sequence_number DESC
+    LIMIT 1
+);
 
 run
 SELECT *
@@ -83,4 +90,11 @@ FROM iceberg_rewrite_data_files(
     'my_datalake.default.partitioned_rewrite_bench',
     min_input_files => 1,
     rewrite_all => true
+);
+
+cleanup
+SELECT *
+FROM iceberg_rollback_to_snapshot(
+    'my_datalake.default.partitioned_rewrite_bench',
+    getvariable('pre_rewrite_snapshot')
 );

--- a/benchmark/rewrite_data_files/partitioned_rewrite.benchmark
+++ b/benchmark/rewrite_data_files/partitioned_rewrite.benchmark
@@ -1,0 +1,86 @@
+# name: benchmark/rewrite_data_files/partitioned_rewrite.benchmark
+# description: rewrite many small files across partitions with a single partitioned COPY
+# group: [rewrite_data_files]
+
+name Partitioned rewrite data files
+group rewrite_data_files
+subgroup partitioned
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Build a partitioned table with many small files across several partition values.
+# The rewrite should scan candidate files once and write through a single partitioned
+# COPY (IcebergCopyOptions), rather than one Iceberg scan + COPY per partition value.
+load
+SET enable_external_file_cache=false;
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+ATTACH '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://127.0.0.1:8181',
+);
+CREATE SCHEMA if not exists my_datalake.default;
+DROP TABLE IF EXISTS my_datalake.default.partitioned_rewrite_bench;
+CREATE TABLE my_datalake.default.partitioned_rewrite_bench (
+    id BIGINT,
+    category VARCHAR,
+    payload VARCHAR
+) PARTITIONED BY (category);
+INSERT INTO my_datalake.default.partitioned_rewrite_bench
+SELECT
+    range,
+    chr((65 + (range % 16))::INTEGER),
+    'payload-' || range::VARCHAR
+FROM range(16000);
+INSERT INTO my_datalake.default.partitioned_rewrite_bench
+SELECT
+    range + 16000,
+    chr((65 + (range % 16))::INTEGER),
+    'payload-' || (range + 16000)::VARCHAR
+FROM range(16000);
+INSERT INTO my_datalake.default.partitioned_rewrite_bench
+SELECT
+    range + 32000,
+    chr((65 + (range % 16))::INTEGER),
+    'payload-' || (range + 32000)::VARCHAR
+FROM range(16000);
+INSERT INTO my_datalake.default.partitioned_rewrite_bench
+SELECT
+    range + 48000,
+    chr((65 + (range % 16))::INTEGER),
+    'payload-' || (range + 48000)::VARCHAR
+FROM range(16000);
+INSERT INTO my_datalake.default.partitioned_rewrite_bench
+SELECT
+    range + 64000,
+    chr((65 + (range % 16))::INTEGER),
+    'payload-' || (range + 64000)::VARCHAR
+FROM range(16000);
+INSERT INTO my_datalake.default.partitioned_rewrite_bench
+SELECT
+    range + 80000,
+    chr((65 + (range % 16))::INTEGER),
+    'payload-' || (range + 80000)::VARCHAR
+FROM range(16000);
+
+run
+SELECT *
+FROM iceberg_rewrite_data_files(
+    'my_datalake.default.partitioned_rewrite_bench',
+    min_input_files => 1,
+    rewrite_all => true
+);

--- a/src/function/metadata/iceberg_rewrite_data_files.cpp
+++ b/src/function/metadata/iceberg_rewrite_data_files.cpp
@@ -16,7 +16,6 @@
 #include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "function/iceberg_functions.hpp"
-#include "maintenance/rewrite_data_files_executor.hpp"
 #include "maintenance/rewrite_data_files_operator.hpp"
 #include "maintenance/rewrite_data_files_planner.hpp"
 
@@ -91,7 +90,8 @@ static RewriteDataFilesPlanInput ParseRewritePlanInput(TableFunctionBindInput &i
 	return result;
 }
 
-static unique_ptr<QueryNode> BuildGroupSelect(const QualifiedName &table_name, const vector<RewriteCandidate> &group) {
+static unique_ptr<QueryNode> BuildCandidateSelect(const QualifiedName &table_name,
+                                                  const vector<RewriteCandidate> &candidates) {
 	auto select = make_uniq<SelectNode>();
 	select->select_list.push_back(make_uniq<StarExpression>());
 
@@ -102,18 +102,23 @@ static unique_ptr<QueryNode> BuildGroupSelect(const QualifiedName &table_name, c
 
 	vector<unique_ptr<ParsedExpression>> in_children;
 	in_children.push_back(make_uniq<ColumnRefExpression>("filename"));
-	for (auto &candidate : group) {
+	for (auto &candidate : candidates) {
 		in_children.push_back(make_uniq<ConstantExpression>(Value(candidate.file_path)));
 	}
 	//! Read through the attached Iceberg table so the scan layer applies MoR
-	//! position/equality deletes, then scope the scan to this rewrite group's
+	//! position/equality deletes, then scope the scan to the selected rewrite
 	//! source files using the `filename` virtual column.
 	select->where_clause = make_uniq<OperatorExpression>(ExpressionType::COMPARE_IN, std::move(in_children));
 	return std::move(select);
 }
 
-static unique_ptr<LogicalOperator> BindGroupCopy(Binder &binder, const RewritePlan &plan,
-                                                 const vector<RewriteCandidate> &group) {
+//! Bind a LogicalCopyToFile over the candidate scan. The logical COPY is not
+//! executed as-is: CreatePlan peels it off and rebuilds a PhysicalCopyToFile via
+//! IcebergInsert::PlanCopyForInsert (partitioned IcebergCopyOptions). Binding
+//! COPY still matters because RemoveUnusedColumns treats LOGICAL_COPY_TO_FILE as
+//! "everything referenced", preserving all table columns for the later physical
+//! rewrite copy.
+static unique_ptr<LogicalOperator> BindCandidateCopy(Binder &binder, const RewritePlan &plan) {
 	auto &metadata = plan.table_info->table_metadata;
 	auto schema_id = metadata.GetCurrentSchemaId();
 	auto schema_it = metadata.GetSchemas().find(schema_id);
@@ -123,7 +128,7 @@ static unique_ptr<LogicalOperator> BindGroupCopy(Binder &binder, const RewritePl
 
 	auto &fs = FileSystem::GetFileSystem(binder.context);
 	CopyStatement copy_statement;
-	copy_statement.info->select_statement = BuildGroupSelect(plan.table_name, group);
+	copy_statement.info->select_statement = BuildCandidateSelect(plan.table_name, plan.selected_candidates);
 	copy_statement.info->file_path = metadata.GetDataPath(fs);
 	copy_statement.info->format = "parquet";
 	copy_statement.info->is_from = false;
@@ -132,18 +137,12 @@ static unique_ptr<LogicalOperator> BindGroupCopy(Binder &binder, const RewritePl
 	copy_statement.info->options["filename_pattern"].push_back(Value("{uuidv7}"));
 	copy_statement.info->options["file_size_bytes"].push_back(
 	    Value::UBIGINT(static_cast<uint64_t>(plan.target_file_size_bytes)));
-	//! FILE_SIZE_BYTES forces COPY through DuckDB's rotated-file path creation so
-	//! RETURN_STATS reports concrete parquet paths instead of the directory root.
 	copy_statement.info->options["return_stats"].push_back(Value::BOOLEAN(true));
 	copy_statement.info->options["per_thread_output"].push_back(Value::BOOLEAN(false));
 	copy_statement.info->options["append"].push_back(Value::BOOLEAN(true));
 
 	auto copy_binder = Binder::CreateBinder(binder.context, &binder);
 	auto bound_copy = copy_binder->Bind(copy_statement);
-	if (bound_copy.types.size() < 4) {
-		throw InternalException(
-		    "iceberg_rewrite_data_files: expected COPY RETURN_STATS to return at least four columns");
-	}
 	return std::move(bound_copy.plan);
 }
 
@@ -158,8 +157,8 @@ static unique_ptr<LogicalOperator> RewriteDataFilesBindOperator(ClientContext &c
 	auto plan = PlanRewrite(context, plan_input);
 
 	auto result = make_uniq<LogicalRewriteDataFiles>(bind_index.index, std::move(plan));
-	for (idx_t group_idx = 0; group_idx < result->plan.file_groups.size(); group_idx++) {
-		result->children.push_back(BindGroupCopy(*input.binder, result->plan, result->plan.file_groups[group_idx]));
+	if (!result->plan.selected_candidates.empty()) {
+		result->children.push_back(BindCandidateCopy(*input.binder, result->plan));
 	}
 
 	return_names = {"rewritten_data_files", "added_data_files", "rewritten_bytes"};

--- a/src/function/metadata/iceberg_rewrite_data_files.cpp
+++ b/src/function/metadata/iceberg_rewrite_data_files.cpp
@@ -16,7 +16,6 @@
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "function/iceberg_functions.hpp"
-#include "maintenance/rewrite_data_files_executor.hpp"
 #include "maintenance/rewrite_data_files_operator.hpp"
 #include "maintenance/rewrite_data_files_planner.hpp"
 
@@ -91,7 +90,8 @@ static RewriteDataFilesPlanInput ParseRewritePlanInput(TableFunctionBindInput &i
 	return result;
 }
 
-static unique_ptr<QueryNode> BuildGroupSelect(const QualifiedName &table_name, const vector<RewriteCandidate> &group) {
+static unique_ptr<QueryNode> BuildCandidateSelect(const QualifiedName &table_name,
+                                                  const vector<RewriteCandidate> &candidates) {
 	auto select = make_uniq<SelectNode>();
 	select->select_list.push_back(make_uniq<StarExpression>());
 
@@ -102,18 +102,23 @@ static unique_ptr<QueryNode> BuildGroupSelect(const QualifiedName &table_name, c
 
 	vector<unique_ptr<ParsedExpression>> in_children;
 	in_children.push_back(make_uniq<ColumnRefExpression>("filename"));
-	for (auto &candidate : group) {
+	for (auto &candidate : candidates) {
 		in_children.push_back(make_uniq<ConstantExpression>(Value(candidate.file_path)));
 	}
 	//! Read through the attached Iceberg table so the scan layer applies MoR
-	//! position/equality deletes, then scope the scan to this rewrite group's
+	//! position/equality deletes, then scope the scan to the selected rewrite
 	//! source files using the `filename` virtual column.
 	select->where_clause = make_uniq<OperatorExpression>(ExpressionType::COMPARE_IN, std::move(in_children));
 	return std::move(select);
 }
 
-static unique_ptr<LogicalOperator> BindGroupCopy(Binder &binder, const RewritePlan &plan,
-                                                 const vector<RewriteCandidate> &group) {
+//! Bind a LogicalCopyToFile over the candidate scan. The logical COPY is not
+//! executed as-is: CreatePlan peels it off and rebuilds a PhysicalCopyToFile via
+//! IcebergInsert::PlanCopyForInsert (partitioned IcebergCopyOptions). Binding
+//! COPY still matters because RemoveUnusedColumns treats LOGICAL_COPY_TO_FILE as
+//! "everything referenced", preserving all table columns for the later physical
+//! rewrite copy.
+static unique_ptr<LogicalOperator> BindCandidateCopy(Binder &binder, const RewritePlan &plan) {
 	auto &metadata = plan.table_info->table_metadata;
 	auto schema_id = metadata.GetCurrentSchemaId();
 	auto schema_it = metadata.GetSchemas().find(schema_id);
@@ -123,7 +128,7 @@ static unique_ptr<LogicalOperator> BindGroupCopy(Binder &binder, const RewritePl
 
 	auto &fs = FileSystem::GetFileSystem(binder.context);
 	CopyStatement copy_statement;
-	copy_statement.info->select_statement = BuildGroupSelect(plan.table_name, group);
+	copy_statement.info->select_statement = BuildCandidateSelect(plan.table_name, plan.selected_candidates);
 	copy_statement.info->file_path = metadata.GetDataPath(fs);
 	copy_statement.info->format = "parquet";
 	copy_statement.info->is_from = false;
@@ -132,18 +137,12 @@ static unique_ptr<LogicalOperator> BindGroupCopy(Binder &binder, const RewritePl
 	copy_statement.info->options["filename_pattern"].push_back(Value("{uuidv7}"));
 	copy_statement.info->options["file_size_bytes"].push_back(
 	    Value::UBIGINT(static_cast<uint64_t>(plan.target_file_size_bytes)));
-	//! FILE_SIZE_BYTES forces COPY through DuckDB's rotated-file path creation so
-	//! RETURN_STATS reports concrete parquet paths instead of the directory root.
 	copy_statement.info->options["return_stats"].push_back(Value::BOOLEAN(true));
 	copy_statement.info->options["per_thread_output"].push_back(Value::BOOLEAN(false));
 	copy_statement.info->options["append"].push_back(Value::BOOLEAN(true));
 
 	auto copy_binder = Binder::CreateBinder(binder.context, &binder);
 	auto bound_copy = copy_binder->Bind(copy_statement);
-	if (bound_copy.types.size() < 4) {
-		throw InternalException(
-		    "iceberg_rewrite_data_files: expected COPY RETURN_STATS to return at least four columns");
-	}
 	return std::move(bound_copy.plan);
 }
 
@@ -157,8 +156,8 @@ static unique_ptr<LogicalOperator> RewriteDataFilesBindOperator(ClientContext &c
 	auto plan = PlanRewrite(context, plan_input);
 
 	auto result = make_uniq<LogicalRewriteDataFiles>(bind_index.index, std::move(plan));
-	for (idx_t group_idx = 0; group_idx < result->plan.file_groups.size(); group_idx++) {
-		result->children.push_back(BindGroupCopy(*input.binder, result->plan, result->plan.file_groups[group_idx]));
+	if (!result->plan.selected_candidates.empty()) {
+		result->children.push_back(BindCandidateCopy(*input.binder, result->plan));
 	}
 
 	return_names = {"rewritten_data_files", "added_data_files", "rewritten_bytes"};

--- a/src/include/maintenance/rewrite_data_files_executor.hpp
+++ b/src/include/maintenance/rewrite_data_files_executor.hpp
@@ -20,16 +20,7 @@ struct RewriteExecutionResult {
 	vector<RewriteCandidate> rewritten_candidates;
 };
 
-//! Convert one COPY RETURN_STATS row into an ADDED manifest entry. Partition
-//! values and sequence-number semantics come from the frozen rewrite plan.
-//! Column stats / bounds are populated from the RETURN_STATS map.
-IcebergManifestEntry BuildRewriteManifestEntry(ClientContext &context, const vector<RewriteCandidate> &group,
-                                               int64_t starting_sequence_number, int64_t record_count,
-                                               const string &produced_file, int64_t file_size_in_bytes,
-                                               const Value &column_stats, const IcebergTableMetadata &table_metadata,
-                                               const string &table_name);
-
-//! Commit all completed rewrite groups as one Iceberg REPLACE snapshot.
+//! Commit all completed rewrite output as one Iceberg REPLACE snapshot.
 void CommitRewrite(ClientContext &context, const RewritePlan &plan, RewriteExecutionResult &result);
 
 //! Best-effort cleanup for files produced before a rewrite failure.
@@ -38,5 +29,11 @@ void CleanupRewriteFiles(ClientContext &context, const IcebergTable &table_info,
 //! Validate that the currently loaded table snapshot still matches the frozen
 //! rewrite plan. Empty-table plans require the table to remain snapshot-less.
 void ValidateRewriteSnapshot(const RewritePlan &plan, const IcebergTable &table_info, const string &phase);
+
+//! Account selected input files once into the rewrite execution result.
+void AccountSelectedCandidates(const RewritePlan &plan, RewriteExecutionResult &result);
+
+//! Pin rewrite sequence numbers on entries produced via IcebergInsert::AddFiles.
+void PinRewriteSequenceNumbers(vector<IcebergManifestEntry> &entries, int64_t starting_sequence_number);
 
 } // namespace duckdb

--- a/src/include/maintenance/rewrite_data_files_executor.hpp
+++ b/src/include/maintenance/rewrite_data_files_executor.hpp
@@ -20,16 +20,7 @@ struct RewriteExecutionResult {
 	vector<RewriteCandidate> rewritten_candidates;
 };
 
-//! Convert one COPY RETURN_STATS row into an ADDED manifest entry. Partition
-//! values and sequence-number semantics come from the frozen rewrite plan.
-//! Column stats / bounds are populated from the RETURN_STATS map.
-IcebergManifestEntry BuildRewriteManifestEntry(ClientContext &context, const vector<RewriteCandidate> &group,
-                                               int64_t starting_sequence_number, int64_t record_count,
-                                               const string &produced_file, int64_t file_size_in_bytes,
-                                               const Value &column_stats, const IcebergTableMetadata &table_metadata,
-                                               const string &table_name);
-
-//! Commit all completed rewrite groups as one Iceberg REPLACE snapshot.
+//! Commit all completed rewrite output as one Iceberg REPLACE snapshot.
 void CommitRewrite(ClientContext &context, const RewritePlan &plan, RewriteExecutionResult &result);
 
 //! Best-effort cleanup for files produced before a rewrite failure.
@@ -39,5 +30,11 @@ void CleanupRewriteFiles(ClientContext &context, const IcebergTableInformation &
 //! Validate that the currently loaded table snapshot still matches the frozen
 //! rewrite plan. Empty-table plans require the table to remain snapshot-less.
 void ValidateRewriteSnapshot(const RewritePlan &plan, const IcebergTableInformation &table_info, const string &phase);
+
+//! Account selected input files once into the rewrite execution result.
+void AccountSelectedCandidates(const RewritePlan &plan, RewriteExecutionResult &result);
+
+//! Pin rewrite sequence numbers on entries produced via IcebergInsert::AddFiles.
+void PinRewriteSequenceNumbers(vector<IcebergManifestEntry> &entries, int64_t starting_sequence_number);
 
 } // namespace duckdb

--- a/src/include/maintenance/rewrite_data_files_planner.hpp
+++ b/src/include/maintenance/rewrite_data_files_planner.hpp
@@ -28,9 +28,10 @@ struct RewritePlan {
 	int64_t target_file_size_bytes = 134217728;
 	//! Keep the loaded metadata alive until commit.
 	shared_ptr<IcebergTable> table_info;
+	//! All live DATA files considered during planning.
 	vector<RewriteCandidate> candidates;
-	//! Partition-local rewrite groups.
-	vector<vector<RewriteCandidate>> file_groups;
+	//! Files selected for rewrite after per-partition size / min_input_files gating.
+	vector<RewriteCandidate> selected_candidates;
 };
 
 struct RewriteDataFilesPlanInput {

--- a/src/include/maintenance/rewrite_data_files_planner.hpp
+++ b/src/include/maintenance/rewrite_data_files_planner.hpp
@@ -28,9 +28,10 @@ struct RewritePlan {
 	int64_t target_file_size_bytes = 134217728;
 	//! Keep the loaded metadata alive until commit.
 	shared_ptr<IcebergTableInformation> table_info;
+	//! All live DATA files considered during planning.
 	vector<RewriteCandidate> candidates;
-	//! Partition-local rewrite groups.
-	vector<vector<RewriteCandidate>> file_groups;
+	//! Files selected for rewrite after per-partition size / min_input_files gating.
+	vector<RewriteCandidate> selected_candidates;
 };
 
 struct RewriteDataFilesPlanInput {

--- a/src/maintenance/rewrite_data_files_executor.cpp
+++ b/src/maintenance/rewrite_data_files_executor.cpp
@@ -9,40 +9,25 @@
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_metadata.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
-#include "core/metadata/schema/iceberg_table_schema.hpp"
-#include "storage/statistics/iceberg_data_file_stats.hpp"
 
 namespace duckdb {
 
-IcebergManifestEntry BuildRewriteManifestEntry(ClientContext &context, const vector<RewriteCandidate> &group,
-                                               int64_t starting_sequence_number, int64_t record_count,
-                                               const string &produced_file, int64_t file_size_in_bytes,
-                                               const Value &column_stats, const IcebergTableMetadata &table_metadata,
-                                               const string &table_name) {
-	if (group.empty()) {
-		throw InternalException("iceberg_rewrite_data_files: cannot build a manifest entry for an empty group");
+void AccountSelectedCandidates(const RewritePlan &plan, RewriteExecutionResult &result) {
+	result.rewritten_data_files = static_cast<int64_t>(plan.selected_candidates.size());
+	result.rewritten_bytes = 0;
+	result.rewritten_candidates.clear();
+	result.rewritten_candidates.reserve(plan.selected_candidates.size());
+	for (auto &candidate : plan.selected_candidates) {
+		result.rewritten_bytes += candidate.file_size_in_bytes;
+		result.rewritten_candidates.push_back(candidate);
 	}
+}
 
-	IcebergManifestEntry entry;
-	entry.status = IcebergManifestEntryStatusType::ADDED;
-	//! Preserve equality-delete applicability after compaction.
-	entry.SetSequenceNumber(starting_sequence_number);
-	entry.data_file.content = IcebergManifestEntryContentType::DATA;
-	entry.data_file.file_format = "parquet";
-	entry.data_file.file_path = produced_file;
-	entry.data_file.record_count = record_count;
-	entry.data_file.file_size_in_bytes = file_size_in_bytes;
-	//! The planner buckets candidates so every file in one group shares the same
-	//! partition tuple. Reuse candidate 0 instead of re-deriving it.
-	entry.data_file.partition_info = group.front().partition_info;
-	if (table_metadata.HasSortOrder()) {
-		auto &sort_order = table_metadata.GetLatestSortOrder();
-		if (sort_order.IsSorted()) {
-			entry.data_file.sort_order_id = sort_order.sort_order_id;
-		}
+void PinRewriteSequenceNumbers(vector<IcebergManifestEntry> &entries, int64_t starting_sequence_number) {
+	for (auto &entry : entries) {
+		//! Preserve equality-delete applicability after compaction.
+		entry.SetSequenceNumber(starting_sequence_number);
 	}
-	IcebergDataFileStats::PopulateFromReturnStats(context, entry.data_file, column_stats, table_metadata, table_name);
-	return entry;
 }
 
 void ValidateRewriteSnapshot(const RewritePlan &plan, const IcebergTable &table_info, const string &phase) {

--- a/src/maintenance/rewrite_data_files_executor.cpp
+++ b/src/maintenance/rewrite_data_files_executor.cpp
@@ -9,40 +9,25 @@
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_metadata.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
-#include "core/metadata/schema/iceberg_table_schema.hpp"
-#include "storage/statistics/iceberg_data_file_stats.hpp"
 
 namespace duckdb {
 
-IcebergManifestEntry BuildRewriteManifestEntry(ClientContext &context, const vector<RewriteCandidate> &group,
-                                               int64_t starting_sequence_number, int64_t record_count,
-                                               const string &produced_file, int64_t file_size_in_bytes,
-                                               const Value &column_stats, const IcebergTableMetadata &table_metadata,
-                                               const string &table_name) {
-	if (group.empty()) {
-		throw InternalException("iceberg_rewrite_data_files: cannot build a manifest entry for an empty group");
+void AccountSelectedCandidates(const RewritePlan &plan, RewriteExecutionResult &result) {
+	result.rewritten_data_files = static_cast<int64_t>(plan.selected_candidates.size());
+	result.rewritten_bytes = 0;
+	result.rewritten_candidates.clear();
+	result.rewritten_candidates.reserve(plan.selected_candidates.size());
+	for (auto &candidate : plan.selected_candidates) {
+		result.rewritten_bytes += candidate.file_size_in_bytes;
+		result.rewritten_candidates.push_back(candidate);
 	}
+}
 
-	IcebergManifestEntry entry;
-	entry.status = IcebergManifestEntryStatusType::ADDED;
-	//! Preserve equality-delete applicability after compaction.
-	entry.SetSequenceNumber(starting_sequence_number);
-	entry.data_file.content = IcebergManifestEntryContentType::DATA;
-	entry.data_file.file_format = "parquet";
-	entry.data_file.file_path = produced_file;
-	entry.data_file.record_count = record_count;
-	entry.data_file.file_size_in_bytes = file_size_in_bytes;
-	//! The planner buckets candidates so every file in one group shares the same
-	//! partition tuple. Reuse candidate 0 instead of re-deriving it.
-	entry.data_file.partition_info = group.front().partition_info;
-	if (table_metadata.HasSortOrder()) {
-		auto &sort_order = table_metadata.GetLatestSortOrder();
-		if (sort_order.IsSorted()) {
-			entry.data_file.sort_order_id = sort_order.sort_order_id;
-		}
+void PinRewriteSequenceNumbers(vector<IcebergManifestEntry> &entries, int64_t starting_sequence_number) {
+	for (auto &entry : entries) {
+		//! Preserve equality-delete applicability after compaction.
+		entry.SetSequenceNumber(starting_sequence_number);
 	}
-	IcebergDataFileStats::PopulateFromReturnStats(context, entry.data_file, column_stats, table_metadata, table_name);
-	return entry;
 }
 
 void ValidateRewriteSnapshot(const RewritePlan &plan, const IcebergTableInformation &table_info, const string &phase) {

--- a/src/maintenance/rewrite_data_files_operator.cpp
+++ b/src/maintenance/rewrite_data_files_operator.cpp
@@ -1,16 +1,18 @@
 #include "maintenance/rewrite_data_files_operator.hpp"
 
 #include "duckdb/common/exception.hpp"
-#include "duckdb/execution/operator/set/physical_union.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/execution/operator/persistent/physical_copy_to_file.hpp"
 #include "duckdb/parallel/meta_pipeline.hpp"
 #include "duckdb/parallel/pipeline.hpp"
+#include "duckdb/planner/operator/logical_copy_to_file.hpp"
 
 #include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
+#include "core/metadata/schema/iceberg_table_schema.hpp"
+#include "execution/operator/iceberg_insert.hpp"
 #include "maintenance/maintenance_table_loader.hpp"
 #include "maintenance/rewrite_data_files_executor.hpp"
-#include "duckdb/planner/expression/bound_reference_expression.hpp"
-#include "duckdb/planner/expression/bound_constant_expression.hpp"
-#include "duckdb/execution/operator/projection/physical_projection.hpp"
 
 namespace duckdb {
 
@@ -22,8 +24,7 @@ static vector<LogicalType> RewriteResultTypes() {
 
 struct RewriteDataFilesGlobalState : public GlobalSinkState {
 	RewriteDataFilesGlobalState(ClientContext &context_p, const RewritePlan &source_plan)
-	    : context(context_p), plan(source_plan), group_seen(source_plan.file_groups.size(), false),
-	      group_accounted(source_plan.file_groups.size(), false) {
+	    : context(context_p), plan(source_plan), insert_state(context_p) {
 		plan.table_info = ReloadIcebergTableShared(context, plan.table_name, "iceberg_rewrite_data_files");
 		ValidateRewriteSnapshot(plan, *plan.table_info, "execution");
 	}
@@ -37,8 +38,7 @@ struct RewriteDataFilesGlobalState : public GlobalSinkState {
 	ClientContext &context;
 	RewritePlan plan;
 	mutex lock;
-	vector<bool> group_seen;
-	vector<bool> group_accounted;
+	IcebergInsertGlobalState insert_state;
 	vector<string> produced_paths;
 	RewriteExecutionResult result;
 	bool committed = false;
@@ -80,37 +80,41 @@ string LogicalRewriteDataFiles::GetName() const {
 }
 
 PhysicalOperator &LogicalRewriteDataFiles::CreatePlan(ClientContext &context, PhysicalPlanGenerator &planner) {
-	auto &rewrite = planner.Make<PhysicalRewriteDataFiles>(std::move(plan), estimated_cardinality);
+	auto &rewrite =
+	    planner.Make<PhysicalRewriteDataFiles>(std::move(plan), estimated_cardinality).Cast<PhysicalRewriteDataFiles>();
 	if (children.empty()) {
 		return rewrite;
 	}
 
-	ArenaLinkedList<reference<PhysicalOperator>> physical_children(planner.ArenaRef());
-	for (idx_t group_idx = 0; group_idx < children.size(); group_idx++) {
-		auto &child = children[group_idx];
-		auto &child_plan = planner.CreatePlan(*child);
-		auto child_types = child_plan.GetTypes();
-
-		vector<unique_ptr<Expression>> projection_expressions;
-		//! Prefix COPY RETURN_STATS rows so the Sink can map each output file back to its rewrite group.
-		projection_expressions.push_back(make_uniq<BoundConstantExpression>(Value::UBIGINT(group_idx)));
-		for (idx_t i = 0; i < child_types.size(); i++) {
-			auto &child_type = child_types[i];
-			projection_expressions.push_back(make_uniq<BoundReferenceExpression>(child_type, i));
-		}
-		child_types.insert(child_types.begin(), LogicalType::UBIGINT);
-		auto &physical_projection = planner.Make<PhysicalProjection>(child_types, std::move(projection_expressions), 1);
-		physical_projection.children.push_back(child_plan);
-		physical_children.push_back(physical_projection);
-	}
-	if (physical_children.size() == 1) {
-		rewrite.children.push_back(physical_children[0]);
-		return rewrite;
+	D_ASSERT(children.size() == 1);
+	D_ASSERT(rewrite.plan.table_info);
+	auto &metadata = rewrite.plan.table_info->table_metadata;
+	auto schema_id = metadata.GetCurrentSchemaId();
+	auto schema_it = metadata.GetSchemas().find(schema_id);
+	if (schema_it == metadata.GetSchemas().end()) {
+		throw InternalException("iceberg_rewrite_data_files: current schema id %d not found in metadata", schema_id);
 	}
 
-	auto &union_op = planner.Make<PhysicalUnion>(physical_children[0].get().GetTypes(), physical_children,
-	                                             estimated_cardinality, true);
-	rewrite.children.push_back(union_op);
+	//! Bind attached a LogicalCopyToFile so RemoveUnusedColumns keeps all table
+	//! columns. Peel that logical COPY away and rebuild the physical copy with
+	//! IcebergInsert::PlanCopyForInsert (partitioned IcebergCopyOptions).
+	auto &logical_child = *children[0];
+	if (logical_child.type != LogicalOperatorType::LOGICAL_COPY_TO_FILE || logical_child.children.size() != 1) {
+		throw InternalException(
+		    "iceberg_rewrite_data_files: expected a single LogicalCopyToFile child with one scan child");
+	}
+	auto &scan = planner.CreatePlan(*logical_child.children[0]);
+	IcebergCopyInput copy_input(context, metadata, *schema_it->second);
+	auto &copy = IcebergInsert::PlanCopyForInsert(context, planner, copy_input, &scan).Cast<PhysicalCopyToFile>();
+	copy.file_size_bytes = NumericCast<idx_t>(rewrite.plan.target_file_size_bytes);
+	//! A file can never be smaller than a single row group; rotation only happens at row-group
+	//! boundaries. Cap batch_size_bytes to the rewrite target so FILE_SIZE_BYTES rotation remains
+	//! effective (mirrors IcebergInsert::GetCopyOptions).
+	if (copy.batch_size_bytes.IsValid() && copy.file_size_bytes.IsValid() &&
+	    copy.batch_size_bytes.GetIndex() > copy.file_size_bytes.GetIndex()) {
+		copy.batch_size_bytes = copy.file_size_bytes;
+	}
+	rewrite.children.push_back(copy);
 	return rewrite;
 }
 
@@ -146,51 +150,18 @@ unique_ptr<LocalSinkState> PhysicalRewriteDataFiles::GetLocalSinkState(Execution
 SinkResultType PhysicalRewriteDataFiles::Sink(ExecutionContext &context, DataChunk &chunk,
                                               OperatorSinkInput &input) const {
 	auto &gstate = input.global_state.Cast<RewriteDataFilesGlobalState>();
-	for (idx_t row = 0; row < chunk.size(); row++) {
-		//! COPY RETURN_STATS emits one row per produced file (prefixed with group_idx):
-		//!   0 group_idx
-		//!   1 filename
-		//!   2 count
-		//!   3 file_size_bytes
-		//!   4 footer_size_bytes
-		//!   5 column_statistics
-		//!   6 partition_keys
-		if (chunk.ColumnCount() < 6) {
-			throw InternalException(
-			    "iceberg_rewrite_data_files: expected COPY RETURN_STATS result with at least five columns");
-		}
-		auto group_idx = chunk.GetValue(0, row).GetValue<uint64_t>();
-		if (static_cast<idx_t>(group_idx) >= gstate.plan.file_groups.size()) {
-			throw InternalException("iceberg_rewrite_data_files: COPY returned unknown group index %lld", group_idx);
-		}
-		auto produced_file = chunk.GetValue(1, row).GetValue<string>();
-		if (produced_file.empty()) {
-			throw InternalException("iceberg_rewrite_data_files: COPY for group %lld returned an empty file path",
-			                        group_idx);
-		}
-		auto count = NumericCast<int64_t>(chunk.GetValue(2, row).GetValue<uint64_t>());
-		auto file_size_in_bytes = NumericCast<int64_t>(chunk.GetValue(3, row).GetValue<uint64_t>());
-		auto column_stats = chunk.GetValue(5, row);
-		auto &group = gstate.plan.file_groups[group_idx];
-		auto &table_info = *gstate.plan.table_info;
-		auto entry = BuildRewriteManifestEntry(
-		    gstate.context, group, gstate.plan.starting_sequence_number, count, produced_file, file_size_in_bytes,
-		    column_stats, table_info.table_metadata, gstate.plan.table_name.Name().GetIdentifierName());
+	auto &table_info = *gstate.plan.table_info;
+	auto table_name = gstate.plan.table_name.Name().GetIdentifierName();
 
-		{
-			lock_guard<mutex> guard(gstate.lock);
-			gstate.group_seen[group_idx] = true;
-			gstate.produced_paths.push_back(produced_file);
-			gstate.result.new_entries.push_back(std::move(entry));
-			gstate.result.added_data_files++;
-			if (!gstate.group_accounted[group_idx]) {
-				gstate.group_accounted[group_idx] = true;
-				gstate.result.rewritten_data_files += static_cast<int64_t>(group.size());
-				for (auto &candidate : group) {
-					gstate.result.rewritten_bytes += candidate.file_size_in_bytes;
-					gstate.result.rewritten_candidates.push_back(candidate);
-				}
+	{
+		lock_guard<mutex> guard(gstate.lock);
+		gstate.insert_state.AddFiles(chunk, table_name, table_info.table_metadata);
+		for (idx_t row = 0; row < chunk.size(); row++) {
+			auto produced_file = chunk.GetValue(0, row).GetValue<string>();
+			if (produced_file.empty()) {
+				throw InternalException("iceberg_rewrite_data_files: COPY returned an empty file path");
 			}
+			gstate.produced_paths.push_back(produced_file);
 		}
 	}
 	return SinkResultType::NEED_MORE_INPUT;
@@ -201,12 +172,14 @@ SinkFinalizeType PhysicalRewriteDataFiles::Finalize(Pipeline &pipeline, Event &e
 	auto &gstate = input.global_state.Cast<RewriteDataFilesGlobalState>();
 	{
 		lock_guard<mutex> guard(gstate.lock);
-		for (idx_t group_idx = 0; group_idx < gstate.group_seen.size(); group_idx++) {
-			if (!gstate.group_seen[group_idx]) {
-				throw InternalException("iceberg_rewrite_data_files: COPY returned no result for group %llu",
-				                        static_cast<unsigned long long>(group_idx));
-			}
+		if (gstate.insert_state.written_files.empty()) {
+			throw InternalException(
+			    "iceberg_rewrite_data_files: COPY returned no written files for selected candidates");
 		}
+		gstate.result.new_entries = IcebergInsert::GetInsertManifestEntries(gstate.insert_state);
+		PinRewriteSequenceNumbers(gstate.result.new_entries, gstate.plan.starting_sequence_number);
+		gstate.result.added_data_files = static_cast<int64_t>(gstate.result.new_entries.size());
+		AccountSelectedCandidates(gstate.plan, gstate.result);
 	}
 	CommitRewrite(context, gstate.plan, gstate.result);
 	gstate.committed = true;
@@ -249,7 +222,7 @@ string PhysicalRewriteDataFiles::GetName() const {
 
 InsertionOrderPreservingMap<string> PhysicalRewriteDataFiles::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
-	result["Groups"] = std::to_string(plan.file_groups.size());
+	result["Selected Files"] = std::to_string(plan.selected_candidates.size());
 	return result;
 }
 

--- a/src/maintenance/rewrite_data_files_operator.cpp
+++ b/src/maintenance/rewrite_data_files_operator.cpp
@@ -104,8 +104,8 @@ PhysicalOperator &LogicalRewriteDataFiles::CreatePlan(ClientContext &context, Ph
 		    "iceberg_rewrite_data_files: expected a single LogicalCopyToFile child with one scan child");
 	}
 	auto &scan = planner.CreatePlan(*logical_child.children[0]);
-	//! Install vended storage secrets before writing compacted files (mirrors IcebergInsert).
-	rewrite.plan.table_info->LoadCredentials(context);
+	//! Vended credentials are already installed: PlanRewrite loads them for the manifests,
+	//! and BindCandidateCopy's table scan bind calls PrepareIcebergScanFromEntry.
 	IcebergCopyInput copy_input(context, metadata, *schema_it->second);
 	auto &copy = IcebergInsert::PlanCopyForInsert(context, planner, copy_input, &scan).Cast<PhysicalCopyToFile>();
 	copy.file_size_bytes = NumericCast<idx_t>(rewrite.plan.target_file_size_bytes);

--- a/src/maintenance/rewrite_data_files_operator.cpp
+++ b/src/maintenance/rewrite_data_files_operator.cpp
@@ -104,6 +104,8 @@ PhysicalOperator &LogicalRewriteDataFiles::CreatePlan(ClientContext &context, Ph
 		    "iceberg_rewrite_data_files: expected a single LogicalCopyToFile child with one scan child");
 	}
 	auto &scan = planner.CreatePlan(*logical_child.children[0]);
+	//! Install vended storage secrets before writing compacted files (mirrors IcebergInsert).
+	rewrite.plan.table_info->LoadCredentials(context);
 	IcebergCopyInput copy_input(context, metadata, *schema_it->second);
 	auto &copy = IcebergInsert::PlanCopyForInsert(context, planner, copy_input, &scan).Cast<PhysicalCopyToFile>();
 	copy.file_size_bytes = NumericCast<idx_t>(rewrite.plan.target_file_size_bytes);

--- a/src/maintenance/rewrite_data_files_operator.cpp
+++ b/src/maintenance/rewrite_data_files_operator.cpp
@@ -1,16 +1,18 @@
 #include "maintenance/rewrite_data_files_operator.hpp"
 
 #include "duckdb/common/exception.hpp"
-#include "duckdb/execution/operator/set/physical_union.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/execution/operator/persistent/physical_copy_to_file.hpp"
 #include "duckdb/parallel/meta_pipeline.hpp"
 #include "duckdb/parallel/pipeline.hpp"
+#include "duckdb/planner/operator/logical_copy_to_file.hpp"
 
 #include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
+#include "core/metadata/schema/iceberg_table_schema.hpp"
+#include "execution/operator/iceberg_insert.hpp"
 #include "maintenance/maintenance_table_loader.hpp"
 #include "maintenance/rewrite_data_files_executor.hpp"
-#include "duckdb/planner/expression/bound_reference_expression.hpp"
-#include "duckdb/planner/expression/bound_constant_expression.hpp"
-#include "duckdb/execution/operator/projection/physical_projection.hpp"
 
 namespace duckdb {
 
@@ -22,8 +24,7 @@ static vector<LogicalType> RewriteResultTypes() {
 
 struct RewriteDataFilesGlobalState : public GlobalSinkState {
 	RewriteDataFilesGlobalState(ClientContext &context_p, const RewritePlan &source_plan)
-	    : context(context_p), plan(source_plan), group_seen(source_plan.file_groups.size(), false),
-	      group_accounted(source_plan.file_groups.size(), false) {
+	    : context(context_p), plan(source_plan), insert_state(context_p) {
 		plan.table_info = ReloadIcebergTableShared(context, plan.table_name, "iceberg_rewrite_data_files");
 		ValidateRewriteSnapshot(plan, *plan.table_info, "execution");
 	}
@@ -37,8 +38,7 @@ struct RewriteDataFilesGlobalState : public GlobalSinkState {
 	ClientContext &context;
 	RewritePlan plan;
 	mutex lock;
-	vector<bool> group_seen;
-	vector<bool> group_accounted;
+	IcebergInsertGlobalState insert_state;
 	vector<string> produced_paths;
 	RewriteExecutionResult result;
 	bool committed = false;
@@ -80,37 +80,41 @@ string LogicalRewriteDataFiles::GetName() const {
 }
 
 PhysicalOperator &LogicalRewriteDataFiles::CreatePlan(ClientContext &context, PhysicalPlanGenerator &planner) {
-	auto &rewrite = planner.Make<PhysicalRewriteDataFiles>(std::move(plan), estimated_cardinality);
+	auto &rewrite =
+	    planner.Make<PhysicalRewriteDataFiles>(std::move(plan), estimated_cardinality).Cast<PhysicalRewriteDataFiles>();
 	if (children.empty()) {
 		return rewrite;
 	}
 
-	ArenaLinkedList<reference<PhysicalOperator>> physical_children(planner.ArenaRef());
-	for (idx_t group_idx = 0; group_idx < children.size(); group_idx++) {
-		auto &child = children[group_idx];
-		auto &child_plan = planner.CreatePlan(*child);
-		auto child_types = child_plan.GetTypes();
-
-		vector<unique_ptr<Expression>> projection_expressions;
-		//! Prefix COPY RETURN_STATS rows so the Sink can map each output file back to its rewrite group.
-		projection_expressions.push_back(make_uniq<BoundConstantExpression>(Value::UBIGINT(group_idx)));
-		for (idx_t i = 0; i < child_types.size(); i++) {
-			auto &child_type = child_types[i];
-			projection_expressions.push_back(make_uniq<BoundReferenceExpression>(child_type, i));
-		}
-		child_types.insert(child_types.begin(), LogicalType::UBIGINT);
-		auto &physical_projection = planner.Make<PhysicalProjection>(child_types, std::move(projection_expressions), 1);
-		physical_projection.children.push_back(child_plan);
-		physical_children.push_back(physical_projection);
-	}
-	if (physical_children.size() == 1) {
-		rewrite.children.push_back(physical_children[0]);
-		return rewrite;
+	D_ASSERT(children.size() == 1);
+	D_ASSERT(rewrite.plan.table_info);
+	auto &metadata = rewrite.plan.table_info->table_metadata;
+	auto schema_id = metadata.GetCurrentSchemaId();
+	auto schema_it = metadata.GetSchemas().find(schema_id);
+	if (schema_it == metadata.GetSchemas().end()) {
+		throw InternalException("iceberg_rewrite_data_files: current schema id %d not found in metadata", schema_id);
 	}
 
-	auto &union_op = planner.Make<PhysicalUnion>(physical_children[0].get().GetTypes(), physical_children,
-	                                             estimated_cardinality, true);
-	rewrite.children.push_back(union_op);
+	//! Bind attached a LogicalCopyToFile so RemoveUnusedColumns keeps all table
+	//! columns. Peel that logical COPY away and rebuild the physical copy with
+	//! IcebergInsert::PlanCopyForInsert (partitioned IcebergCopyOptions).
+	auto &logical_child = *children[0];
+	if (logical_child.type != LogicalOperatorType::LOGICAL_COPY_TO_FILE || logical_child.children.size() != 1) {
+		throw InternalException(
+		    "iceberg_rewrite_data_files: expected a single LogicalCopyToFile child with one scan child");
+	}
+	auto &scan = planner.CreatePlan(*logical_child.children[0]);
+	IcebergCopyInput copy_input(context, metadata, *schema_it->second);
+	auto &copy = IcebergInsert::PlanCopyForInsert(context, planner, copy_input, &scan).Cast<PhysicalCopyToFile>();
+	copy.file_size_bytes = NumericCast<idx_t>(rewrite.plan.target_file_size_bytes);
+	//! A file can never be smaller than a single row group; rotation only happens at row-group
+	//! boundaries. Cap batch_size_bytes to the rewrite target so FILE_SIZE_BYTES rotation remains
+	//! effective (mirrors IcebergInsert::GetCopyOptions).
+	if (copy.batch_size_bytes.IsValid() && copy.file_size_bytes.IsValid() &&
+	    copy.batch_size_bytes.GetIndex() > copy.file_size_bytes.GetIndex()) {
+		copy.batch_size_bytes = copy.file_size_bytes;
+	}
+	rewrite.children.push_back(copy);
 	return rewrite;
 }
 
@@ -146,51 +150,18 @@ unique_ptr<LocalSinkState> PhysicalRewriteDataFiles::GetLocalSinkState(Execution
 SinkResultType PhysicalRewriteDataFiles::Sink(ExecutionContext &context, DataChunk &chunk,
                                               OperatorSinkInput &input) const {
 	auto &gstate = input.global_state.Cast<RewriteDataFilesGlobalState>();
-	for (idx_t row = 0; row < chunk.size(); row++) {
-		//! COPY RETURN_STATS emits one row per produced file (prefixed with group_idx):
-		//!   0 group_idx
-		//!   1 filename
-		//!   2 count
-		//!   3 file_size_bytes
-		//!   4 footer_size_bytes
-		//!   5 column_statistics
-		//!   6 partition_keys
-		if (chunk.ColumnCount() < 6) {
-			throw InternalException(
-			    "iceberg_rewrite_data_files: expected COPY RETURN_STATS result with at least five columns");
-		}
-		auto group_idx = chunk.GetValue(0, row).GetValue<uint64_t>();
-		if (static_cast<idx_t>(group_idx) >= gstate.plan.file_groups.size()) {
-			throw InternalException("iceberg_rewrite_data_files: COPY returned unknown group index %lld", group_idx);
-		}
-		auto produced_file = chunk.GetValue(1, row).GetValue<string>();
-		if (produced_file.empty()) {
-			throw InternalException("iceberg_rewrite_data_files: COPY for group %lld returned an empty file path",
-			                        group_idx);
-		}
-		auto count = NumericCast<int64_t>(chunk.GetValue(2, row).GetValue<uint64_t>());
-		auto file_size_in_bytes = NumericCast<int64_t>(chunk.GetValue(3, row).GetValue<uint64_t>());
-		auto column_stats = chunk.GetValue(5, row);
-		auto &group = gstate.plan.file_groups[group_idx];
-		auto &table_info = *gstate.plan.table_info;
-		auto entry = BuildRewriteManifestEntry(
-		    gstate.context, group, gstate.plan.starting_sequence_number, count, produced_file, file_size_in_bytes,
-		    column_stats, table_info.table_metadata, gstate.plan.table_name.Name().GetIdentifierName());
+	auto &table_info = *gstate.plan.table_info;
+	auto table_name = gstate.plan.table_name.Name().GetIdentifierName();
 
-		{
-			lock_guard<mutex> guard(gstate.lock);
-			gstate.group_seen[group_idx] = true;
-			gstate.produced_paths.push_back(produced_file);
-			gstate.result.new_entries.push_back(std::move(entry));
-			gstate.result.added_data_files++;
-			if (!gstate.group_accounted[group_idx]) {
-				gstate.group_accounted[group_idx] = true;
-				gstate.result.rewritten_data_files += static_cast<int64_t>(group.size());
-				for (auto &candidate : group) {
-					gstate.result.rewritten_bytes += candidate.file_size_in_bytes;
-					gstate.result.rewritten_candidates.push_back(candidate);
-				}
+	{
+		lock_guard<mutex> guard(gstate.lock);
+		gstate.insert_state.AddFiles(chunk, table_name, table_info.table_metadata);
+		for (idx_t row = 0; row < chunk.size(); row++) {
+			auto produced_file = chunk.GetValue(0, row).GetValue<string>();
+			if (produced_file.empty()) {
+				throw InternalException("iceberg_rewrite_data_files: COPY returned an empty file path");
 			}
+			gstate.produced_paths.push_back(produced_file);
 		}
 	}
 	return SinkResultType::NEED_MORE_INPUT;
@@ -201,12 +172,14 @@ SinkFinalizeType PhysicalRewriteDataFiles::Finalize(Pipeline &pipeline, Event &e
 	auto &gstate = input.global_state.Cast<RewriteDataFilesGlobalState>();
 	{
 		lock_guard<mutex> guard(gstate.lock);
-		for (idx_t group_idx = 0; group_idx < gstate.group_seen.size(); group_idx++) {
-			if (!gstate.group_seen[group_idx]) {
-				throw InternalException("iceberg_rewrite_data_files: COPY returned no result for group %llu",
-				                        static_cast<unsigned long long>(group_idx));
-			}
+		if (gstate.insert_state.written_files.empty()) {
+			throw InternalException(
+			    "iceberg_rewrite_data_files: COPY returned no written files for selected candidates");
 		}
+		gstate.result.new_entries = IcebergInsert::GetInsertManifestEntries(gstate.insert_state);
+		PinRewriteSequenceNumbers(gstate.result.new_entries, gstate.plan.starting_sequence_number);
+		gstate.result.added_data_files = static_cast<int64_t>(gstate.result.new_entries.size());
+		AccountSelectedCandidates(gstate.plan, gstate.result);
 	}
 	CommitRewrite(context, gstate.plan, gstate.result);
 	gstate.committed = true;
@@ -250,7 +223,7 @@ string PhysicalRewriteDataFiles::GetName() const {
 
 InsertionOrderPreservingMap<string> PhysicalRewriteDataFiles::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
-	result["Groups"] = std::to_string(plan.file_groups.size());
+	result["Selected Files"] = std::to_string(plan.selected_candidates.size());
 	return result;
 }
 

--- a/src/maintenance/rewrite_data_files_planner.cpp
+++ b/src/maintenance/rewrite_data_files_planner.cpp
@@ -74,7 +74,9 @@ void GroupCandidates(RewritePlan &plan, int64_t target_file_size_bytes, int64_t 
 		if (!rewrite_all && static_cast<int64_t>(kv.second.size()) < min_input_files) {
 			continue;
 		}
-		plan.file_groups.push_back(std::move(kv.second));
+		for (auto &cand : kv.second) {
+			plan.selected_candidates.push_back(std::move(cand));
+		}
 	}
 }
 

--- a/src/maintenance/rewrite_data_files_planner.cpp
+++ b/src/maintenance/rewrite_data_files_planner.cpp
@@ -146,6 +146,9 @@ RewritePlan PlanRewrite(ClientContext &context, const RewriteDataFilesPlanInput 
 	snapshot_info.snapshot = latest_snapshot;
 	snapshot_info.schema_id = table_metadata.GetCurrentSchemaId();
 
+	//! Install vended storage secrets before reading manifest lists from object storage.
+	table_info.LoadCredentials(context);
+
 	IcebergOptions options;
 	auto manifest_list =
 	    IcebergManifestList::Load(table_metadata.GetLocation(), table_metadata, snapshot_info, context, options);

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_plan_shape.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_plan_shape.test
@@ -1,0 +1,69 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_plan_shape.test
+# description: partitioned rewrite uses one Iceberg scan and one Copy To File
+# group: [maintenance]
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.rewrite_plan_shape;
+
+statement ok
+create table my_datalake.default.rewrite_plan_shape (id INTEGER, category VARCHAR, payload VARCHAR)
+partitioned by (category);
+
+statement ok
+insert into my_datalake.default.rewrite_plan_shape values (1, 'a', 'a1'), (2, 'b', 'b1');
+
+statement ok
+insert into my_datalake.default.rewrite_plan_shape values (3, 'a', 'a2'), (4, 'b', 'b2');
+
+statement ok
+insert into my_datalake.default.rewrite_plan_shape values (5, 'a', 'a3'), (6, 'b', 'b3');
+
+statement ok
+insert into my_datalake.default.rewrite_plan_shape values (7, 'a', 'a4'), (8, 'b', 'b4');
+
+statement ok
+insert into my_datalake.default.rewrite_plan_shape values (9, 'a', 'a5'), (10, 'b', 'b5');
+
+statement ok
+insert into my_datalake.default.rewrite_plan_shape values (11, 'a', 'a6'), (12, 'b', 'b6');
+
+# One partitioned COPY over a single Iceberg scan — no UNION of per-partition copies.
+query II
+explain select * from iceberg_rewrite_data_files('my_datalake.default.rewrite_plan_shape');
+----
+physical_plan	<REGEX>:.*ICEBERG_REWRITE_DATA_FILES.*COPY_TO_FILE.*ICEBERG_SCAN.*
+
+query II
+explain select * from iceberg_rewrite_data_files('my_datalake.default.rewrite_plan_shape');
+----
+physical_plan	<!REGEX>:.*UNION.*
+
+query III
+call iceberg_rewrite_data_files('my_datalake.default.rewrite_plan_shape');
+----
+12	2	<REGEX>:[1-9][0-9]*
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_plan_shape')
+where content = 'DATA' and status <> 'DELETED';
+----
+2
+
+statement ok
+drop table if exists my_datalake.default.rewrite_plan_shape;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_select.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_select.test
@@ -1,0 +1,46 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_select.test
+# description: SELECT FROM iceberg_rewrite_data_files on a partitioned table
+# group: [maintenance]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+statement ok
+drop table if exists my_datalake.default.rewrite_select_probe;
+
+statement ok
+create table my_datalake.default.rewrite_select_probe (id INTEGER, category VARCHAR, payload VARCHAR)
+partitioned by (category);
+
+statement ok
+insert into my_datalake.default.rewrite_select_probe values (1, 'a', 'a1'), (2, 'b', 'b1');
+
+statement ok
+insert into my_datalake.default.rewrite_select_probe values (3, 'a', 'a2'), (4, 'b', 'b2');
+
+statement ok
+insert into my_datalake.default.rewrite_select_probe values (5, 'a', 'a3'), (6, 'b', 'b3');
+
+statement ok
+insert into my_datalake.default.rewrite_select_probe values (7, 'a', 'a4'), (8, 'b', 'b4');
+
+statement ok
+insert into my_datalake.default.rewrite_select_probe values (9, 'a', 'a5'), (10, 'b', 'b5');
+
+statement ok
+insert into my_datalake.default.rewrite_select_probe values (11, 'a', 'a6'), (12, 'b', 'b6');
+
+query III
+select * from iceberg_rewrite_data_files('my_datalake.default.rewrite_select_probe');
+----
+12	2	<REGEX>:[1-9][0-9]*
+
+statement ok
+drop table if exists my_datalake.default.rewrite_select_probe;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_spark_mor_residual_deletes.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_spark_mor_residual_deletes.test
@@ -97,7 +97,7 @@ query I
 select count(*)
 from iceberg_metadata('my_datalake.default.spark_rewrite_mor_residual_deletes')
 where content = 'DATA' and status = 'ADDED'
-  and file_path not like '%/category=%';
+  and file_path like '%/category=compact/%';
 ----
 1
 


### PR DESCRIPTION
## Summary
- Reuse `IcebergInsert::GetCopyOptions` / `PlanCopyForInsert` so partitioned `iceberg_rewrite_data_files` uses one Iceberg scan and one partitioned `PhysicalCopyToFile` instead of one COPY subtree per partition value.
- Keep per-partition selection gating (`min_input_files` / target size), flatten selected candidates for a single `filename IN (...)` rewrite, and build manifests via `AddFiles` + sequence-number pinning.
- Add plan-shape / SELECT coverage and a `Regression.yml ` partitioned-rewrite test.

Conversation at https://github.com/duckdb/duckdb-iceberg/issues/1191#issuecomment-5141052632

## Notes
- Still limited to a single default partition spec (multi-spec deferred).
- Unpartitioned sorted tables can now get `PhysicalOrder` via `PlanCopyForInsert`; dedicated write-order regression tests are left for a follow-up PR.