### PR TITLE
[Dev] `IcebergTableEntry` -> `IcebergTableSchemaVersion` and `IcebergTableInformation` -> `IcebergTable`

### DIFF
--- a/src/catalog/rest/api/catalog_api.cpp
+++ b/src/catalog/rest/api/catalog_api.cpp
@@ -12,7 +12,7 @@
 #include "iceberg_logging.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "common/iceberg_utils.hpp"
 #include "catalog/rest/api/api_utils.hpp"
 #include "catalog/rest/storage/iceberg_authorization.hpp"

--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -16,11 +16,10 @@
 
 namespace duckdb {
 
-IcebergAddSnapshot::IcebergAddSnapshot(const IcebergTableInformation &table_info,
-                                       IcebergSnapshotOperationType operation)
+IcebergAddSnapshot::IcebergAddSnapshot(const IcebergTable &table_info, IcebergSnapshotOperationType operation)
     : IcebergTableUpdate(IcebergTableUpdateType::ADD_SNAPSHOT), operation(operation) {
 	//! FIXME: Do we also need to capture the current partition spec and sort order?
-	//! This is a bit of a code smell, the `IcebergTableInformation` should instead be const
+	//! This is a bit of a code smell, the `IcebergTable` should instead be const
 	//! and all transactional changes should live in the IcebergTransactionData
 	schema_id = table_info.table_metadata.GetCurrentSchemaId();
 }
@@ -30,7 +29,7 @@ bool IcebergAddSnapshot::IsRetryable() const {
 	return operation == IcebergSnapshotOperationType::APPEND || operation == IcebergSnapshotOperationType::DELETE;
 }
 
-static rest_api_objects::TableUpdate CreateAddSnapshotUpdate(const IcebergTableInformation &table_info,
+static rest_api_objects::TableUpdate CreateAddSnapshotUpdate(const IcebergTable &table_info,
                                                              const IcebergSnapshot &snapshot) {
 	rest_api_objects::TableUpdate table_update;
 
@@ -130,7 +129,7 @@ static int64_t ReconstructTotalFilesSize(IcebergCommitState &commit_state, int32
 	return total_files_size;
 }
 
-static IcebergManifestListEntry WriteManifestListEntry(const IcebergTableInformation &table_info,
+static IcebergManifestListEntry WriteManifestListEntry(const IcebergTable &table_info,
                                                        const IcebergManifestListEntry &list_entry,
                                                        CopyFunction &avro_copy, DatabaseInstance &db,
                                                        ClientContext &context) {
@@ -143,9 +142,8 @@ static IcebergManifestListEntry WriteManifestListEntry(const IcebergTableInforma
 }
 
 static vector<IcebergManifestListEntry>
-CreateCommitManifestFiles(const vector<IcebergManifestListEntry> &manifest_files,
-                          const IcebergTableInformation &table_info, IcebergCommitState &commit_state,
-                          int64_t sequence_number) {
+CreateCommitManifestFiles(const vector<IcebergManifestListEntry> &manifest_files, const IcebergTable &table_info,
+                          IcebergCommitState &commit_state, int64_t sequence_number) {
 	vector<IcebergManifestListEntry> result;
 	result.reserve(manifest_files.size());
 	auto &fs = FileSystem::GetFileSystem(commit_state.context);

--- a/src/catalog/rest/api/iceberg_manifest_merge.cpp
+++ b/src/catalog/rest/api/iceberg_manifest_merge.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/logging/logger.hpp"
 
 #include "catalog/rest/api/iceberg_table_update.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "catalog/rest/api/catalog_utils.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "planning/metadata_io/avro/avro_scan.hpp"

--- a/src/catalog/rest/api/iceberg_scan_planning.cpp
+++ b/src/catalog/rest/api/iceberg_scan_planning.cpp
@@ -13,7 +13,7 @@
 #include "iceberg_logging.hpp"
 #include "catalog/rest/api/catalog_utils.hpp"
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/storage/iceberg_authorization.hpp"
 #include "core/expression/iceberg_value.hpp"
@@ -67,7 +67,7 @@ struct PlanningAccumulator {
 	PlanTasksContainer plan_tasks;
 };
 
-static IRCEndpointBuilder TableEndpoint(IcebergTableInformation &table_info) {
+static IRCEndpointBuilder TableEndpoint(IcebergTable &table_info) {
 	auto &catalog = table_info.catalog;
 	auto result = catalog.GetBaseUrl();
 	result.AddPrefixComponents(catalog.prefix);
@@ -287,8 +287,7 @@ static string SerializePlanRequest(const rest_api_objects::PlanTableScanRequest 
 	return writer.ToString(JSONWriteFlags::ALLOW_INF_AND_NAN);
 }
 
-static void FetchPlanTasks(ClientContext &context, IcebergTableInformation &table_info,
-                           PlanningAccumulator &accumulator) {
+static void FetchPlanTasks(ClientContext &context, IcebergTable &table_info, PlanningAccumulator &accumulator) {
 	for (auto &task_identifier : accumulator.plan_tasks.Tasks()) {
 		if (context.IsInterrupted()) {
 			throw InterruptException();
@@ -313,8 +312,8 @@ static void FetchPlanTasks(ClientContext &context, IcebergTableInformation &tabl
 	}
 }
 
-static void FetchCredentials(ClientContext &context, IcebergTableInformation &table_info,
-                             const optional<string> &plan_id, IcebergServerSideScanPlan &result) {
+static void FetchCredentials(ClientContext &context, IcebergTable &table_info, const optional<string> &plan_id,
+                             IcebergServerSideScanPlan &result) {
 	if (!result.storage_credentials.empty() ||
 	    table_info.catalog.supported_urls.find(IcebergServerSideScanPlanning::CREDENTIALS_ENDPOINT) ==
 	        table_info.catalog.supported_urls.end()) {
@@ -399,7 +398,7 @@ static vector<IcebergManifestListEntry> MakeManifests(FileSystem &fs, const Iceb
 
 } // namespace
 
-bool IcebergServerSideScanPlanning::Plan(ClientContext &context, IcebergTableInformation &table_info,
+bool IcebergServerSideScanPlanning::Plan(ClientContext &context, IcebergTable &table_info,
                                          rest_api_objects::PlanTableScanRequest request,
                                          IcebergServerSideScanPlan &result) {
 	auto endpoint = TableEndpoint(table_info);

--- a/src/catalog/rest/api/iceberg_table_update.cpp
+++ b/src/catalog/rest/api/iceberg_table_update.cpp
@@ -1,7 +1,7 @@
 #include "catalog/rest/api/iceberg_table_update.hpp"
 #include "catalog/rest/api/iceberg_manifest_merge.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "duckdb/catalog/catalog_entry/copy_function_catalog_entry.hpp"
 #include "duckdb/common/enums/catalog_type.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
@@ -42,7 +42,7 @@ static void AssignManifestFirstRowIds(const IcebergTableMetadata &metadata,
 	}
 }
 
-IcebergCommitState::IcebergCommitState(const IcebergTableInformation &table_info, ClientContext &context)
+IcebergCommitState::IcebergCommitState(const IcebergTable &table_info, ClientContext &context)
     : table_info(table_info), context(context) {
 	RefreshFromTable();
 }

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -14,10 +14,10 @@
 #include "duckdb/planner/expression_binder/table_function_binder.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "catalog/rest/api/iceberg_type.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_update.hpp"
 #include "common/iceberg_default.hpp"
@@ -53,7 +53,7 @@ bool IcebergSchemaEntry::HandleCreateConflict(CatalogTransaction &transaction, C
 		// FIXME: With Snapshot operation type overwrite, you can handle create or replace for tables.
 		auto &iceberg_transaction = GetICTransaction(transaction);
 		auto &ic_catalog = catalog.Cast<IcebergCatalog>();
-		auto table_key = IcebergTableInformation::GetTableKey(ic_catalog, namespace_items, entry_name);
+		auto table_key = IcebergTable::GetTableKey(ic_catalog, namespace_items, entry_name);
 		auto latest_state = iceberg_transaction.GetLatestTableState(table_key);
 		if (latest_state && latest_state->IsDroppedOrRenamed()) {
 			vector<string> qualified_name = {ic_catalog.GetName().GetIdentifierName()};
@@ -130,8 +130,8 @@ void IcebergSchemaEntry::DropEntry(ClientContext &context, DropInfo &info, bool 
 		auto &table_info = table_info_it->second;
 		auto &table = transaction.DeleteTable(*table_info);
 		//! FIXME: what?
-		// must init schema versions after copy. Schema versions have a pointer to IcebergTableInformation
-		// if the IcebergTableInformation is moved, then the pointer is no longer valid.
+		// must init schema versions after copy. Schema versions have a pointer to IcebergTable
+		// if the IcebergTable is moved, then the pointer is no longer valid.
 		table.InitSchemaVersions();
 	}
 }
@@ -312,7 +312,7 @@ static void ThrowIfColumnReferencedBySortOrder(const IcebergTableMetadata &table
 	    sort_order_field->null_order);
 }
 
-void IntroduceNewSchema(IcebergTableInformation &updated_table, IcebergTransactionData &transaction_data,
+void IntroduceNewSchema(IcebergTable &updated_table, IcebergTransactionData &transaction_data,
                         shared_ptr<IcebergTableSchema> new_schema) {
 	auto new_schema_id = new_schema->schema_id;
 
@@ -349,7 +349,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 	if (!catalog_entry) {
 		throw CatalogException("Table with name \"%s\" does not exist!", info.GetQualifiedName().Name());
 	}
-	auto &table_entry = catalog_entry->Cast<IcebergTableEntry>();
+	auto &table_entry = catalog_entry->Cast<IcebergTableSchemaVersion>();
 	auto &catalog_table_info = table_entry.table_info;
 
 	if (info.type == AlterType::ALTER_TABLE) {
@@ -362,7 +362,7 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			auto other_catalog_entry = tables.GetEntry(context, lookup);
 			if (other_catalog_entry) {
 				//! The table exists at this point, check if it was deleted/renamed in the transaction
-				auto &other_table_entry = other_catalog_entry->Cast<IcebergTableEntry>();
+				auto &other_table_entry = other_catalog_entry->Cast<IcebergTableSchemaVersion>();
 				auto &other_table_info = other_table_entry.table_info;
 				auto other_table_key = other_table_info.GetTableKey();
 				auto state = irc_transaction.GetLatestTableState(other_table_key);

--- a/src/catalog/rest/catalog_entry/table/CMakeLists.txt
+++ b/src/catalog/rest/catalog_entry/table/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(iceberg_catalog_rest_catalog_entry_table OBJECT
-            iceberg_table_entry.cpp iceberg_table_information.cpp)
+            iceberg_table_schema_version.cpp iceberg_table.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES}
     $<TARGET_OBJECTS:iceberg_catalog_rest_catalog_entry_table>

--- a/src/catalog/rest/catalog_entry/table/iceberg_table.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table.cpp
@@ -1,4 +1,4 @@
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/exception.hpp"
@@ -32,7 +32,7 @@
 
 namespace duckdb {
 
-const string &IcebergTableInformation::BaseFilePath() const {
+const string &IcebergTable::BaseFilePath() const {
 	return table_metadata.location;
 }
 
@@ -168,12 +168,13 @@ static void ParseConfigOptions(const case_insensitive_map_t<string> &config, cas
 	endpoint_it->second = endpoint;
 }
 
-IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(ClientContext &context) const {
+IRCAPITableCredentials IcebergTable::GetVendedCredentials(ClientContext &context) const {
 	return GetVendedCredentials(context, storage_credentials);
 }
 
-IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(
-    ClientContext &context, const vector<rest_api_objects::StorageCredential> &storage_credentials) const {
+IRCAPITableCredentials
+IcebergTable::GetVendedCredentials(ClientContext &context,
+                                   const vector<rest_api_objects::StorageCredential> &storage_credentials) const {
 	IRCAPITableCredentials result;
 	auto schema_component = IRCPathComponent::NamespaceComponent(schema.namespace_items, catalog.namespace_separator);
 	auto secret_base_name = UUID::ToString(UUID::GenerateRandomUUID());
@@ -280,18 +281,18 @@ IRCAPITableCredentials IcebergTableInformation::GetVendedCredentials(
 	return result;
 }
 
-bool IcebergTableInformation::IsRenamed() const {
+bool IcebergTable::IsRenamed() const {
 	return original_name != name;
 }
 
-optional_ptr<CatalogEntry> IcebergTableInformation::CreateSchemaVersion(const IcebergTableSchema &table_schema) {
+optional_ptr<CatalogEntry> IcebergTable::CreateSchemaVersion(const IcebergTableSchema &table_schema) {
 	CreateTableInfo info;
 	info.SetTableName(Identifier(name));
 	for (auto &col : table_schema.columns) {
 		info.columns.AddColumn(col->GetColumnDefinition());
 	}
 
-	auto table_entry = make_uniq<IcebergTableEntry>(*this, catalog, schema, info, table_schema.schema_id);
+	auto table_entry = make_uniq<IcebergTableSchemaVersion>(*this, catalog, schema, info, table_schema.schema_id);
 	if (!table_entry->internal) {
 		table_entry->internal = schema.internal;
 	}
@@ -304,7 +305,7 @@ optional_ptr<CatalogEntry> IcebergTableInformation::CreateSchemaVersion(const Ic
 	return result;
 }
 
-idx_t IcebergTableInformation::GetMaxSchemaId() {
+idx_t IcebergTable::GetMaxSchemaId() {
 	idx_t max_schema_id = 0;
 	if (schema_versions.empty()) {
 		throw CatalogException("No schema versions found for table '%s.%s'", schema.name, name);
@@ -317,7 +318,7 @@ idx_t IcebergTableInformation::GetMaxSchemaId() {
 	return max_schema_id;
 }
 
-idx_t IcebergTableInformation::GetNextPartitionSpecId() {
+idx_t IcebergTable::GetNextPartitionSpecId() {
 	idx_t max_partition_spec_id = table_metadata.default_spec_id;
 	for (auto &partition_spec : table_metadata.GetPartitionSpecs()) {
 		auto &partition_spec_id = partition_spec.first;
@@ -328,7 +329,7 @@ idx_t IcebergTableInformation::GetNextPartitionSpecId() {
 	return max_partition_spec_id + 1;
 }
 
-idx_t IcebergTableInformation::GetNextSortOrderId() {
+idx_t IcebergTable::GetNextSortOrderId() {
 	idx_t max_sort_order_id = 0;
 	if (table_metadata.default_sort_order_id.IsValid()) {
 		max_sort_order_id = table_metadata.default_sort_order_id.GetIndex();
@@ -342,7 +343,7 @@ idx_t IcebergTableInformation::GetNextSortOrderId() {
 	return max_sort_order_id + 1;
 }
 
-optional<int64_t> IcebergTableInformation::GetExistingSpecId(IcebergPartitionSpec &spec) {
+optional<int64_t> IcebergTable::GetExistingSpecId(IcebergPartitionSpec &spec) {
 	for (auto &existing_spec : table_metadata.GetPartitionSpecs()) {
 		if (spec.Equals(existing_spec.second)) {
 			return existing_spec.first;
@@ -351,7 +352,7 @@ optional<int64_t> IcebergTableInformation::GetExistingSpecId(IcebergPartitionSpe
 	return std::nullopt;
 }
 
-optional<int64_t> IcebergTableInformation::GetExistingSortOrderId(IcebergSortOrder &spec) {
+optional<int64_t> IcebergTable::GetExistingSortOrderId(IcebergSortOrder &spec) {
 	for (auto &existing_sort_order : table_metadata.GetSortOrderSpecs()) {
 		if (spec.Equals(existing_sort_order.second)) {
 			return existing_sort_order.first;
@@ -360,10 +361,9 @@ optional<int64_t> IcebergTableInformation::GetExistingSortOrderId(IcebergSortOrd
 	return std::nullopt;
 }
 
-IcebergPartitionSpec
-IcebergTableInformation::BuildPartitionSpec(const vector<unique_ptr<ParsedExpression>> &partition_keys,
-                                            const IcebergTableSchema &schema, int32_t spec_id,
-                                            idx_t base_partition_field_id) {
+IcebergPartitionSpec IcebergTable::BuildPartitionSpec(const vector<unique_ptr<ParsedExpression>> &partition_keys,
+                                                      const IcebergTableSchema &schema, int32_t spec_id,
+                                                      idx_t base_partition_field_id) {
 	IcebergPartitionSpec new_spec(spec_id);
 
 	for (auto &key : partition_keys) {
@@ -387,8 +387,8 @@ IcebergTableInformation::BuildPartitionSpec(const vector<unique_ptr<ParsedExpres
 	return new_spec;
 }
 
-IcebergSortOrder IcebergTableInformation::BuildSortOrder(const vector<OrderByNode> &orders,
-                                                         const IcebergTableSchema &schema, int32_t sort_order_id) {
+IcebergSortOrder IcebergTable::BuildSortOrder(const vector<OrderByNode> &orders, const IcebergTableSchema &schema,
+                                              int32_t sort_order_id) {
 	IcebergSortOrder new_sort_order(sort_order_id);
 
 	for (auto &order : orders) {
@@ -409,9 +409,9 @@ IcebergSortOrder IcebergTableInformation::BuildSortOrder(const vector<OrderByNod
 	return new_sort_order;
 }
 
-void IcebergTableInformation::SetPartitionedBy(IcebergTransaction &transaction,
-                                               const vector<unique_ptr<ParsedExpression>> &partition_keys,
-                                               const IcebergTableSchema &schema) {
+void IcebergTable::SetPartitionedBy(IcebergTransaction &transaction,
+                                    const vector<unique_ptr<ParsedExpression>> &partition_keys,
+                                    const IcebergTableSchema &schema) {
 	idx_t base_partition_field_id = 1000;
 	if (table_metadata.HasLastPartitionId()) {
 		base_partition_field_id = table_metadata.GetLastPartitionFieldId() + 1;
@@ -436,8 +436,8 @@ void IcebergTableInformation::SetPartitionedBy(IcebergTransaction &transaction,
 	transaction_data.TableSetDefaultSpec();
 }
 
-void IcebergTableInformation::SetSortedBy(IcebergTransaction &transaction, const vector<OrderByNode> &orders,
-                                          const IcebergTableSchema &schema, bool first_sort_spec) {
+void IcebergTable::SetSortedBy(IcebergTransaction &transaction, const vector<OrderByNode> &orders,
+                               const IcebergTableSchema &schema, bool first_sort_spec) {
 	idx_t new_sort_order_id = 0;
 	if (!first_sort_spec) {
 		new_sort_order_id = GetNextSortOrderId();
@@ -466,7 +466,7 @@ void IcebergTableInformation::SetSortedBy(IcebergTransaction &transaction, const
 	}
 }
 
-optional_ptr<CatalogEntry> IcebergTableInformation::GetSchemaVersion(optional_ptr<BoundAtClause> at) {
+optional_ptr<CatalogEntry> IcebergTable::GetSchemaVersion(optional_ptr<BoundAtClause> at) {
 	if (table_metadata.snapshots.empty()) {
 		return schema_versions[table_metadata.GetCurrentSchemaId()].get();
 	}
@@ -484,7 +484,7 @@ optional_ptr<CatalogEntry> IcebergTableInformation::GetSchemaVersion(optional_pt
 	return schema_versions[schema_id].get();
 }
 
-idx_t IcebergTableInformation::GetIcebergVersion() const {
+idx_t IcebergTable::GetIcebergVersion() const {
 	return table_metadata.iceberg_version;
 }
 
@@ -498,7 +498,7 @@ static void AddHTTPSecretsToOptions(SecretEntry &http_secret_entry, case_insensi
 	                            : http_kv_secret.TryGetValue("verify_ssl").DefaultCastAs(LogicalType::BOOLEAN);
 }
 
-void IcebergTableInformation::LoadCredentials(ClientContext &context) const {
+void IcebergTable::LoadCredentials(ClientContext &context) const {
 	if (catalog.attach_options.access_mode != IRCAccessDelegationMode::VENDED_CREDENTIALS) {
 		// assume secret already exists
 		return;
@@ -506,7 +506,7 @@ void IcebergTableInformation::LoadCredentials(ClientContext &context) const {
 	LoadCredentials(context, GetVendedCredentials(context));
 }
 
-void IcebergTableInformation::LoadCredentials(ClientContext &context, IRCAPITableCredentials table_credentials) const {
+void IcebergTable::LoadCredentials(ClientContext &context, IRCAPITableCredentials table_credentials) const {
 	auto &secret_manager = SecretManager::Get(context);
 
 	auto &transaction = IcebergTransaction::Get(context, catalog);
@@ -602,12 +602,12 @@ void IcebergTableInformation::LoadCredentials(ClientContext &context, IRCAPITabl
 	}
 }
 
-optional_ptr<CatalogEntry> IcebergTableInformation::GetLatestSchema() {
+optional_ptr<CatalogEntry> IcebergTable::GetLatestSchema() {
 	return GetSchemaVersion(nullptr);
 }
 
-string IcebergTableInformation::GetTableKey(const IcebergCatalog &catalog, const vector<string> &namespace_items,
-                                            const string &table_name) {
+string IcebergTable::GetTableKey(const IcebergCatalog &catalog, const vector<string> &namespace_items,
+                                 const string &table_name) {
 	if (namespace_items.empty()) {
 		return table_name;
 	}
@@ -615,11 +615,11 @@ string IcebergTableInformation::GetTableKey(const IcebergCatalog &catalog, const
 	return schema_component.encoded + "." + table_name;
 }
 
-string IcebergTableInformation::GetTableKey() const {
+string IcebergTable::GetTableKey() const {
 	return GetTableKey(catalog, schema.namespace_items, name);
 }
 
-bool IcebergTableInformation::HasTransactionUpdates() const {
+bool IcebergTable::HasTransactionUpdates() const {
 	if (!transaction_data) {
 		return false;
 	}
@@ -639,7 +639,7 @@ bool IcebergTableInformation::HasTransactionUpdates() const {
 	return false;
 }
 
-void IcebergTableInformation::RefreshFromCatalog(ClientContext &context) {
+void IcebergTable::RefreshFromCatalog(ClientContext &context) {
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	auto table_key = GetTableKey();
 	auto get_table_result = IRCAPI::GetTable(context, ic_catalog, schema, name);
@@ -655,8 +655,8 @@ void IcebergTableInformation::RefreshFromCatalog(ClientContext &context) {
 	ic_catalog.table_request_cache.SetOrOverwrite(table_key, std::move(get_table_result.result_));
 }
 
-IcebergTableInformation IcebergTableInformation::Copy() const {
-	auto clone = IcebergTableInformation(catalog, schema, name);
+IcebergTable IcebergTable::Copy() const {
+	auto clone = IcebergTable(catalog, schema, name);
 	clone.table_metadata = table_metadata.Copy();
 	clone.config = config;
 	clone.initialization_source = initialization_source;
@@ -666,8 +666,8 @@ IcebergTableInformation IcebergTableInformation::Copy() const {
 	return clone;
 }
 
-IcebergTableMetadata IcebergTableInformation::CreateMetadataFromLog(ClientContext &context,
-                                                                    timestamp_ms_t transaction_start_ms) const {
+IcebergTableMetadata IcebergTable::CreateMetadataFromLog(ClientContext &context,
+                                                         timestamp_ms_t transaction_start_ms) const {
 	auto &log = table_metadata.metadata_log;
 
 	optional_idx log_item_index;
@@ -693,7 +693,7 @@ IcebergTableMetadata IcebergTableInformation::CreateMetadataFromLog(ClientContex
 	return IcebergTableMetadata::FromTableMetadata(parsed_metadata);
 }
 
-IcebergTableInformation IcebergTableInformation::Copy(IcebergTransaction &iceberg_transaction) const {
+IcebergTable IcebergTable::Copy(IcebergTransaction &iceberg_transaction) const {
 	auto locked_context = iceberg_transaction.context.lock();
 	auto &context = *locked_context;
 
@@ -727,19 +727,18 @@ IcebergTableInformation IcebergTableInformation::Copy(IcebergTransaction &iceber
 	return ret;
 }
 
-void IcebergTableInformation::InitSchemaVersions() {
+void IcebergTable::InitSchemaVersions() {
 	schema_versions.clear();
 	for (auto &table_schema : table_metadata.GetSchemas()) {
 		CreateSchemaVersion(*table_schema.second);
 	}
 }
 
-IcebergTableInformation::IcebergTableInformation(IcebergCatalog &catalog, IcebergSchemaEntry &schema,
-                                                 const string &name)
+IcebergTable::IcebergTable(IcebergCatalog &catalog, IcebergSchemaEntry &schema, const string &name)
     : catalog(catalog), schema(schema), name(name), original_name(name) {
 }
 
-IcebergTransactionData &IcebergTableInformation::GetOrCreateTransactionData(IcebergTransaction &transaction) {
+IcebergTransactionData &IcebergTable::GetOrCreateTransactionData(IcebergTransaction &transaction) {
 	lock_guard<mutex> guard(transaction.lock);
 	if (!transaction_data) {
 		auto context = transaction.context.lock();
@@ -748,8 +747,7 @@ IcebergTransactionData &IcebergTableInformation::GetOrCreateTransactionData(Iceb
 	return *transaction_data;
 }
 
-void IcebergTableInformation::InitializeFromLoadTableResult(
-    const rest_api_objects::LoadTableResult &load_table_result) {
+void IcebergTable::InitializeFromLoadTableResult(const rest_api_objects::LoadTableResult &load_table_result) {
 	initialization_source = load_table_result;
 	table_metadata = IcebergTableMetadata::FromTableMetadata(load_table_result.metadata);
 	if (auto &val = load_table_result.config) {

--- a/src/catalog/rest/catalog_entry/table/iceberg_table_schema_version.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table_schema_version.cpp
@@ -1,4 +1,4 @@
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/logging/logger.hpp"
@@ -21,7 +21,7 @@
 #include "planning/iceberg_multi_file_reader.hpp"
 #include "catalog/rest/storage/authorization/sigv4.hpp"
 #include "rest_catalog/objects/list.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "common/iceberg_default.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
 
@@ -29,22 +29,23 @@ namespace duckdb {
 class OAuth2Authorization;
 constexpr column_t IcebergMultiFileReader::COLUMN_IDENTIFIER_LAST_SEQUENCE_NUMBER;
 
-IcebergTableEntry::IcebergTableEntry(IcebergTableInformation &table_info, Catalog &catalog, SchemaCatalogEntry &schema,
-                                     CreateTableInfo &info, optional_idx schema_id)
+IcebergTableSchemaVersion::IcebergTableSchemaVersion(IcebergTable &table_info, Catalog &catalog,
+                                                     SchemaCatalogEntry &schema, CreateTableInfo &info,
+                                                     optional_idx schema_id)
     : TableCatalogEntry(catalog, schema, info), table_info(table_info), schema_id(schema_id) {
 	this->internal = false;
 }
 
-unique_ptr<BaseStatistics> IcebergTableEntry::GetStatistics(ClientContext &context, column_t column_id) {
+unique_ptr<BaseStatistics> IcebergTableSchemaVersion::GetStatistics(ClientContext &context, column_t column_id) {
 	return nullptr;
 }
 
-void IcebergTableEntry::PrepareIcebergScanFromEntry(ClientContext &context) const {
+void IcebergTableSchemaVersion::PrepareIcebergScanFromEntry(ClientContext &context) const {
 	table_info.LoadCredentials(context);
 }
 
-TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data,
-                                                 const EntryLookupInfo &lookup) {
+TableFunction IcebergTableSchemaVersion::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data,
+                                                         const EntryLookupInfo &lookup) {
 	auto &db = DatabaseInstance::GetDatabase(context);
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 	auto data = CatalogTransaction::GetSystemTransaction(db);
@@ -59,7 +60,8 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 	PrepareIcebergScanFromEntry(context);
 
 	if (!schema_id.IsValid()) {
-		throw InternalException("GetScanFunction was called with a dummy IcebergTableEntry, this should never happen");
+		throw InternalException(
+		    "GetScanFunction was called with a dummy IcebergTableSchemaVersion, this should never happen");
 	}
 	const auto schema_id = this->schema_id.GetIndex();
 	const auto &metadata = table_info.table_metadata;
@@ -105,15 +107,15 @@ TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_
 	return iceberg_scan_function;
 }
 
-TableFunction IcebergTableEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) {
-	throw InternalException("IcebergTableEntry::GetScanFunction called without entry lookup info");
+TableFunction IcebergTableSchemaVersion::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) {
+	throw InternalException("IcebergTableSchemaVersion::GetScanFunction called without entry lookup info");
 }
 
-virtual_column_map_t IcebergTableEntry::GetVirtualColumns() const {
+virtual_column_map_t IcebergTableSchemaVersion::GetVirtualColumns() const {
 	return VirtualColumns();
 }
 
-virtual_column_map_t IcebergTableEntry::VirtualColumns() {
+virtual_column_map_t IcebergTableSchemaVersion::VirtualColumns() {
 	virtual_column_map_t result;
 	result.emplace(MultiFileReader::COLUMN_IDENTIFIER_FILENAME, TableColumn("filename", LogicalType::VARCHAR));
 	result.emplace(COLUMN_IDENTIFIER_ROW_ID, TableColumn("_row_id", LogicalType::BIGINT));
@@ -125,7 +127,7 @@ virtual_column_map_t IcebergTableEntry::VirtualColumns() {
 }
 
 //! NOTE: IcebergDelete::FindIcebergScan needs to change in tandem with this method
-vector<column_t> IcebergTableEntry::GetRowIdColumns() const {
+vector<column_t> IcebergTableSchemaVersion::GetRowIdColumns() const {
 	vector<column_t> result;
 	auto &table_metadata = table_info.table_metadata;
 	if (table_metadata.iceberg_version >= 3) {
@@ -138,7 +140,7 @@ vector<column_t> IcebergTableEntry::GetRowIdColumns() const {
 	return result;
 }
 
-LogicalType IcebergTableEntry::GetExpectedTypeForInsert(const ColumnDefinition &column) const {
+LogicalType IcebergTableSchemaVersion::GetExpectedTypeForInsert(const ColumnDefinition &column) const {
 	auto type = column.Type();
 	if (type.id() == LogicalTypeId::STRUCT) {
 		return LogicalType::INVALID;
@@ -146,15 +148,14 @@ LogicalType IcebergTableEntry::GetExpectedTypeForInsert(const ColumnDefinition &
 	return type;
 }
 
-unique_ptr<Expression> IcebergTableEntry::GetDefaultExpressionForColumn(ClientContext &context,
-                                                                        const LogicalType &input_type,
-                                                                        const LogicalType &result_type,
-                                                                        ColumnBinding binding,
-                                                                        const Expression &constant_value) const {
+unique_ptr<Expression>
+IcebergTableSchemaVersion::GetDefaultExpressionForColumn(ClientContext &context, const LogicalType &input_type,
+                                                         const LogicalType &result_type, ColumnBinding binding,
+                                                         const Expression &constant_value) const {
 	return IcebergDefaultProjectionResolver::ResolveDefault(context, input_type, result_type, binding, constant_value);
 }
 
-TableStorageInfo IcebergTableEntry::GetStorageInfo(ClientContext &context) {
+TableStorageInfo IcebergTableSchemaVersion::GetStorageInfo(ClientContext &context) {
 	TableStorageInfo result;
 	// TODO fill info
 	return result;

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -10,8 +10,8 @@
 #include "duckdb/common/exception/conversion_exception.hpp"
 
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
 #include "catalog/rest/api/catalog_api.hpp"
 #include "catalog/rest/api/catalog_utils.hpp"
@@ -22,7 +22,7 @@
 
 namespace duckdb {
 
-void LoadTableResultCache::EvictIfCurrent(const IcebergTableInformation &table) {
+void LoadTableResultCache::EvictIfCurrent(const IcebergTable &table) {
 	lock_guard<mutex> guard(lock);
 	auto it = tables.find(table.GetTableKey());
 	if (it == tables.end()) {

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -14,10 +14,10 @@
 #include "catalog/rest/api/catalog_api.hpp"
 #include "catalog/rest/api/catalog_utils.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
 #include "catalog/rest/storage/authorization/sigv4.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "catalog/rest/storage/authorization/oauth2.hpp"
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
 #include "core/metadata/partition/iceberg_partition_spec.hpp"
@@ -29,7 +29,7 @@ namespace duckdb {
 IcebergTableSet::IcebergTableSet(IcebergSchemaEntry &schema) : schema(schema), catalog(schema.ParentCatalog()) {
 }
 
-bool IcebergTableSet::FillEntry(ClientContext &context, IcebergTableInformation &table) {
+bool IcebergTableSet::FillEntry(ClientContext &context, IcebergTable &table) {
 	if (!table.schema_versions.empty()) {
 		return true;
 	}
@@ -73,7 +73,7 @@ bool IcebergTableSet::FillEntry(ClientContext &context, IcebergTableInformation 
 	return true;
 }
 
-IcebergTableEntry &IcebergTableSet::GetOrCreateDummy(IcebergTableInformation &table_info) const {
+IcebergTableSchemaVersion &IcebergTableSet::GetOrCreateDummy(IcebergTable &table_info) const {
 	if (table_info.dummy_entry) {
 		return *table_info.dummy_entry;
 	}
@@ -84,7 +84,7 @@ IcebergTableEntry &IcebergTableSet::GetOrCreateDummy(IcebergTableInformation &ta
 	auto col = ColumnDefinition(Identifier("__"), LogicalType::UNKNOWN);
 	columns.push_back(std::move(col));
 	info.columns = ColumnList(std::move(columns));
-	auto table_entry = make_uniq<IcebergTableEntry>(table_info, catalog, schema, info, optional_idx());
+	auto table_entry = make_uniq<IcebergTableSchemaVersion>(table_info, catalog, schema, info, optional_idx());
 	if (!table_entry->internal) {
 		table_entry->internal = schema.internal;
 	}
@@ -121,11 +121,11 @@ void IcebergTableSet::Scan(ClientContext &context, const std::function<void(Cata
 	}
 }
 
-const case_insensitive_map_t<shared_ptr<IcebergTableInformation>> &IcebergTableSet::GetEntries() {
+const case_insensitive_map_t<shared_ptr<IcebergTable>> &IcebergTableSet::GetEntries() {
 	return entries;
 }
 
-case_insensitive_map_t<shared_ptr<IcebergTableInformation>> &IcebergTableSet::GetEntriesMutable() {
+case_insensitive_map_t<shared_ptr<IcebergTable>> &IcebergTableSet::GetEntriesMutable() {
 	return entries;
 }
 
@@ -143,7 +143,7 @@ void IcebergTableSet::LoadEntries(ClientContext &context) {
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	auto tables = IRCAPI::GetTables(context, ic_catalog, schema);
 	for (auto &table : tables) {
-		entries.emplace(table.name, make_shared_ptr<IcebergTableInformation>(ic_catalog, schema, table.name));
+		entries.emplace(table.name, make_shared_ptr<IcebergTable>(ic_catalog, schema, table.name));
 	}
 	iceberg_transaction.listed_schemas.insert(schema.name.GetIdentifierName());
 }
@@ -167,21 +167,21 @@ static Value ParseTableProperty(TableFunctionBinder &binder, ClientContext &cont
 	return val;
 }
 
-shared_ptr<IcebergTableInformation>
-IcebergTableSet::CreateEntryInternal(lock_guard<mutex> &guard, const string &name, IcebergTableInformation &&table,
-                                     shared_ptr<IcebergTableInformation> &old_entry) {
+shared_ptr<IcebergTable> IcebergTableSet::CreateEntryInternal(lock_guard<mutex> &guard, const string &name,
+                                                              IcebergTable &&table,
+                                                              shared_ptr<IcebergTable> &old_entry) {
 	auto it = entries.find(name);
 	if (it != entries.end()) {
 		old_entry = std::move(it->second);
-		it->second = make_shared_ptr<IcebergTableInformation>(std::move(table));
+		it->second = make_shared_ptr<IcebergTable>(std::move(table));
 	} else {
-		it = entries.emplace(name, make_shared_ptr<IcebergTableInformation>(std::move(table))).first;
+		it = entries.emplace(name, make_shared_ptr<IcebergTable>(std::move(table))).first;
 	}
 	return it->second;
 }
 
-IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context, IcebergCatalog &catalog,
-                                                         IcebergSchemaEntry &schema, CreateTableInfo &info) {
+IcebergTable &IcebergTableSet::CreateNewEntry(ClientContext &context, IcebergCatalog &catalog,
+                                              IcebergSchemaEntry &schema, CreateTableInfo &info) {
 	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
 
 	auto binder = Binder::CreateBinder(context);
@@ -238,8 +238,7 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 		bootstrap_metadata.table_properties.emplace(option.first, option_val);
 	}
 
-	auto initial_partition_spec =
-	    IcebergTableInformation::BuildPartitionSpec(info.partition_keys, *new_schema, 0, 1000);
+	auto initial_partition_spec = IcebergTable::BuildPartitionSpec(info.partition_keys, *new_schema, 0, 1000);
 	IcebergCreateTableRequest create_table_request(info.GetTableName().GetIdentifierName(), new_schema,
 	                                               std::move(initial_partition_spec), iceberg_version.GetIndex(),
 	                                               bootstrap_metadata.table_properties, bootstrap_metadata.location);
@@ -249,12 +248,11 @@ IcebergTableInformation &IcebergTableSet::CreateNewEntry(ClientContext &context,
 	auto new_table_result = make_uniq<const rest_api_objects::LoadTableResult>(
 	    IRCAPI::CommitNewTable(context, catalog, schema.namespace_items, create_table_request));
 
-	auto key =
-	    IcebergTableInformation::GetTableKey(catalog, schema.namespace_items, info.GetTableName().GetIdentifierName());
+	auto key = IcebergTable::GetTableKey(catalog, schema.namespace_items, info.GetTableName().GetIdentifierName());
 	auto &load_table_result = *new_table_result;
 	auto &alter_update = iceberg_transaction.GetOrCreateAlter();
-	auto &table_info = alter_update.CreateTable(
-	    key, IcebergTableInformation(catalog, schema, info.GetTableName().GetIdentifierName()));
+	auto &table_info =
+	    alter_update.CreateTable(key, IcebergTable(catalog, schema, info.GetTableName().GetIdentifierName()));
 	table_info.InitializeFromLoadTableResult(load_table_result);
 	catalog.table_request_cache.SetOrOverwrite(key, std::move(new_table_result));
 
@@ -287,7 +285,7 @@ optional_ptr<CatalogEntry> IcebergTableSet::GetEntry(ClientContext &context, con
 	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
 	const auto &table_name = lookup.GetEntryName();
 	// first check transaction entries
-	const auto table_key = IcebergTableInformation::GetTableKey(ic_catalog, schema.namespace_items, table_name);
+	const auto table_key = IcebergTable::GetTableKey(ic_catalog, schema.namespace_items, table_name);
 	auto latest_state = iceberg_transaction.GetLatestTableState(table_key);
 
 	auto at = lookup.GetAtClause();
@@ -304,9 +302,8 @@ optional_ptr<CatalogEntry> IcebergTableSet::GetEntry(ClientContext &context, con
 	}
 
 	//! Preserve the old version in case our replacement fails
-	shared_ptr<IcebergTableInformation> old_version;
-	auto new_version =
-	    CreateEntryInternal(l, table_name, IcebergTableInformation(ic_catalog, schema, table_name), old_version);
+	shared_ptr<IcebergTable> old_version;
+	auto new_version = CreateEntryInternal(l, table_name, IcebergTable(ic_catalog, schema, table_name), old_version);
 	auto &table_info = *new_version;
 	if (!FillEntry(context, table_info)) {
 		if (old_version) {

--- a/src/catalog/rest/storage/iceberg_table_secret_provider.cpp
+++ b/src/catalog/rest/storage/iceberg_table_secret_provider.cpp
@@ -11,7 +11,7 @@
 
 #include "catalog/rest/api/catalog_api.hpp"
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
 #include "catalog/rest/storage/authorization/oauth2.hpp"
@@ -174,7 +174,7 @@ static CreateSecretInput ReVendVendedCredentials(ClientContext &context, CreateS
 	if (!table_entry_p) {
 		throw CatalogException("Table by name %s could not be located in secret refresh", table_name);
 	}
-	auto &table_entry = table_entry_p->Cast<IcebergTableEntry>();
+	auto &table_entry = table_entry_p->Cast<IcebergTableSchemaVersion>();
 	auto &table_info = table_entry.table_info;
 
 	auto refreshed_credentials =

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -20,7 +20,7 @@
 #include "catalog/rest/api/iceberg_retry.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/storage/iceberg_authorization.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "catalog/rest/api/iceberg_add_snapshot.hpp"
 #include "catalog/rest/api/iceberg_create_table_request.hpp"
 #include "catalog/rest/api/catalog_api.hpp"
@@ -39,30 +39,29 @@ namespace duckdb {
 IcebergTransactionTableState::IcebergTransactionTableState() : status(IcebergTableStatus::MISSING) {
 }
 
-IcebergTransactionTableState::IcebergTransactionTableState(shared_ptr<IcebergTableInformation> catalog_table)
+IcebergTransactionTableState::IcebergTransactionTableState(shared_ptr<IcebergTable> catalog_table)
     : catalog_table(std::move(catalog_table)), status(IcebergTableStatus::ALIVE) {
 }
 
-IcebergTransactionTableState::IcebergTransactionTableState(IcebergTableInformation &&transaction_table_p)
-    : transaction_table(make_uniq<IcebergTableInformation>(std::move(transaction_table_p))),
-      status(IcebergTableStatus::ALIVE) {
+IcebergTransactionTableState::IcebergTransactionTableState(IcebergTable &&transaction_table_p)
+    : transaction_table(make_uniq<IcebergTable>(std::move(transaction_table_p))), status(IcebergTableStatus::ALIVE) {
 	if (!transaction_table->table_metadata.GetSchemas().empty()) {
 		transaction_table->InitSchemaVersions();
 	}
 }
 
-const IcebergTableInformation &IcebergTransactionTableState::GetInfo() const {
+const IcebergTable &IcebergTransactionTableState::GetInfo() const {
 	return const_cast<IcebergTransactionTableState &>(*this).GetInfo();
 }
 
-IcebergTableInformation &IcebergTransactionTableState::GetOrCreateTransactionInfo(IcebergTransaction &transaction) {
+IcebergTable &IcebergTransactionTableState::GetOrCreateTransactionInfo(IcebergTransaction &transaction) {
 	if (transaction_table) {
 		return *transaction_table;
 	}
 	if (!catalog_table) {
 		throw InternalException("Cannot materialize transaction table state without table information");
 	}
-	transaction_table = make_uniq<IcebergTableInformation>(catalog_table->Copy(transaction));
+	transaction_table = make_uniq<IcebergTable>(catalog_table->Copy(transaction));
 	transaction_table->InitSchemaVersions();
 	return *transaction_table;
 }
@@ -125,8 +124,7 @@ static rest_api_objects::TableUpdate CreateSetSnapshotRefUpdate(int64_t snapshot
 	return table_update;
 }
 
-static bool NeedsAssertSchemaId(const IcebergTransactionData &transaction_data,
-                                const IcebergTableInformation &table_info) {
+static bool NeedsAssertSchemaId(const IcebergTransactionData &transaction_data, const IcebergTable &table_info) {
 	(void)table_info;
 	return transaction_data.assert_schema_id;
 }
@@ -242,7 +240,7 @@ static bool DeleteCanReapply(const IcebergTableMetadata &metadata, int64_t base_
 
 //! Throw if a retried DELETE can't be safely re-applied. No-op on the first
 //! attempt (tip == scan) and for non-delete transactions.
-static void VerifyDeleteRetryability(const IcebergTableInformation &table_info,
+static void VerifyDeleteRetryability(const IcebergTable &table_info,
                                      optional_ptr<const IcebergSnapshot> current_snapshot) {
 	if (!table_info.transaction_data) {
 		return;
@@ -273,7 +271,7 @@ static void VerifyDeleteRetryability(const IcebergTableInformation &table_info,
 	    table_info.name, std::to_string(scan_snapshot_id), std::to_string(tip_snapshot_id));
 }
 
-static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, IcebergTableInformation &table_info,
+static SingleTableStagedCommit StageSingleTableCommit(DatabaseInstance &db, IcebergTable &table_info,
                                                       ClientContext &context) {
 	SingleTableStagedCommit info;
 	IcebergCommitState commit_state(table_info, context);
@@ -351,8 +349,8 @@ static MultiTableStagedCommit StageMultiTableCommit(DatabaseInstance &db, Iceber
 	return info;
 }
 
-static optional_ptr<IcebergTableInformation> GetSingleUpdatedTable(IcebergTransactionAlterUpdate &alter_update) {
-	optional_ptr<IcebergTableInformation> result;
+static optional_ptr<IcebergTable> GetSingleUpdatedTable(IcebergTransactionAlterUpdate &alter_update) {
+	optional_ptr<IcebergTable> result;
 	for (auto &entry : alter_update.updated_tables) {
 		auto &table_info = entry.second.get();
 		if (!table_info.HasTransactionUpdates()) {
@@ -579,7 +577,7 @@ void IcebergTransaction::DoTableRename(IcebergTransactionRenameUpdate &rename_up
 	schema.DropEntry(context, drop_info, true);
 
 	lock_guard<mutex> guard(schema.tables.GetEntryLock());
-	shared_ptr<IcebergTableInformation> old_version;
+	shared_ptr<IcebergTable> old_version;
 	schema.tables.CreateEntryInternal(guard, new_name, std::move(new_table), old_version);
 	if (old_version) {
 		throw TransactionException("Table %s was already created by a different transaction!", new_name);
@@ -781,7 +779,7 @@ void IcebergTransaction::CleanupFiles() {
 					continue;
 				}
 				// we need to recreate the keys in the current context.
-				auto &ic_table_entry = table.GetLatestSchema()->Cast<IcebergTableEntry>();
+				auto &ic_table_entry = table.GetLatestSchema()->Cast<IcebergTableSchemaVersion>();
 				ic_table_entry.PrepareIcebergScanFromEntry(temp_context);
 
 				auto &add_snapshot = update->Cast<IcebergAddSnapshot>();
@@ -851,15 +849,14 @@ IcebergTransactionTableState &IcebergTransaction::SetLatestTableState(const stri
 	return it->second;
 }
 
-IcebergTransactionTableState &IcebergTransaction::SetCatalogTableState(shared_ptr<IcebergTableInformation> table) {
+IcebergTransactionTableState &IcebergTransaction::SetCatalogTableState(shared_ptr<IcebergTable> table) {
 	auto table_key = table->GetTableKey();
 	auto result = current_table_data.emplace(table_key, IcebergTransactionTableState(std::move(table)));
 	return result.first->second;
 }
 
-IcebergTransactionTableState &IcebergTransaction::SetTransactionTableState(const string &table_key,
-                                                                           IcebergTableInformation &&table,
-                                                                           IcebergTableStatus status) {
+IcebergTransactionTableState &
+IcebergTransaction::SetTransactionTableState(const string &table_key, IcebergTable &&table, IcebergTableStatus status) {
 	auto it = current_table_data.find(table_key);
 	if (it == current_table_data.end()) {
 		it = current_table_data.emplace(table_key, IcebergTransactionTableState(std::move(table))).first;
@@ -873,8 +870,7 @@ IcebergTransactionTableState &IcebergTransaction::SetTransactionTableState(const
 	return it->second;
 }
 
-IcebergTransactionTableState &
-IcebergTransaction::GetOrCreateTransactionTableState(const IcebergTableInformation &table) {
+IcebergTransactionTableState &IcebergTransaction::GetOrCreateTransactionTableState(const IcebergTable &table) {
 	auto table_key = table.GetTableKey();
 	auto state = GetLatestTableState(table_key);
 	if (state) {
@@ -896,7 +892,7 @@ IcebergTransactionAlterUpdate &IcebergTransaction::GetOrCreateAlter() {
 	return *alter_update;
 }
 
-IcebergTableInformation &IcebergTransaction::DeleteTable(IcebergTableInformation &table) {
+IcebergTable &IcebergTransaction::DeleteTable(IcebergTable &table) {
 	auto table_key = table.GetTableKey();
 	auto state = GetLatestTableState(table_key);
 	if (HasTableUpdate()) {
@@ -913,7 +909,7 @@ IcebergTableInformation &IcebergTransaction::DeleteTable(IcebergTableInformation
 	return state->GetInfo();
 }
 
-IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation &table, const string &new_name) {
+IcebergTable &IcebergTransaction::RenameTable(IcebergTable &table, const string &new_name) {
 	auto table_key = table.GetTableKey();
 	auto state = GetLatestTableState(table_key);
 	if (HasTableUpdate()) {
@@ -931,13 +927,13 @@ IcebergTableInformation &IcebergTransaction::RenameTable(IcebergTableInformation
 	auto new_table_key = new_table.GetTableKey();
 	auto &new_state = SetTransactionTableState(new_table_key, std::move(new_table), IcebergTableStatus::ALIVE);
 
-	//! Create the rename update, creating the new IcebergTableInformation in the process
+	//! Create the rename update, creating the new IcebergTable in the process
 	transaction_update.emplace<IcebergTransactionRenameUpdate>(*this, source_table, new_state.GetInfo(), new_name);
 	return state->GetInfo();
 }
 
-void ApplyTableUpdate(IcebergTableInformation &table_info, IcebergTransaction &iceberg_transaction,
-                      const std::function<void(IcebergTableInformation &)> &callback) {
+void ApplyTableUpdate(IcebergTable &table_info, IcebergTransaction &iceberg_transaction,
+                      const std::function<void(IcebergTable &)> &callback) {
 	auto &alter = iceberg_transaction.GetOrCreateAlter();
 	auto &updated_table = alter.GetOrInitializeTable(table_info);
 	callback(updated_table);

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -10,7 +10,7 @@
 #include "core/metadata/snapshot/iceberg_snapshot.hpp"
 #include "catalog/rest/iceberg_table_set.hpp"
 #include "catalog/rest/api/table_update.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "planning/metadata_io/avro/avro_scan.hpp"
 #include "planning/metadata_io/manifest/iceberg_manifest_reader.hpp"
 #include "planning/metadata_io/manifest_list/iceberg_manifest_list_reader.hpp"
@@ -93,7 +93,7 @@ static optional<int64_t> LoadExistingManifestList(ClientContext &context, const 
 }
 
 IcebergTransactionData::IcebergTransactionData(ClientContext &context, IcebergTransaction &transaction,
-                                               const IcebergTableInformation &table_info)
+                                               const IcebergTable &table_info)
     : context(context), transaction(transaction), table_info(table_info) {
 	initial_table_uuid = table_info.table_metadata.table_uuid;
 	if (table_info.table_metadata.next_row_id) {
@@ -159,7 +159,7 @@ bool IcebergTransactionData::SupportsAppendRetry() const {
 	return true;
 }
 
-bool IcebergTransactionData::RetryStateMatches(const IcebergTableInformation &table) const {
+bool IcebergTransactionData::RetryStateMatches(const IcebergTable &table) const {
 	if (table.table_metadata.table_uuid != initial_table_uuid) {
 		return false;
 	}

--- a/src/catalog/rest/transaction/iceberg_transaction_update.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_update.cpp
@@ -9,7 +9,7 @@ IcebergTransactionAlterUpdate::IcebergTransactionAlterUpdate(IcebergTransaction 
 IcebergTransactionAlterUpdate::~IcebergTransactionAlterUpdate() {
 }
 
-IcebergTableInformation &IcebergTransactionAlterUpdate::GetOrInitializeTable(const IcebergTableInformation &table) {
+IcebergTable &IcebergTransactionAlterUpdate::GetOrInitializeTable(const IcebergTable &table) {
 	auto table_key = table.GetTableKey();
 	auto it = updated_tables.find(table_key);
 	if (it == updated_tables.end()) {
@@ -34,8 +34,7 @@ bool IcebergTransactionAlterUpdate::HasUpdates() const {
 	return false;
 }
 
-IcebergTableInformation &IcebergTransactionAlterUpdate::CreateTable(const string &table_key,
-                                                                    IcebergTableInformation &&table) {
+IcebergTable &IcebergTransactionAlterUpdate::CreateTable(const string &table_key, IcebergTable &&table) {
 	auto &state = transaction.SetTransactionTableState(table_key, std::move(table), IcebergTableStatus::ALIVE);
 	auto &created_table = state.GetInfo();
 	auto emplace_res = updated_tables.emplace(table_key, created_table);
@@ -46,17 +45,14 @@ IcebergTableInformation &IcebergTransactionAlterUpdate::CreateTable(const string
 	return created_table;
 }
 
-IcebergTransactionDeleteUpdate::IcebergTransactionDeleteUpdate(IcebergTransaction &transaction,
-                                                               IcebergTableInformation &table)
+IcebergTransactionDeleteUpdate::IcebergTransactionDeleteUpdate(IcebergTransaction &transaction, IcebergTable &table)
     : transaction(transaction), deleted_table(table) {
 }
 IcebergTransactionDeleteUpdate::~IcebergTransactionDeleteUpdate() {
 }
 
-IcebergTransactionRenameUpdate::IcebergTransactionRenameUpdate(IcebergTransaction &transaction,
-                                                               IcebergTableInformation &table,
-                                                               IcebergTableInformation &new_table,
-                                                               const string &new_name)
+IcebergTransactionRenameUpdate::IcebergTransactionRenameUpdate(IcebergTransaction &transaction, IcebergTable &table,
+                                                               IcebergTable &new_table, const string &new_name)
     : transaction(transaction), table(table), new_table(new_table), new_name(new_name) {
 }
 IcebergTransactionRenameUpdate::~IcebergTransactionRenameUpdate() {

--- a/src/common/iceberg_utils.cpp
+++ b/src/common/iceberg_utils.cpp
@@ -10,8 +10,8 @@
 #include "duckdb/transaction/meta_transaction.hpp"
 #include "duckdb/common/operator/add.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "duckdb/catalog/catalog_entry_retriever.hpp"
 
@@ -212,7 +212,7 @@ string IcebergUtils::GetStorageLocation(ClientContext &context, const string &in
 			if (table.catalog.GetCatalogType() != "iceberg") {
 				throw InvalidInputException("Table %s is not an Iceberg table", input);
 			}
-			auto &table_entry = catalog_entry->Cast<IcebergTableEntry>();
+			auto &table_entry = catalog_entry->Cast<IcebergTableSchemaVersion>();
 			storage_location = table_entry.table_info.table_metadata.GetLocation();
 			// Prepare Iceberg Scan from entry will create the secret needed to access the table
 			table_entry.PrepareIcebergScanFromEntry(context);
@@ -236,7 +236,7 @@ IcebergResolvedMetadata IcebergUtils::ResolveTableMetadata(ClientContext &contex
 				throw InvalidInputException("Table %s is not an Iceberg table", input);
 			}
 
-			auto &iceberg_table = catalog_entry->Cast<IcebergTableEntry>();
+			auto &iceberg_table = catalog_entry->Cast<IcebergTableSchemaVersion>();
 			iceberg_table.PrepareIcebergScanFromEntry(context);
 			auto &metadata = iceberg_table.table_info.table_metadata;
 			return IcebergResolvedMetadata(metadata.GetLocation(), metadata.Copy());

--- a/src/core/metadata/manifest/iceberg_manifest.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest.cpp
@@ -10,7 +10,7 @@
 #include "catalog/rest/api/iceberg_create_table_request.hpp"
 #include "catalog/rest/api/catalog_utils.hpp"
 #include "core/expression/iceberg_value.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 
 #include <optional>
 

--- a/src/core/metadata/manifest/iceberg_manifest_list.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest_list.cpp
@@ -10,7 +10,7 @@
 
 #include "core/metadata/partition/iceberg_partition_spec.hpp"
 #include "core/expression/iceberg_value.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "core/expression/iceberg_transform.hpp"
 #include "planning/metadata_io/avro/avro_scan.hpp"
 #include "common/iceberg_utils.hpp"

--- a/src/core/metadata/snapshot/iceberg_snapshot.cpp
+++ b/src/core/metadata/snapshot/iceberg_snapshot.cpp
@@ -6,7 +6,7 @@
 
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "common/iceberg_utils.hpp"
 
 namespace duckdb {

--- a/src/core/metadata/snapshot/iceberg_snapshot_metrics.cpp
+++ b/src/core/metadata/snapshot/iceberg_snapshot_metrics.cpp
@@ -7,7 +7,7 @@
 
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "common/iceberg_utils.hpp"
 
 namespace duckdb {

--- a/src/execution/helpers/equality_delete_helpers.cpp
+++ b/src/execution/helpers/equality_delete_helpers.cpp
@@ -21,8 +21,8 @@
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/filter/table_filter_functions.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "common/iceberg_utils.hpp"
 #include "core/expression/iceberg_value.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
@@ -252,7 +252,7 @@ static bool TryGetEqualityDeleteValuesFromExpression(const Expression &expr,
 
 } // namespace
 
-bool IcebergDelete::TryGetEqualityDeletePredicates(ClientContext &context, IcebergTableEntry &table,
+bool IcebergDelete::TryGetEqualityDeletePredicates(ClientContext &context, IcebergTableSchemaVersion &table,
                                                    PhysicalOperator &child_plan,
                                                    vector<IcebergEqualityDeletePredicate> &equality_predicates) {
 	//! Gated behind an explicit testing-only setting.

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -15,8 +15,8 @@
 
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "planning/iceberg_multi_file_reader.hpp"
 #include "planning/iceberg_multi_file_list.hpp"
 #include "core/metadata/snapshot/iceberg_snapshot.hpp"
@@ -29,7 +29,7 @@
 namespace duckdb {
 class IcebergDeleteLocalState;
 class IcebergDeleteGlobalState;
-class IcebergTableEntry;
+class IcebergTableSchemaVersion;
 
 static bool IsScanCreatedByDelete(const PhysicalTableScan &scan) {
 	if (scan.function.GetName() != "iceberg_scan") {
@@ -78,7 +78,7 @@ optional_ptr<PhysicalTableScan> IcebergDelete::FindIcebergScan(PhysicalOperator 
 	return nullptr;
 }
 
-IcebergDelete::IcebergDelete(PhysicalPlan &physical_plan, IcebergTableEntry &table,
+IcebergDelete::IcebergDelete(PhysicalPlan &physical_plan, IcebergTableSchemaVersion &table,
                              optional_ptr<IcebergMultiFileList> multi_file_list, PhysicalOperator &child,
                              vector<idx_t> row_id_indexes)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, {LogicalType::BIGINT}, 1), table(table),
@@ -462,13 +462,13 @@ SinkFinalizeType IcebergDelete::Finalize(Pipeline &pipeline, Event &event, Clien
 	}
 
 	// write out the new manifest file
-	auto &irc_table = table.Cast<IcebergTableEntry>();
+	auto &irc_table = table.Cast<IcebergTableSchemaVersion>();
 
 	auto &table_info = irc_table.table_info;
 	auto iceberg_delete_files = GenerateDeleteManifestEntries(global_state);
 
 	if (!global_state.written_files.empty()) {
-		ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
+		ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTable &tbl) {
 			auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
 			transaction_data.AddDeleteSnapshot(std::move(iceberg_delete_files),
 			                                   std::move(global_state.altered_manifests));
@@ -511,7 +511,7 @@ InsertionOrderPreservingMap<string> IcebergDelete::ParamsToString() const {
 }
 
 PhysicalOperator &IcebergDelete::PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner,
-                                            IcebergTableEntry &table, PhysicalOperator &child_plan,
+                                            IcebergTableSchemaVersion &table, PhysicalOperator &child_plan,
                                             vector<idx_t> &&row_id_indexes) {
 	auto scan = FindIcebergScan(child_plan);
 
@@ -538,7 +538,7 @@ PhysicalOperator &IcebergCatalog::PlanDelete(ClientContext &context, PhysicalPla
 	if (op.return_chunk) {
 		throw BinderException("RETURNING clause not yet supported for deletion from Iceberg table");
 	}
-	auto &table_entry = op.table.Cast<IcebergTableEntry>();
+	auto &table_entry = op.table.Cast<IcebergTableSchemaVersion>();
 	table_entry.PrepareIcebergScanFromEntry(context);
 
 	auto &irc_transaction = IcebergTransaction::Get(context, *this);

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -21,10 +21,10 @@
 #include "duckdb/common/string_util.hpp"
 
 #include "catalog/rest/iceberg_catalog.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "execution/operator/iceberg_delete.hpp"
 #include "execution/operator/physical_iceberg_create_table.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "core/metadata/schema/iceberg_column_definition.hpp"
 #include "core/metadata/schema/iceberg_table_schema.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
@@ -239,7 +239,7 @@ void IcebergInsertGlobalState::AddFiles(DataChunk &chunk, const string &table_na
 void IcebergInsert::AddWrittenFiles(IcebergInsertGlobalState &global_state, DataChunk &chunk,
                                     optional_ptr<TableCatalogEntry> table) {
 	D_ASSERT(table);
-	auto &ic_table = table->Cast<IcebergTableEntry>();
+	auto &ic_table = table->Cast<IcebergTableSchemaVersion>();
 	auto &table_metadata = ic_table.table_info.table_metadata;
 	global_state.AddFiles(chunk, ic_table.name.GetIdentifierName(), table_metadata);
 }
@@ -292,7 +292,7 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 		// Table does not exist (INSERT INTO) or was not created in Physical Create Iceberg table (CTAS). Throw Error
 		throw InternalException("Table to insert into does not exist.");
 	}
-	auto &irc_table = effective_table->Cast<IcebergTableEntry>();
+	auto &irc_table = effective_table->Cast<IcebergTableSchemaVersion>();
 	auto &table_info = irc_table.table_info;
 	auto &transaction = IcebergTransaction::Get(context, effective_table->catalog);
 	auto &iceberg_transaction = transaction.Cast<IcebergTransaction>();
@@ -308,7 +308,7 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 		auto &delete_global_state = update_delete_op->sink_state->Cast<IcebergDeleteGlobalState>();
 		auto delete_manifest_entries = IcebergDelete::GenerateDeleteManifestEntries(delete_global_state);
 		if (!written_files.empty()) {
-			ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
+			ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTable &tbl) {
 				auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
 				transaction_data.AddUpdateSnapshot(std::move(delete_manifest_entries), std::move(written_files),
 				                                   std::move(delete_global_state.altered_manifests));
@@ -323,7 +323,7 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 	} else {
 		// Regular insert: commit an append snapshot.
 		if (!written_files.empty()) {
-			ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
+			ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTable &tbl) {
 				auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
 				IcebergManifestDeletes empty_deletes;
 				transaction_data.AddSnapshot(IcebergSnapshotOperationType::APPEND, std::move(written_files),
@@ -833,7 +833,7 @@ PhysicalOperator &IcebergInsert::PlanCopyForInsert(ClientContext &context, Physi
 }
 
 PhysicalOperator &IcebergInsert::PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner,
-                                            IcebergTableEntry &table) {
+                                            IcebergTableSchemaVersion &table) {
 	optional_idx partition_id;
 	vector<LogicalType> return_types;
 	// the one return value is how many rows we are inserting
@@ -854,7 +854,7 @@ PhysicalOperator &IcebergCatalog::PlanInsert(ClientContext &context, PhysicalPla
 	if (!op.column_index_map.empty()) {
 		plan = planner.ResolveDefaultsProjection(op, *plan);
 	}
-	auto &table_entry = op.table.Cast<IcebergTableEntry>();
+	auto &table_entry = op.table.Cast<IcebergTableSchemaVersion>();
 	table_entry.PrepareIcebergScanFromEntry(context);
 
 	auto &irc_transaction = IcebergTransaction::Get(context, *this);
@@ -911,7 +911,7 @@ static unique_ptr<IcebergTableMetadata> BuildPlaceholderMetadata(ClientContext &
 	// PlanCopyForInsert appends the partition projection at plan time. The real spec is
 	// applied during PhysicalIcebergCreateTable::MakeCreateTableRequest, but the projection
 	// indices are derived from the same partition_keys/schema and so remain consistent.
-	auto placeholder_spec = IcebergTableInformation::BuildPartitionSpec(create_info.partition_keys, *schema, 0, 1000);
+	auto placeholder_spec = IcebergTable::BuildPartitionSpec(create_info.partition_keys, *schema, 0, 1000);
 	metadata->partition_specs.emplace(0, std::move(placeholder_spec));
 	return metadata;
 }

--- a/src/execution/operator/iceberg_update.cpp
+++ b/src/execution/operator/iceberg_update.cpp
@@ -11,15 +11,15 @@
 #include "execution/operator/iceberg_insert.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_update.hpp"
 #include "planning/iceberg_multi_file_list.hpp"
 
 namespace duckdb {
 
-IcebergUpdate::IcebergUpdate(PhysicalPlan &physical_plan, IcebergTableEntry &table, vector<PhysicalIndex> columns_p,
-                             PhysicalOperator &child, PhysicalOperator &delete_op_p,
+IcebergUpdate::IcebergUpdate(PhysicalPlan &physical_plan, IcebergTableSchemaVersion &table,
+                             vector<PhysicalIndex> columns_p, PhysicalOperator &child, PhysicalOperator &delete_op_p,
                              vector<unique_ptr<Expression>> expressions_p,
                              vector<unique_ptr<Expression>> bound_defaults)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, {}, 1), table(table),
@@ -44,7 +44,7 @@ IcebergUpdate::IcebergUpdate(PhysicalPlan &physical_plan, IcebergTableEntry &tab
 }
 
 IcebergUpdate &IcebergUpdate::PlanUpdateOperator(ClientContext &context, PhysicalPlanGenerator &planner,
-                                                 IcebergTableEntry &table, LogicalUpdate &op,
+                                                 IcebergTableSchemaVersion &table, LogicalUpdate &op,
                                                  PhysicalOperator &child_plan, IcebergCopyInput &copy_input) {
 	auto &table_metadata = table.table_info.table_metadata;
 	if (table_metadata.iceberg_version < 2) {
@@ -225,7 +225,7 @@ PhysicalOperator &IcebergCatalog::PlanUpdate(ClientContext &context, PhysicalPla
 		throw BinderException("RETURNING clause not yet supported for updates of a Iceberg table");
 	}
 
-	auto &table_entry = op.table.Cast<IcebergTableEntry>();
+	auto &table_entry = op.table.Cast<IcebergTableSchemaVersion>();
 	table_entry.PrepareIcebergScanFromEntry(context);
 
 	auto &irc_transaction = IcebergTransaction::Get(context, *this);
@@ -254,8 +254,8 @@ PhysicalOperator &IcebergCatalog::PlanUpdate(ClientContext &context, PhysicalPla
 	return insert_op;
 }
 
-void IcebergTableEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get, LogicalProjection &proj,
-                                              LogicalUpdate &update, ClientContext &context) {
+void IcebergTableSchemaVersion::BindUpdateConstraints(Binder &binder, LogicalGet &get, LogicalProjection &proj,
+                                                      LogicalUpdate &update, ClientContext &context) {
 	// all updates in DuckDB-Iceberg are deletes + inserts
 	update.update_is_del_and_insert = true;
 

--- a/src/execution/operator/merge_into/iceberg_merge_into.cpp
+++ b/src/execution/operator/merge_into/iceberg_merge_into.cpp
@@ -10,7 +10,7 @@
 #include "execution/operator/merge_into/iceberg_merge_update.hpp"
 #include "execution/operator/merge_into/iceberg_merge_into.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "execution/operator/iceberg_update.hpp"
 #include "execution/operator/iceberg_delete.hpp"
 #include "execution/operator/iceberg_insert.hpp"
@@ -147,7 +147,7 @@ static unique_ptr<MergeIntoOperator> IcebergPlanMergeIntoAction(IcebergCatalog &
 	}
 	auto return_types = op.types;
 
-	auto &table_entry = op.table.Cast<IcebergTableEntry>();
+	auto &table_entry = op.table.Cast<IcebergTableSchemaVersion>();
 	table_entry.PrepareIcebergScanFromEntry(context);
 
 	auto &irc_transaction = IcebergTransaction::Get(context, catalog);
@@ -270,7 +270,7 @@ PhysicalOperator &IcebergCatalog::PlanMergeInto(ClientContext &context, Physical
 	}
 	map<MergeActionCondition, vector<unique_ptr<MergeIntoOperator>>> actions;
 
-	auto &table_entry = op.table.Cast<IcebergTableEntry>();
+	auto &table_entry = op.table.Cast<IcebergTableSchemaVersion>();
 	table_entry.PrepareIcebergScanFromEntry(context);
 
 	// plan the merge into clauses

--- a/src/execution/operator/physical_iceberg_create_table.cpp
+++ b/src/execution/operator/physical_iceberg_create_table.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/main/database.hpp"
 
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "execution/operator/iceberg_insert.hpp"
 
@@ -37,7 +37,7 @@ void PhysicalIcebergCreateTable::MakeCreateTableRequest(ClientContext &client_co
 		if (!table) {
 			throw InternalException("Iceberg CTAS: CreateTable request failed");
 		}
-		auto &ic_table = table->Cast<IcebergTableEntry>();
+		auto &ic_table = table->Cast<IcebergTableSchemaVersion>();
 		// Load any per-table credentials (e.g. SigV4 for the data location).
 		ic_table.PrepareIcebergScanFromEntry(client_context);
 

--- a/src/function/ducklake/iceberg_to_ducklake.cpp
+++ b/src/function/ducklake/iceberg_to_ducklake.cpp
@@ -32,8 +32,8 @@
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
 #include "catalog/rest/iceberg_schema_set.hpp"
 #include "catalog/rest/iceberg_table_set.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 
 #include "core/metadata/iceberg_table_metadata.hpp"
 
@@ -98,7 +98,7 @@ public:
 	}
 
 public:
-	void AddTable(IcebergTableInformation &table_info, ClientContext &context, const IcebergOptions &options) {
+	void AddTable(IcebergTable &table_info, ClientContext &context, const IcebergOptions &options) {
 		auto &metadata = table_info.table_metadata;
 		if (table_names_to_skip.count(table_info.name)) {
 			//! FIXME: perhaps log that the table was skipped
@@ -757,7 +757,7 @@ private:
 		return res.first->second;
 	}
 
-	DuckLakeTable &GetTable(const IcebergTableInformation &table_info) {
+	DuckLakeTable &GetTable(const IcebergTable &table_info) {
 		auto &metadata = table_info.table_metadata;
 		auto table_uuid = metadata.table_uuid;
 		auto it = tables.find(table_uuid);

--- a/src/function/metadata/iceberg_load_table_response.cpp
+++ b/src/function/metadata/iceberg_load_table_response.cpp
@@ -14,18 +14,18 @@
 #include "catalog/rest/api/url_utils.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "rest_catalog/objects/list.hpp"
 #include "duckdb/common/json_document.hpp"
 
 namespace duckdb {
 
 struct IcebergLoadTableResponseBindData : public TableFunctionData {
-	IcebergTableEntry &table_entry;
+	IcebergTableSchemaVersion &table_entry;
 	IcebergCatalog &ic_catalog;
 	IcebergSchemaEntry &ic_schema;
 
-	IcebergLoadTableResponseBindData(IcebergTableEntry &table_entry, IcebergCatalog &ic_catalog,
+	IcebergLoadTableResponseBindData(IcebergTableSchemaVersion &table_entry, IcebergCatalog &ic_catalog,
 	                                 IcebergSchemaEntry &ic_schema)
 	    : table_entry(table_entry), ic_catalog(ic_catalog), ic_schema(ic_schema) {
 	}
@@ -87,7 +87,7 @@ static unique_ptr<FunctionData> IcebergLoadTableResponseBind(ClientContext &cont
 		throw InvalidInputException("Table '%s' is not an Iceberg REST catalog table", input_string);
 	}
 
-	auto &table_entry = catalog_entry->Cast<IcebergTableEntry>();
+	auto &table_entry = catalog_entry->Cast<IcebergTableSchemaVersion>();
 	auto &ic_catalog = table_entry.catalog.Cast<IcebergCatalog>();
 	auto &ic_schema = table_entry.schema.Cast<IcebergSchemaEntry>();
 

--- a/src/function/metadata/iceberg_rewrite_data_files.cpp
+++ b/src/function/metadata/iceberg_rewrite_data_files.cpp
@@ -13,7 +13,7 @@
 #include "duckdb/parser/statement/copy_statement.hpp"
 #include "duckdb/parser/tableref/basetableref.hpp"
 #include "duckdb/planner/binder.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "function/iceberg_functions.hpp"
 #include "maintenance/rewrite_data_files_executor.hpp"

--- a/src/function/metadata/iceberg_schema_properties_functions.cpp
+++ b/src/function/metadata/iceberg_schema_properties_functions.cpp
@@ -11,8 +11,8 @@
 
 #include "function/iceberg_functions.hpp"
 #include "common/iceberg_utils.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"

--- a/src/function/metadata/iceberg_table_properties_functions.cpp
+++ b/src/function/metadata/iceberg_table_properties_functions.cpp
@@ -10,8 +10,8 @@
 
 #include "function/iceberg_functions.hpp"
 #include "common/iceberg_utils.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
@@ -22,7 +22,7 @@
 namespace duckdb {
 
 struct SetIcebergTablePropertiesBindData : public TableFunctionData {
-	optional_ptr<IcebergTableEntry> iceberg_table;
+	optional_ptr<IcebergTableSchemaVersion> iceberg_table;
 	case_insensitive_map_t<string> properties;
 	vector<string> remove_properties;
 };
@@ -80,7 +80,7 @@ static unique_ptr<FunctionData> SetIcebergTablePropertiesBind(ClientContext &con
 	if (!CheckTableIsIcebergTable(iceberg_table)) {
 		throw InvalidInputException("Cannot call set_iceberg_table_properties on non-iceberg table");
 	}
-	ret->iceberg_table = iceberg_table->Cast<IcebergTableEntry>();
+	ret->iceberg_table = iceberg_table->Cast<IcebergTableSchemaVersion>();
 	// This mutates the catalog: declare the modification so the statement is treated as a write (e.g. so it
 	// is rejected against a read-only transaction, and so catalog-version tracking observes the change).
 	if (input.binder) {
@@ -114,7 +114,7 @@ static unique_ptr<FunctionData> RemoveIcebergTablePropertiesBind(ClientContext &
 	if (!CheckTableIsIcebergTable(iceberg_table)) {
 		throw InvalidInputException("Cannot call set_iceberg_table_properties on non-iceberg table");
 	}
-	ret->iceberg_table = iceberg_table->Cast<IcebergTableEntry>();
+	ret->iceberg_table = iceberg_table->Cast<IcebergTableSchemaVersion>();
 	// This mutates the catalog: declare the modification so the statement is treated as a write (e.g. so it
 	// is rejected against a read-only transaction, and so catalog-version tracking observes the change).
 	if (input.binder) {
@@ -146,7 +146,7 @@ static unique_ptr<FunctionData> GetIcebergTablePropertiesBind(ClientContext &con
 	if (!CheckTableIsIcebergTable(iceberg_table)) {
 		throw InvalidInputException("Cannot call set_iceberg_table_properties on non-iceberg table");
 	}
-	ret->iceberg_table = iceberg_table->Cast<IcebergTableEntry>();
+	ret->iceberg_table = iceberg_table->Cast<IcebergTableSchemaVersion>();
 
 	return_types.insert(return_types.end(), LogicalType::VARCHAR);
 	return_types.insert(return_types.end(), LogicalType::VARCHAR);
@@ -176,7 +176,7 @@ static void SetIcebergTablePropertiesFunction(ClientContext &context, TableFunct
 	auto &table_info = iceberg_table->table_info;
 
 	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
-	ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
+	ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTable &tbl) {
 		auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
 		transaction_data.TableSetProperties(bind_data.properties);
 	});
@@ -205,7 +205,7 @@ static void RemoveIcebergTablePropertiesFunction(ClientContext &context, TableFu
 	auto iceberg_table = bind_data.iceberg_table;
 	auto &table_info = iceberg_table->table_info;
 	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
-	ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
+	ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTable &tbl) {
 		auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
 		transaction_data.TableRemoveProperties(bind_data.remove_properties);
 	});
@@ -231,8 +231,7 @@ static void GetIcebergTablePropertiesFunction(ClientContext &context, TableFunct
 	auto &iceberg_transaction = IcebergTransaction::Get(context, iceberg_table->catalog);
 	auto table_key = iceberg_table->table_info.GetTableKey();
 	auto table_txn_state = iceberg_transaction.GetLatestTableState(table_key);
-	const IcebergTableInformation &txn_table_info =
-	    table_txn_state ? table_txn_state->GetInfo() : iceberg_table->table_info;
+	const IcebergTable &txn_table_info = table_txn_state ? table_txn_state->GetInfo() : iceberg_table->table_info;
 
 	const auto &properties = txn_table_info.table_metadata.GetTableProperties();
 	if (properties.empty()) {

--- a/src/function/scan/iceberg_scan.cpp
+++ b/src/function/scan/iceberg_scan.cpp
@@ -25,7 +25,7 @@
 #include "common/iceberg_utils.hpp"
 #include "planning/iceberg_multi_file_reader.hpp"
 #include "function/iceberg_functions.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 
 #include "duckdb/common/multi_file/multi_file_states.hpp"
 #include "duckdb/function/partition_stats.hpp"
@@ -49,7 +49,7 @@ static void AddNamedParameters(TableFunction &fun) {
 
 virtual_column_map_t IcebergVirtualColumns(ClientContext &context, optional_ptr<FunctionData> bind_data_p) {
 	auto &bind_data = bind_data_p->Cast<MultiFileBindData>();
-	auto result = IcebergTableEntry::VirtualColumns();
+	auto result = IcebergTableSchemaVersion::VirtualColumns();
 	bind_data.virtual_columns = result;
 	return result;
 }

--- a/src/include/catalog/rest/api/catalog_api.hpp
+++ b/src/include/catalog/rest/api/catalog_api.hpp
@@ -16,7 +16,7 @@ namespace duckdb {
 class IcebergCatalog;
 struct IcebergCreateTableRequest;
 class IcebergSchemaEntry;
-class IcebergTableEntry;
+class IcebergTableSchemaVersion;
 
 struct IRCAPISchema {
 	//! The (potentially multiple) levels that the namespace is made up of

--- a/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
+++ b/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
@@ -13,14 +13,14 @@
 
 namespace duckdb {
 
-struct IcebergTableInformation;
+struct IcebergTable;
 struct IcebergManifestList;
 
 struct IcebergAddSnapshot : public IcebergTableUpdate {
 	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::ADD_SNAPSHOT;
 
 public:
-	IcebergAddSnapshot(const IcebergTableInformation &table_info,
+	IcebergAddSnapshot(const IcebergTable &table_info,
 	                   IcebergSnapshotOperationType operation = IcebergSnapshotOperationType::OVERWRITE);
 
 public:

--- a/src/include/catalog/rest/api/iceberg_scan_planning.hpp
+++ b/src/include/catalog/rest/api/iceberg_scan_planning.hpp
@@ -11,7 +11,7 @@ namespace duckdb {
 
 class ClientContext;
 class IcebergCatalog;
-struct IcebergTableInformation;
+struct IcebergTable;
 
 struct IcebergServerSideScanPlan {
 	vector<IcebergManifestListEntry> data_manifests;
@@ -34,8 +34,8 @@ public:
 	    "GET /v1/{prefix}/namespaces/{namespace}/tables/{table}/credentials";
 
 	//! Returns false only when the server explicitly declines planning with HTTP 406.
-	static bool Plan(ClientContext &context, IcebergTableInformation &table_info,
-	                 rest_api_objects::PlanTableScanRequest request, IcebergServerSideScanPlan &result);
+	static bool Plan(ClientContext &context, IcebergTable &table_info, rest_api_objects::PlanTableScanRequest request,
+	                 IcebergServerSideScanPlan &result);
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/api/iceberg_table_update.hpp
+++ b/src/include/catalog/rest/api/iceberg_table_update.hpp
@@ -7,7 +7,7 @@
 
 namespace duckdb {
 
-struct IcebergTableInformation;
+struct IcebergTable;
 struct IcebergTransactionData;
 
 enum class IcebergTableUpdateType : uint8_t {
@@ -35,12 +35,12 @@ enum class IcebergTableUpdateType : uint8_t {
 
 struct IcebergCommitState {
 public:
-	IcebergCommitState(const IcebergTableInformation &table_info, ClientContext &context);
+	IcebergCommitState(const IcebergTable &table_info, ClientContext &context);
 	void RefreshFromTable();
 	void LoadExistingManifests(DatabaseInstance &db, vector<IcebergManifestListEntry> &&existing_manifests);
 
 public:
-	const IcebergTableInformation &table_info;
+	const IcebergTable &table_info;
 	optional_ptr<const IcebergSnapshot> latest_snapshot;
 	//! Snapshot(s) created in this commit
 	vector<IcebergSnapshot> created_snapshots;

--- a/src/include/catalog/rest/api/table_update.hpp
+++ b/src/include/catalog/rest/api/table_update.hpp
@@ -16,7 +16,7 @@
 
 namespace duckdb {
 
-struct IcebergTableInformation;
+struct IcebergTable;
 
 struct AddSchemaUpdate : public IcebergTableUpdate {
 public:

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table.hpp
@@ -3,7 +3,7 @@
 #include "duckdb/catalog/catalog_entry.hpp"
 #include "duckdb/storage/external_file_cache/caching_file_system_wrapper.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "core/metadata/manifest/iceberg_manifest.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
@@ -21,9 +21,9 @@ struct IRCAPITableCredentials {
 	vector<CreateSecretInput> storage_credentials;
 };
 
-struct IcebergTableInformation {
+struct IcebergTable {
 public:
-	IcebergTableInformation(IcebergCatalog &catalog, IcebergSchemaEntry &schema, const string &name);
+	IcebergTable(IcebergCatalog &catalog, IcebergSchemaEntry &schema, const string &name);
 
 public:
 	void LoadCredentials(ClientContext &context) const;
@@ -62,9 +62,9 @@ public:
 	IcebergTableMetadata CreateMetadataFromLog(ClientContext &context, timestamp_ms_t transaction_start_ms) const;
 	// With metadata-log enabled, reconstruct the complete table state at transaction start. Otherwise pin and copy
 	// the complete catalog state that was resolved for this transaction.
-	IcebergTableInformation Copy(IcebergTransaction &iceberg_transaction) const;
+	IcebergTable Copy(IcebergTransaction &iceberg_transaction) const;
 	// This copy is used for deletes, where we don't care about valid table state
-	IcebergTableInformation Copy() const;
+	IcebergTable Copy() const;
 	void InitSchemaVersions();
 
 	bool HasTransactionUpdates() const;
@@ -78,9 +78,9 @@ public:
 	IcebergTableMetadata table_metadata;
 	case_insensitive_map_t<string> config;
 	vector<rest_api_objects::StorageCredential> storage_credentials;
-	unordered_map<int32_t, unique_ptr<IcebergTableEntry>> schema_versions;
+	unordered_map<int32_t, unique_ptr<IcebergTableSchemaVersion>> schema_versions;
 	// dummy entry to hold existence of a table, but no schema versions
-	unique_ptr<IcebergTableEntry> dummy_entry;
+	unique_ptr<IcebergTableSchemaVersion> dummy_entry;
 	unique_ptr<IcebergTransactionData> transaction_data;
 	//! The cached response this table was initialized from, used as an identity and never dereferenced.
 	optional_ptr<const rest_api_objects::LoadTableResult> initialization_source;

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp
@@ -7,12 +7,12 @@
 
 namespace duckdb {
 
-struct IcebergTableInformation;
+struct IcebergTable;
 
-class IcebergTableEntry : public TableCatalogEntry {
+class IcebergTableSchemaVersion : public TableCatalogEntry {
 public:
-	IcebergTableEntry(IcebergTableInformation &table_info, Catalog &catalog, SchemaCatalogEntry &schema,
-	                  CreateTableInfo &info, optional_idx schema_id);
+	IcebergTableSchemaVersion(IcebergTable &table_info, Catalog &catalog, SchemaCatalogEntry &schema,
+	                          CreateTableInfo &info, optional_idx schema_id);
 
 	static virtual_column_map_t VirtualColumns();
 	virtual_column_map_t GetVirtualColumns() const override;
@@ -35,7 +35,7 @@ public:
 	                           ClientContext &context) override;
 
 public:
-	IcebergTableInformation &table_info;
+	IcebergTable &table_info;
 	//! 'schema_id' used to create the entry, or invalid if this is a dummy
 	optional_idx schema_id;
 };

--- a/src/include/catalog/rest/iceberg_catalog.hpp
+++ b/src/include/catalog/rest/iceberg_catalog.hpp
@@ -17,7 +17,7 @@
 namespace duckdb {
 
 class IcebergSchemaEntry;
-struct IcebergTableInformation;
+struct IcebergTable;
 
 class MetadataCacheValue {
 public:
@@ -81,7 +81,7 @@ public:
 	}
 
 	//! Evict only if the table was initialized from the result that is still cached for its key.
-	void EvictIfCurrent(const IcebergTableInformation &table);
+	void EvictIfCurrent(const IcebergTable &table);
 
 private:
 	IcebergAttachOptions &attach_options;

--- a/src/include/catalog/rest/iceberg_table_set.hpp
+++ b/src/include/catalog/rest/iceberg_table_set.hpp
@@ -3,8 +3,8 @@
 
 #include "duckdb/catalog/catalog_entry.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
 
 namespace duckdb {
@@ -19,30 +19,29 @@ public:
 public:
 	optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const EntryLookupInfo &lookup);
 	void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
-	static IcebergTableInformation &CreateNewEntry(ClientContext &context, IcebergCatalog &catalog,
-	                                               IcebergSchemaEntry &schema, CreateTableInfo &info);
-	shared_ptr<IcebergTableInformation> CreateEntryInternal(lock_guard<mutex> &guard, const string &name,
-	                                                        IcebergTableInformation &&table,
-	                                                        shared_ptr<IcebergTableInformation> &old_entry);
-	const case_insensitive_map_t<shared_ptr<IcebergTableInformation>> &GetEntries();
-	case_insensitive_map_t<shared_ptr<IcebergTableInformation>> &GetEntriesMutable();
+	static IcebergTable &CreateNewEntry(ClientContext &context, IcebergCatalog &catalog, IcebergSchemaEntry &schema,
+	                                    CreateTableInfo &info);
+	shared_ptr<IcebergTable> CreateEntryInternal(lock_guard<mutex> &guard, const string &name, IcebergTable &&table,
+	                                             shared_ptr<IcebergTable> &old_entry);
+	const case_insensitive_map_t<shared_ptr<IcebergTable>> &GetEntries();
+	case_insensitive_map_t<shared_ptr<IcebergTable>> &GetEntriesMutable();
 	mutex &GetEntryLock();
 
 private:
-	IcebergTableEntry &GetOrCreateDummy(IcebergTableInformation &table_info) const;
+	IcebergTableSchemaVersion &GetOrCreateDummy(IcebergTable &table_info) const;
 
 public:
 	void LoadEntries(ClientContext &context);
 	//! return true if request to LoadTableInformation was successful and entry has been filled
 	//! or if entry is already filled. Returns False otherwise
-	bool FillEntry(ClientContext &context, IcebergTableInformation &table);
+	bool FillEntry(ClientContext &context, IcebergTable &table);
 
 public:
 	IcebergSchemaEntry &schema;
 	Catalog &catalog;
 
 private:
-	case_insensitive_map_t<shared_ptr<IcebergTableInformation>> entries;
+	case_insensitive_map_t<shared_ptr<IcebergTable>> entries;
 	mutex entry_lock;
 };
 

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -9,18 +9,18 @@
 namespace duckdb {
 class IcebergCatalog;
 class IcebergSchemaEntry;
-class IcebergTableEntry;
+class IcebergTableSchemaVersion;
 
 enum class IcebergTableStatus : uint8_t { ALIVE, DROPPED, RENAMED, MISSING };
 
 struct IcebergTransactionTableState {
 public:
 	IcebergTransactionTableState();
-	explicit IcebergTransactionTableState(shared_ptr<IcebergTableInformation> catalog_table);
-	explicit IcebergTransactionTableState(IcebergTableInformation &&transaction_table);
+	explicit IcebergTransactionTableState(shared_ptr<IcebergTable> catalog_table);
+	explicit IcebergTransactionTableState(IcebergTable &&transaction_table);
 
 public:
-	IcebergTableInformation &GetInfo() {
+	IcebergTable &GetInfo() {
 		if (transaction_table) {
 			return *transaction_table;
 		}
@@ -30,8 +30,8 @@ public:
 		}
 		return *catalog_table;
 	}
-	const IcebergTableInformation &GetInfo() const;
-	IcebergTableInformation &GetOrCreateTransactionInfo(IcebergTransaction &transaction);
+	const IcebergTable &GetInfo() const;
+	IcebergTable &GetOrCreateTransactionInfo(IcebergTransaction &transaction);
 
 public:
 	bool IsDroppedOrRenamed() const {
@@ -49,10 +49,10 @@ public:
 
 private:
 	//! The catalog state is retained as the source for lazily materializing transaction-local state.
-	shared_ptr<IcebergTableInformation> catalog_table;
+	shared_ptr<IcebergTable> catalog_table;
 	//! Lazily materialized transaction-local state. Its stable address is referenced by table updates and schema
 	//! entries.
-	unique_ptr<IcebergTableInformation> transaction_table;
+	unique_ptr<IcebergTable> transaction_table;
 	IcebergTableStatus status;
 };
 
@@ -87,15 +87,15 @@ public:
 	void DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
 	void DoSingleTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update, ClientContext &context);
 	optional_ptr<IcebergTransactionTableState> GetLatestTableState(const string &table_key);
-	IcebergTransactionTableState &SetCatalogTableState(shared_ptr<IcebergTableInformation> table);
-	IcebergTransactionTableState &SetTransactionTableState(const string &table_key, IcebergTableInformation &&table,
+	IcebergTransactionTableState &SetCatalogTableState(shared_ptr<IcebergTable> table);
+	IcebergTransactionTableState &SetTransactionTableState(const string &table_key, IcebergTable &&table,
 	                                                       IcebergTableStatus status);
-	IcebergTransactionTableState &GetOrCreateTransactionTableState(const IcebergTableInformation &table);
+	IcebergTransactionTableState &GetOrCreateTransactionTableState(const IcebergTable &table);
 	IcebergTransactionTableState &SetLatestTableState(const string &table_key, IcebergTableStatus status);
 	bool StartedBefore(timestamp_ms_t timestamp_ms) const;
 	IcebergTransactionAlterUpdate &GetOrCreateAlter();
-	IcebergTableInformation &DeleteTable(IcebergTableInformation &table);
-	IcebergTableInformation &RenameTable(IcebergTableInformation &table, const string &new_name);
+	IcebergTable &DeleteTable(IcebergTable &table);
+	IcebergTable &RenameTable(IcebergTable &table, const string &new_name);
 	bool MultiTableCommitAvailable() const;
 
 private:
@@ -126,7 +126,7 @@ public:
 	//! alive when a transaction creates a schema after referencing a stale entry with the same name.
 	case_insensitive_map_t<shared_ptr<IcebergSchemaEntry>> created_schemas;
 	//! Tables referenced by this transaction that have to stay alive for the duration of the transaction.
-	case_insensitive_map_t<shared_ptr<IcebergTableInformation>> tables;
+	case_insensitive_map_t<shared_ptr<IcebergTable>> tables;
 	//! The visible state of every resolved table in this transaction.
 	case_insensitive_map_t<IcebergTransactionTableState> current_table_data;
 	//! Declared after the schema and table states so update references are destroyed before the referenced states.
@@ -144,7 +144,7 @@ public:
 	case_insensitive_map_t<SchemaPropertyUpdates> schema_property_updates;
 };
 
-void ApplyTableUpdate(IcebergTableInformation &table_info, IcebergTransaction &iceberg_transaction,
-                      const std::function<void(IcebergTableInformation &)> &callback);
+void ApplyTableUpdate(IcebergTable &table_info, IcebergTransaction &iceberg_transaction,
+                      const std::function<void(IcebergTable &)> &callback);
 
 } // namespace duckdb

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -17,18 +17,17 @@
 
 namespace duckdb {
 
-struct IcebergTableInformation;
+struct IcebergTable;
 struct IcebergCreateTableRequest;
 
 struct IcebergTransactionData {
 public:
-	IcebergTransactionData(ClientContext &context, IcebergTransaction &transaction,
-	                       const IcebergTableInformation &table_info);
+	IcebergTransactionData(ClientContext &context, IcebergTransaction &transaction, const IcebergTable &table_info);
 
 public:
 	int64_t GetCommitRetryCount() const;
 	bool SupportsAppendRetry() const;
-	bool RetryStateMatches(const IcebergTableInformation &table_info) const;
+	bool RetryStateMatches(const IcebergTable &table_info) const;
 	//! Whether this transaction stages a DELETE snapshot; gates the commit-retry safety check.
 	bool ContainsDelete() const;
 
@@ -70,7 +69,7 @@ public:
 
 	ClientContext &context;
 	IcebergTransaction &transaction;
-	const IcebergTableInformation &table_info;
+	const IcebergTable &table_info;
 	//! schema updates etc.
 	vector<unique_ptr<IcebergTableUpdate>> updates;
 	vector<unique_ptr<IcebergTableRequirement>> requirements;

--- a/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_update.hpp
@@ -5,7 +5,7 @@
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 
 namespace duckdb {
 
@@ -18,38 +18,38 @@ public:
 	~IcebergTransactionAlterUpdate();
 
 public:
-	IcebergTableInformation &CreateTable(const string &table_key, IcebergTableInformation &&table);
-	IcebergTableInformation &GetOrInitializeTable(const IcebergTableInformation &table);
+	IcebergTable &CreateTable(const string &table_key, IcebergTable &&table);
+	IcebergTable &GetOrInitializeTable(const IcebergTable &table);
 	bool HasUpdates() const;
 
 public:
 	IcebergTransaction &transaction;
 	//! All the tables touched in this atomic block
-	case_insensitive_map_t<reference<IcebergTableInformation>> updated_tables;
+	case_insensitive_map_t<reference<IcebergTable>> updated_tables;
 };
 
 //! Drop a table
 struct IcebergTransactionDeleteUpdate {
 public:
-	IcebergTransactionDeleteUpdate(IcebergTransaction &transaction, IcebergTableInformation &table);
+	IcebergTransactionDeleteUpdate(IcebergTransaction &transaction, IcebergTable &table);
 	~IcebergTransactionDeleteUpdate();
 
 public:
 	IcebergTransaction &transaction;
-	reference<IcebergTableInformation> deleted_table;
+	reference<IcebergTable> deleted_table;
 };
 
 //! Rename a table
 struct IcebergTransactionRenameUpdate {
 public:
-	IcebergTransactionRenameUpdate(IcebergTransaction &transaction, IcebergTableInformation &table,
-	                               IcebergTableInformation &new_table, const string &new_name);
+	IcebergTransactionRenameUpdate(IcebergTransaction &transaction, IcebergTable &table, IcebergTable &new_table,
+	                               const string &new_name);
 	~IcebergTransactionRenameUpdate();
 
 public:
 	IcebergTransaction &transaction;
-	reference<IcebergTableInformation> table;
-	reference<IcebergTableInformation> new_table;
+	reference<IcebergTable> table;
+	reference<IcebergTable> new_table;
 	string new_name;
 };
 

--- a/src/include/common/iceberg_utils.hpp
+++ b/src/include/common/iceberg_utils.hpp
@@ -13,7 +13,7 @@
 #include "duckdb/catalog/catalog_entry/copy_function_catalog_entry.hpp"
 #include "duckdb/storage/external_file_cache/caching_file_system.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
 
 namespace duckdb {

--- a/src/include/core/metadata/manifest/iceberg_manifest.hpp
+++ b/src/include/core/metadata/manifest/iceberg_manifest.hpp
@@ -16,7 +16,7 @@
 
 namespace duckdb {
 
-struct IcebergTableInformation;
+struct IcebergTable;
 struct IcebergManifestFile;
 
 using sequence_number_t = int64_t;

--- a/src/include/core/metadata/snapshot/iceberg_snapshot.hpp
+++ b/src/include/core/metadata/snapshot/iceberg_snapshot.hpp
@@ -7,7 +7,7 @@
 namespace duckdb {
 
 struct IcebergTableMetadata;
-struct IcebergTableInformation;
+struct IcebergTable;
 
 enum class IcebergSnapshotOperationType : uint8_t { APPEND, REPLACE, OVERWRITE, DELETE };
 

--- a/src/include/execution/operator/iceberg_delete.hpp
+++ b/src/include/execution/operator/iceberg_delete.hpp
@@ -12,7 +12,7 @@
 #include "duckdb/planner/operator/logical_delete.hpp"
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
 #include "core/metadata/manifest/iceberg_manifest.hpp"
 
@@ -113,7 +113,7 @@ public:
 class IcebergDelete : public PhysicalOperator {
 public:
 #ifdef ICEBERG_ENABLE_EQUALITY_DELETE_WRITES
-	IcebergDelete(PhysicalPlan &physical_plan, IcebergTableEntry &table,
+	IcebergDelete(PhysicalPlan &physical_plan, IcebergTableSchemaVersion &table,
 	              optional_ptr<IcebergMultiFileList> multi_file_list, PhysicalOperator &child,
 	              vector<idx_t> row_id_indexes, bool is_equality_delete,
 	              vector<IcebergEqualityDeletePredicate> equality_predicates)
@@ -130,12 +130,12 @@ public:
 	static constexpr bool is_equality_delete = false;
 #endif
 
-	IcebergDelete(PhysicalPlan &physical_plan, IcebergTableEntry &table,
+	IcebergDelete(PhysicalPlan &physical_plan, IcebergTableSchemaVersion &table,
 	              optional_ptr<IcebergMultiFileList> multi_file_list, PhysicalOperator &child,
 	              vector<idx_t> row_id_indexes);
 
 	//! The table to delete from
-	IcebergTableEntry &table;
+	IcebergTableSchemaVersion &table;
 	//! MultiFile list of the Iceberg Scan of the table we are deleting from.
 	//! May be null when the planner has optimized the
 	//! source scan away (e.g. an always-false WHERE clause like `id = NULL`).
@@ -155,12 +155,12 @@ public:
 	}
 
 	static PhysicalOperator &PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner,
-	                                    IcebergTableEntry &table, PhysicalOperator &child_plan,
+	                                    IcebergTableSchemaVersion &table, PhysicalOperator &child_plan,
 	                                    vector<idx_t> &&row_id_indexes);
 
 	//! Detects whether `child_plan`'s pushed-down filters describe a pure conjunction of equality
 	//! predicates, and if so extracts them into `equality_predicates`. Returns false otherwise.
-	static bool TryGetEqualityDeletePredicates(ClientContext &context, IcebergTableEntry &table,
+	static bool TryGetEqualityDeletePredicates(ClientContext &context, IcebergTableSchemaVersion &table,
 	                                           PhysicalOperator &child_plan,
 	                                           vector<IcebergEqualityDeletePredicate> &equality_predicates);
 

--- a/src/include/execution/operator/iceberg_insert.hpp
+++ b/src/include/execution/operator/iceberg_insert.hpp
@@ -13,7 +13,7 @@
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/common/index_vector.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
 #include "core/metadata/partition/iceberg_partition_spec.hpp"
 #include "core/metadata/schema/iceberg_table_schema.hpp"
@@ -142,7 +142,7 @@ public:
 	static IcebergCopyOptions GetCopyOptions(ClientContext &context, const IcebergCopyInput &copy_input);
 
 	static PhysicalOperator &PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner,
-	                                    IcebergTableEntry &table);
+	                                    IcebergTableSchemaVersion &table);
 	static vector<IcebergManifestEntry> GetInsertManifestEntries(IcebergInsertGlobalState &global_state);
 	static void AddWrittenFiles(IcebergInsertGlobalState &global_state, DataChunk &chunk,
 	                            optional_ptr<TableCatalogEntry> table);

--- a/src/include/execution/operator/iceberg_update.hpp
+++ b/src/include/execution/operator/iceberg_update.hpp
@@ -13,19 +13,19 @@
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
 
 #include "execution/operator/iceberg_insert.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
 
 namespace duckdb {
 
 class IcebergUpdate : public PhysicalOperator {
 public:
-	IcebergUpdate(PhysicalPlan &physical_plan, IcebergTableEntry &table, vector<PhysicalIndex> columns,
+	IcebergUpdate(PhysicalPlan &physical_plan, IcebergTableSchemaVersion &table, vector<PhysicalIndex> columns,
 	              PhysicalOperator &child, PhysicalOperator &delete_op, vector<unique_ptr<Expression>> expressions,
 	              vector<unique_ptr<Expression>> bound_defaults);
 
 	//! The table to update
-	IcebergTableEntry &table;
+	IcebergTableSchemaVersion &table;
 	//! The order of to-be-inserted columns
 	vector<PhysicalIndex> columns;
 	//! The delete operator for deleting the old data
@@ -36,8 +36,8 @@ public:
 
 public:
 	static IcebergUpdate &PlanUpdateOperator(ClientContext &context, PhysicalPlanGenerator &planner,
-	                                         IcebergTableEntry &table, LogicalUpdate &op, PhysicalOperator &child_plan,
-	                                         IcebergCopyInput &copy_input);
+	                                         IcebergTableSchemaVersion &table, LogicalUpdate &op,
+	                                         PhysicalOperator &child_plan, IcebergCopyInput &copy_input);
 
 public:
 	// Operator interface

--- a/src/include/execution/operator/merge_into/iceberg_merge_insert.hpp
+++ b/src/include/execution/operator/merge_into/iceberg_merge_insert.hpp
@@ -5,7 +5,7 @@
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/common/index_vector.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
 
 namespace duckdb {

--- a/src/include/execution/operator/merge_into/iceberg_merge_update.hpp
+++ b/src/include/execution/operator/merge_into/iceberg_merge_update.hpp
@@ -6,7 +6,7 @@
 #include "duckdb/common/index_vector.hpp"
 
 #include "execution/operator/iceberg_update.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
 
 namespace duckdb {

--- a/src/include/execution/operator/physical_iceberg_create_table.hpp
+++ b/src/include/execution/operator/physical_iceberg_create_table.hpp
@@ -17,7 +17,7 @@
 namespace duckdb {
 
 class IcebergSchemaEntry;
-class IcebergTableEntry;
+class IcebergTableSchemaVersion;
 class PhysicalCopyToFile;
 
 //! Shared mutable state populated at execution time by PhysicalIcebergCreateTable.
@@ -28,7 +28,7 @@ struct IcebergCTASCreateState {
 	//! Set to true once the CreateTable REST call has completed successfully.
 	bool created = false;
 	//! Populated after CreateTable returns.
-	optional_ptr<IcebergTableEntry> table_entry;
+	optional_ptr<IcebergTableSchemaVersion> table_entry;
 };
 
 class IcebergCreateTableGlobalState : public GlobalOperatorState {

--- a/src/include/maintenance/maintenance_table_loader.hpp
+++ b/src/include/maintenance/maintenance_table_loader.hpp
@@ -6,11 +6,11 @@
 
 namespace duckdb {
 
-struct IcebergTableInformation;
+struct IcebergTable;
 
 //! Load metadata into a new table-information instance instead of reusing an
 //! already-filled catalog entry.
-shared_ptr<IcebergTableInformation> ReloadIcebergTableShared(ClientContext &context, const QualifiedName &table_name,
-                                                             const string &function_name);
+shared_ptr<IcebergTable> ReloadIcebergTableShared(ClientContext &context, const QualifiedName &table_name,
+                                                  const string &function_name);
 
 } // namespace duckdb

--- a/src/include/maintenance/rewrite_data_files_executor.hpp
+++ b/src/include/maintenance/rewrite_data_files_executor.hpp
@@ -9,7 +9,7 @@
 
 namespace duckdb {
 
-struct IcebergTableInformation;
+struct IcebergTable;
 struct RewriteExecutionResult {
 	int64_t rewritten_data_files = 0;
 	int64_t added_data_files = 0;
@@ -33,11 +33,10 @@ IcebergManifestEntry BuildRewriteManifestEntry(ClientContext &context, const vec
 void CommitRewrite(ClientContext &context, const RewritePlan &plan, RewriteExecutionResult &result);
 
 //! Best-effort cleanup for files produced before a rewrite failure.
-void CleanupRewriteFiles(ClientContext &context, const IcebergTableInformation &table_info,
-                         const vector<string> &produced_paths);
+void CleanupRewriteFiles(ClientContext &context, const IcebergTable &table_info, const vector<string> &produced_paths);
 
 //! Validate that the currently loaded table snapshot still matches the frozen
 //! rewrite plan. Empty-table plans require the table to remain snapshot-less.
-void ValidateRewriteSnapshot(const RewritePlan &plan, const IcebergTableInformation &table_info, const string &phase);
+void ValidateRewriteSnapshot(const RewritePlan &plan, const IcebergTable &table_info, const string &phase);
 
 } // namespace duckdb

--- a/src/include/maintenance/rewrite_data_files_planner.hpp
+++ b/src/include/maintenance/rewrite_data_files_planner.hpp
@@ -12,7 +12,7 @@
 
 namespace duckdb {
 
-struct IcebergTableInformation;
+struct IcebergTable;
 
 struct RewriteCandidate {
 	string file_path;
@@ -27,7 +27,7 @@ struct RewritePlan {
 	int64_t starting_sequence_number = 0;
 	int64_t target_file_size_bytes = 134217728;
 	//! Keep the loaded metadata alive until commit.
-	shared_ptr<IcebergTableInformation> table_info;
+	shared_ptr<IcebergTable> table_info;
 	vector<RewriteCandidate> candidates;
 	//! Partition-local rewrite groups.
 	vector<vector<RewriteCandidate>> file_groups;

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -29,7 +29,7 @@
 
 namespace duckdb {
 
-class IcebergTableEntry;
+class IcebergTableSchemaVersion;
 class IcebergScanPlanProvider;
 struct IcebergScanPlanContext;
 struct IcebergMultiFileList;
@@ -54,11 +54,11 @@ public:
 	OpenFileInfo GetFile(idx_t i) const override;
 
 public:
-	void SetTable(IcebergTableEntry &table);
+	void SetTable(IcebergTableSchemaVersion &table);
 	shared_ptr<IcebergDeleteData> GetExistingPositionalDeleteData(const string &file_path) const;
 	IcebergPartition GetPartitionForDataFile(const string &file_path) const;
 	void SetScanOrder(unique_ptr<RowGroupOrderOptions> options);
-	optional_ptr<IcebergTableEntry> GetTable() const;
+	optional_ptr<IcebergTableSchemaVersion> GetTable() const;
 	void DisableServerSidePlanning();
 
 	//! Narrow integration surface used by IcebergMultiFileReader.

--- a/src/include/planning/scan_plan/iceberg_scan_plan_provider.hpp
+++ b/src/include/planning/scan_plan/iceberg_scan_plan_provider.hpp
@@ -10,7 +10,7 @@ namespace duckdb {
 
 class ClientContext;
 class FileSystem;
-class IcebergTableEntry;
+class IcebergTableSchemaVersion;
 class IcebergScanOrder;
 struct IcebergTableFilters;
 struct IcebergTransactionData;
@@ -37,7 +37,7 @@ public:
 
 	static unique_ptr<IcebergScanPlanProvider>
 	Create(IcebergScanPlanState &shared_state, IcebergScanPlanContext context,
-	       optional_ptr<IcebergTableEntry> table_entry, const IcebergTableFilters &table_filters,
+	       optional_ptr<IcebergTableSchemaVersion> table_entry, const IcebergTableFilters &table_filters,
 	       const IcebergScanOrder &scan_order, bool server_side_planning_enabled);
 
 	virtual void LoadManifestList() = 0;

--- a/src/include/planning/scan_plan/iceberg_scan_plan_state.hpp
+++ b/src/include/planning/scan_plan/iceberg_scan_plan_state.hpp
@@ -14,7 +14,7 @@
 
 namespace duckdb {
 
-class IcebergTableEntry;
+class IcebergTableSchemaVersion;
 struct IcebergDeleteManifestLoadState;
 
 struct IcebergDeleteFileLoadState {
@@ -56,7 +56,7 @@ struct IcebergScanPlanState {
 	FileSystem &fs;
 	shared_ptr<IcebergScanInfo> scan_info;
 	string path;
-	optional_ptr<IcebergTableEntry> table;
+	optional_ptr<IcebergTableSchemaVersion> table;
 	IcebergOptions options;
 
 	mutable annotated_mutex lock;

--- a/src/maintenance/maintenance_table_loader.cpp
+++ b/src/maintenance/maintenance_table_loader.cpp
@@ -5,8 +5,8 @@
 #include "duckdb/common/exception.hpp"
 
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/iceberg_schema_set.hpp"
 #include "catalog/rest/iceberg_table_set.hpp"
@@ -37,13 +37,13 @@ static IcebergSchemaEntry &LoadIcebergSchema(ClientContext &context, const Quali
 
 } // namespace
 
-shared_ptr<IcebergTableInformation> ReloadIcebergTableShared(ClientContext &context, const QualifiedName &table_name,
-                                                             const string &function_name) {
+shared_ptr<IcebergTable> ReloadIcebergTableShared(ClientContext &context, const QualifiedName &table_name,
+                                                  const string &function_name) {
 	auto &iceberg_schema = LoadIcebergSchema(context, table_name, function_name);
 	auto &tables = iceberg_schema.tables;
 	auto table_name_string = table_name.Name().GetIdentifierName();
-	auto table_info = make_shared_ptr<IcebergTableInformation>(iceberg_schema.ParentCatalog().Cast<IcebergCatalog>(),
-	                                                           iceberg_schema, table_name_string);
+	auto table_info = make_shared_ptr<IcebergTable>(iceberg_schema.ParentCatalog().Cast<IcebergCatalog>(),
+	                                                iceberg_schema, table_name_string);
 	if (!tables.FillEntry(context, *table_info)) {
 		throw InvalidInputException("%s: table '%s' not found in schema '%s.%s'", function_name, table_name_string,
 		                            table_name.Catalog().GetIdentifierName(), table_name.Schema().GetIdentifierName());

--- a/src/maintenance/rewrite_data_files_executor.cpp
+++ b/src/maintenance/rewrite_data_files_executor.cpp
@@ -3,7 +3,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/logging/logger.hpp"
 #include "iceberg_logging.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
 #include "catalog/rest/transaction/iceberg_transaction_data.hpp"
@@ -45,7 +45,7 @@ IcebergManifestEntry BuildRewriteManifestEntry(ClientContext &context, const vec
 	return entry;
 }
 
-void ValidateRewriteSnapshot(const RewritePlan &plan, const IcebergTableInformation &table_info, const string &phase) {
+void ValidateRewriteSnapshot(const RewritePlan &plan, const IcebergTable &table_info, const string &phase) {
 	auto snapshot = table_info.table_metadata.GetLatestSnapshot();
 	if (plan.starting_snapshot_id < 0) {
 		if (snapshot) {
@@ -61,8 +61,7 @@ void ValidateRewriteSnapshot(const RewritePlan &plan, const IcebergTableInformat
 	}
 }
 
-void CleanupRewriteFiles(ClientContext &context, const IcebergTableInformation &table_info,
-                         const vector<string> &produced_paths) {
+void CleanupRewriteFiles(ClientContext &context, const IcebergTable &table_info, const vector<string> &produced_paths) {
 	auto &fs = FileSystem::GetFileSystem(context);
 	for (auto &path : produced_paths) {
 		try {
@@ -89,7 +88,7 @@ void CommitRewrite(ClientContext &context, const RewritePlan &plan, RewriteExecu
 		deletes.InvalidateFile(cand.file_path);
 	}
 
-	ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTableInformation &tbl) {
+	ApplyTableUpdate(table_info, iceberg_transaction, [&](IcebergTable &tbl) {
 		ValidateRewriteSnapshot(plan, tbl, "transaction commit");
 		auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
 		transaction_data.AddSnapshot(IcebergSnapshotOperationType::REPLACE, std::move(result.new_entries),

--- a/src/maintenance/rewrite_data_files_operator.cpp
+++ b/src/maintenance/rewrite_data_files_operator.cpp
@@ -5,7 +5,7 @@
 #include "duckdb/parallel/meta_pipeline.hpp"
 #include "duckdb/parallel/pipeline.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "maintenance/maintenance_table_loader.hpp"
 #include "maintenance/rewrite_data_files_executor.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"

--- a/src/maintenance/rewrite_data_files_planner.cpp
+++ b/src/maintenance/rewrite_data_files_planner.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/value.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "iceberg_options.hpp"

--- a/src/planning/deletes/iceberg_delete_file_scanner.cpp
+++ b/src/planning/deletes/iceberg_delete_file_scanner.cpp
@@ -1,6 +1,6 @@
 #include "planning/deletes/iceberg_delete_file_scanner.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "common/iceberg_utils.hpp"
 #include "core/deletes/iceberg_deletion_vector.hpp"
 #include "core/deletes/iceberg_positional_delete.hpp"

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -8,7 +8,7 @@
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/storage/table/row_group_reorderer.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
 #include "common/iceberg_utils.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
@@ -142,11 +142,11 @@ IcebergDeletePlanningContext IcebergMultiFileList::GetDeletePlanningContext() co
 	        GetScanPlanProvider()};
 }
 
-optional_ptr<IcebergTableEntry> IcebergMultiFileList::GetTable() const {
+optional_ptr<IcebergTableSchemaVersion> IcebergMultiFileList::GetTable() const {
 	return shared_state->table;
 }
 
-void IcebergMultiFileList::SetTable(IcebergTableEntry &table) {
+void IcebergMultiFileList::SetTable(IcebergTableSchemaVersion &table) {
 	shared_state->table = table;
 }
 

--- a/src/planning/iceberg_optimizer.cpp
+++ b/src/planning/iceberg_optimizer.cpp
@@ -9,7 +9,7 @@
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "core/metadata/schema/iceberg_column_definition.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_information.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 #include "planning/iceberg_multi_file_list.hpp"
 #include "planning/iceberg_multi_file_reader.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"

--- a/src/planning/metadata_io/deletes/iceberg_deletes_file_reader.cpp
+++ b/src/planning/metadata_io/deletes/iceberg_deletes_file_reader.cpp
@@ -6,14 +6,14 @@
 #include "duckdb/main/database.hpp"
 
 #include "function/iceberg_functions.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 
 namespace duckdb {
 
 static virtual_column_map_t IcebergDeleteVirtualColumns(ClientContext &context,
                                                         optional_ptr<FunctionData> bind_data_p) {
 	auto &bind_data = bind_data_p->Cast<MultiFileBindData>();
-	auto result = IcebergTableEntry::VirtualColumns();
+	auto result = IcebergTableSchemaVersion::VirtualColumns();
 	bind_data.virtual_columns = result;
 	return result;
 }

--- a/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
+++ b/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
@@ -4,7 +4,7 @@
 #include "planning/pruning/iceberg_table_filter.hpp"
 #include "planning/scan_order/iceberg_scan_order.hpp"
 #include "catalog/rest/transaction/iceberg_transaction.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "catalog/rest/api/iceberg_expression.hpp"
 #include "catalog/rest/api/iceberg_type.hpp"

--- a/src/planning/scan_plan/iceberg_scan_plan_provider.cpp
+++ b/src/planning/scan_plan/iceberg_scan_plan_provider.cpp
@@ -2,7 +2,7 @@
 
 #include "catalog/rest/api/iceberg_expression.hpp"
 #include "catalog/rest/api/iceberg_type.hpp"
-#include "catalog/rest/catalog_entry/table/iceberg_table_entry.hpp"
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "catalog/rest/iceberg_catalog.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/storage/table/row_group_reorderer.hpp"
@@ -15,7 +15,7 @@ namespace {
 
 enum class ScanPlanningMode : uint8_t { UNSPECIFIED, SERVER_SIDE_ONLY, CLIENT_SIDE_ONLY };
 
-static ScanPlanningMode GetScanPlanningMode(optional_ptr<IcebergTableEntry> table) {
+static ScanPlanningMode GetScanPlanningMode(optional_ptr<IcebergTableSchemaVersion> table) {
 	if (!table) {
 		return ScanPlanningMode::CLIENT_SIDE_ONLY;
 	}
@@ -37,10 +37,12 @@ static ScanPlanningMode GetScanPlanningMode(optional_ptr<IcebergTableEntry> tabl
 
 } // namespace
 
-unique_ptr<IcebergScanPlanProvider>
-IcebergScanPlanProvider::Create(IcebergScanPlanState &shared_state, IcebergScanPlanContext context,
-                                optional_ptr<IcebergTableEntry> table_entry, const IcebergTableFilters &table_filters,
-                                const IcebergScanOrder &scan_order, bool server_side_planning_enabled) {
+unique_ptr<IcebergScanPlanProvider> IcebergScanPlanProvider::Create(IcebergScanPlanState &shared_state,
+                                                                    IcebergScanPlanContext context,
+                                                                    optional_ptr<IcebergTableSchemaVersion> table_entry,
+                                                                    const IcebergTableFilters &table_filters,
+                                                                    const IcebergScanOrder &scan_order,
+                                                                    bool server_side_planning_enabled) {
 	if (!context.snapshot.snapshot) {
 		return make_uniq<ClientSideScanPlanProvider>(shared_state, context);
 	}


### PR DESCRIPTION
This PR takes care of some confusion in the old name of `IcebergTableEntry` that I've wanted to tackle for a while now.
Hopefully this doesn't cause any merge conflicts on open PRs.