### PR TITLE
Add iceberg_rollback_to_snapshot table function

### DIFF
--- a/src/catalog/rest/api/table_update.cpp
+++ b/src/catalog/rest/api/table_update.cpp
@@ -266,4 +266,22 @@ void SetLocation::CreateUpdate(DatabaseInstance &db, ClientContext &context, Ice
 	req.set_location_update->location = location;
 }
 
+SetSnapshotRef::SetSnapshotRef(int64_t snapshot_id_p, string ref_name_p)
+    : IcebergTableUpdate(IcebergTableUpdateType::SET_SNAPSHOT_REF), snapshot_id(snapshot_id_p),
+      ref_name(std::move(ref_name_p)) {
+}
+
+void SetSnapshotRef::CreateUpdate(DatabaseInstance &db, ClientContext &context,
+                                  IcebergCommitState &commit_state) const {
+	(void)db;
+	(void)context;
+	commit_state.table_change.updates.push_back(rest_api_objects::TableUpdate());
+	auto &req = commit_state.table_change.updates.back();
+	req.set_snapshot_ref_update = rest_api_objects::SetSnapshotRefUpdate();
+	req.set_snapshot_ref_update->base_update.action = "set-snapshot-ref";
+	req.set_snapshot_ref_update->ref_name = ref_name;
+	req.set_snapshot_ref_update->snapshot_reference.type = "branch";
+	req.set_snapshot_ref_update->snapshot_reference.snapshot_id = snapshot_id;
+}
+
 } // namespace duckdb

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -111,19 +111,6 @@ static rest_api_objects::TableRequirement CreateAssertNoSnapshotRequirement() {
 	return req;
 }
 
-static rest_api_objects::TableUpdate CreateSetSnapshotRefUpdate(int64_t snapshot_id) {
-	rest_api_objects::TableUpdate table_update;
-
-	table_update.set_snapshot_ref_update = rest_api_objects::SetSnapshotRefUpdate();
-	auto &update = *table_update.set_snapshot_ref_update;
-	update.base_update.action = "set-snapshot-ref";
-
-	update.ref_name = "main";
-	update.snapshot_reference.type = "branch";
-	update.snapshot_reference.snapshot_id = snapshot_id;
-	return table_update;
-}
-
 static bool NeedsAssertSchemaId(const IcebergTransactionData &transaction_data, const IcebergTable &table_info) {
 	(void)table_info;
 	return transaction_data.assert_schema_id;
@@ -305,8 +292,8 @@ static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, Iceb
 		if (!snapshot.snapshot_id) {
 			throw InvalidConfigurationException("snapshot.snapshot_id is not set");
 		}
-		auto set_snapshot_ref_update = CreateSetSnapshotRefUpdate(*snapshot.snapshot_id);
-		commit_state.table_change.updates.push_back(std::move(set_snapshot_ref_update));
+		SetSnapshotRef set_snapshot_ref(*snapshot.snapshot_id);
+		set_snapshot_ref.CreateUpdate(db, context, commit_state);
 	}
 
 	if (transaction_data.pending_current_schema_id.has_value()) {

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -383,4 +383,48 @@ void IcebergTransactionData::TableSetLocation() {
 	updates.push_back(make_uniq<SetLocation>(table_info.table_metadata.location));
 }
 
+static bool IsAncestorOfCurrentSnapshot(const IcebergTableMetadata &metadata, int64_t target_snapshot_id,
+                                        int64_t current_snapshot_id) {
+	if (target_snapshot_id == current_snapshot_id) {
+		return true;
+	}
+	optional_ptr<const IcebergSnapshot> cursor = metadata.FindSnapshotByIdInternal(current_snapshot_id);
+	while (cursor) {
+		if (!cursor->parent_snapshot_id) {
+			return false;
+		}
+		auto parent_id = *cursor->parent_snapshot_id;
+		if (parent_id == target_snapshot_id) {
+			return true;
+		}
+		cursor = metadata.FindSnapshotByIdInternal(parent_id);
+	}
+	return false;
+}
+
+void IcebergTransactionData::TableRollbackToSnapshot(int64_t snapshot_id) {
+	auto &metadata = table_info.table_metadata;
+	auto target = metadata.FindSnapshotByIdInternal(snapshot_id);
+	if (!target) {
+		throw InvalidInputException("Cannot roll back to unknown snapshot id: %lld", snapshot_id);
+	}
+
+	auto current = metadata.GetLatestSnapshot();
+	if (!current || !current->snapshot_id) {
+		throw InvalidInputException("Cannot roll back table with no current snapshot");
+	}
+	auto current_snapshot_id = *current->snapshot_id;
+	if (!IsAncestorOfCurrentSnapshot(metadata, snapshot_id, current_snapshot_id)) {
+		throw InvalidInputException("Cannot roll back to snapshot, not an ancestor of the current state: %lld",
+		                            snapshot_id);
+	}
+
+	// Optimistic concurrency: require main still points at the snapshot we observed.
+	requirements.push_back(make_uniq<AssertRefSnapshotId>(current_snapshot_id));
+	updates.push_back(make_uniq<SetSnapshotRef>(snapshot_id));
+
+	// Iceberg intentionally does not roll current-schema-id back with the snapshot;
+	// schema evolution stays forward-only. See https://github.com/apache/iceberg/issues/5591
+}
+
 } // namespace duckdb

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -378,4 +378,51 @@ void IcebergTransactionData::TableSetLocation() {
 	updates.push_back(make_uniq<SetLocation>(table_info.table_metadata.location));
 }
 
