### PR TITLE
failing test: iceberg_rewrite_data_files must preserve table sort order

### DIFF
--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_sorted_unpartitioned.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_sorted_unpartitioned.test
@@ -1,0 +1,157 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_sorted_unpartitioned.test
+# description: rewritten files must respect table sort order in physical write order
+# group: [maintenance]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+statement ok
+set threads=1;
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS my_datalake.default;
+
+statement ok
+drop table if exists my_datalake.default.rewrite_sorted_unpartitioned;
+
+statement ok
+create table my_datalake.default.rewrite_sorted_unpartitioned (
+	a int,
+	b int
+);
+
+statement ok
+alter table my_datalake.default.rewrite_sorted_unpartitioned set sorted by (
+	a asc nulls last,
+	b asc nulls last
+);
+
+statement ok
+set variable table_sort_order_id = (
+	select metadata."default-sort-order-id"
+	from iceberg_load_table_response(my_datalake.default.rewrite_sorted_unpartitioned)
+);
+
+# Insert unordered rows across several small files so rewrite has work to do.
+statement ok
+insert into my_datalake.default.rewrite_sorted_unpartitioned values (2, 20), (1, 30);
+
+statement ok
+insert into my_datalake.default.rewrite_sorted_unpartitioned values (2, 10), (1, 40);
+
+statement ok
+insert into my_datalake.default.rewrite_sorted_unpartitioned values (3, 5), (1, 10);
+
+statement ok
+insert into my_datalake.default.rewrite_sorted_unpartitioned values (4, 1), (0, 99);
+
+statement ok
+insert into my_datalake.default.rewrite_sorted_unpartitioned values (5, 2), (1, 20);
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_sorted_unpartitioned')
+where content = 'DATA' and status <> 'DELETED';
+----
+5
+
+query III
+call iceberg_rewrite_data_files(
+	'my_datalake.default.rewrite_sorted_unpartitioned',
+	min_input_files => 5
+);
+----
+5	1	<REGEX>:[1-9][0-9]*
+
+query II
+select a, b from my_datalake.default.rewrite_sorted_unpartitioned order by a, b;
+----
+0	99
+1	10
+1	20
+1	30
+1	40
+2	10
+2	20
+3	5
+4	1
+5	2
+
+statement ok
+set variable latest_manifest_sequence = (
+	select max(manifest_sequence_number)
+	from iceberg_metadata(my_datalake.default.rewrite_sorted_unpartitioned)
+);
+
+query I
+select count(*)
+from iceberg_metadata(my_datalake.default.rewrite_sorted_unpartitioned)
+where manifest_sequence_number = cast(getvariable('latest_manifest_sequence') as bigint)
+and manifest_content = 'DATA'
+and status = 'ADDED';
+----
+1
+
+statement ok
+set variable file_path = (
+	select file_path
+	from iceberg_metadata(my_datalake.default.rewrite_sorted_unpartitioned)
+	where manifest_sequence_number = cast(getvariable('latest_manifest_sequence') as bigint)
+	and manifest_content = 'DATA'
+	and status = 'ADDED'
+	limit 1
+);
+
+statement ok
+set variable manifest_path = (
+	select manifest_path
+	from iceberg_metadata(my_datalake.default.rewrite_sorted_unpartitioned)
+	where manifest_sequence_number = cast(getvariable('latest_manifest_sequence') as bigint)
+	and manifest_content = 'DATA'
+	and status = 'ADDED'
+	limit 1
+);
+
+# Start transaction to keep necessary credentials in scope
+statement ok
+begin
+
+# Rewritten Parquet must be physically ordered by the table sort order.
+query I
+with ordered_rows as (
+	select
+		filename,
+		file_row_number,
+		a,
+		b,
+		lag(a) over(partition by filename order by file_row_number) prev_a,
+		lag(b) over(partition by filename order by file_row_number) prev_b
+	from my_datalake.default.rewrite_sorted_unpartitioned
+	where filename = getvariable('file_path')
+)
+select count(*)
+from ordered_rows
+where prev_a is not null
+and (a < prev_a or (a = prev_a and b < prev_b));
+----
+0
+
+query I
+select min(sort_order_id) = cast(getvariable('table_sort_order_id') as integer)
+from (select unnest(data_file) from read_avro(getvariable('manifest_path')))
+where sort_order_id is not null;
+----
+1
+
+statement ok
+drop table my_datalake.default.rewrite_sorted_unpartitioned;
+
+statement ok
+commit


### PR DESCRIPTION
## Summary
- `iceberg_rewrite_data_files` should Parquet in physical table sort order (`file_row_number` + `lag`) and stamp the correct `sort_order_id` on the ADDED manifest entry.
- writes today does not re-sort data; it only stamps `sort_order_id`.
- Tests-only PR