### PR TITLE
Write delete manifests under the partition spec of the data files they target

### DIFF
--- a/scripts/data_generators/tests/default/spark_mor_delete_partition_evolution/__init__.py
+++ b/scripts/data_generators/tests/default/spark_mor_delete_partition_evolution/__init__.py
@@ -1,0 +1,17 @@
+from scripts.data_generators.tests.base import IcebergTest
+import pathlib
+
+
+POLARIS_SKIP_REASON = (
+    "Polaris requires partition and sort updates to be applied as delete-and-insert operations, "
+    "which Spark does not support for this generator"
+)
+
+
+@IcebergTest.register()
+class Test(IcebergTest):
+    skips = {"polaris": POLARIS_SKIP_REASON}
+
+    def __init__(self):
+        path = pathlib.PurePath(__file__)
+        super().__init__(__file__)

--- a/scripts/data_generators/tests/default/spark_mor_delete_partition_evolution/test.sql
+++ b/scripts/data_generators/tests/default/spark_mor_delete_partition_evolution/test.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE TABLE default.spark_mor_delete_partition_evolution (
+    id INT,
+    ts TIMESTAMP,
+    val STRING
+)
+USING ICEBERG
+PARTITIONED BY (days(ts))
+TBLPROPERTIES (
+    'format-version' = '2',
+    'write.delete.mode' = 'merge-on-read',
+    'write.update.mode' = 'merge-on-read'
+);
+
+INSERT INTO default.spark_mor_delete_partition_evolution VALUES
+    (1, TIMESTAMP '2021-05-01 09:00:00', 'a'),
+    (2, TIMESTAMP '2021-05-01 10:30:00', 'b');
+
+ALTER TABLE default.spark_mor_delete_partition_evolution
+REPLACE PARTITION FIELD days(ts)
+WITH hours(ts);
+
+INSERT INTO default.spark_mor_delete_partition_evolution VALUES
+    (3, TIMESTAMP '2021-06-02 11:00:00', 'c');
+
+DELETE FROM default.spark_mor_delete_partition_evolution
+WHERE val = 'b';

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -206,7 +206,7 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 }
 
 void IcebergTransactionData::AddDeleteManifestFiles(IcebergAddSnapshot &add_snapshot,
-                                                    IcebergDeleteManifestEntries &&delete_files,
+                                                    partitioned_manifest_entry_map_t &&delete_files,
                                                     sequence_number_t sequence_number) {
 	auto &table_metadata = table_info.table_metadata;
 	auto &fs = FileSystem::GetFileSystem(context);
@@ -220,7 +220,7 @@ void IcebergTransactionData::AddDeleteManifestFiles(IcebergAddSnapshot &add_snap
 	}
 }
 