+static bool IsAncestorOfCurrentSnapshot(const IcebergTableMetadata &metadata, int64_t target_snapshot_id,
+                                        int64_t current_snapshot_id) {
+	if (target_snapshot_id == current_snapshot_id) {
+		return true;
+	}
+	optional_ptr<const IcebergSnapshot> cursor = metadata.FindSnapshotByIdInternal(current_snapshot_id);
+	while (cursor) {
+		if (!cursor->parent_snapshot_id) {
+			return false;
+		}
+		auto parent_id = *cursor->parent_snapshot_id;
+		if (parent_id == target_snapshot_id) {
+			return true;
+		}
+		cursor = metadata.FindSnapshotByIdInternal(parent_id);
+	}
+	return false;
+}
+
+void IcebergTransactionData::TableRollbackToSnapshot(int64_t snapshot_id) {
+	auto &metadata = table_info.table_metadata;
+	auto target = metadata.FindSnapshotByIdInternal(snapshot_id);
+	if (!target) {
+		throw InvalidInputException("Cannot roll back to unknown snapshot id: %lld", snapshot_id);
+	}
+
+	auto current = metadata.GetLatestSnapshot();
+	if (!current || !current->snapshot_id) {
+		throw InvalidInputException("Cannot roll back table with no current snapshot");
+	}
+	auto current_snapshot_id = *current->snapshot_id;
+	if (!IsAncestorOfCurrentSnapshot(metadata, snapshot_id, current_snapshot_id)) {
+		throw InvalidInputException("Cannot roll back to snapshot, not an ancestor of the current state: %lld",
+		                            snapshot_id);
+	}
+
+	// Optimistic concurrency: require main still points at the snapshot we observed.
+	requirements.push_back(make_uniq<AssertRefSnapshotId>(current_snapshot_id));
+	updates.push_back(make_uniq<SetSnapshotRef>(snapshot_id));
+
+	// Align current schema with the target snapshot when it differs.
+	auto target_schema_id = target->GetSchemaId();
+	if (target_schema_id != metadata.GetCurrentSchemaId()) {
+		pending_current_schema_id = target_schema_id;
+	}
+}
+
 } // namespace duckdb

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -418,11 +418,8 @@ void IcebergTransactionData::TableRollbackToSnapshot(int64_t snapshot_id) {
 	requirements.push_back(make_uniq<AssertRefSnapshotId>(current_snapshot_id));
 	updates.push_back(make_uniq<SetSnapshotRef>(snapshot_id));
 
-	// Align current schema with the target snapshot when it differs.
-	auto target_schema_id = target->GetSchemaId();
-	if (target_schema_id != metadata.GetCurrentSchemaId()) {
-		pending_current_schema_id = target_schema_id;
-	}
+	// Iceberg intentionally does not roll current-schema-id back with the snapshot;
+	// schema evolution stays forward-only. See https://github.com/apache/iceberg/issues/5591
 }
 
 } // namespace duckdb

--- a/src/core/metadata/snapshot/iceberg_snapshot.cpp
+++ b/src/core/metadata/snapshot/iceberg_snapshot.cpp
@@ -98,6 +98,10 @@ IcebergSnapshot IcebergSnapshot::ParseSnapshot(const rest_api_objects::Snapshot 
 	}
 	ret.metrics = IcebergSnapshotMetrics(snapshot.summary.additional_properties);
 
