### PR TITLE
Move a statement's staged manifest deletes onto the transaction

### DIFF
--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -91,6 +91,7 @@ void IcebergAddSnapshot::ConstructManifestList(IcebergManifestList &new_manifest
                                                IcebergSnapshotMetrics &snapshot_metrics) const {
 	//! Construct the manifest list
 	//! FIXME: RETRY_BLOCKER: no guarantee that no new deletes are introduced
+	auto &altered_manifests = commit_state.table_info.transaction_data->GetPendingDeletes(*this);
 	if (altered_manifests.IsEmpty()) {
 		for (auto &manifest_list_entry : commit_state.manifests) {
 			AddManifestListEntry(new_manifest_list, std::move(manifest_list_entry));

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -138,6 +138,14 @@ bool IcebergTransactionData::ContainsDelete() const {
 	return false;
 }
 
+const IcebergManifestDeletes &IcebergTransactionData::GetPendingDeletes(const IcebergAddSnapshot &snapshot) const {
+	auto entry = pending_deletes.find(snapshot);
+	if (entry == pending_deletes.end()) {
+		throw InternalException("No pending deletes were staged for this snapshot");
+	}
+	return entry->second;
+}
+
 bool IcebergTransactionData::SupportsAppendRetry() const {
 	if (!requirements.empty() || pending_current_schema_id.has_value()) {
 		return false;
@@ -220,7 +228,7 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 	if (table_metadata.current_snapshot_id) {
 		TableAddAssertCurrentSchemaId();
 	}
-	add_snapshot->altered_manifests = std::move(altered_manifests);
+	pending_deletes.emplace(*add_snapshot, std::move(altered_manifests));
 
 	alters.push_back(*add_snapshot);
 	updates.push_back(std::move(add_snapshot));
@@ -257,7 +265,7 @@ void IcebergTransactionData::AddDeleteSnapshot(partitioned_manifest_entry_map_t 
 	if (table_metadata.current_snapshot_id) {
 		TableAddAssertCurrentSchemaId();
 	}
-	add_snapshot->altered_manifests = std::move(altered_manifests);
+	pending_deletes.emplace(*add_snapshot, std::move(altered_manifests));
 
 	alters.push_back(*add_snapshot);
 	updates.push_back(std::move(add_snapshot));
@@ -286,7 +294,7 @@ void IcebergTransactionData::AddUpdateSnapshot(partitioned_manifest_entry_map_t 
 	// Add a manifest_file for the new insert data
 	add_snapshot->AddManifestFile(IcebergManifestListEntry::CreateFromEntries(
 	    fs, sequence_number, table_metadata, data_manifest_metadata, std::move(data_files), next_row_id));
-	add_snapshot->altered_manifests = std::move(altered_manifests);
+	pending_deletes.emplace(*add_snapshot, std::move(altered_manifests));
 
 	alters.push_back(*add_snapshot);
 	updates.push_back(std::move(add_snapshot));

--- a/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
+++ b/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
@@ -34,9 +34,6 @@ public:
 		return operation;
 	}
 
-public:
-	IcebergManifestDeletes altered_manifests;
-
 private:
 	vector<IcebergManifestListEntry> manifest_files;
 	int32_t schema_id;

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb/common/optional.hpp"
+#include "duckdb/common/reference_map.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/function/copy_function.hpp"
 
@@ -30,6 +31,8 @@ public:
 	bool RetryStateMatches(const IcebergTable &table_info) const;
 	//! Whether this transaction stages a DELETE snapshot; gates the commit-retry safety check.
 	bool ContainsDelete() const;
+	//! The manifest deletes staged by the statement this snapshot belongs to.
+	const IcebergManifestDeletes &GetPendingDeletes(const IcebergAddSnapshot &snapshot) const;
 
 	void AddSnapshot(IcebergSnapshotOperationType operation, vector<IcebergManifestEntry> &&data_files,
 	                 IcebergManifestDeletes &&altered_manifests);
@@ -78,6 +81,9 @@ public:
 
 	//! Every insert/update/delete creates an alter of the table data
 	vector<reference<IcebergAddSnapshot>> alters;
+	//! Manifest deletes staged by each alter, attributed to the snapshot of the statement that produced them.
+	//! Kept here rather than on the snapshot so every pending change of the transaction lives in one place.
+	reference_map_t<const IcebergAddSnapshot, IcebergManifestDeletes> pending_deletes;
 	//! Snapshot this transaction is based on (the tip when the manifest list was first cached).
 	//! Drives the delete commit-retry safety check.
 	optional<int64_t> base_snapshot_id;


### PR DESCRIPTION
## Summary

Move the manifest deletes a statement stages from `IcebergAddSnapshot` onto
`IcebergTransactionData`, attributed to the snapshot of the statement that produced
them. No behaviour change — the same deletes reach the same manifest rewrite; only
where they are stored changes.

## Why

`IcebergAddSnapshot`'s constructor carries a note:

> This is a bit of a code smell, the `IcebergTableInformation` should instead be const
> and all transactional changes should live in the `IcebergTransactionData`

The deletes a statement stages are transactional change, and they were living on the
snapshot object rather than on the transaction. After this they have one home, and
`IcebergAddSnapshot` carries no transactional state of its own beyond the manifests it
is going to write.

## Why the store is keyed rather than flat

A transaction commits one snapshot per statement, chained (`base → S1 → S2 → …`). Each
snapshot's manifest rewrite has to cover exactly the files *that* statement invalidated.
A single flattened set would mark a file deleted in every snapshot of the chain,
including the ones that precede the statement that deleted it — so an intermediate
snapshot would over-report and time travel would show a file gone before the statement
that removed it. The per-statement attribution is therefore load-bearing, and
`pending_deletes` keeps it.

The key is the statement's own `IcebergAddSnapshot` (`reference_map_t`), so the
attribution is established by the insert and resolved by identity at commit. There is no
index or id for the snapshot to hold and keep aligned with a container.

## Relation to #1287

#1287 (plan-time metadata-only DELETE) adds a second consumer for these deletes: a read
inside an uncommitted transaction has to treat manifest-level dropped files as gone
before the commit rewrites anything. On that branch this is a separate flattened
`invalidated_files` on the transaction, kept in step with the per-snapshot copies by an
explicit `Merge` on every mutation — the overlap raised in review there, along with the
question of whether a transaction-level structure would inherit the same over-reporting
problem.

This PR is the answer to both. One keyed store means commit still reads only its own
entry, so there is no over-reporting; and #1287 rebases onto this to derive its read-side
view from `pending_deletes` rather than maintaining a parallel union, which removes the
dual write.