-void IcebergTransactionData::AddDeleteSnapshot(IcebergDeleteManifestEntries &&delete_files,
+void IcebergTransactionData::AddDeleteSnapshot(partitioned_manifest_entry_map_t &&delete_files,
                                                IcebergManifestDeletes &&altered_manifests) {
 	//! NOTE: Lock has to be held to make sure the rows are assigned the correct row ids
 	lock_guard<mutex> guard(lock);
@@ -242,7 +242,7 @@ void IcebergTransactionData::AddDeleteSnapshot(IcebergDeleteManifestEntries &&de
 	updates.push_back(std::move(add_snapshot));
 }
 
-void IcebergTransactionData::AddUpdateSnapshot(IcebergDeleteManifestEntries &&delete_files,
+void IcebergTransactionData::AddUpdateSnapshot(partitioned_manifest_entry_map_t &&delete_files,
                                                vector<IcebergManifestEntry> &&data_files,
                                                IcebergManifestDeletes &&altered_manifests) {
 	//! NOTE: Lock has to be held to make sure the rows are assigned the correct row ids

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -176,16 +176,14 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 
 	IcebergManifestContentType manifest_content_type;
 	switch (operation) {
-	case IcebergSnapshotOperationType::DELETE:
-		manifest_content_type = IcebergManifestContentType::DELETE;
-		break;
 	case IcebergSnapshotOperationType::APPEND:
 	case IcebergSnapshotOperationType::REPLACE:
 		//! This helper currently writes DATA manifest entries; REPLACE itself is not limited to data files.
 		manifest_content_type = IcebergManifestContentType::DATA;
 		break;
 	default:
-		throw NotImplementedException("Cannot have use snapshot operation type OVERWRITE here");
+		throw NotImplementedException("Snapshot operation type %d does not write data manifests",
+		                              static_cast<uint8_t>(operation));
 	};
 
 	auto temp_sequence_number = table_metadata.last_sequence_number + alters.size() + 1;
@@ -207,7 +205,44 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 	updates.push_back(std::move(add_snapshot));
 }
 
-void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&delete_files,
+void IcebergTransactionData::AddDeleteManifestFiles(IcebergAddSnapshot &add_snapshot,
+                                                    IcebergDeleteManifestEntries &&delete_files,
+                                                    sequence_number_t sequence_number) {
+	auto &table_metadata = table_info.table_metadata;
+	auto &fs = FileSystem::GetFileSystem(context);
+	//! One manifest per partition spec: a manifest declares a single spec, and the entries it holds carry
+	//! partition values in that spec.
+	for (auto &entry : delete_files) {
+		auto manifest_metadata =
+		    IcebergManifestMetadata::FromTableMetadata(table_metadata, IcebergManifestContentType::DELETE, entry.first);
+		add_snapshot.AddManifestFile(IcebergManifestListEntry::CreateFromEntries(
+		    fs, sequence_number, table_metadata, manifest_metadata, std::move(entry.second), next_row_id));
+	}
+}
+
+void IcebergTransactionData::AddDeleteSnapshot(IcebergDeleteManifestEntries &&delete_files,
+                                               IcebergManifestDeletes &&altered_manifests) {
+	//! NOTE: Lock has to be held to make sure the rows are assigned the correct row ids
+	lock_guard<mutex> guard(lock);
+
+	auto &table_metadata = table_info.table_metadata;
+	CacheExistingManifestList(guard, table_metadata);
+
+	const auto sequence_number = table_metadata.last_sequence_number + alters.size() + 1;
+
+	auto add_snapshot = make_uniq<IcebergAddSnapshot>(table_info, IcebergSnapshotOperationType::DELETE);
+	AddDeleteManifestFiles(*add_snapshot, std::move(delete_files), sequence_number);
+	// make sure we are still inserting into the current schema
+	if (table_metadata.current_snapshot_id) {
+		TableAddAssertCurrentSchemaId();
+	}
+	add_snapshot->altered_manifests = std::move(altered_manifests);
+
+	alters.push_back(*add_snapshot);
+	updates.push_back(std::move(add_snapshot));
+}
+
+void IcebergTransactionData::AddUpdateSnapshot(IcebergDeleteManifestEntries &&delete_files,
                                                vector<IcebergManifestEntry> &&data_files,
                                                IcebergManifestDeletes &&altered_manifests) {
 	//! NOTE: Lock has to be held to make sure the rows are assigned the correct row ids
@@ -222,20 +257,14 @@ void IcebergTransactionData::AddUpdateSnapshot(vector<IcebergManifestEntry> &&de
 	const auto sequence_number = last_sequence_number + alters.size() + 1;
 
 	auto &fs = FileSystem::GetFileSystem(context);
-	auto delete_manifest_metadata =
-	    IcebergManifestMetadata::FromTableMetadata(table_metadata, IcebergManifestContentType::DELETE);
 	auto data_manifest_metadata =
 	    IcebergManifestMetadata::FromTableMetadata(table_metadata, IcebergManifestContentType::DATA);
 
-	auto delete_manifest_file = IcebergManifestListEntry::CreateFromEntries(
-	    fs, sequence_number, table_metadata, delete_manifest_metadata, std::move(delete_files), next_row_id);
-	// Add a manifest_file for the new insert data
-	auto data_manifest_file = IcebergManifestListEntry::CreateFromEntries(
-	    fs, sequence_number, table_metadata, data_manifest_metadata, std::move(data_files), next_row_id);
-
 	auto add_snapshot = make_uniq<IcebergAddSnapshot>(table_info);
-	add_snapshot->AddManifestFile(std::move(delete_manifest_file));
-	add_snapshot->AddManifestFile(std::move(data_manifest_file));
+	AddDeleteManifestFiles(*add_snapshot, std::move(delete_files), sequence_number);
+	// Add a manifest_file for the new insert data
+	add_snapshot->AddManifestFile(IcebergManifestListEntry::CreateFromEntries(
+	    fs, sequence_number, table_metadata, data_manifest_metadata, std::move(data_files), next_row_id));
 	add_snapshot->altered_manifests = std::move(altered_manifests);
 
 	alters.push_back(*add_snapshot);

--- a/src/execution/helpers/equality_delete_helpers.cpp
+++ b/src/execution/helpers/equality_delete_helpers.cpp
@@ -347,6 +347,28 @@ bool IcebergDelete::TryGetEqualityDeletePredicates(ClientContext &context, Icebe
 	return true;
 }
 
+//! This writer gives an equality delete no partition values, so only an unpartitioned spec makes it apply at
+//! all; a partitioned one would scope it to a partition it never names. Lowest id, to keep the choice stable.
+static int32_t GlobalEqualityDeleteSpecId(const IcebergTableMetadata &metadata) {
+	int32_t result = 0;
+	bool found = false;
+	for (auto &entry : metadata.GetPartitionSpecs()) {
+		if (!entry.second.IsUnpartitioned()) {
+			continue;
+		}
+		if (!found || entry.first < result) {
+			result = entry.first;
+			found = true;
+		}
+	}
+	if (!found) {
+		throw NotImplementedException(
+		    "Cannot write an equality delete for this table: none of its partition specs are unpartitioned, and "
+		    "writing partition-scoped equality deletes is not supported");
+	}
+	return result;
+}
+
 void IcebergDelete::WriteEqualityDeleteFile(ClientContext &context, IcebergDeleteGlobalState &global_state) const {
 	D_ASSERT(!equality_predicates.empty());
 
@@ -433,9 +455,8 @@ void IcebergDelete::WriteEqualityDeleteFile(ClientContext &context, IcebergDelet
 	delete_file.delete_count = rows.size();
 	delete_file.file_size_bytes = stats.file_size_bytes;
 	delete_file.equality_ids = std::move(equality_ids);
-	//! An equality delete targets no single data file, so it goes into a manifest of the current spec.
-	delete_file.data_file_partitioning.partition_spec_id =
-	    NumericCast<int32_t>(table.table_info.table_metadata.default_spec_id);
+	//! An equality delete targets no single data file, so it is not tied to any one partition.
+	delete_file.partition_info.partition_spec_id = GlobalEqualityDeleteSpecId(table.table_info.table_metadata);
 
 	// Record per-field metrics for the equality-delete values so scans can prune this delete file when its
 	// equality-field range is disjoint from the scan predicate / a data file's bounds. Each field's bound

--- a/src/execution/helpers/equality_delete_helpers.cpp
+++ b/src/execution/helpers/equality_delete_helpers.cpp
@@ -433,6 +433,9 @@ void IcebergDelete::WriteEqualityDeleteFile(ClientContext &context, IcebergDelet
 	delete_file.delete_count = rows.size();
 	delete_file.file_size_bytes = stats.file_size_bytes;
 	delete_file.equality_ids = std::move(equality_ids);
+	//! An equality delete targets no single data file, so it goes into a manifest of the current spec.
+	delete_file.data_file_partitioning.partition_spec_id =
+	    NumericCast<int32_t>(table.table_info.table_metadata.default_spec_id);
 
 	// Record per-field metrics for the equality-delete values so scans can prune this delete file when its
 	// equality-field range is disjoint from the scan predicate / a data file's bounds. Each field's bound

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -342,7 +342,7 @@ void IcebergDelete::FlushDeletes(IcebergTransaction &transaction, ClientContext 
 
 		IcebergDeleteFileInfo delete_file;
 		delete_file.data_file_path = filename;
-		delete_file.data_file_partitioning = multi_file_list->GetPartitioningForDataFile(filename);
+		delete_file.partition_info = multi_file_list->GetPartitionForDataFile(filename);
 
 		auto &fs = FileSystem::GetFileSystem(context);
 
@@ -374,10 +374,10 @@ void IcebergDelete::FlushDeletes(IcebergTransaction &transaction, ClientContext 
 	}
 }
 
-IcebergDeleteManifestEntries IcebergDelete::GenerateDeleteManifestEntries(IcebergDeleteGlobalState &global_state) {
+partitioned_manifest_entry_map_t IcebergDelete::GenerateDeleteManifestEntries(IcebergDeleteGlobalState &global_state) {
 	lock_guard<mutex> guard(global_state.lock);
 	auto &delete_files = global_state.written_files;
-	IcebergDeleteManifestEntries iceberg_delete_files;
+	partitioned_manifest_entry_map_t iceberg_delete_files;
 	for (auto &delete_entry : delete_files) {
 		auto data_file_name = delete_entry.first;
 		auto &delete_file = delete_entry.second;
@@ -400,7 +400,7 @@ IcebergDeleteManifestEntries IcebergDelete::GenerateDeleteManifestEntries(Iceber
 			//! Record the equality-delete value bounds so the file can be pruned on metrics.
 			data_file.lower_bounds = delete_file.lower_bounds;
 			data_file.upper_bounds = delete_file.upper_bounds;
-			iceberg_delete_files[delete_file.data_file_partitioning.partition_spec_id].push_back(manifest_entry);
+			iceberg_delete_files[delete_file.partition_info.partition_spec_id].push_back(manifest_entry);
 			continue;
 		}
 
@@ -422,11 +422,11 @@ IcebergDeleteManifestEntries IcebergDelete::GenerateDeleteManifestEntries(Iceber
 		// set referenced_data_file
 		data_file.referenced_data_file = data_file_name;
 		// copy partition info from the data file being deleted
-		auto &partitioning = delete_file.data_file_partitioning;
-		data_file.partition_info = partitioning.partition_info;
+		auto &partition = delete_file.partition_info;
+		data_file.partition_info = partition.fields;
 		//! Keyed by the data file's spec, not the table's current one: the values above are expressed in that
 		//! spec, and a reader only applies a delete whose partition (spec included) equals the data file's.
-		iceberg_delete_files[partitioning.partition_spec_id].push_back(manifest_entry);
+		iceberg_delete_files[partition.partition_spec_id].push_back(manifest_entry);
 	}
 	return iceberg_delete_files;
 }

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -342,7 +342,7 @@ void IcebergDelete::FlushDeletes(IcebergTransaction &transaction, ClientContext 
 
 		IcebergDeleteFileInfo delete_file;
 		delete_file.data_file_path = filename;
-		delete_file.partition_info = multi_file_list->GetPartitionInfoForDataFile(filename);
+		delete_file.data_file_partitioning = multi_file_list->GetPartitioningForDataFile(filename);
 
 		auto &fs = FileSystem::GetFileSystem(context);
 
@@ -374,10 +374,10 @@ void IcebergDelete::FlushDeletes(IcebergTransaction &transaction, ClientContext 
 	}
 }
 
-vector<IcebergManifestEntry> IcebergDelete::GenerateDeleteManifestEntries(IcebergDeleteGlobalState &global_state) {
+IcebergDeleteManifestEntries IcebergDelete::GenerateDeleteManifestEntries(IcebergDeleteGlobalState &global_state) {
 	lock_guard<mutex> guard(global_state.lock);
 	auto &delete_files = global_state.written_files;
-	vector<IcebergManifestEntry> iceberg_delete_files;
+	IcebergDeleteManifestEntries iceberg_delete_files;
 	for (auto &delete_entry : delete_files) {
 		auto data_file_name = delete_entry.first;
 		auto &delete_file = delete_entry.second;
@@ -400,7 +400,7 @@ vector<IcebergManifestEntry> IcebergDelete::GenerateDeleteManifestEntries(Iceber
 			//! Record the equality-delete value bounds so the file can be pruned on metrics.
 			data_file.lower_bounds = delete_file.lower_bounds;
 			data_file.upper_bounds = delete_file.upper_bounds;
-			iceberg_delete_files.push_back(manifest_entry);
+			iceberg_delete_files[delete_file.data_file_partitioning.partition_spec_id].push_back(manifest_entry);
 			continue;
 		}
 
@@ -422,8 +422,11 @@ vector<IcebergManifestEntry> IcebergDelete::GenerateDeleteManifestEntries(Iceber
 		// set referenced_data_file
 		data_file.referenced_data_file = data_file_name;
 		// copy partition info from the data file being deleted
-		data_file.partition_info = delete_file.partition_info;
-		iceberg_delete_files.push_back(manifest_entry);
+		auto &partitioning = delete_file.data_file_partitioning;
+		data_file.partition_info = partitioning.partition_info;
+		//! Keyed by the data file's spec, not the table's current one: the values above are expressed in that
+		//! spec, and a reader only applies a delete whose partition (spec included) equals the data file's.
+		iceberg_delete_files[partitioning.partition_spec_id].push_back(manifest_entry);
 	}
 	return iceberg_delete_files;
 }
@@ -465,8 +468,8 @@ SinkFinalizeType IcebergDelete::Finalize(Pipeline &pipeline, Event &event, Clien
 	if (!global_state.written_files.empty()) {
 		ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
 			auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
-			transaction_data.AddSnapshot(IcebergSnapshotOperationType::DELETE, std::move(iceberg_delete_files),
-			                             std::move(global_state.altered_manifests));
+			transaction_data.AddDeleteSnapshot(std::move(iceberg_delete_files),
+			                                   std::move(global_state.altered_manifests));
 
 			//! Add or overwrite the currently active transaction-local delete files
 			for (auto &entry : global_state.written_files) {

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -34,7 +34,8 @@ public:
 
 	void AddSnapshot(IcebergSnapshotOperationType operation, vector<IcebergManifestEntry> &&data_files,
 	                 IcebergManifestDeletes &&altered_manifests);
-	void AddUpdateSnapshot(vector<IcebergManifestEntry> &&delete_files, vector<IcebergManifestEntry> &&data_files,
+	void AddDeleteSnapshot(IcebergDeleteManifestEntries &&delete_files, IcebergManifestDeletes &&altered_manifests);
+	void AddUpdateSnapshot(IcebergDeleteManifestEntries &&delete_files, vector<IcebergManifestEntry> &&data_files,
 	                       IcebergManifestDeletes &&altered_manifests);
 	// add a schema update for a table
 	void TableAddSchema(int32_t schema_id);
@@ -57,6 +58,9 @@ public:
 
 private:
 	void CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata);
+	//! Writes one delete manifest per partition spec present in 'delete_files'.
+	void AddDeleteManifestFiles(IcebergAddSnapshot &add_snapshot, IcebergDeleteManifestEntries &&delete_files,
+	                            sequence_number_t sequence_number);
 
 public:
 	string initial_table_uuid;

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -34,8 +34,8 @@ public:
 
 	void AddSnapshot(IcebergSnapshotOperationType operation, vector<IcebergManifestEntry> &&data_files,
 	                 IcebergManifestDeletes &&altered_manifests);
-	void AddDeleteSnapshot(IcebergDeleteManifestEntries &&delete_files, IcebergManifestDeletes &&altered_manifests);
-	void AddUpdateSnapshot(IcebergDeleteManifestEntries &&delete_files, vector<IcebergManifestEntry> &&data_files,
+	void AddDeleteSnapshot(partitioned_manifest_entry_map_t &&delete_files, IcebergManifestDeletes &&altered_manifests);
+	void AddUpdateSnapshot(partitioned_manifest_entry_map_t &&delete_files, vector<IcebergManifestEntry> &&data_files,
 	                       IcebergManifestDeletes &&altered_manifests);
 	// add a schema update for a table
 	void TableAddSchema(int32_t schema_id);
@@ -59,7 +59,7 @@ public:
 private:
 	void CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata);
 	//! Writes one delete manifest per partition spec present in 'delete_files'.
-	void AddDeleteManifestFiles(IcebergAddSnapshot &add_snapshot, IcebergDeleteManifestEntries &&delete_files,
+	void AddDeleteManifestFiles(IcebergAddSnapshot &add_snapshot, partitioned_manifest_entry_map_t &&delete_files,
 	                            sequence_number_t sequence_number);
 
 public:

--- a/src/include/core/metadata/manifest/iceberg_manifest.hpp
+++ b/src/include/core/metadata/manifest/iceberg_manifest.hpp
@@ -65,11 +65,11 @@ struct IcebergPartitionInfo {
 	}
 };
 
-//! How a data file is partitioned: the values, plus the spec they were produced with.
+//! The partition a file belongs to: the per-field values, plus the spec they were produced with.
 //! Partition values are only meaningful together with their spec, so the two travel as a pair.
-struct IcebergDataFilePartitioning {
+struct IcebergPartition {
 	int32_t partition_spec_id = 0;
-	vector<IcebergPartitionInfo> partition_info;
+	vector<IcebergPartitionInfo> fields;
 };
 
 struct IcebergDataFile {
@@ -145,9 +145,12 @@ private:
 	optional<sequence_number_t> file_sequence_number;
 };
 
-//! Delete-manifest entries grouped by the partition spec of the data files they target, so each group can be
-//! written into a manifest declaring that spec.
-using IcebergDeleteManifestEntries = map<int32_t, vector<IcebergManifestEntry>>;
+//! Manifest entries grouped by partition spec id, so each group can be written into a manifest declaring
+//! that spec.
+using partitioned_manifest_entry_map_t = map<int32_t, vector<IcebergManifestEntry>>;
+
+//! A file's partition values looked up by partition field id.
+using partition_value_map_t = unordered_map<uint64_t, reference<const Value>>;
 
 struct IcebergManifestListEntry;
 

--- a/src/include/core/metadata/manifest/iceberg_manifest.hpp
+++ b/src/include/core/metadata/manifest/iceberg_manifest.hpp
@@ -65,6 +65,13 @@ struct IcebergPartitionInfo {
 	}
 };
 
+//! How a data file is partitioned: the values, plus the spec they were produced with.
+//! Partition values are only meaningful together with their spec, so the two travel as a pair.
+struct IcebergDataFilePartitioning {
+	int32_t partition_spec_id = 0;
+	vector<IcebergPartitionInfo> partition_info;
+};
+
 struct IcebergDataFile {
 public:
 	static map<idx_t, LogicalType> GetFieldIdToTypeMapping(const IcebergSnapshotScanInfo &snapshot_info,
@@ -137,6 +144,10 @@ private:
 	optional<sequence_number_t> sequence_number;
 	optional<sequence_number_t> file_sequence_number;
 };
+
+//! Delete-manifest entries grouped by the partition spec of the data files they target, so each group can be
+//! written into a manifest declaring that spec.
+using IcebergDeleteManifestEntries = map<int32_t, vector<IcebergManifestEntry>>;
 
 struct IcebergManifestListEntry;
 

--- a/src/include/execution/operator/iceberg_delete.hpp
+++ b/src/include/execution/operator/iceberg_delete.hpp
@@ -62,7 +62,9 @@ struct IcebergDeleteFileInfo {
 	idx_t pos_min_value;
 	optional_idx content_size_in_bytes;
 	optional_idx content_offset;
-	vector<IcebergPartitionInfo> partition_info;
+	//! The partitioning of the data file this delete targets. A delete file has to be written into a manifest
+	//! of that same spec, not the table's current one, or readers can't tell that the two partitions are equal.
+	IcebergDataFilePartitioning data_file_partitioning;
 	//! When non-empty, this is an equality-delete file; holds the field-ids it applies to
 	vector<int32_t> equality_ids;
 	//! Per-field serialized lower/upper bounds of the equality-delete values (field-id -> bound blob).
@@ -167,7 +169,7 @@ public:
 	                          OperatorSinkFinalizeInput &input) const override;
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
 	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
-	static vector<IcebergManifestEntry> GenerateDeleteManifestEntries(IcebergDeleteGlobalState &global_state);
+	static IcebergDeleteManifestEntries GenerateDeleteManifestEntries(IcebergDeleteGlobalState &global_state);
 
 	bool IsSink() const override {
 		return true;

--- a/src/include/execution/operator/iceberg_delete.hpp
+++ b/src/include/execution/operator/iceberg_delete.hpp
@@ -62,9 +62,9 @@ struct IcebergDeleteFileInfo {
 	idx_t pos_min_value;
 	optional_idx content_size_in_bytes;
 	optional_idx content_offset;
-	//! The partitioning of the data file this delete targets. A delete file has to be written into a manifest
+	//! The partition of the data file this delete targets. A delete file has to be written into a manifest
 	//! of that same spec, not the table's current one, or readers can't tell that the two partitions are equal.
-	IcebergDataFilePartitioning data_file_partitioning;
+	IcebergPartition partition_info;
 	//! When non-empty, this is an equality-delete file; holds the field-ids it applies to
 	vector<int32_t> equality_ids;
 	//! Per-field serialized lower/upper bounds of the equality-delete values (field-id -> bound blob).
@@ -169,7 +169,7 @@ public:
 	                          OperatorSinkFinalizeInput &input) const override;
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
 	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
-	static IcebergDeleteManifestEntries GenerateDeleteManifestEntries(IcebergDeleteGlobalState &global_state);
+	static partitioned_manifest_entry_map_t GenerateDeleteManifestEntries(IcebergDeleteGlobalState &global_state);
 
 	bool IsSink() const override {
 		return true;

--- a/src/include/planning/deletes/iceberg_delete_planner.hpp
+++ b/src/include/planning/deletes/iceberg_delete_planner.hpp
@@ -42,7 +42,8 @@ struct IcebergDeletePlanner {
 	                                      const IcebergManifestEntry &delete_manifest_entry);
 	static bool DeleteEntryAppliesToDataFile(const IcebergDeletePlanningContext &context, idx_t delete_manifest_idx,
 	                                         const IcebergManifestEntry &delete_manifest_entry,
-	                                         const BoundIcebergManifestEntry &data_manifest_entry);
+	                                         const BoundIcebergManifestEntry &data_manifest_entry,
+	                                         const partition_value_map_t &data_partition_values);
 	static shared_ptr<IcebergDeleteData> GetExistingPositionalDeleteData(const IcebergDeletePlanningContext &context,
 	                                                                     const string &file_path);
 };

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -56,7 +56,7 @@ public:
 public:
 	void SetTable(IcebergTableEntry &table);
 	shared_ptr<IcebergDeleteData> GetExistingPositionalDeleteData(const string &file_path) const;
-	IcebergDataFilePartitioning GetPartitioningForDataFile(const string &file_path) const;
+	IcebergPartition GetPartitionForDataFile(const string &file_path) const;
 	void SetScanOrder(unique_ptr<RowGroupOrderOptions> options);
 	optional_ptr<IcebergTableEntry> GetTable() const;
 	void DisableServerSidePlanning();

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -56,7 +56,7 @@ public:
 public:
 	void SetTable(IcebergTableEntry &table);
 	shared_ptr<IcebergDeleteData> GetExistingPositionalDeleteData(const string &file_path) const;
-	vector<IcebergPartitionInfo> GetPartitionInfoForDataFile(const string &file_path) const;
+	IcebergDataFilePartitioning GetPartitioningForDataFile(const string &file_path) const;
 	void SetScanOrder(unique_ptr<RowGroupOrderOptions> options);
 	optional_ptr<IcebergTableEntry> GetTable() const;
 	void DisableServerSidePlanning();

--- a/src/include/planning/pruning/iceberg_file_pruner.hpp
+++ b/src/include/planning/pruning/iceberg_file_pruner.hpp
@@ -22,7 +22,10 @@ public:
 	bool DeleteFileMatchesDataFile(const IcebergManifestFile &delete_manifest,
 	                               const IcebergManifestEntry &delete_manifest_entry,
 	                               const IcebergManifestFile &data_manifest,
-	                               const IcebergManifestEntry &data_manifest_entry) const;
+	                               const IcebergManifestEntry &data_manifest_entry,
+	                               const partition_value_map_t &data_partition_values) const;
+	//! Built once per data file: every delete file considered for it is matched against the same values.
+	static partition_value_map_t PartitionValueMap(const IcebergDataFile &data_file);
 
 private:
 	bool FilePartitionMatchesFilter(const IcebergDataFile &data_file, const IcebergManifestFile &manifest_file) const;

--- a/src/include/planning/scan_plan/iceberg_scan_plan_state.hpp
+++ b/src/include/planning/scan_plan/iceberg_scan_plan_state.hpp
@@ -80,7 +80,7 @@ struct IcebergScanPlanState {
 	//! Declared after manifest owners so references in parsed positional-delete data are destroyed first.
 	mutable unordered_map<string, shared_ptr<IcebergDeleteData>> positional_delete_data DUCKDB_GUARDED_BY(delete_lock);
 
-	mutable unordered_map<string, vector<IcebergPartitionInfo>> data_file_partition_info DUCKDB_GUARDED_BY(lock);
+	mutable unordered_map<string, IcebergDataFilePartitioning> data_file_partitioning DUCKDB_GUARDED_BY(lock);
 };
 
 } // namespace duckdb

--- a/src/include/planning/scan_plan/iceberg_scan_plan_state.hpp
+++ b/src/include/planning/scan_plan/iceberg_scan_plan_state.hpp
@@ -80,7 +80,7 @@ struct IcebergScanPlanState {
 	//! Declared after manifest owners so references in parsed positional-delete data are destroyed first.
 	mutable unordered_map<string, shared_ptr<IcebergDeleteData>> positional_delete_data DUCKDB_GUARDED_BY(delete_lock);
 
-	mutable unordered_map<string, IcebergDataFilePartitioning> data_file_partitioning DUCKDB_GUARDED_BY(lock);
+	mutable unordered_map<string, IcebergPartition> data_file_partitions DUCKDB_GUARDED_BY(lock);
 };
 
 } // namespace duckdb

--- a/src/planning/deletes/iceberg_delete_planner.cpp
+++ b/src/planning/deletes/iceberg_delete_planner.cpp
@@ -41,7 +41,8 @@ bool IcebergDeletePlanner::DeleteEntryMatchesFilters(const IcebergDeletePlanning
 bool IcebergDeletePlanner::DeleteEntryAppliesToDataFile(const IcebergDeletePlanningContext &context,
                                                         idx_t delete_manifest_idx,
                                                         const IcebergManifestEntry &delete_manifest_entry,
-                                                        const BoundIcebergManifestEntry &data_manifest_entry) {
+                                                        const BoundIcebergManifestEntry &data_manifest_entry,
+                                                        const partition_value_map_t &data_partition_values) {
 	auto &delete_file = delete_manifest_entry.data_file;
 	auto &data_file = data_manifest_entry.entry.data_file;
 	if (!context.provider.DeleteFileAppliesToDataFile(data_file.file_path, delete_file.file_path)) {
@@ -51,7 +52,8 @@ bool IcebergDeletePlanner::DeleteEntryAppliesToDataFile(const IcebergDeletePlann
 	auto &delete_manifest = context.delete_manifests[delete_manifest_idx].entry.file;
 	auto &data_manifest = context.data_manifests[data_manifest_entry.manifest_file_idx].entry.file;
 	return IcebergFilePruner(context.context, context.metadata, context.schema, context.table_filters)
-	    .DeleteFileMatchesDataFile(delete_manifest, delete_manifest_entry, data_manifest, data_manifest_entry.entry);
+	    .DeleteFileMatchesDataFile(delete_manifest, delete_manifest_entry, data_manifest, data_manifest_entry.entry,
+	                               data_partition_values);
 }
 
 shared_ptr<IcebergDeleteData>

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -368,10 +368,10 @@ IcebergManifestFile IcebergMultiFileList::GetManifestFileForDataFile(idx_t file_
 	return data_manifests[manifest_file_idx].entry.file;
 }
 
-IcebergDataFilePartitioning IcebergMultiFileList::GetPartitioningForDataFile(const string &file_path) const {
+IcebergPartition IcebergMultiFileList::GetPartitionForDataFile(const string &file_path) const {
 	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	auto entry = shared_state->data_file_partitioning.find(file_path);
-	if (entry != shared_state->data_file_partitioning.end()) {
+	auto entry = shared_state->data_file_partitions.find(file_path);
+	if (entry != shared_state->data_file_partitions.end()) {
 		return entry->second;
 	}
 	throw InvalidConfigurationException("Could not find data file '%s' in manifest entries", file_path);
@@ -456,9 +456,9 @@ IcebergMultiFileList::GetDataFile(idx_t file_id, annotated_lock_guard<annotated_
 			if (options.allow_moved_paths) {
 				entry_path = IcebergUtils::GetFullPath(GetPath(), entry_path, fs);
 			}
-			IcebergDataFilePartitioning partitioning {manifest_file.partition_spec_id, data_file.partition_info};
-			shared_state->data_file_partitioning[entry_path] = partitioning;
-			shared_state->data_file_partitioning[data_file.file_path] = std::move(partitioning);
+			IcebergPartition partition {manifest_file.partition_spec_id, data_file.partition_info};
+			shared_state->data_file_partitions[entry_path] = partition;
+			shared_state->data_file_partitions[data_file.file_path] = std::move(partition);
 
 			if (manifest_entry.status == IcebergManifestEntryStatusType::DELETED) {
 				continue;
@@ -637,6 +637,7 @@ IcebergDeletePlan IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifes
 		annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
 		auto delete_files = provider->GetDeleteFiles(manifest_indexes);
 		delete_context = make_uniq<IcebergDeletePlanningContext>(GetDeletePlanningContext());
+		auto data_partition_values = IcebergFilePruner::PartitionValueMap(data_manifest_entry.entry.data_file);
 		unordered_set<IcebergDeleteFileLoadState *> seen_loads;
 		for (auto delete_file : delete_files) {
 			if (delete_file.manifest_idx >= delete_manifests.size()) {
@@ -655,7 +656,8 @@ IcebergDeletePlan IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifes
 				continue;
 			}
 			if (!IcebergDeletePlanner::DeleteEntryAppliesToDataFile(*delete_context, delete_file.manifest_idx,
-			                                                        delete_entry, data_manifest_entry)) {
+			                                                        delete_entry, data_manifest_entry,
+			                                                        data_partition_values)) {
 				continue;
 			}
 

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -368,10 +368,10 @@ IcebergManifestFile IcebergMultiFileList::GetManifestFileForDataFile(idx_t file_
 	return data_manifests[manifest_file_idx].entry.file;
 }
 
-vector<IcebergPartitionInfo> IcebergMultiFileList::GetPartitionInfoForDataFile(const string &file_path) const {
+IcebergDataFilePartitioning IcebergMultiFileList::GetPartitioningForDataFile(const string &file_path) const {
 	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	auto entry = shared_state->data_file_partition_info.find(file_path);
-	if (entry != shared_state->data_file_partition_info.end()) {
+	auto entry = shared_state->data_file_partitioning.find(file_path);
+	if (entry != shared_state->data_file_partitioning.end()) {
 		return entry->second;
 	}
 	throw InvalidConfigurationException("Could not find data file '%s' in manifest entries", file_path);
@@ -456,8 +456,9 @@ IcebergMultiFileList::GetDataFile(idx_t file_id, annotated_lock_guard<annotated_
 			if (options.allow_moved_paths) {
 				entry_path = IcebergUtils::GetFullPath(GetPath(), entry_path, fs);
 			}
-			shared_state->data_file_partition_info[entry_path] = data_file.partition_info;
-			shared_state->data_file_partition_info[data_file.file_path] = data_file.partition_info;
+			IcebergDataFilePartitioning partitioning {manifest_file.partition_spec_id, data_file.partition_info};
+			shared_state->data_file_partitioning[entry_path] = partitioning;
+			shared_state->data_file_partitioning[data_file.file_path] = std::move(partitioning);
 
 			if (manifest_entry.status == IcebergManifestEntryStatusType::DELETED) {
 				continue;

--- a/src/planning/pruning/iceberg_file_pruner.cpp
+++ b/src/planning/pruning/iceberg_file_pruner.cpp
@@ -245,10 +245,19 @@ bool IcebergFilePruner::DeleteManifestMatchesDataFile(const IcebergManifestFile 
 	return true;
 }
 
+partition_value_map_t IcebergFilePruner::PartitionValueMap(const IcebergDataFile &data_file) {
+	partition_value_map_t result;
+	for (auto &partition : data_file.partition_info) {
+		result.emplace(partition.field_id, partition.value);
+	}
+	return result;
+}
+
 bool IcebergFilePruner::DeleteFileMatchesDataFile(const IcebergManifestFile &delete_manifest,
                                                   const IcebergManifestEntry &delete_manifest_entry,
                                                   const IcebergManifestFile &data_manifest,
-                                                  const IcebergManifestEntry &data_manifest_entry) const {
+                                                  const IcebergManifestEntry &data_manifest_entry,
+                                                  const partition_value_map_t &data_partition_values) const {
 	auto &delete_file = delete_manifest_entry.data_file;
 	auto &data_file = data_manifest_entry.data_file;
 	if (delete_file.referenced_data_file && *delete_file.referenced_data_file != data_file.file_path) {
@@ -288,30 +297,28 @@ bool IcebergFilePruner::DeleteFileMatchesDataFile(const IcebergManifestFile &del
 		return false;
 	}
 
-	//! A partition struct is read as the union of the specs covered by its reader, and data and delete manifests
-	//! are read separately, so the same spec can yield a different set of fields on each side: a field belonging
-	//! to another spec is materialized as NULL for one file and missing for the other. Match on field id and
-	//! treat a missing field as NULL, rather than pairing the two structs up by position.
-	unordered_map<uint64_t, reference<const Value>> data_partition_values;
-	for (auto &data_partition : data_file.partition_info) {
-		data_partition_values.emplace(data_partition.field_id, data_partition.value);
-	}
-
-	for (auto &delete_partition : delete_file.partition_info) {
-		auto it = data_partition_values.find(delete_partition.field_id);
-		if (it == data_partition_values.end()) {
-			if (!delete_partition.value.IsNull()) {
+	//! Both files are under this spec, so its fields are the partition. Each side is projected over the union of
+	//! the specs its own manifest covers, so a field can be absent on one side; absent means NULL.
+	for (auto &field : partition_spec_it->second.fields) {
+		const Value *delete_value = nullptr;
+		for (auto &delete_partition : delete_file.partition_info) {
+			if (delete_partition.field_id == field.partition_field_id) {
+				delete_value = &delete_partition.value;
+				break;
+			}
+		}
+		const Value *data_value = nullptr;
+		auto data_it = data_partition_values.find(field.partition_field_id);
+		if (data_it != data_partition_values.end()) {
+			data_value = &data_it->second.get();
+		}
+		if (!delete_value || !data_value) {
+			if ((delete_value && !delete_value->IsNull()) || (data_value && !data_value->IsNull())) {
 				return false;
 			}
 			continue;
 		}
-		if (!Value::NotDistinctFrom(delete_partition.value, it->second.get())) {
-			return false;
-		}
-		data_partition_values.erase(it);
-	}
-	for (auto &data_partition : data_partition_values) {
-		if (!data_partition.second.get().IsNull()) {
+		if (!Value::NotDistinctFrom(*delete_value, *data_value)) {
 			return false;
 		}
 	}

--- a/src/planning/pruning/iceberg_file_pruner.cpp
+++ b/src/planning/pruning/iceberg_file_pruner.cpp
@@ -288,23 +288,30 @@ bool IcebergFilePruner::DeleteFileMatchesDataFile(const IcebergManifestFile &del
 		return false;
 	}
 
-	if (delete_file.partition_info.size() != data_file.partition_info.size()) {
-		throw InvalidConfigurationException(
-		    "Delete file %s has %llu partition values, but data file %s has %llu for partition spec %d",
-		    delete_file.file_path, delete_file.partition_info.size(), data_file.file_path,
-		    data_file.partition_info.size(), delete_manifest.partition_spec_id);
+	//! A partition struct is read as the union of the specs covered by its reader, and data and delete manifests
+	//! are read separately, so the same spec can yield a different set of fields on each side: a field belonging
+	//! to another spec is materialized as NULL for one file and missing for the other. Match on field id and
+	//! treat a missing field as NULL, rather than pairing the two structs up by position.
+	unordered_map<uint64_t, reference<const Value>> data_partition_values;
+	for (auto &data_partition : data_file.partition_info) {
+		data_partition_values.emplace(data_partition.field_id, data_partition.value);
 	}
-	for (idx_t partition_idx = 0; partition_idx < delete_file.partition_info.size(); partition_idx++) {
-		auto &delete_partition = delete_file.partition_info[partition_idx];
-		auto &data_partition = data_file.partition_info[partition_idx];
-		if (delete_partition.field_id != data_partition.field_id) {
-			throw InvalidConfigurationException(
-			    "Delete file %s has partition field id %llu at index %llu, but data file %s has field id %llu for "
-			    "partition spec %d",
-			    delete_file.file_path, delete_partition.field_id, partition_idx, data_file.file_path,
-			    data_partition.field_id, delete_manifest.partition_spec_id);
+
+	for (auto &delete_partition : delete_file.partition_info) {
+		auto it = data_partition_values.find(delete_partition.field_id);
+		if (it == data_partition_values.end()) {
+			if (!delete_partition.value.IsNull()) {
+				return false;
+			}
+			continue;
 		}
-		if (!Value::NotDistinctFrom(delete_partition.value, data_partition.value)) {
+		if (!Value::NotDistinctFrom(delete_partition.value, it->second.get())) {
+			return false;
+		}
+		data_partition_values.erase(it);
+	}
+	for (auto &data_partition : data_partition_values) {
+		if (!data_partition.second.get().IsNull()) {
 			return false;
 		}
 	}

--- a/test/configs/polaris.json
+++ b/test/configs/polaris.json
@@ -30,6 +30,7 @@
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_insert_into_sorted_table_fails.test",
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_into_sorted_table_fails.test",
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/test_requests_to_partitioned_table.test",
+				"test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/read_mor_delete_partition_evolution.test",
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/irc_catalog_read_deletes.test",
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/test_read_upper_and_lower_bounds.test",
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/iceberg_catalog_eager_refresh.test"

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/partitions/delete_after_partition_spec_evolution.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/partitions/delete_after_partition_spec_evolution.test
@@ -1,0 +1,66 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/partitions/delete_after_partition_spec_evolution.test
+# description: A delete against a data file written under a previous partition spec must go into a manifest declaring that spec, so that reads still see the delete partition and the data partition as equal
+# group: [partitions]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+set logging_level='debug'
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.test_delete_after_spec_evolution;
+
+statement ok
+CREATE TABLE my_datalake.default.test_delete_after_spec_evolution (id INT, ts TIMESTAMP, val VARCHAR)
+PARTITIONED BY (day(ts));
+
+statement ok
+INSERT INTO my_datalake.default.test_delete_after_spec_evolution VALUES
+    (1, '2021-05-01 09:00:00'::TIMESTAMP, 'a'),
+    (2, '2021-05-01 10:30:00'::TIMESTAMP, 'b');
+
+statement ok
+ALTER TABLE my_datalake.default.test_delete_after_spec_evolution SET PARTITIONED BY (hour(ts));
+
+# The predicate is on a non-partition column, so the whole data file is scanned and the delete takes
+# the row-level path. The data file it targets was written under the old spec.
+query I
+DELETE FROM my_datalake.default.test_delete_after_spec_evolution WHERE val = 'b';
+----
+1
+
+query III
+SELECT id, ts, val FROM my_datalake.default.test_delete_after_spec_evolution ORDER BY id;
+----
+1	2021-05-01 09:00:00	a
+
+# The delete file is committed and live either way - what matters is that reads apply it.
+query I
+SELECT count(*) FROM iceberg_metadata(my_datalake.default.test_delete_after_spec_evolution)
+WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+1
+
+# Deleting the remaining row of a file written under the older spec must empty the table.
+statement ok
+DELETE FROM my_datalake.default.test_delete_after_spec_evolution WHERE val = 'a';
+
+query I
+SELECT count(*) FROM my_datalake.default.test_delete_after_spec_evolution;
+----
+0
+
+statement ok
+DROP TABLE my_datalake.default.test_delete_after_spec_evolution;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/partitions/delete_with_mixed_partition_specs.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/partitions/delete_with_mixed_partition_specs.test
@@ -1,0 +1,62 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/partitions/delete_with_mixed_partition_specs.test
+# description: A table holding data files under two partition specs must still apply a delete to a file written under the older one, even though the two specs project a different set of partition fields
+# group: [partitions]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+set logging_level='debug'
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.test_delete_mixed_specs;
+
+statement ok
+CREATE TABLE my_datalake.default.test_delete_mixed_specs (id INT, ts TIMESTAMP, val VARCHAR)
+PARTITIONED BY (day(ts));
+
+statement ok
+INSERT INTO my_datalake.default.test_delete_mixed_specs VALUES
+    (1, '2021-05-01 09:00:00'::TIMESTAMP, 'a'),
+    (2, '2021-05-01 10:30:00'::TIMESTAMP, 'b');
+
+statement ok
+ALTER TABLE my_datalake.default.test_delete_mixed_specs SET PARTITIONED BY (hour(ts));
+
+# A second data file under the new spec. Reading now merges both specs into the partition struct of the
+# data manifests, while the delete manifest below only covers the old one.
+statement ok
+INSERT INTO my_datalake.default.test_delete_mixed_specs VALUES
+    (3, '2021-06-02 11:00:00'::TIMESTAMP, 'c');
+
+statement ok
+DELETE FROM my_datalake.default.test_delete_mixed_specs WHERE val = 'b';
+
+query III
+SELECT id, ts, val FROM my_datalake.default.test_delete_mixed_specs ORDER BY id;
+----
+1	2021-05-01 09:00:00	a
+3	2021-06-02 11:00:00	c
+
+# A delete against the file written under the newer spec must not disturb the older one.
+statement ok
+DELETE FROM my_datalake.default.test_delete_mixed_specs WHERE val = 'c';
+
+query III
+SELECT id, ts, val FROM my_datalake.default.test_delete_mixed_specs ORDER BY id;
+----
+1	2021-05-01 09:00:00	a
+
+statement ok
+DROP TABLE my_datalake.default.test_delete_mixed_specs;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/read_mor_delete_partition_evolution.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/read_mor_delete_partition_evolution.test
@@ -1,0 +1,38 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/read_mor_delete_partition_evolution.test
+# description: read a table holding data files under two partition specs with a merge-on-read delete against the older one - the delete manifest covers one spec while the data manifests cover both, so the two partition structs project a different set of fields
+# group: [reads]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require icu
+
+statement ok
+set timezone='UTC'
+
+# The delete removes id 2 from the data file written under the day spec, while id 3 lives in a file
+# written under the hour spec.
+query III
+SELECT id, ts, val FROM my_datalake.default.spark_mor_delete_partition_evolution ORDER BY id;
+----
+1	2021-05-01 09:00:00+00	a
+3	2021-06-02 11:00:00+00	c
+
+query I
+SELECT count(*) FROM my_datalake.default.spark_mor_delete_partition_evolution;
+----
+2
+
+# The delete is a live positional delete, not a rewritten data file.
+query I
+SELECT count(*) FROM iceberg_metadata('my_datalake.default.spark_mor_delete_partition_evolution')
+WHERE content = 'POSITION_DELETES' AND status != 'DELETED';
+----
+1

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/partitions/update_after_partition_spec_evolution.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/partitions/update_after_partition_spec_evolution.test
@@ -35,8 +35,7 @@ statement ok
 ALTER TABLE my_datalake.default.test_update_after_spec_evolution SET PARTITIONED BY (hour(ts));
 
 # An update writes the new row under the current spec and a delete file hiding the old one, which
-# belongs with the spec of the data file it targets. If the two end up in one manifest, the delete is
-# either discarded (the row appears twice) or read under the wrong spec.
+# belongs with the spec of the data file it targets.
 query I
 UPDATE my_datalake.default.test_update_after_spec_evolution SET val = 'updated' WHERE val = 'b';
 ----

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/partitions/update_after_partition_spec_evolution.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/update/partitions/update_after_partition_spec_evolution.test
@@ -1,0 +1,57 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/update/partitions/update_after_partition_spec_evolution.test
+# description: An update to a data file written under a previous partition spec must not leave the old version of the row visible alongside the new one
+# group: [partitions]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+set logging_level='debug'
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.test_update_after_spec_evolution;
+
+statement ok
+CREATE TABLE my_datalake.default.test_update_after_spec_evolution (id INT, ts TIMESTAMP, val VARCHAR)
+PARTITIONED BY (day(ts));
+
+statement ok
+INSERT INTO my_datalake.default.test_update_after_spec_evolution VALUES
+    (1, '2021-05-01 09:00:00'::TIMESTAMP, 'a'),
+    (2, '2021-05-01 10:30:00'::TIMESTAMP, 'b');
+
+statement ok
+ALTER TABLE my_datalake.default.test_update_after_spec_evolution SET PARTITIONED BY (hour(ts));
+
+# An update writes the new row under the current spec and a delete file hiding the old one, which
+# belongs with the spec of the data file it targets. If the two end up in one manifest, the delete is
+# either discarded (the row appears twice) or read under the wrong spec.
+query I
+UPDATE my_datalake.default.test_update_after_spec_evolution SET val = 'updated' WHERE val = 'b';
+----
+1
+
+query III
+SELECT id, ts, val FROM my_datalake.default.test_update_after_spec_evolution ORDER BY id, val;
+----
+1	2021-05-01 09:00:00	a
+2	2021-05-01 10:30:00	updated
+
+query I
+SELECT count(*) FROM my_datalake.default.test_update_after_spec_evolution;
+----
+2
+
+statement ok
+DROP TABLE my_datalake.default.test_update_after_spec_evolution;


### PR DESCRIPTION
Fixes #1274.

Two independent defects, one per commit. #1274 has the full analysis and the cross-engine comparison.

**Delete manifests declared the wrong partition spec.** `AddSnapshot` / `AddUpdateSnapshot` built the
delete manifest from the table's `default_spec_id`, while its entries carry the partition values of
the data file being deleted. Once the spec changes the manifest declares one spec and its entries are
written in another, so a reader comparing the delete's partition to the data file's — as the
[spec](https://iceberg.apache.org/spec/#scan-planning) requires — cannot match them, and `DELETE` /
`UPDATE` report success while having no effect on reads. Delete entries are now grouped by the spec of
the data file they reference and one manifest is emitted per spec, as Iceberg's own writer does.
Equality deletes target no single data file and stay on the current spec.

**Partition values were compared by position.** Data and delete manifests are read by separate
readers, each projecting the union of the specs it covers, so one spec can surface a different set of
fields on either side. Pairing the two structs up by index threw on any table holding data files under
two specs with a delete against the older one, which is reachable by reading a table another engine
wrote, with no DuckDB write involved. Values are now matched on field id, with a field missing from
one side's projection treated as NULL.

### Tests

Four cases, each confirmed failing before the change:

| Test | Covers |
|---|---|
| `delete/partitions/delete_after_partition_spec_evolution` | delete against an older-spec data file |
| `update/partitions/update_after_partition_spec_evolution` | update, which writes the replacement row under the current spec |
| `delete/partitions/delete_with_mixed_partition_specs` | data files under two specs, delete against the older |
| `reads/read_mor_delete_partition_evolution` | the same, on Spark-written metadata, read-only |

The last one uses a new Spark fixture (`spark_mor_delete_partition_evolution`) so a regression in
reading foreign metadata is caught independently of DuckDB's write path. Polaris skips it for the same
reason it already skips `complicated_partitioned_table` — it rejects `REPLACE PARTITION FIELD` from
Spark.

On freshly generated fixture data the full catalog-backed suite passes (401 test cases, 93,123
assertions), as do the `reads`, `delete`, `update`, `merge` and `maintenance` suites individually.
