### PR TITLE
Respect explicit Iceberg version guessing

### DIFF
--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -268,7 +268,7 @@ string IcebergTableMetadata::GetMetaDataPath(ClientContext &context, const strin
 		version_hint = GetTableVersionFromHint(meta_path, fs, DEFAULT_VERSION_HINT_FILE);
 		return GenerateMetaDataUrl(fs, meta_path, version_hint, options);
 	}
-	if (!UnsafeVersionGuessingEnabled(context)) {
+	if (!options.version_explicitly_set && !UnsafeVersionGuessingEnabled(context)) {
 		// Make sure we're allowed to guess versions
 		throw InvalidConfigurationException(
 		    "Failed to read iceberg table. No version was provided and no version-hint could be found, globbing the "

--- a/src/function/metadata/iceberg_snapshots.cpp
+++ b/src/function/metadata/iceberg_snapshots.cpp
@@ -60,6 +60,7 @@ static unique_ptr<FunctionData> IcebergSnapshotsBind(ClientContext &context, Tab
 			options.metadata_compression_codec = StringValue::Get(kv.second);
 		} else if (loption == "version") {
 			options.table_version = StringValue::Get(kv.second);
+			options.version_explicitly_set = true;
 		} else if (loption == "version_name_format") {
 			auto value = StringValue::Get(kv.second);
 			auto string_substitutions = IcebergUtils::CountOccurrences(value, "%s");

--- a/src/iceberg_options.cpp
+++ b/src/iceberg_options.cpp
@@ -19,6 +19,7 @@ IcebergOptions::IcebergOptions(named_parameter_map_t &named_parameters) : Iceber
 			metadata_compression_codec = StringValue::Get(val);
 		} else if (loption == "version") {
 			table_version = StringValue::Get(val);
+			version_explicitly_set = true;
 		} else if (loption == "version_name_format") {
 			auto value = StringValue::Get(kv.second);
 			auto string_substitutions = IcebergUtils::CountOccurrences(value, "%s");
@@ -56,6 +57,7 @@ IcebergOptions &IcebergOptions::operator=(const IcebergOptions &other) {
 	metadata_compression_codec = other.metadata_compression_codec;
 	infer_schema = other.infer_schema;
 	table_version = other.table_version;
+	version_explicitly_set = other.version_explicitly_set;
 	version_name_format = other.version_name_format;
 	snapshot_lookup.reset();
 	if (other.snapshot_lookup) {

--- a/src/include/iceberg_options.hpp
+++ b/src/include/iceberg_options.hpp
@@ -28,11 +28,9 @@ static string ENABLE_EQUALITY_DELETES_CONFIG_VARIABLE = "unsafe_and_disabled_for
 static constexpr const char *UNSAFE_STRUCT_NULL_DEFAULT_INTERP_CONFIG_VARIABLE =
     "__iceberg_unsafe_struct_null_default_interp";
 
-// When this is provided (and unsafe_enable_version_guessing is true)
-// we first look for DEFAULT_VERSION_HINT_FILE, if it doesn't exist we
-// then search for versions matching the DEFAULT_TABLE_VERSION_FORMAT
-// We take the lexographically "greatest" one as the latest version
-// Note that this will voliate ACID constraints in some situations.
+// Explicit '?' opts into version guessing for one call. Omitted versions require
+// unsafe_enable_version_guessing before globbing. The lexicographically greatest
+// metadata filename is selected, which may violate ACID constraints.
 static string UNKNOWN_TABLE_VERSION = "?";
 
 // First arg is version string, arg is either empty or ".gz" if gzip
@@ -57,6 +55,7 @@ public:
 	string metadata_compression_codec = "none";
 	bool infer_schema = true;
 	string table_version = DEFAULT_TABLE_VERSION;
+	bool version_explicitly_set = false;
 	string version_name_format = DEFAULT_TABLE_VERSION_FORMAT;
 
 	optional<IcebergSnapshotLookup> snapshot_lookup;

--- a/src/planning/iceberg_multi_file_reader.cpp
+++ b/src/planning/iceberg_multi_file_reader.cpp
@@ -572,6 +572,7 @@ bool IcebergMultiFileReader::ParseOption(const string &key, const Value &val, Mu
 	}
 	if (loption == "version") {
 		this->options.table_version = StringValue::Get(val);
+		this->options.version_explicitly_set = true;
 		return true;
 	}
 	if (loption == "version_name_format") {

--- a/test/sql/local/iceberg_scans/iceberg_metadata.test
+++ b/test/sql/local/iceberg_scans/iceberg_metadata.test
@@ -62,6 +62,52 @@ SELECT * FROM ICEBERG_METADATA('{WORKING_DIRECTORY}/data/persistent/iceberg/line
 ----
 <REGEX>:.*SET unsafe_enable_version_guessing.*
 
+query I
+SELECT count(*)
+FROM ICEBERG_METADATA(
+	'{WORKING_DIRECTORY}/data/persistent/iceberg/lineitem_iceberg_no_hint',
+	ALLOW_MOVED_PATHS=TRUE,
+	version='?'
+);
+----
+2
+
+statement error
+SELECT count(*)
+FROM ICEBERG_SCAN(
+	'{WORKING_DIRECTORY}/data/persistent/iceberg/lineitem_iceberg_no_hint',
+	ALLOW_MOVED_PATHS=TRUE
+);
+----
+<REGEX>:.*SET unsafe_enable_version_guessing.*
+
+query I
+SELECT count(*)
+FROM ICEBERG_SCAN(
+	'{WORKING_DIRECTORY}/data/persistent/iceberg/lineitem_iceberg_no_hint',
+	ALLOW_MOVED_PATHS=TRUE,
+	version='?'
+);
+----
+51793
+
+statement error
+SELECT count(*)
+FROM ICEBERG_SNAPSHOTS(
+	'{WORKING_DIRECTORY}/data/persistent/iceberg/lineitem_iceberg_no_hint'
+);
+----
+<REGEX>:.*SET unsafe_enable_version_guessing.*
+
+query I
+SELECT count(*)
+FROM ICEBERG_SNAPSHOTS(
+	'{WORKING_DIRECTORY}/data/persistent/iceberg/lineitem_iceberg_no_hint',
+	version='?'
+);
+----
+2
+
 statement ok
 SET unsafe_enable_version_guessing = true;
 


### PR DESCRIPTION
## Summary

- Treat an explicit `version = '?'` as a per-call opt-in to Iceberg metadata version guessing.
- Keep implicit version guessing protected by `unsafe_enable_version_guessing`.
- Cover `iceberg_scan`, `iceberg_metadata`, and `iceberg_snapshots`.

Closes #731.

## Root cause

`IcebergOptions::table_version` defaults to `"?"`. As a result, the metadata resolver could not distinguish between:

- a caller omitting the `version` parameter; and
- a caller explicitly supplying `version = '?'`.

Both cases reached the global `unsafe_enable_version_guessing` check, so the documented per-call form still required the global setting.

## Changes

- Added an explicitness marker to `IcebergOptions`.
- Set and propagated it through:
  - generic named-parameter parsing;
  - the multi-file Iceberg scan path;
  - `iceberg_snapshots` parameter parsing;
  - `IcebergOptions` copy assignment.
- Bypassed the global setting only when `version = '?'` was explicitly supplied.
- Preserved existing behavior for numeric versions, hint files, direct metadata paths, and omitted versions.

## Behavior

| Input | Result |
|---|---|
| No version, no hint, setting disabled | Error |
| Explicit `version = '?'`, setting disabled | Guess latest metadata version |
| No version, setting enabled | Guess latest metadata version |
| Explicit numeric version | Read the requested version |
| Existing `version-hint.text` | Use the version hint |

## Tests

- `iceberg_metadata.test`: 183 assertions passed.
  - Omitted-version safety controls.
  - Explicit `?` through `iceberg_metadata`.
  - Explicit `?` through `iceberg_scan`.
  - Explicit `?` through `iceberg_snapshots`.
- `version_name_format_error.test`: passed.
- Changed-file format check: passed.
- `git diff --check`: passed.