+	if (snapshot.parent_snapshot_id) {
+		ret.parent_snapshot_id = *snapshot.parent_snapshot_id;
+	}
+
 	auto &op = snapshot.summary.operation;
 	if (op == "append") {
 		ret.operation = IcebergSnapshotOperationType::APPEND;

--- a/src/function/iceberg_functions.cpp
+++ b/src/function/iceberg_functions.cpp
@@ -25,6 +25,7 @@ vector<TableFunctionSet> IcebergFunctions::GetTableFunctions(ExtensionLoader &lo
 	functions.push_back(GetIcebergToDuckLakeFunction());
 	functions.push_back(GetIcebergLoadTableResponseFunction());
 	functions.push_back(GetIcebergRewriteDataFilesFunction());
+	functions.push_back(GetIcebergRollbackToSnapshotFunction());
 
 	return functions;
 }

--- a/src/function/metadata/CMakeLists.txt
+++ b/src/function/metadata/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(
   iceberg_metadata.cpp
   iceberg_partition_stats.cpp
   iceberg_rewrite_data_files.cpp
+  iceberg_rollback_to_snapshot.cpp
   iceberg_schema_properties_functions.cpp
   iceberg_snapshots.cpp
   iceberg_table_properties_functions.cpp)

--- a/src/function/metadata/iceberg_rollback_to_snapshot.cpp
+++ b/src/function/metadata/iceberg_rollback_to_snapshot.cpp
@@ -1,0 +1,140 @@
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/qualified_name.hpp"
+
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
+#include "catalog/rest/transaction/iceberg_transaction.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_data.hpp"
+#include "common/iceberg_utils.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
+#include "function/iceberg_functions.hpp"
+
+namespace duckdb {
+
+namespace {
+
+struct IcebergRollbackToSnapshotBindData : public TableFunctionData {
+	optional_ptr<IcebergTableSchemaVersion> iceberg_table;
+	int64_t snapshot_id = 0;
+};
+
+struct IcebergRollbackToSnapshotGlobalState : public GlobalTableFunctionState {
+	static unique_ptr<GlobalTableFunctionState> Init(ClientContext &, TableFunctionInitInput &) {
+		return make_uniq<IcebergRollbackToSnapshotGlobalState>();
+	}
+
+	bool finished = false;
+};
+
+static bool CheckTableIsIcebergTable(optional_ptr<CatalogEntry> entry) {
+	auto &catalog_entry = entry->Cast<InCatalogEntry>();
+	auto &catalog = catalog_entry.catalog;
+	if (catalog.GetCatalogType() != "iceberg") {
+		return false;
+	}
+	if (entry->type != CatalogType::TABLE_ENTRY) {
+		return false;
+	}
+	return true;
+}
+
+static void VerifyInputIsNotAFile(ClientContext &context, string &input_string) {
+	auto qualified_name = QualifiedName::ParseComponents(input_string);
+	if (qualified_name.size() == 1) {
+		auto &fs = FileSystem::GetFileSystem(context);
+		if (fs.DirectoryExists(input_string) || fs.FileExists(input_string)) {
+			throw InvalidInputException("Cannot call iceberg_rollback_to_snapshot() on a file/directory");
+		}
+	}
+}
+
+static unique_ptr<FunctionData> IcebergRollbackToSnapshotBind(ClientContext &context, TableFunctionBindInput &input,
+                                                              vector<LogicalType> &return_types,
+                                                              vector<Identifier> &names) {
+	auto ret = make_uniq<IcebergRollbackToSnapshotBindData>();
+
+	auto input_string = input.inputs[0].ToString();
+	VerifyInputIsNotAFile(context, input_string);
+	auto parts = QualifiedName::ParseComponents(input_string);
+	if (parts.size() != 3) {
+		throw InvalidInputException(
+		    "iceberg_rollback_to_snapshot: table identifier must be 'catalog.schema.table', got '%s'", input_string);
+	}
+	for (auto &part : parts) {
+		if (part.empty()) {
+			throw InvalidInputException("iceberg_rollback_to_snapshot: table identifier '%s' has an empty component",
+			                            input_string);
+		}
+	}
+
+	auto iceberg_table = IcebergUtils::GetTableEntry(context, input_string);
+	if (!CheckTableIsIcebergTable(iceberg_table)) {
+		throw InvalidInputException("Cannot call iceberg_rollback_to_snapshot on non-iceberg table");
+	}
+	ret->iceberg_table = iceberg_table->Cast<IcebergTableSchemaVersion>();
+	// Accept BIGINT / UBIGINT from iceberg_snapshots without overflowing signed range unexpectedly.
+	auto snapshot_value = input.inputs[1].DefaultCastAs(LogicalType::BIGINT);
+	ret->snapshot_id = snapshot_value.GetValue<int64_t>();
+
+	if (input.binder) {
+		DatabaseModificationType modification;
+		modification |= DatabaseModificationType::ALTER_TABLE;
+		input.binder->GetStatementProperties().RegisterDBModify(iceberg_table->ParentCatalog(), context, modification);
+	}
+
+	return_types.push_back(LogicalType::BIGINT);
+	return_types.push_back(LogicalType::BIGINT);
+	names.emplace_back("previous_snapshot_id");
+	names.emplace_back("current_snapshot_id");
+	return std::move(ret);
+}
+
+static void IcebergRollbackToSnapshotFunction(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
+	auto &bind_data = data.bind_data->Cast<IcebergRollbackToSnapshotBindData>();
+	auto &global_state = data.global_state->Cast<IcebergRollbackToSnapshotGlobalState>();
+
+	if (!bind_data.iceberg_table || global_state.finished) {
+		output.SetChildCardinality(0);
+		return;
+	}
+
+	auto iceberg_table = bind_data.iceberg_table;
+	auto &table_info = iceberg_table->table_info;
+	auto previous_snapshot = table_info.table_metadata.GetLatestSnapshot();
+	int64_t previous_snapshot_id = 0;
+	if (previous_snapshot && previous_snapshot->snapshot_id) {
+		previous_snapshot_id = *previous_snapshot->snapshot_id;
+	}
+
+	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
+	ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTable &tbl) {
+		auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
+		transaction_data.TableRollbackToSnapshot(bind_data.snapshot_id);
+	});
+
+	FlatVector::GetDataMutable<int64_t>(output.data[0])[0] = previous_snapshot_id;
+	FlatVector::GetDataMutable<int64_t>(output.data[1])[0] = bind_data.snapshot_id;
+	output.SetChildCardinality(1);
+	global_state.finished = true;
+}
+
+} // namespace
+
+TableFunctionSet IcebergFunctions::GetIcebergRollbackToSnapshotFunction() {
+	TableFunctionSet function_set("iceberg_rollback_to_snapshot");
+	auto fun = TableFunction({LogicalType::VARCHAR, LogicalType::BIGINT}, IcebergRollbackToSnapshotFunction,
+	                         IcebergRollbackToSnapshotBind, IcebergRollbackToSnapshotGlobalState::Init);
+	function_set.AddFunction(fun);
+	// iceberg_snapshots exposes snapshot_id as UBIGINT; accept that without requiring a cast.
+	fun = TableFunction({LogicalType::VARCHAR, LogicalType::UBIGINT}, IcebergRollbackToSnapshotFunction,
+	                    IcebergRollbackToSnapshotBind, IcebergRollbackToSnapshotGlobalState::Init);
+	function_set.AddFunction(fun);
+	return function_set;
+}
+
+} // namespace duckdb

