### PR TITLE
[ManifestReader] Use the `format_version` and `partition_spec_id` from the manifests metadata

### DIFF
--- a/src/include/planning/metadata_io/manifest/iceberg_manifest_reader.hpp
+++ b/src/include/planning/metadata_io/manifest/iceberg_manifest_reader.hpp
@@ -4,9 +4,19 @@
 
 namespace duckdb {
 
+struct IcebergManifestReaderInput {
+public:
+	IcebergManifestReaderInput(const IcebergManifestMetadata &metadata, const IcebergPartitionSpec &partition_spec)
+	    : metadata(metadata), partition_spec(partition_spec) {
+	}
+
+public:
+	const IcebergManifestMetadata &metadata;
+	const IcebergPartitionSpec &partition_spec;
+};
+
 namespace manifest_file {
 
-//! Produces IcebergManifestEntries read, from the 'manifest_file'
 class ManifestReader : public BaseManifestReader {
 public:
 	ManifestReader(const AvroScan &scan);
@@ -17,7 +27,7 @@ public:
 
 public:
 	static void ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &partition_field_id_to_type,
-	                      const IcebergTableMetadata &table_metadata, vector<IcebergManifestEntry> &result);
+	                      IcebergManifestReaderInput &reader_input, vector<IcebergManifestEntry> &result);
 };
 
 } // namespace manifest_file

