### PR TITLE
[Dev] Version the `IcebergManifestDeletes`

### DIFF
--- a/src/catalog/rest/api/iceberg_add_snapshot.cpp
+++ b/src/catalog/rest/api/iceberg_add_snapshot.cpp
@@ -43,7 +43,7 @@ static rest_api_objects::TableUpdate CreateAddSnapshotUpdate(const IcebergTable 
 static optional<IcebergManifestListEntry> RewriteManifestFile(const IcebergManifestListEntry &list_entry,
                                                               CopyFunction &avro_copy, DatabaseInstance &db,
                                                               IcebergCommitState &commit_state, int32_t schema_id,
-                                                              const IcebergManifestDeletes &deletes,
+                                                              const VersionedIcebergManifestDeletes &deletes,
                                                               IcebergSnapshotMetrics &snapshot_metrics) {
 	auto loaded_manifest = list_entry.HasManifestEntries()
 	                           ? list_entry
@@ -91,7 +91,7 @@ void IcebergAddSnapshot::ConstructManifestList(IcebergManifestList &new_manifest
                                                IcebergSnapshotMetrics &snapshot_metrics) const {
 	//! Construct the manifest list
 	//! FIXME: RETRY_BLOCKER: no guarantee that no new deletes are introduced
-	if (altered_manifests.IsEmpty()) {
+	if (!manifest_deletes) {
 		for (auto &manifest_list_entry : commit_state.manifests) {
 			AddManifestListEntry(new_manifest_list, std::move(manifest_list_entry));
 		}
@@ -101,7 +101,7 @@ void IcebergAddSnapshot::ConstructManifestList(IcebergManifestList &new_manifest
 
 	for (auto &manifest_list_entry : commit_state.manifests) {
 		auto rewritten_manifest = RewriteManifestFile(manifest_list_entry, avro_copy, db, commit_state, schema_id,
-		                                              altered_manifests, snapshot_metrics);
+		                                              *manifest_deletes, snapshot_metrics);
 		if (!rewritten_manifest) {
 			AddManifestListEntry(new_manifest_list, std::move(manifest_list_entry));
 			continue;
@@ -241,6 +241,10 @@ void IcebergAddSnapshot::CreateUpdate(DatabaseInstance &db, ClientContext &conte
 
 void IcebergAddSnapshot::AddManifestFile(IcebergManifestListEntry &&manifest_file) {
 	manifest_files.push_back(std::move(manifest_file));
+}
+
+void IcebergAddSnapshot::SetManifestDeletes(VersionedIcebergManifestDeletes manifest_deletes_p) {
+	manifest_deletes.emplace(std::move(manifest_deletes_p));
 }
 
 const vector<IcebergManifestListEntry> &IcebergAddSnapshot::GetManifestFiles() const {

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -138,6 +138,10 @@ bool IcebergTransactionData::ContainsDelete() const {
 	return false;
 }
 
+bool IcebergTransactionData::IsFileInvalidated(const string &file_path) const {
+	return manifest_deletes.IsInvalidated(file_path);
+}
+
 bool IcebergTransactionData::SupportsAppendRetry() const {
 	if (!requirements.empty() || pending_current_schema_id.has_value()) {
 		return false;
@@ -220,10 +224,7 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
 	if (table_metadata.current_snapshot_id) {
 		TableAddAssertCurrentSchemaId();
 	}
-	add_snapshot->altered_manifests = std::move(altered_manifests);
-
-	alters.push_back(*add_snapshot);
-	updates.push_back(std::move(add_snapshot));
+	AddSnapshotUpdate(std::move(add_snapshot), std::move(altered_manifests));
 }
 
 void IcebergTransactionData::AddDeleteManifestFiles(IcebergAddSnapshot &add_snapshot,
@@ -239,6 +240,16 @@ void IcebergTransactionData::AddDeleteManifestFiles(IcebergAddSnapshot &add_snap
 		add_snapshot.AddManifestFile(IcebergManifestListEntry::CreateFromEntries(
 		    fs, sequence_number, table_metadata, manifest_metadata, std::move(entry.second), next_row_id));
 	}
+}
+
+void IcebergTransactionData::AddSnapshotUpdate(unique_ptr<IcebergAddSnapshot> add_snapshot,
+                                               IcebergManifestDeletes &&altered_manifests) {
+	auto versioned_deletes = manifest_deletes.AtVersion(alters.size());
+	if (versioned_deletes.Merge(std::move(altered_manifests))) {
+		add_snapshot->SetManifestDeletes(std::move(versioned_deletes));
+	}
+	alters.push_back(*add_snapshot);
+	updates.push_back(std::move(add_snapshot));
 }
 
 void IcebergTransactionData::AddDeleteSnapshot(partitioned_manifest_entry_map_t &&delete_files,
@@ -257,10 +268,7 @@ void IcebergTransactionData::AddDeleteSnapshot(partitioned_manifest_entry_map_t 
 	if (table_metadata.current_snapshot_id) {
 		TableAddAssertCurrentSchemaId();
 	}
-	add_snapshot->altered_manifests = std::move(altered_manifests);
-
-	alters.push_back(*add_snapshot);
-	updates.push_back(std::move(add_snapshot));
+	AddSnapshotUpdate(std::move(add_snapshot), std::move(altered_manifests));
 }
 
 void IcebergTransactionData::AddUpdateSnapshot(partitioned_manifest_entry_map_t &&delete_files,
@@ -286,10 +294,7 @@ void IcebergTransactionData::AddUpdateSnapshot(partitioned_manifest_entry_map_t 
 	// Add a manifest_file for the new insert data
 	add_snapshot->AddManifestFile(IcebergManifestListEntry::CreateFromEntries(
 	    fs, sequence_number, table_metadata, data_manifest_metadata, std::move(data_files), next_row_id));
-	add_snapshot->altered_manifests = std::move(altered_manifests);
-
-	alters.push_back(*add_snapshot);
-	updates.push_back(std::move(add_snapshot));
+	AddSnapshotUpdate(std::move(add_snapshot), std::move(altered_manifests));
 }
 
 void IcebergTransactionData::TableAddSchema(int32_t schema_id) {

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -472,14 +472,6 @@ SinkFinalizeType IcebergDelete::Finalize(Pipeline &pipeline, Event &event, Clien
 			auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
 			transaction_data.AddDeleteSnapshot(std::move(iceberg_delete_files),
 			                                   std::move(global_state.altered_manifests));
-
-			//! Add or overwrite the currently active transaction-local delete files
-			for (auto &entry : global_state.written_files) {
-				auto &delete_file = entry.second;
-				if (table_info.table_metadata.iceberg_version >= 3) {
-					transaction_data.transactional_delete_files[delete_file.data_file_path] = delete_file.file_name;
-				}
-			}
 		});
 	}
 	return SinkFinalizeType::READY;

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -312,12 +312,6 @@ SinkFinalizeType IcebergInsert::Finalize(Pipeline &pipeline, Event &event, Clien
 				auto &transaction_data = tbl.GetOrCreateTransactionData(iceberg_transaction);
 				transaction_data.AddUpdateSnapshot(std::move(delete_manifest_entries), std::move(written_files),
 				                                   std::move(delete_global_state.altered_manifests));
-				for (auto &entry : delete_global_state.written_files) {
-					auto &delete_file = entry.second;
-					if (table_info.table_metadata.iceberg_version >= 3) {
-						transaction_data.transactional_delete_files[delete_file.data_file_path] = delete_file.file_name;
-					}
-				}
 			});
 		}
 	} else {

--- a/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
+++ b/src/include/catalog/rest/api/iceberg_add_snapshot.hpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/value.hpp"
+#include "duckdb/common/optional.hpp"
 
 #include "catalog/rest/api/iceberg_table_update.hpp"
 #include "core/metadata/manifest/iceberg_manifest.hpp"
@@ -30,15 +31,14 @@ public:
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 	const vector<IcebergManifestListEntry> &GetManifestFiles() const;
 	void AddManifestFile(IcebergManifestListEntry &&manifest_file);
+	void SetManifestDeletes(VersionedIcebergManifestDeletes manifest_deletes);
 	IcebergSnapshotOperationType GetOperation() const {
 		return operation;
 	}
 
-public:
-	IcebergManifestDeletes altered_manifests;
-
 private:
 	vector<IcebergManifestListEntry> manifest_files;
+	optional<VersionedIcebergManifestDeletes> manifest_deletes;
 	int32_t schema_id;
 	IcebergSnapshotOperationType operation;
 };

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -30,6 +30,7 @@ public:
 	bool RetryStateMatches(const IcebergTable &table_info) const;
 	//! Whether this transaction stages a DELETE snapshot; gates the commit-retry safety check.
 	bool ContainsDelete() const;
+	bool IsFileInvalidated(const string &file_path) const;
 
 	void AddSnapshot(IcebergSnapshotOperationType operation, vector<IcebergManifestEntry> &&data_files,
 	                 IcebergManifestDeletes &&altered_manifests);
@@ -60,6 +61,7 @@ private:
 	//! Writes one delete manifest per partition spec present in 'delete_files'.
 	void AddDeleteManifestFiles(IcebergAddSnapshot &add_snapshot, partitioned_manifest_entry_map_t &&delete_files,
 	                            sequence_number_t sequence_number);
+	void AddSnapshotUpdate(unique_ptr<IcebergAddSnapshot> add_snapshot, IcebergManifestDeletes &&altered_manifests);
 
 public:
 	string initial_table_uuid;
@@ -70,6 +72,8 @@ public:
 	ClientContext &context;
 	IcebergTransaction &transaction;
 	const IcebergTable &table_info;
+	//! Transaction-wide invalidated file paths, tagged with the alter that first invalidated them
+	IcebergManifestDeletes manifest_deletes;
 	//! schema updates etc.
 	vector<unique_ptr<IcebergTableUpdate>> updates;
 	vector<unique_ptr<IcebergTableRequirement>> requirements;
@@ -81,8 +85,6 @@ public:
 	//! Snapshot this transaction is based on (the tip when the manifest list was first cached).
 	//! Drives the delete commit-retry safety check.
 	optional<int64_t> base_snapshot_id;
-	//! The 'referenced_data_file' -> 'data_file.file_path' of the currently active transaction-local deletes
-	case_insensitive_map_t<string> transactional_delete_files;
 	//! Track the current row id for this transaction
 	int64_t next_row_id = 0;
 

--- a/src/include/catalog/rest/transaction/iceberg_transaction_metadata.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_metadata.hpp
@@ -1,25 +1,66 @@
 #pragma once
 
-#include "duckdb/common/case_insensitive_map.hpp"
-#include "core/deletes/iceberg_delete_data.hpp"
+#include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unordered_map.hpp"
 
 namespace duckdb {
+
+struct VersionedIcebergManifestDeletes;
 
 struct IcebergManifestDeletes {
 public:
 	void InvalidateFile(const string &file_path) {
-		data_files.insert(file_path);
+		data_files.emplace(file_path, optional_idx());
 	}
 	bool IsInvalidated(const string &file_path) const {
 		return data_files.count(file_path);
 	}
+	VersionedIcebergManifestDeletes AtVersion(idx_t alter_version);
 	bool IsEmpty() const {
 		return data_files.empty();
 	}
 
 private:
-	//! The 'data_file.file_path' of invalidated data files
-	unordered_set<string> data_files;
+	idx_t Merge(IcebergManifestDeletes &&other, idx_t alter_version) {
+		idx_t added_count = 0;
+		for (auto &entry : other.data_files) {
+			added_count += data_files.emplace(entry.first, alter_version).second;
+		}
+		return added_count;
+	}
+	bool IsInvalidatedAt(const string &file_path, idx_t alter_version) const {
+		auto entry = data_files.find(file_path);
+		return entry != data_files.end() && entry->second.IsValid() && entry->second.GetIndex() == alter_version;
+	}
+
+private:
+	friend struct VersionedIcebergManifestDeletes;
+
+	//! The 'data_file.file_path' of invalidated files, optionally tagged with the alter that invalidated them
+	unordered_map<string, optional_idx> data_files;
 };
+
+struct VersionedIcebergManifestDeletes {
+public:
+	VersionedIcebergManifestDeletes(IcebergManifestDeletes &manifest_deletes_p, idx_t alter_version_p)
+	    : manifest_deletes(manifest_deletes_p), alter_version(alter_version_p) {
+	}
+
+	idx_t Merge(IcebergManifestDeletes &&other) {
+		return manifest_deletes.Merge(std::move(other), alter_version);
+	}
+	bool IsInvalidated(const string &file_path) const {
+		return manifest_deletes.IsInvalidatedAt(file_path, alter_version);
+	}
+
+private:
+	IcebergManifestDeletes &manifest_deletes;
+	idx_t alter_version;
+};
+
+inline VersionedIcebergManifestDeletes IcebergManifestDeletes::AtVersion(idx_t alter_version) {
+	return VersionedIcebergManifestDeletes(*this, alter_version);
+}
 
 } // namespace duckdb

--- a/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
+++ b/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
@@ -368,10 +368,6 @@ void ClientSideScanPlanProvider::ReadDeleteManifests(const vector<idx_t> &manife
 
 vector<IcebergDeleteFileReference> ClientSideScanPlanProvider::GetDeleteFiles(const vector<idx_t> &manifest_indexes) {
 	vector<IcebergDeleteFileReference> result;
-	optional_ptr<const case_insensitive_map_t<string>> transactional_delete_files;
-	if (context.transaction_data) {
-		transactional_delete_files = context.transaction_data->transactional_delete_files;
-	}
 	auto committed_manifest_count = DeleteManifests().size();
 	auto total_manifest_count = committed_manifest_count + shared_state.transaction_delete_manifests.size();
 	for (auto manifest_idx : manifest_indexes) {
@@ -390,9 +386,8 @@ vector<IcebergDeleteFileReference> ClientSideScanPlanProvider::GetDeleteFiles(co
 				if (manifest_entry.status == IcebergManifestEntryStatusType::DELETED) {
 					continue;
 				}
-				auto &referenced_data_file = manifest_entry.data_file.referenced_data_file;
-				if (referenced_data_file && transactional_delete_files &&
-				    transactional_delete_files->count(*referenced_data_file)) {
+				if (context.transaction_data &&
+				    context.transaction_data->IsFileInvalidated(manifest_entry.data_file.file_path)) {
 					continue;
 				}
 				result.push_back({manifest_idx, entry_idx});
@@ -403,13 +398,12 @@ vector<IcebergDeleteFileReference> ClientSideScanPlanProvider::GetDeleteFiles(co
 			auto &manifest_entries = manifest_list_entry.GetManifestEntries();
 			for (idx_t entry_idx = 0; entry_idx < manifest_entries.size(); entry_idx++) {
 				auto &manifest_entry = manifest_entries[entry_idx];
-				auto &data_file = manifest_entry.data_file;
-				auto &referenced_data_file = data_file.referenced_data_file;
-				if (referenced_data_file && transactional_delete_files) {
-					auto it = transactional_delete_files->find(*referenced_data_file);
-					if (it != transactional_delete_files->end() && it->second != data_file.file_path) {
-						continue;
-					}
+				if (manifest_entry.status == IcebergManifestEntryStatusType::DELETED) {
+					continue;
+				}
+				if (context.transaction_data &&
+				    context.transaction_data->IsFileInvalidated(manifest_entry.data_file.file_path)) {
+					continue;
 				}
 				result.push_back({manifest_idx, entry_idx});
 			}


### PR DESCRIPTION

We can now put all deletes in the `IcebergTransactionData`, while still being able to know which files were deleted in which IcebergAddSnapshot at COMMIT.

This PR removes `transactional_delete_files` from `IcebergTransactionData` and replaces it with the use of the newly added `manifest_deletes`.

This PR supersedes https://github.com/duckdb/duckdb-iceberg/pull/1301