--- a/src/function/metadata/iceberg_rollback_to_snapshot.cpp
+++ b/src/function/metadata/iceberg_rollback_to_snapshot.cpp
@@ -6,7 +6,8 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "common/iceberg_utils.hpp"
@@ -18,7 +19,7 @@ namespace duckdb {
 namespace {
 
 struct IcebergRollbackToSnapshotBindData : public TableFunctionData {
-	optional_ptr<IcebergTableEntry> iceberg_table;
+	optional_ptr<IcebergTableSchemaVersion> iceberg_table;
 	int64_t snapshot_id = 0;
 };
 
@@ -75,7 +76,7 @@ static unique_ptr<FunctionData> IcebergRollbackToSnapshotBind(ClientContext &con
 	if (!CheckTableIsIcebergTable(iceberg_table)) {
 		throw InvalidInputException("Cannot call iceberg_rollback_to_snapshot on non-iceberg table");
 	}
-	ret->iceberg_table = iceberg_table->Cast<IcebergTableEntry>();
+	ret->iceberg_table = iceberg_table->Cast<IcebergTableSchemaVersion>();
 	// Accept BIGINT / UBIGINT from iceberg_snapshots without overflowing signed range unexpectedly.
 	auto snapshot_value = input.inputs[1].DefaultCastAs(LogicalType::BIGINT);
 	ret->snapshot_id = snapshot_value.GetValue<int64_t>();

--- a/src/function/metadata/iceberg_rollback_to_snapshot.cpp
+++ b/src/function/metadata/iceberg_rollback_to_snapshot.cpp
@@ -1,0 +1,139 @@
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/qualified_name.hpp"
+
+#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/transaction/iceberg_transaction.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_data.hpp"
+#include "common/iceberg_utils.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
+#include "function/iceberg_functions.hpp"
+
+namespace duckdb {
+
+namespace {
+
+struct IcebergRollbackToSnapshotBindData : public TableFunctionData {
+	optional_ptr<IcebergTableEntry> iceberg_table;
+	int64_t snapshot_id = 0;
+};
+
+struct IcebergRollbackToSnapshotGlobalState : public GlobalTableFunctionState {
+	static unique_ptr<GlobalTableFunctionState> Init(ClientContext &, TableFunctionInitInput &) {
+		return make_uniq<IcebergRollbackToSnapshotGlobalState>();
+	}
+
+	bool finished = false;
+};
+
+static bool CheckTableIsIcebergTable(optional_ptr<CatalogEntry> entry) {
+	auto &catalog_entry = entry->Cast<InCatalogEntry>();
+	auto &catalog = catalog_entry.catalog;
+	if (catalog.GetCatalogType() != "iceberg") {
+		return false;
+	}
+	if (entry->type != CatalogType::TABLE_ENTRY) {
+		return false;
+	}
+	return true;
+}
+
+static void VerifyInputIsNotAFile(ClientContext &context, string &input_string) {
+	auto qualified_name = QualifiedName::ParseComponents(input_string);
+	if (qualified_name.size() == 1) {
+		auto &fs = FileSystem::GetFileSystem(context);
+		if (fs.DirectoryExists(input_string) || fs.FileExists(input_string)) {
+			throw InvalidInputException("Cannot call iceberg_rollback_to_snapshot() on a file/directory");
+		}
+	}
+}
+
+static unique_ptr<FunctionData> IcebergRollbackToSnapshotBind(ClientContext &context, TableFunctionBindInput &input,
+                                                              vector<LogicalType> &return_types,
+                                                              vector<string> &names) {
+	auto ret = make_uniq<IcebergRollbackToSnapshotBindData>();
+
+	auto input_string = input.inputs[0].ToString();
+	VerifyInputIsNotAFile(context, input_string);
+	auto parts = QualifiedName::ParseComponents(input_string);
+	if (parts.size() != 3) {
+		throw InvalidInputException(
+		    "iceberg_rollback_to_snapshot: table identifier must be 'catalog.schema.table', got '%s'", input_string);
+	}
+	for (auto &part : parts) {
+		if (part.empty()) {
+			throw InvalidInputException("iceberg_rollback_to_snapshot: table identifier '%s' has an empty component",
+			                            input_string);
+		}
+	}
+
+	auto iceberg_table = IcebergUtils::GetTableEntry(context, input_string);
+	if (!CheckTableIsIcebergTable(iceberg_table)) {
+		throw InvalidInputException("Cannot call iceberg_rollback_to_snapshot on non-iceberg table");
+	}
+	ret->iceberg_table = iceberg_table->Cast<IcebergTableEntry>();
+	// Accept BIGINT / UBIGINT from iceberg_snapshots without overflowing signed range unexpectedly.
+	auto snapshot_value = input.inputs[1].DefaultCastAs(LogicalType::BIGINT);
+	ret->snapshot_id = snapshot_value.GetValue<int64_t>();
+
+	if (input.binder) {
+		DatabaseModificationType modification;
+		modification |= DatabaseModificationType::ALTER_TABLE;
+		input.binder->GetStatementProperties().RegisterDBModify(iceberg_table->ParentCatalog(), context, modification);
+	}
+
+	return_types.push_back(LogicalType::BIGINT);
+	return_types.push_back(LogicalType::BIGINT);
+	names.emplace_back("previous_snapshot_id");
+	names.emplace_back("current_snapshot_id");
+	return std::move(ret);
+}
+
+static void IcebergRollbackToSnapshotFunction(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
+	auto &bind_data = data.bind_data->Cast<IcebergRollbackToSnapshotBindData>();
+	auto &global_state = data.global_state->Cast<IcebergRollbackToSnapshotGlobalState>();
+
+	if (!bind_data.iceberg_table || global_state.finished) {
+		output.SetChildCardinality(0);
+		return;
+	}
+
+	auto iceberg_table = bind_data.iceberg_table;
+	auto &table_info = iceberg_table->table_info;
+	auto previous_snapshot = table_info.table_metadata.GetLatestSnapshot();
+	int64_t previous_snapshot_id = 0;
+	if (previous_snapshot && previous_snapshot->snapshot_id) {
+		previous_snapshot_id = *previous_snapshot->snapshot_id;
+	}
+
+	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
+	ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTable &tbl) {
+		auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
+		transaction_data.TableRollbackToSnapshot(bind_data.snapshot_id);
+	});
+
+	FlatVector::GetDataMutable<int64_t>(output.data[0])[0] = previous_snapshot_id;
+	FlatVector::GetDataMutable<int64_t>(output.data[1])[0] = bind_data.snapshot_id;
+	output.SetChildCardinality(1);
+	global_state.finished = true;
+}
+
+} // namespace
+
+TableFunctionSet IcebergFunctions::GetIcebergRollbackToSnapshotFunction() {
+	TableFunctionSet function_set("iceberg_rollback_to_snapshot");
+	auto fun = TableFunction({LogicalType::VARCHAR, LogicalType::BIGINT}, IcebergRollbackToSnapshotFunction,
+	                         IcebergRollbackToSnapshotBind, IcebergRollbackToSnapshotGlobalState::Init);
+	function_set.AddFunction(fun);
+	// iceberg_snapshots exposes snapshot_id as UBIGINT; accept that without requiring a cast.
+	fun = TableFunction({LogicalType::VARCHAR, LogicalType::UBIGINT}, IcebergRollbackToSnapshotFunction,
+	                    IcebergRollbackToSnapshotBind, IcebergRollbackToSnapshotGlobalState::Init);
+	function_set.AddFunction(fun);
+	return function_set;
+}
+
+} // namespace duckdb

--- a/src/include/catalog/rest/api/table_update.hpp
+++ b/src/include/catalog/rest/api/table_update.hpp
@@ -186,4 +186,14 @@ struct SetLocation : public IcebergTableUpdate {
 	string location;
 };
 
+struct SetSnapshotRef : public IcebergTableUpdate {
+	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::SET_SNAPSHOT_REF;
+
+	explicit SetSnapshotRef(int64_t snapshot_id, string ref_name = "main");
+	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+
+	int64_t snapshot_id;
+	string ref_name;
+};
+
 } // namespace duckdb

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -55,6 +55,8 @@ public:
 	void TableSetProperties(const case_insensitive_map_t<string> &properties);
 	void TableRemoveProperties(const vector<string> &properties);
 	void TableSetLocation();
