### PR TITLE
[Dev] Use `annotated_mutex` inside the `IcebergCatalog` and friends

### DIFF
--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -109,6 +109,7 @@ void IcebergSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
 }
 
 void IcebergSchemaEntry::DropEntry(ClientContext &context, DropInfo &info, bool delete_entry) {
+	annotated_lock_guard<annotated_mutex> guard(tables.GetEntryLock());
 	auto table_name = info.GetQualifiedName().Name();
 	// find if info has a table name, if so look for it in
 	auto table_info_it = tables.GetEntries().find(table_name.GetIdentifierName());

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -109,32 +109,7 @@ void IcebergSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
 }
 
 void IcebergSchemaEntry::DropEntry(ClientContext &context, DropInfo &info, bool delete_entry) {
-	annotated_lock_guard<annotated_mutex> guard(tables.GetEntryLock());
-	auto table_name = info.GetQualifiedName().Name();
-	// find if info has a table name, if so look for it in
-	auto table_info_it = tables.GetEntries().find(table_name.GetIdentifierName());
-	if (table_info_it == tables.GetEntries().end()) {
-		if (info.if_not_found == OnEntryNotFound::RETURN_NULL) {
-			return;
-		}
-		throw CatalogException("Table %s does not exist", table_name);
-	}
-	if (info.cascade) {
-		throw NotImplementedException("DROP TABLE <table_name> CASCADE is not supported for Iceberg tables currently");
-	}
-	if (delete_entry) {
-		// Remove the entry from the catalog
-		tables.GetEntriesMutable().erase(table_name.GetIdentifierName());
-	} else {
-		// Add the table to the transaction's deleted_tables
-		auto &transaction = IcebergTransaction::Get(context, catalog).Cast<IcebergTransaction>();
-		auto &table_info = table_info_it->second;
-		auto &table = transaction.DeleteTable(*table_info);
-		//! FIXME: what?
-		// must init schema versions after copy. Schema versions have a pointer to IcebergTable
-		// if the IcebergTable is moved, then the pointer is no longer valid.
-		table.InitSchemaVersions();
-	}
+	tables.DropEntry(context, info, delete_entry);
 }
 
 optional_ptr<CatalogEntry> IcebergSchemaEntry::CreateFunction(CatalogTransaction transaction,

--- a/src/catalog/rest/iceberg_schema_set.cpp
+++ b/src/catalog/rest/iceberg_schema_set.cpp
@@ -15,7 +15,7 @@ IcebergSchemaSet::IcebergSchemaSet(Catalog &catalog) : catalog(catalog) {
 
 optional_ptr<CatalogEntry> IcebergSchemaSet::GetEntry(ClientContext &context, const string &name,
                                                       OnEntryNotFound if_not_found) {
-	lock_guard<mutex> l(entry_lock);
+	annotated_lock_guard<annotated_mutex> l(entry_lock);
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
 
@@ -92,7 +92,7 @@ void IcebergSchemaSet::Scan(ClientContext &context, const std::function<void(Cat
 }
 
 vector<shared_ptr<IcebergSchemaEntry>> IcebergSchemaSet::GetEntries(ClientContext &context) {
-	lock_guard<mutex> l(entry_lock);
+	annotated_lock_guard<annotated_mutex> l(entry_lock);
 	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
 	LoadEntriesInternal(context);
 	vector<shared_ptr<IcebergSchemaEntry>> result;
@@ -118,12 +118,12 @@ vector<shared_ptr<IcebergSchemaEntry>> IcebergSchemaSet::GetEntries(ClientContex
 
 void IcebergSchemaSet::AddEntry(const string &name, shared_ptr<IcebergSchemaEntry> entry) {
 	D_ASSERT(entry);
-	lock_guard<mutex> l(entry_lock);
+	annotated_lock_guard<annotated_mutex> l(entry_lock);
 	entries[name] = std::move(entry);
 }
 
 void IcebergSchemaSet::RemoveEntry(const string &name) {
-	lock_guard<mutex> l(entry_lock);
+	annotated_lock_guard<annotated_mutex> l(entry_lock);
 	entries.erase(name);
 }
 
@@ -132,7 +132,7 @@ static string GetSchemaName(const vector<string> &items) {
 }
 
 void IcebergSchemaSet::LoadEntries(ClientContext &context) {
-	lock_guard<mutex> l(entry_lock);
+	annotated_lock_guard<annotated_mutex> l(entry_lock);
 	LoadEntriesInternal(context);
 }
 

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -98,9 +98,9 @@ IcebergTableSchemaVersion &IcebergTableSet::GetOrCreateDummy(IcebergTable &table
 }
 
 void IcebergTableSet::Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback) {
-	lock_guard<mutex> lock(entry_lock);
+	annotated_lock_guard<annotated_mutex> lock(entry_lock);
 	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
-	LoadEntries(context);
+	LoadEntriesInternal(context);
 	for (auto &entry : entries) {
 		auto &table_info = *entry.second;
 		auto table_key = table_info.GetTableKey();
@@ -130,11 +130,16 @@ case_insensitive_map_t<shared_ptr<IcebergTable>> &IcebergTableSet::GetEntriesMut
 	return entries;
 }
 
-mutex &IcebergTableSet::GetEntryLock() {
+annotated_mutex &IcebergTableSet::GetEntryLock() {
 	return entry_lock;
 }
 
 void IcebergTableSet::LoadEntries(ClientContext &context) {
+	annotated_lock_guard<annotated_mutex> lock(entry_lock);
+	LoadEntriesInternal(context);
+}
+
+void IcebergTableSet::LoadEntriesInternal(ClientContext &context) {
 	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
 	bool schema_listed = iceberg_transaction.listed_schemas.find(schema.name.GetIdentifierName()) !=
 	                     iceberg_transaction.listed_schemas.end();
@@ -168,8 +173,8 @@ static Value ParseTableProperty(TableFunctionBinder &binder, ClientContext &cont
 	return val;
 }
 
-shared_ptr<IcebergTable> IcebergTableSet::CreateEntryInternal(lock_guard<mutex> &guard, const string &name,
-                                                              IcebergTable &&table,
+shared_ptr<IcebergTable> IcebergTableSet::CreateEntryInternal(annotated_lock_guard<annotated_mutex> &guard,
+                                                              const string &name, IcebergTable &&table,
                                                               shared_ptr<IcebergTable> &old_entry) {
 	auto it = entries.find(name);
 	if (it != entries.end()) {
@@ -281,7 +286,7 @@ IcebergTable &IcebergTableSet::CreateNewEntry(ClientContext &context, IcebergCat
 }
 
 optional_ptr<CatalogEntry> IcebergTableSet::GetEntry(ClientContext &context, const EntryLookupInfo &lookup) {
-	lock_guard<mutex> l(entry_lock);
+	annotated_lock_guard<annotated_mutex> l(entry_lock);
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
 	const auto &table_name = lookup.GetEntryName();

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -122,21 +122,51 @@ void IcebergTableSet::Scan(ClientContext &context, const std::function<void(Cata
 	}
 }
 
-const case_insensitive_map_t<shared_ptr<IcebergTable>> &IcebergTableSet::GetEntries() {
-	return entries;
-}
-
-case_insensitive_map_t<shared_ptr<IcebergTable>> &IcebergTableSet::GetEntriesMutable() {
-	return entries;
-}
-
-annotated_mutex &IcebergTableSet::GetEntryLock() {
-	return entry_lock;
-}
-
-void IcebergTableSet::LoadEntries(ClientContext &context) {
+void IcebergTableSet::ScanTables(ClientContext &context, const std::function<void(IcebergTable &)> &callback) {
 	annotated_lock_guard<annotated_mutex> lock(entry_lock);
 	LoadEntriesInternal(context);
+	for (auto &entry : entries) {
+		callback(*entry.second);
+	}
+}
+
+void IcebergTableSet::DropEntry(ClientContext &context, DropInfo &info, bool delete_entry) {
+	annotated_lock_guard<annotated_mutex> lock(entry_lock);
+	auto table_name = info.GetQualifiedName().Name();
+	auto entry = entries.find(table_name.GetIdentifierName());
+	if (entry == entries.end()) {
+		if (info.if_not_found == OnEntryNotFound::RETURN_NULL) {
+			return;
+		}
+		throw CatalogException("Table %s does not exist", table_name);
+	}
+	if (info.cascade) {
+		throw NotImplementedException("DROP TABLE <table_name> CASCADE is not supported for Iceberg tables currently");
+	}
+	if (delete_entry) {
+		entries.erase(entry);
+		return;
+	}
+
+	// Add the table to the transaction's deleted tables.
+	auto &transaction = IcebergTransaction::Get(context, catalog).Cast<IcebergTransaction>();
+	auto &table = transaction.DeleteTable(*entry->second);
+	//! FIXME: Schema versions point back to their IcebergTable and must be reinitialized after the copy.
+	table.InitSchemaVersions();
+}
+
+void IcebergTableSet::RenameEntry(const string &name, const string &new_name, IcebergTable &&new_table) {
+	annotated_lock_guard<annotated_mutex> lock(entry_lock);
+	auto source = entries.find(name);
+	if (source == entries.end()) {
+		throw CatalogException("Table %s does not exist", name);
+	}
+	entries.erase(source);
+	shared_ptr<IcebergTable> old_version;
+	CreateEntryInternal(new_name, std::move(new_table), old_version);
+	if (old_version) {
+		throw TransactionException("Table %s was already created by a different transaction!", new_name);
+	}
 }
 
 void IcebergTableSet::LoadEntriesInternal(ClientContext &context) {
@@ -173,8 +203,7 @@ static Value ParseTableProperty(TableFunctionBinder &binder, ClientContext &cont
 	return val;
 }
 
-shared_ptr<IcebergTable> IcebergTableSet::CreateEntryInternal(annotated_lock_guard<annotated_mutex> &guard,
-                                                              const string &name, IcebergTable &&table,
+shared_ptr<IcebergTable> IcebergTableSet::CreateEntryInternal(const string &name, IcebergTable &&table,
                                                               shared_ptr<IcebergTable> &old_entry) {
 	auto it = entries.find(name);
 	if (it != entries.end()) {
@@ -309,7 +338,7 @@ optional_ptr<CatalogEntry> IcebergTableSet::GetEntry(ClientContext &context, con
 
 	//! Preserve the old version in case our replacement fails
 	shared_ptr<IcebergTable> old_version;
-	auto new_version = CreateEntryInternal(l, table_name, IcebergTable(ic_catalog, schema, table_name), old_version);
+	auto new_version = CreateEntryInternal(table_name, IcebergTable(ic_catalog, schema, table_name), old_version);
 	auto &table_info = *new_version;
 	if (!FillEntry(context, table_info)) {
 		if (old_version) {

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -576,7 +576,7 @@ void IcebergTransaction::DoTableRename(IcebergTransactionRenameUpdate &rename_up
 	drop_info.if_not_found = OnEntryNotFound::THROW_EXCEPTION;
 	schema.DropEntry(context, drop_info, true);
 
-	lock_guard<mutex> guard(schema.tables.GetEntryLock());
+	annotated_lock_guard<annotated_mutex> guard(schema.tables.GetEntryLock());
 	shared_ptr<IcebergTable> old_version;
 	schema.tables.CreateEntryInternal(guard, new_name, std::move(new_table), old_version);
 	if (old_version) {

--- a/src/catalog/rest/transaction/iceberg_transaction.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction.cpp
@@ -571,17 +571,7 @@ void IcebergTransaction::DoTableRename(IcebergTransactionRenameUpdate &rename_up
 		catalog.table_request_cache.EvictIfCurrent(new_table);
 	}
 
-	DropInfo drop_info;
-	drop_info.GetQualifiedNameMutable() = Identifier(table_name);
-	drop_info.if_not_found = OnEntryNotFound::THROW_EXCEPTION;
-	schema.DropEntry(context, drop_info, true);
-
-	annotated_lock_guard<annotated_mutex> guard(schema.tables.GetEntryLock());
-	shared_ptr<IcebergTable> old_version;
-	schema.tables.CreateEntryInternal(guard, new_name, std::move(new_table), old_version);
-	if (old_version) {
-		throw TransactionException("Table %s was already created by a different transaction!", new_name);
-	}
+	schema.tables.RenameEntry(table_name, new_name, std::move(new_table));
 }
 
 void IcebergTransaction::DoMultiTableCommitUpdates(IcebergTransactionAlterUpdate &alter_update,

--- a/src/function/ducklake/iceberg_to_ducklake.cpp
+++ b/src/function/ducklake/iceberg_to_ducklake.cpp
@@ -833,13 +833,10 @@ static unique_ptr<FunctionData> IcebergToDuckLakeBind(ClientContext &context, Ta
 	for (auto &schema_entry_ptr : schema_entries) {
 		auto &schema_entry = *schema_entry_ptr;
 		auto &tables = schema_entry.tables;
-		tables.LoadEntries(context);
-		annotated_lock_guard<annotated_mutex> guard(tables.GetEntryLock());
-		for (auto &it : tables.GetEntriesMutable()) {
-			auto &table = it.second;
-			tables.FillEntry(context, *table);
-			ret->AddTable(*table, context, options);
-		}
+		tables.ScanTables(context, [&](IcebergTable &table) {
+			tables.FillEntry(context, table);
+			ret->AddTable(table, context, options);
+		});
 	}
 
 	ret->AssignSchemaBeginSnapshots();

--- a/src/function/ducklake/iceberg_to_ducklake.cpp
+++ b/src/function/ducklake/iceberg_to_ducklake.cpp
@@ -834,6 +834,7 @@ static unique_ptr<FunctionData> IcebergToDuckLakeBind(ClientContext &context, Ta
 		auto &schema_entry = *schema_entry_ptr;
 		auto &tables = schema_entry.tables;
 		tables.LoadEntries(context);
+		annotated_lock_guard<annotated_mutex> guard(tables.GetEntryLock());
 		for (auto &it : tables.GetEntriesMutable()) {
 			auto &table = it.second;
 			tables.FillEntry(context, *table);

--- a/src/include/catalog/rest/iceberg_schema_set.hpp
+++ b/src/include/catalog/rest/iceberg_schema_set.hpp
@@ -3,6 +3,8 @@
 
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/string.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/thread_annotation.hpp"
 #include "duckdb/common/vector.hpp"
 
 #include "catalog_entry/schema/iceberg_schema_entry.hpp"
@@ -23,15 +25,16 @@ public:
 	void RemoveEntry(const string &name);
 
 protected:
-	void LoadEntriesInternal(ClientContext &context);
-	shared_ptr<IcebergSchemaEntry> CreateEntryInternal(shared_ptr<IcebergSchemaEntry> entry);
+	void LoadEntriesInternal(ClientContext &context) DUCKDB_REQUIRES(entry_lock);
+	shared_ptr<IcebergSchemaEntry> CreateEntryInternal(shared_ptr<IcebergSchemaEntry> entry)
+	    DUCKDB_REQUIRES(entry_lock);
 
 public:
 	Catalog &catalog;
 
 private:
-	case_insensitive_map_t<shared_ptr<IcebergSchemaEntry>> entries;
-	mutex entry_lock;
+	annotated_mutex entry_lock;
+	case_insensitive_map_t<shared_ptr<IcebergSchemaEntry>> entries DUCKDB_GUARDED_BY(entry_lock);
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/iceberg_table_set.hpp
+++ b/src/include/catalog/rest/iceberg_table_set.hpp
@@ -11,6 +11,7 @@
 
 namespace duckdb {
 struct CreateTableInfo;
+struct DropInfo;
 class IcebergSchemaEntry;
 class IcebergTransaction;
 
@@ -21,21 +22,19 @@ public:
 public:
 	optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const EntryLookupInfo &lookup);
 	void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
+	void ScanTables(ClientContext &context, const std::function<void(IcebergTable &)> &callback);
+	void DropEntry(ClientContext &context, DropInfo &info, bool delete_entry);
+	void RenameEntry(const string &name, const string &new_name, IcebergTable &&new_table);
 	static IcebergTable &CreateNewEntry(ClientContext &context, IcebergCatalog &catalog, IcebergSchemaEntry &schema,
 	                                    CreateTableInfo &info);
-	shared_ptr<IcebergTable> CreateEntryInternal(annotated_lock_guard<annotated_mutex> &guard, const string &name,
-	                                             IcebergTable &&table, shared_ptr<IcebergTable> &old_entry)
-	    DUCKDB_REQUIRES(entry_lock);
-	const case_insensitive_map_t<shared_ptr<IcebergTable>> &GetEntries() DUCKDB_REQUIRES(entry_lock);
-	case_insensitive_map_t<shared_ptr<IcebergTable>> &GetEntriesMutable() DUCKDB_REQUIRES(entry_lock);
-	annotated_mutex &GetEntryLock() DUCKDB_RETURN_CAPABILITY(entry_lock);
 
 private:
 	IcebergTableSchemaVersion &GetOrCreateDummy(IcebergTable &table_info) const DUCKDB_REQUIRES(entry_lock);
 	void LoadEntriesInternal(ClientContext &context) DUCKDB_REQUIRES(entry_lock);
+	shared_ptr<IcebergTable> CreateEntryInternal(const string &name, IcebergTable &&table,
+	                                             shared_ptr<IcebergTable> &old_entry) DUCKDB_REQUIRES(entry_lock);
 
 public:
-	void LoadEntries(ClientContext &context);
 	//! return true if request to LoadTableInformation was successful and entry has been filled
 	//! or if entry is already filled. Returns False otherwise
 	bool FillEntry(ClientContext &context, IcebergTable &table);

--- a/src/include/catalog/rest/iceberg_table_set.hpp
+++ b/src/include/catalog/rest/iceberg_table_set.hpp
@@ -2,6 +2,8 @@
 #pragma once
 
 #include "duckdb/catalog/catalog_entry.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/thread_annotation.hpp"
 
 #include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
@@ -21,14 +23,16 @@ public:
 	void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
 	static IcebergTable &CreateNewEntry(ClientContext &context, IcebergCatalog &catalog, IcebergSchemaEntry &schema,
 	                                    CreateTableInfo &info);
-	shared_ptr<IcebergTable> CreateEntryInternal(lock_guard<mutex> &guard, const string &name, IcebergTable &&table,
-	                                             shared_ptr<IcebergTable> &old_entry);
-	const case_insensitive_map_t<shared_ptr<IcebergTable>> &GetEntries();
-	case_insensitive_map_t<shared_ptr<IcebergTable>> &GetEntriesMutable();
-	mutex &GetEntryLock();
+	shared_ptr<IcebergTable> CreateEntryInternal(annotated_lock_guard<annotated_mutex> &guard, const string &name,
+	                                             IcebergTable &&table, shared_ptr<IcebergTable> &old_entry)
+	    DUCKDB_REQUIRES(entry_lock);
+	const case_insensitive_map_t<shared_ptr<IcebergTable>> &GetEntries() DUCKDB_REQUIRES(entry_lock);
+	case_insensitive_map_t<shared_ptr<IcebergTable>> &GetEntriesMutable() DUCKDB_REQUIRES(entry_lock);
+	annotated_mutex &GetEntryLock() DUCKDB_RETURN_CAPABILITY(entry_lock);
 
 private:
-	IcebergTableSchemaVersion &GetOrCreateDummy(IcebergTable &table_info) const;
+	IcebergTableSchemaVersion &GetOrCreateDummy(IcebergTable &table_info) const DUCKDB_REQUIRES(entry_lock);
+	void LoadEntriesInternal(ClientContext &context) DUCKDB_REQUIRES(entry_lock);
 
 public:
 	void LoadEntries(ClientContext &context);
@@ -41,8 +45,8 @@ public:
 	Catalog &catalog;
 
 private:
-	case_insensitive_map_t<shared_ptr<IcebergTable>> entries;
-	mutex entry_lock;
+	annotated_mutex entry_lock;
+	case_insensitive_map_t<shared_ptr<IcebergTable>> entries DUCKDB_GUARDED_BY(entry_lock);
 };
 
 } // namespace duckdb


### PR DESCRIPTION
This helps us keep our locking correct through static analysis, and the annotations also help to more easily reason about requirement of locks in places.