--- a/src/include/planning/metadata_io/manifest/iceberg_manifest_reader.hpp
+++ b/src/include/planning/metadata_io/manifest/iceberg_manifest_reader.hpp
@@ -6,13 +6,15 @@ namespace duckdb {
 
 struct IcebergManifestReaderInput {
 public:
-	IcebergManifestReaderInput(const IcebergManifestMetadata &metadata, const IcebergPartitionSpec &partition_spec)
-	    : metadata(metadata), partition_spec(partition_spec) {
+	IcebergManifestReaderInput(const IcebergManifestMetadata &metadata, const IcebergPartitionSpec &partition_spec,
+	                           int32_t table_format_version)
+	    : metadata(metadata), partition_spec(partition_spec), table_format_version(table_format_version) {
 	}
 
 public:
 	const IcebergManifestMetadata &metadata;
 	const IcebergPartitionSpec &partition_spec;
+	const int32_t table_format_version;
 };
 
 namespace manifest_file {

--- a/src/planning/metadata_io/avro/iceberg_avro_multi_file_reader.cpp
+++ b/src/planning/metadata_io/avro/iceberg_avro_multi_file_reader.cpp
@@ -313,8 +313,8 @@ BuildManifestSchema(const IcebergSnapshot &snapshot, const IcebergTableMetadata 
 	if (iceberg_version >= 2) {
 		MultiFileColumnDefinition content("content", LogicalType::INTEGER);
 		content.identifier = Value::INTEGER(CONTENT);
-		//! Default to 0 if missing (V1 compatibility)
-		content.default_expression = make_uniq<ConstantExpression>(Value::INTEGER(0));
+		//! Preserve missing content as NULL. ManifestReader applies the V1 default and validates V2+ manifests.
+		content.default_expression = make_uniq<ConstantExpression>(Value(content.type));
 		data_file.children.push_back(content);
 	}
 
@@ -651,7 +651,7 @@ void IcebergAvroMultiFileReader::FinalizeChunk(ClientContext &context, const Mul
 		}
 		auto &partition_spec = *partition_spec_p;
 
-		IcebergManifestReaderInput input(manifest_metadata, partition_spec);
+		IcebergManifestReaderInput input(manifest_metadata, partition_spec, metadata.iceberg_version);
 
 		auto &manifest_entries = manifest_file.GetOrCreateManifestEntries();
 		idx_t start_index = manifest_entries.size();

--- a/src/planning/metadata_io/avro/iceberg_avro_multi_file_reader.cpp
+++ b/src/planning/metadata_io/avro/iceberg_avro_multi_file_reader.cpp
@@ -641,9 +641,21 @@ void IcebergAvroMultiFileReader::FinalizeChunk(ClientContext &context, const Mul
 		auto manifest_file_idx = manifest_scan_info.GetManifestIndex(reader.file_list_idx.GetIndex());
 		auto &manifest_file = manifest_scan_info.manifest_files[manifest_file_idx];
 
+		auto &manifest_metadata = *manifest_file.manifest_metadata;
+		auto spec_id = manifest_metadata.partition_spec_id;
+		auto partition_spec_p = metadata.FindPartitionSpecById(spec_id);
+		if (!partition_spec_p) {
+			throw InvalidConfigurationException("Manifest file '%s' key-value metadata references partition-spec-id: "
+			                                    "%d, but no spec with that ID exists in the metadata",
+			                                    manifest_file.file.manifest_path, spec_id);
+		}
+		auto &partition_spec = *partition_spec_p;
+
+		IcebergManifestReaderInput input(manifest_metadata, partition_spec);
+
 		auto &manifest_entries = manifest_file.GetOrCreateManifestEntries();
 		idx_t start_index = manifest_entries.size();
-		manifest_file::ManifestReader::ReadChunk(output_chunk, manifest_scan_info.partition_field_id_to_type, metadata,
+		manifest_file::ManifestReader::ReadChunk(output_chunk, manifest_scan_info.partition_field_id_to_type, input,
 		                                         manifest_entries);
 		if (manifest_scan_info.read_state) {
 			auto &read_state = *manifest_scan_info.read_state;

--- a/src/planning/metadata_io/manifest/iceberg_manifest_reader.cpp
+++ b/src/planning/metadata_io/manifest/iceberg_manifest_reader.cpp
@@ -112,10 +112,10 @@ static vector<int64_t> GetSplitOffsets(const Int64ListEntries::ValueEntry &entry
 }
 
 void ManifestReader::ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &partition_field_id_to_type,
-                               const IcebergTableMetadata &metadata, vector<IcebergManifestEntry> &result) {
+                               IcebergManifestReaderInput &input, vector<IcebergManifestEntry> &result) {
 	idx_t count = chunk.size();
-	auto &partition_specs = metadata.partition_specs;
-	auto &iceberg_version = metadata.iceberg_version;
+	auto &partition_spec = input.partition_spec;
+	auto &iceberg_version = input.metadata.format_version;
 
 	//! Setup logic
 
@@ -274,15 +274,12 @@ void ManifestReader::ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &
 		for (auto &it : partition_vectors) {
 			auto field_id = it.first;
 			auto &partition_vector = it.second.get();
-			for (auto &id_spec : partition_specs) {
-				auto &spec = id_spec.second;
-				for (auto &field : spec.fields) {
-					if (field_id == field.partition_field_id) {
-						IcebergPartitionInfo info;
-						info.field_id = static_cast<uint64_t>(field_id);
-						info.value = partition_vector.GetValue(i);
-						data_file.partition_info.push_back(std::move(info));
-					}
+			for (auto &field : partition_spec.fields) {
+				if (field_id == field.partition_field_id) {
+					IcebergPartitionInfo info;
+					info.field_id = static_cast<uint64_t>(field_id);
+					info.value = partition_vector.GetValue(i);
+					data_file.partition_info.push_back(std::move(info));
 				}
 			}
 		}

--- a/src/planning/metadata_io/manifest/iceberg_manifest_reader.cpp
+++ b/src/planning/metadata_io/manifest/iceberg_manifest_reader.cpp
@@ -115,7 +115,8 @@ void ManifestReader::ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &
                                IcebergManifestReaderInput &input, vector<IcebergManifestEntry> &result) {
 	idx_t count = chunk.size();
 	auto &partition_spec = input.partition_spec;
-	auto &iceberg_version = input.metadata.format_version;
+	auto &manifest_format_version = input.metadata.format_version;
+	auto &table_format_version = input.table_format_version;
 
 	//! Setup logic
 
@@ -183,7 +184,7 @@ void ManifestReader::ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &
 	optional<Int32Entries> content_entries;
 	optional_ptr<Vector> referenced_data_file;
 	optional<StringEntries> referenced_data_file_entries;
-	if (iceberg_version >= 2) {
+	if (table_format_version >= 2) {
 		content = data_file_entries[entry_index++];
 		content_entries.emplace(content->Values<int32_t>());
 
@@ -193,7 +194,7 @@ void ManifestReader::ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &
 
 	optional_ptr<Vector> first_row_id;
 	optional<Int64Entries> first_row_id_entries;
-	if (iceberg_version >= 3) {
+	if (table_format_version >= 3) {
 		first_row_id = data_file_entries[entry_index++];
 		first_row_id_entries.emplace(first_row_id->Values<int64_t>());
 	}
@@ -202,7 +203,7 @@ void ManifestReader::ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &
 
 	optional_ptr<Vector> content_size_in_bytes;
 	optional<Int64Entries> content_size_in_bytes_entries;
-	if (iceberg_version >= 3) {
+	if (table_format_version >= 3) {
 		content_offset = data_file_entries[entry_index++];
 		content_size_in_bytes = data_file_entries[entry_index++];
 		content_offset_entries.emplace(content_offset->Values<int64_t>());
@@ -241,10 +242,16 @@ void ManifestReader::ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &
 		data_file.split_offsets = GetSplitOffsets(split_offsets_entries[i]);
 		data_file.sort_order_id = ReadOptionalField<int32_t>(sort_order_id_entries[i]);
 
-		entry.SetSnapshotId(ReadOptionalField<int64_t>(snapshot_id_entries[i]));
+		if (manifest_format_version >= 2) {
+			entry.SetSnapshotId(ReadOptionalField<int64_t>(snapshot_id_entries[i]));
+		} else {
+			entry.SetSnapshotId(ReadRequiredField<int64_t>("snapshot_id", snapshot_id_entries[i]));
+		}
 
 		//! >= V2
-		if (iceberg_version >= 2) {
+		if (manifest_format_version >= 2) {
+			D_ASSERT(content_entries);
+			D_ASSERT(referenced_data_file_entries);
 			data_file.content =
 			    (IcebergManifestEntryContentType)ReadRequiredField<int32_t>("content", (*content_entries)[i]);
 			data_file.equality_ids = GetEqualityIds(equality_ids_entries[i]);
@@ -265,7 +272,10 @@ void ManifestReader::ReadChunk(DataChunk &chunk, const map<idx_t, LogicalType> &
 		}
 
 		//! >= V3
-		if (iceberg_version >= 3) {
+		if (manifest_format_version >= 3) {
+			D_ASSERT(first_row_id_entries);
+			D_ASSERT(content_offset_entries);
+			D_ASSERT(content_size_in_bytes_entries);
 			data_file.SetFirstRowId(ReadOptionalField<int64_t>((*first_row_id_entries)[i]));
 			data_file.content_offset = ReadOptionalField<int64_t>((*content_offset_entries)[i]);
 			data_file.content_size_in_bytes = ReadOptionalField<int64_t>((*content_size_in_bytes_entries)[i]);

--- a/test/sql/local/iceberg_scans/iceberg_column_stats.test
+++ b/test/sql/local/iceberg_scans/iceberg_column_stats.test
@@ -17,25 +17,24 @@ require iceberg
 query IIIIIIIIIIII
 SELECT * FROM ICEBERG_COLUMN_STATS('{WORKING_DIRECTORY}/data/persistent/hive_partitioned_table', ALLOW_MOVED_PATHS=TRUE) order by all;
 ----
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-01/00000-3-249d8105-f013-47e6-8600-a855387633e5-00001.parquet	{'r0': 2024-01-01, 'r1': 2024-01-01, 'r2': NULL}	event_date	DATE	2024-01-01	2024-01-01	36	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-01/00000-3-249d8105-f013-47e6-8600-a855387633e5-00001.parquet	{'r0': 2024-01-01, 'r1': 2024-01-01, 'r2': NULL}	event_type	VARCHAR	click	click	41	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-01/00000-3-249d8105-f013-47e6-8600-a855387633e5-00001.parquet	{'r0': 2024-01-01, 'r1': 2024-01-01, 'r2': NULL}	user_id	BIGINT	12345	12345	40	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-02/00000-3-249d8105-f013-47e6-8600-a855387633e5-00002.parquet	{'r0': 2024-01-02, 'r1': 2024-01-02, 'r2': NULL}	event_date	DATE	2024-01-02	2024-01-02	36	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-02/00000-3-249d8105-f013-47e6-8600-a855387633e5-00002.parquet	{'r0': 2024-01-02, 'r1': 2024-01-02, 'r2': NULL}	event_type	VARCHAR	purchase	purchase	43	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-02/00000-3-249d8105-f013-47e6-8600-a855387633e5-00002.parquet	{'r0': 2024-01-02, 'r1': 2024-01-02, 'r2': NULL}	user_id	BIGINT	67890	67890	40	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=click/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00002.parquet	{'r0': 2024-01-03, 'r1': 2024-01-03, 'r2': click}	event_date	DATE	2024-01-03	2024-01-03	36	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=click/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00002.parquet	{'r0': 2024-01-03, 'r1': 2024-01-03, 'r2': click}	event_type	VARCHAR	click	click	41	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=click/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00002.parquet	{'r0': 2024-01-03, 'r1': 2024-01-03, 'r2': click}	user_id	BIGINT	24680	24680	40	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00001.parquet	{'r0': 2024-01-03, 'r1': 2024-01-03, 'r2': view}	event_date	DATE	2024-01-03	2024-01-03	36	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00001.parquet	{'r0': 2024-01-03, 'r1': 2024-01-03, 'r2': view}	event_type	VARCHAR	view	view	40	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00001.parquet	{'r0': 2024-01-03, 'r1': 2024-01-03, 'r2': view}	user_id	BIGINT	13579	13579	40	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=purchase/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00003.parquet	{'r0': 2024-01-04, 'r1': 2024-01-04, 'r2': purchase}	event_date	DATE	2024-01-04	2024-01-04	36	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=purchase/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00003.parquet	{'r0': 2024-01-04, 'r1': 2024-01-04, 'r2': purchase}	event_type	VARCHAR	purchase	purchase	43	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=purchase/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00003.parquet	{'r0': 2024-01-04, 'r1': 2024-01-04, 'r2': purchase}	user_id	BIGINT	97531	97531	40	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00004.parquet	{'r0': 2024-01-04, 'r1': 2024-01-04, 'r2': view}	event_date	DATE	2024-01-04	2024-01-04	36	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00004.parquet	{'r0': 2024-01-04, 'r1': 2024-01-04, 'r2': view}	event_type	VARCHAR	view	view	40	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00004.parquet	{'r0': 2024-01-04, 'r1': 2024-01-04, 'r2': view}	user_id	BIGINT	86420	86420	40	1	0	NULL
-
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-01/00000-3-249d8105-f013-47e6-8600-a855387633e5-00001.parquet	{'r0': 2024-01-01}	event_date	DATE	2024-01-01	2024-01-01	36	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-01/00000-3-249d8105-f013-47e6-8600-a855387633e5-00001.parquet	{'r0': 2024-01-01}	event_type	VARCHAR	click	click	41	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-01/00000-3-249d8105-f013-47e6-8600-a855387633e5-00001.parquet	{'r0': 2024-01-01}	user_id	BIGINT	12345	12345	40	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-02/00000-3-249d8105-f013-47e6-8600-a855387633e5-00002.parquet	{'r0': 2024-01-02}	event_date	DATE	2024-01-02	2024-01-02	36	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-02/00000-3-249d8105-f013-47e6-8600-a855387633e5-00002.parquet	{'r0': 2024-01-02}	event_type	VARCHAR	purchase	purchase	43	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-02/00000-3-249d8105-f013-47e6-8600-a855387633e5-00002.parquet	{'r0': 2024-01-02}	user_id	BIGINT	67890	67890	40	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=click/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00002.parquet	{'r0': 2024-01-03, 'r1': click}	event_date	DATE	2024-01-03	2024-01-03	36	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=click/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00002.parquet	{'r0': 2024-01-03, 'r1': click}	event_type	VARCHAR	click	click	41	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=click/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00002.parquet	{'r0': 2024-01-03, 'r1': click}	user_id	BIGINT	24680	24680	40	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00001.parquet	{'r0': 2024-01-03, 'r1': view}	event_date	DATE	2024-01-03	2024-01-03	36	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00001.parquet	{'r0': 2024-01-03, 'r1': view}	event_type	VARCHAR	view	view	40	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00001.parquet	{'r0': 2024-01-03, 'r1': view}	user_id	BIGINT	13579	13579	40	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=purchase/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00003.parquet	{'r0': 2024-01-04, 'r1': purchase}	event_date	DATE	2024-01-04	2024-01-04	36	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=purchase/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00003.parquet	{'r0': 2024-01-04, 'r1': purchase}	event_type	VARCHAR	purchase	purchase	43	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=purchase/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00003.parquet	{'r0': 2024-01-04, 'r1': purchase}	user_id	BIGINT	97531	97531	40	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00004.parquet	{'r0': 2024-01-04, 'r1': view}	event_date	DATE	2024-01-04	2024-01-04	36	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00004.parquet	{'r0': 2024-01-04, 'r1': view}	event_type	VARCHAR	view	view	40	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00004.parquet	{'r0': 2024-01-04, 'r1': view}	user_id	BIGINT	86420	86420	40	1	0	NULL
 
 query IIIIIIIIIIII
 SELECT * FROM ICEBERG_COLUMN_STATS('{WORKING_DIRECTORY}/data/persistent/hive_partitioned_table', ALLOW_MOVED_PATHS=TRUE, version='1') order by all;
@@ -44,25 +43,24 @@ SELECT * FROM ICEBERG_COLUMN_STATS('{WORKING_DIRECTORY}/data/persistent/hive_par
 query IIIIIIIIIIII
 SELECT * FROM ICEBERG_COLUMN_STATS('{WORKING_DIRECTORY}/data/persistent/hive_partitioned_table', ALLOW_MOVED_PATHS=TRUE, version_name_format='v%s%s.metadata.json') order by all;
 ----
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-01/00000-3-249d8105-f013-47e6-8600-a855387633e5-00001.parquet	{'r0': 2024-01-01, 'r1': 2024-01-01, 'r2': NULL}	event_date	DATE	2024-01-01	2024-01-01	36	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-01/00000-3-249d8105-f013-47e6-8600-a855387633e5-00001.parquet	{'r0': 2024-01-01, 'r1': 2024-01-01, 'r2': NULL}	event_type	VARCHAR	click	click	41	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-01/00000-3-249d8105-f013-47e6-8600-a855387633e5-00001.parquet	{'r0': 2024-01-01, 'r1': 2024-01-01, 'r2': NULL}	user_id	BIGINT	12345	12345	40	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-02/00000-3-249d8105-f013-47e6-8600-a855387633e5-00002.parquet	{'r0': 2024-01-02, 'r1': 2024-01-02, 'r2': NULL}	event_date	DATE	2024-01-02	2024-01-02	36	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-02/00000-3-249d8105-f013-47e6-8600-a855387633e5-00002.parquet	{'r0': 2024-01-02, 'r1': 2024-01-02, 'r2': NULL}	event_type	VARCHAR	purchase	purchase	43	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-02/00000-3-249d8105-f013-47e6-8600-a855387633e5-00002.parquet	{'r0': 2024-01-02, 'r1': 2024-01-02, 'r2': NULL}	user_id	BIGINT	67890	67890	40	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=click/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00002.parquet	{'r0': 2024-01-03, 'r1': 2024-01-03, 'r2': click}	event_date	DATE	2024-01-03	2024-01-03	36	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=click/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00002.parquet	{'r0': 2024-01-03, 'r1': 2024-01-03, 'r2': click}	event_type	VARCHAR	click	click	41	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=click/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00002.parquet	{'r0': 2024-01-03, 'r1': 2024-01-03, 'r2': click}	user_id	BIGINT	24680	24680	40	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00001.parquet	{'r0': 2024-01-03, 'r1': 2024-01-03, 'r2': view}	event_date	DATE	2024-01-03	2024-01-03	36	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00001.parquet	{'r0': 2024-01-03, 'r1': 2024-01-03, 'r2': view}	event_type	VARCHAR	view	view	40	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00001.parquet	{'r0': 2024-01-03, 'r1': 2024-01-03, 'r2': view}	user_id	BIGINT	13579	13579	40	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=purchase/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00003.parquet	{'r0': 2024-01-04, 'r1': 2024-01-04, 'r2': purchase}	event_date	DATE	2024-01-04	2024-01-04	36	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=purchase/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00003.parquet	{'r0': 2024-01-04, 'r1': 2024-01-04, 'r2': purchase}	event_type	VARCHAR	purchase	purchase	43	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=purchase/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00003.parquet	{'r0': 2024-01-04, 'r1': 2024-01-04, 'r2': purchase}	user_id	BIGINT	97531	97531	40	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00004.parquet	{'r0': 2024-01-04, 'r1': 2024-01-04, 'r2': view}	event_date	DATE	2024-01-04	2024-01-04	36	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00004.parquet	{'r0': 2024-01-04, 'r1': 2024-01-04, 'r2': view}	event_type	VARCHAR	view	view	40	1	0	NULL
-ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00004.parquet	{'r0': 2024-01-04, 'r1': 2024-01-04, 'r2': view}	user_id	BIGINT	86420	86420	40	1	0	NULL
-
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-01/00000-3-249d8105-f013-47e6-8600-a855387633e5-00001.parquet	{'r0': 2024-01-01}	event_date	DATE	2024-01-01	2024-01-01	36	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-01/00000-3-249d8105-f013-47e6-8600-a855387633e5-00001.parquet	{'r0': 2024-01-01}	event_type	VARCHAR	click	click	41	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-01/00000-3-249d8105-f013-47e6-8600-a855387633e5-00001.parquet	{'r0': 2024-01-01}	user_id	BIGINT	12345	12345	40	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-02/00000-3-249d8105-f013-47e6-8600-a855387633e5-00002.parquet	{'r0': 2024-01-02}	event_date	DATE	2024-01-02	2024-01-02	36	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-02/00000-3-249d8105-f013-47e6-8600-a855387633e5-00002.parquet	{'r0': 2024-01-02}	event_type	VARCHAR	purchase	purchase	43	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-02/00000-3-249d8105-f013-47e6-8600-a855387633e5-00002.parquet	{'r0': 2024-01-02}	user_id	BIGINT	67890	67890	40	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=click/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00002.parquet	{'r0': 2024-01-03, 'r1': click}	event_date	DATE	2024-01-03	2024-01-03	36	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=click/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00002.parquet	{'r0': 2024-01-03, 'r1': click}	event_type	VARCHAR	click	click	41	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=click/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00002.parquet	{'r0': 2024-01-03, 'r1': click}	user_id	BIGINT	24680	24680	40	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00001.parquet	{'r0': 2024-01-03, 'r1': view}	event_date	DATE	2024-01-03	2024-01-03	36	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00001.parquet	{'r0': 2024-01-03, 'r1': view}	event_type	VARCHAR	view	view	40	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-03/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00001.parquet	{'r0': 2024-01-03, 'r1': view}	user_id	BIGINT	13579	13579	40	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=purchase/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00003.parquet	{'r0': 2024-01-04, 'r1': purchase}	event_date	DATE	2024-01-04	2024-01-04	36	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=purchase/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00003.parquet	{'r0': 2024-01-04, 'r1': purchase}	event_type	VARCHAR	purchase	purchase	43	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=purchase/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00003.parquet	{'r0': 2024-01-04, 'r1': purchase}	user_id	BIGINT	97531	97531	40	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00004.parquet	{'r0': 2024-01-04, 'r1': view}	event_date	DATE	2024-01-04	2024-01-04	36	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00004.parquet	{'r0': 2024-01-04, 'r1': view}	event_type	VARCHAR	view	view	40	1	0	NULL
+ADDED	DATA	data/persistent/hive_partitioned_table/data/event_date=2024-01-04/event_type=view/00000-8-c8ef1f50-38e5-4f6c-bc66-8b6410198355-00004.parquet	{'r0': 2024-01-04, 'r1': view}	user_id	BIGINT	86420	86420	40	1	0	NULL
 
 query IIIIIIIIIIII
 SELECT * FROM ICEBERG_COLUMN_STATS('{WORKING_DIRECTORY}/data/persistent/hive_partitioned_table', ALLOW_MOVED_PATHS=TRUE, version='2', version_name_format='v%s%s.metadata.json') order by all;

--- a/test/sql/local/iceberg_scans/iceberg_v1_existing_manifest_entry.test
+++ b/test/sql/local/iceberg_scans/iceberg_v1_existing_manifest_entry.test
@@ -15,3 +15,11 @@ select * from iceberg_scan('data/persistent/iceberg_v1_repro/repro/merch_v1/meta
 6	nba	60
 2	nba	20
 3	mlb	30
+
+# V1 manifests omit content and sequence fields. The manifest reader supplies their V1 defaults.
+query III
+select distinct content, data_sequence_number, file_sequence_number
+from iceberg_metadata('data/persistent/iceberg_v1_repro/repro/merch_v1/metadata/00003-8d01e4aa-d143-49c9-898e-b5e477577b70.metadata.json')
+order by all
+----
+DATA	0	0

--- a/test/sql/local/legacy_bare_deletion_vector.test
+++ b/test/sql/local/legacy_bare_deletion_vector.test
@@ -8,6 +8,18 @@ require parquet
 
 require iceberg
 
+# The V3 table's current manifest list contains both a carried-forward V2 data manifest and a V3 delete manifest.
+query III
+SELECT manifest_content, content, count(*)
+FROM iceberg_metadata(
+    '{WORKING_DIRECTORY}/data/persistent/legacy_bare_deletion_vector/warehouse/default/legacy_bare_deletion_vector'
+)
+GROUP BY ALL
+ORDER BY ALL;
+----
+DATA	DATA	1
+DELETE	POSITION_DELETES	1
+
 # Puffin verification remains enabled by default, and the error explains the compatibility setting.
 statement error
 SELECT id, source


### PR DESCRIPTION
The manifest file's Avro key-value metadata contains `format_version` and `partition_spec_id`, by using this we are parsing the manifest entries from the file using the correct format version, which fixes problems where fields that are required by later versions surface as errors when reading older manifests.

This also fixes a problem where we were deserializing `IcebergDataFile` items with many more fields in the `partition` variable than the file actually has. (As can be seen by the fixes to `iceberg_column_stats`)