+	//! Roll main back to an ancestor snapshot (Spark rollback_to_snapshot semantics).
+	void TableRollbackToSnapshot(int64_t snapshot_id);
 
 private:
 	void CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata);

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -54,6 +54,8 @@ public:
 	void TableSetProperties(const case_insensitive_map_t<string> &properties);
 	void TableRemoveProperties(const vector<string> &properties);
 	void TableSetLocation();
+	//! Roll main back to an ancestor snapshot (Spark rollback_to_snapshot semantics).
+	void TableRollbackToSnapshot(int64_t snapshot_id);
 
 private:
 	void CacheExistingManifestList(lock_guard<mutex> &guard, const IcebergTableMetadata &metadata);

--- a/src/include/function/iceberg_functions.hpp
+++ b/src/include/function/iceberg_functions.hpp
@@ -39,6 +39,7 @@ private:
 	static TableFunctionSet SetIcebergSchemaPropertiesFunctions();
 	static TableFunctionSet RemoveIcebergSchemaPropertiesFunctions();
 	static TableFunctionSet GetIcebergRewriteDataFilesFunction();
+	static TableFunctionSet GetIcebergRollbackToSnapshotFunction();
 };
 
 } // namespace duckdb

--- a/test/configs/nessie.json
+++ b/test/configs/nessie.json
@@ -138,7 +138,10 @@
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_into_sorted_table.test",
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/update/partitions/test_update_into_partitioned_sorted_table.test",
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_snapshot_operation_in_transaction.test",
-				"test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_snapshot_summary_delete_metrics.test"
+				"test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_snapshot_summary_delete_metrics.test",
+				"test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rollback_to_snapshot.test",
+				"test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rollback_to_snapshot_partition_transforms.test",
+				"test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rollback_to_snapshot_schema_retained.test"
 			]
 		},
 		{

--- a/test/configs/nessie.json
+++ b/test/configs/nessie.json
@@ -138,7 +138,8 @@
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/update/test_update_into_sorted_table.test",
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/update/partitions/test_update_into_partitioned_sorted_table.test",
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/transactions/test_snapshot_operation_in_transaction.test",
-				"test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_snapshot_summary_delete_metrics.test"
+				"test/sql/local/catalog_test_config_setup/catalog_agnostic/delete/test_snapshot_summary_delete_metrics.test",
+				"test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rollback_to_snapshot.test"
 			]
 		},
 		{

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rollback_to_snapshot.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rollback_to_snapshot.test
@@ -1,0 +1,160 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rollback_to_snapshot.test
+# description: Spark-compatible rollback_to_snapshot moves main to an ancestor snapshot
+# group: [maintenance]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require json
+
+statement ok
+drop table if exists my_datalake.default.rollback_snap;
+
+statement ok
+create table my_datalake.default.rollback_snap (id INTEGER, payload VARCHAR);
+
+statement ok
+insert into my_datalake.default.rollback_snap values (1, 'a'), (2, 'b');
+
+statement ok
+set variable snap1 = (
+	select {
+		snapshot_id: snapshot_id
+	} from iceberg_snapshots(my_datalake.default.rollback_snap)
+	order by sequence_number
+	limit 1
+);
+
+statement ok
+insert into my_datalake.default.rollback_snap values (3, 'c'), (4, 'd');
+
+statement ok
+insert into my_datalake.default.rollback_snap values (5, 'e'), (6, 'f');
+
+query I
+select count(*) from my_datalake.default.rollback_snap;
+----
+6
+
+statement ok
+set variable snap_count_before = (
+	select count(*) from iceberg_snapshots(my_datalake.default.rollback_snap)
+);
+
+statement ok
+set variable current_before = (
+	select snapshot_id from iceberg_snapshots(my_datalake.default.rollback_snap)
+	order by sequence_number desc
+	limit 1
+);
+
+statement ok
+set variable rollback_result = (
+	select {
+		previous_snapshot_id: previous_snapshot_id,
+		current_snapshot_id: current_snapshot_id
+	}
+	from iceberg_rollback_to_snapshot(
+		'my_datalake.default.rollback_snap',
+		getvariable('snap1').snapshot_id
+	)
+);
+
+query II
+select
+	getvariable('rollback_result').previous_snapshot_id = getvariable('current_before'),
+	getvariable('rollback_result').current_snapshot_id = getvariable('snap1').snapshot_id;
+----
+true	true
+
+query I
+select count(*) from my_datalake.default.rollback_snap;
+----
+2
+
+query II
+select id, payload from my_datalake.default.rollback_snap order by id;
+----
+1	a
+2	b
+
+# History is preserved: rollback does not create or remove snapshots.
+query I
+select count(*) from iceberg_snapshots(my_datalake.default.rollback_snap);
+----
+3
+
+query I
+select count(*) = getvariable('snap_count_before')
+from iceberg_snapshots(my_datalake.default.rollback_snap);
+----
+true
+
+# Newest historical snapshot remains in metadata, but current tip is snap1.
+query I
+select snapshot_id != getvariable('snap1').snapshot_id
+from iceberg_snapshots(my_datalake.default.rollback_snap)
+order by sequence_number desc
+limit 1;
+----
+true
+
+query I
+select json_extract_string(metadata::JSON, '$."current-snapshot-id"')::BIGINT
+	= getvariable('snap1').snapshot_id
+from iceberg_load_table_response(my_datalake.default.rollback_snap);
+----
+true
+
+# Same-snapshot rollback is a successful no-op.
+query II
+select
+	previous_snapshot_id = getvariable('snap1').snapshot_id,
+	current_snapshot_id = getvariable('snap1').snapshot_id
+from iceberg_rollback_to_snapshot(
+	'my_datalake.default.rollback_snap',
+	getvariable('snap1').snapshot_id
+);
+----
+true	true
+
+# Unknown snapshot id is rejected.
+statement error
+call iceberg_rollback_to_snapshot('my_datalake.default.rollback_snap', 999999999);
+----
+unknown snapshot
+
+# After rollback, a later snapshot is no longer an ancestor of current main.
+statement ok
+set variable later_snap = (
+	select snapshot_id from iceberg_snapshots(my_datalake.default.rollback_snap)
+	order by sequence_number desc
+	limit 1
+);
+
+statement error
+call iceberg_rollback_to_snapshot(
+	'my_datalake.default.rollback_snap',
+	getvariable('later_snap')
+);
+----
+not an ancestor
+
+# Forward writes still work after rollback.
+statement ok
+insert into my_datalake.default.rollback_snap values (7, 'g');
+
+query I
+select count(*) from my_datalake.default.rollback_snap;
+----
+3
+
+statement ok
+drop table if exists my_datalake.default.rollback_snap;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rollback_to_snapshot_partition_transforms.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rollback_to_snapshot_partition_transforms.test
@@ -1,0 +1,191 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rollback_to_snapshot_partition_transforms.test
+# description: rollback_to_snapshot restores tables partitioned by bucket/day/hour transforms
+# group: [maintenance]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require json
+
+# ---- BUCKET transform ----
+
+statement ok
+drop table if exists my_datalake.default.rollback_bucket;
+
+statement ok
+create table my_datalake.default.rollback_bucket (id INTEGER, payload VARCHAR)
+partitioned by (bucket(4, id));
+
+statement ok
+insert into my_datalake.default.rollback_bucket values (1, 'a'), (2, 'b');
+
+statement ok
+set variable snap_bucket = (
+	select {
+		snapshot_id: snapshot_id
+	} from iceberg_snapshots(my_datalake.default.rollback_bucket)
+	order by sequence_number
+	limit 1
+);
+
+statement ok
+insert into my_datalake.default.rollback_bucket values (3, 'c'), (4, 'd');
+
+query I
+select count(*) from my_datalake.default.rollback_bucket;
+----
+4
+
+statement ok
+call iceberg_rollback_to_snapshot(
+	'my_datalake.default.rollback_bucket',
+	getvariable('snap_bucket').snapshot_id
+);
+
+query I
+select count(*) from my_datalake.default.rollback_bucket;
+----
+2
+
+query II
+select id, payload from my_datalake.default.rollback_bucket order by id;
+----
+1	a
+2	b
+
+query I
+select json_extract_string(metadata::JSON, '$."current-snapshot-id"')::BIGINT
+	= getvariable('snap_bucket').snapshot_id
+from iceberg_load_table_response(my_datalake.default.rollback_bucket);
+----
+true
+
+statement ok
+drop table if exists my_datalake.default.rollback_bucket;
+
+# ---- DAY transform ----
+
+statement ok
+drop table if exists my_datalake.default.rollback_day;
+
+statement ok
+create table my_datalake.default.rollback_day (id INTEGER, dt DATE, payload VARCHAR)
+partitioned by (day(dt));
+
+statement ok
+insert into my_datalake.default.rollback_day values
+	(1, '2021-06-15'::DATE, 'a'),
+	(2, '2021-06-16'::DATE, 'b');
+
+statement ok
+set variable snap_day = (
+	select {
+		snapshot_id: snapshot_id
+	} from iceberg_snapshots(my_datalake.default.rollback_day)
+	order by sequence_number
+	limit 1
+);
+
+statement ok
+insert into my_datalake.default.rollback_day values
+	(3, '2021-06-17'::DATE, 'c'),
+	(4, '2021-06-15'::DATE, 'd');
+
+query I
+select count(*) from my_datalake.default.rollback_day;
+----
+4
+
+statement ok
+call iceberg_rollback_to_snapshot(
+	'my_datalake.default.rollback_day',
+	getvariable('snap_day').snapshot_id
+);
+
+query I
+select count(*) from my_datalake.default.rollback_day;
+----
+2
+
+query III
+select id, dt, payload from my_datalake.default.rollback_day order by id;
+----
+1	2021-06-15	a
+2	2021-06-16	b
+
+query I
+select json_extract_string(metadata::JSON, '$."current-snapshot-id"')::BIGINT
+	= getvariable('snap_day').snapshot_id
+from iceberg_load_table_response(my_datalake.default.rollback_day);
+----
+true
+
+statement ok
+drop table if exists my_datalake.default.rollback_day;
+
+# ---- HOUR transform ----
+
+statement ok
+drop table if exists my_datalake.default.rollback_hour;
+
+statement ok
+create table my_datalake.default.rollback_hour (id INTEGER, ts TIMESTAMP, payload VARCHAR)
+partitioned by (hour(ts));
+
+statement ok
+insert into my_datalake.default.rollback_hour values
+	(1, '2021-06-15 10:00:00'::TIMESTAMP, 'a'),
+	(2, '2021-06-15 11:30:00'::TIMESTAMP, 'b');
+
+statement ok
+set variable snap_hour = (
+	select {
+		snapshot_id: snapshot_id
+	} from iceberg_snapshots(my_datalake.default.rollback_hour)
+	order by sequence_number
+	limit 1
+);
+
+statement ok
+insert into my_datalake.default.rollback_hour values
+	(3, '2021-06-15 14:00:00'::TIMESTAMP, 'c'),
+	(4, '2021-06-15 10:45:00'::TIMESTAMP, 'd');
+
+query I
+select count(*) from my_datalake.default.rollback_hour;
+----
+4
+
+statement ok
+call iceberg_rollback_to_snapshot(
+	'my_datalake.default.rollback_hour',
+	getvariable('snap_hour').snapshot_id
+);
+
+query I
+select count(*) from my_datalake.default.rollback_hour;
+----
+2
+
+query III
+select id, ts, payload from my_datalake.default.rollback_hour order by id;
+----
+1	2021-06-15 10:00:00	a
+2	2021-06-15 11:30:00	b
+
+query I
+select json_extract_string(metadata::JSON, '$."current-snapshot-id"')::BIGINT
+	= getvariable('snap_hour').snapshot_id
+from iceberg_load_table_response(my_datalake.default.rollback_hour);
+----
+true
+
+statement ok
+drop table if exists my_datalake.default.rollback_hour;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rollback_to_snapshot_schema_retained.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rollback_to_snapshot_schema_retained.test
@@ -1,0 +1,104 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rollback_to_snapshot_schema_retained.test
+# description: rollback_to_snapshot keeps current schema after rolling past ADD COLUMN (Iceberg #5591)
+# group: [maintenance]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require json
+
+statement ok
+drop table if exists my_datalake.default.rollback_schema;
+
+statement ok
+create table my_datalake.default.rollback_schema (id INTEGER);
+
+statement ok
+insert into my_datalake.default.rollback_schema values (1), (2);
+
+statement ok
+set variable snap1 = (
+	select {
+		snapshot_id: snapshot_id
+	} from iceberg_snapshots(my_datalake.default.rollback_schema)
+	order by sequence_number
+	limit 1
+);
+
+statement ok
+set variable schema_before_alter = (
+	select metadata."current-schema-id"
+	from iceberg_load_table_response(my_datalake.default.rollback_schema)
+);
+
+statement ok
+alter table my_datalake.default.rollback_schema add column payload varchar;
+
+statement ok
+set variable schema_after_alter = (
+	select metadata."current-schema-id"
+	from iceberg_load_table_response(my_datalake.default.rollback_schema)
+);
+
+query I
+select getvariable('schema_after_alter') != getvariable('schema_before_alter');
+----
+true
+
+statement ok
+insert into my_datalake.default.rollback_schema values (3, 'c'), (4, 'd');
+
+query I
+select count(*) from my_datalake.default.rollback_schema;
+----
+4
+
+statement ok
+call iceberg_rollback_to_snapshot(
+	'my_datalake.default.rollback_schema',
+	getvariable('snap1').snapshot_id
+);
+
+# Data is restored to snap1.
+query I
+select count(*) from my_datalake.default.rollback_schema;
+----
+2
+
+query II
+select id, payload from my_datalake.default.rollback_schema order by id;
+----
+1	NULL
+2	NULL
+
+# Live schema still includes the added column (schema evolution stays forward-only).
+query II
+select column_name, column_type
+from (describe my_datalake.default.rollback_schema)
+order by column_name;
+----
+id	INTEGER
+payload	VARCHAR
+
+query I
+select json_extract_string(metadata::JSON, '$."current-snapshot-id"')::BIGINT
+	= getvariable('snap1').snapshot_id
+from iceberg_load_table_response(my_datalake.default.rollback_schema);
+----
+true
+
+query I
+select metadata."current-schema-id" = getvariable('schema_after_alter')
+from iceberg_load_table_response(my_datalake.default.rollback_schema);
+----
+true
+
+statement ok
+drop table if exists my_datalake.default.rollback_schema;

--- a/test/sql/local/maintenance/rollback_to_snapshot_validation.test
+++ b/test/sql/local/maintenance/rollback_to_snapshot_validation.test
@@ -1,0 +1,39 @@
+# name: test/sql/local/maintenance/rollback_to_snapshot_validation.test
+# description: bind-time validation for iceberg_rollback_to_snapshot parameters
+# group: [maintenance]
+
+require avro
+
+require parquet
+
+require iceberg
+
+statement error
+SELECT * FROM iceberg_rollback_to_snapshot('bad', 1);
+----
+table identifier must be 'catalog.schema.table'
+
+statement error
+SELECT * FROM iceberg_rollback_to_snapshot('a.b', 1);
+----
+table identifier must be 'catalog.schema.table'
+
+statement error
+SELECT * FROM iceberg_rollback_to_snapshot('a.b.c.d', 1);
+----
+table identifier must be 'catalog.schema.table'
+
+statement error
+SELECT * FROM iceberg_rollback_to_snapshot('.b.c', 1);
+----
+has an empty component
+
+statement error
+SELECT * FROM iceberg_rollback_to_snapshot('a..c', 1);
+----
+has an empty component
+
+statement error
+SELECT * FROM iceberg_rollback_to_snapshot('cat.sch.tbl', 1);
+----
+Catalog "cat" does not exist


### PR DESCRIPTION
## Summary
- Add `iceberg_rollback_to_snapshot(catalog.schema.table, snapshot_id)` matching Spark [`rollback_to_snapshot`](https://iceberg.apache.org/docs/latest/spark-procedures/#rollback_to_snapshot): metadata-only `set-snapshot-ref` on `main`, ancestor validation, returns `previous_snapshot_id` / `current_snapshot_id`.
- Reuse a shared `SetSnapshotRef` table update for DML commits and rollback; also populate `parent_snapshot_id` when parsing snapshots so ancestry checks work.
- Add bind-time validation and catalog-agnostic maintenance coverage for restore, same-snapshot no-op, unknown ids, and non-ancestor rejection.

