### PR TITLE
[Benchmarking] Add delays to TPCH benchmarks

### DIFF
--- a/benchmark/tpch/sf=1/dm=5/tpch.benchmark.in
+++ b/benchmark/tpch/sf=1/dm=5/tpch.benchmark.in
@@ -99,7 +99,7 @@ ATTACH '' AS my_datalake (
 
 
 run
-SET debug_fs_delay_mean_ms=5;
+SET debug_fs_delay_mean_ms=3;
 SET enable_external_file_cache=false;
 USE my_datalake.tpch_sf1_dm5;
 pragma tpch(${QUERY_NUMBER_PADDED});

--- a/benchmark/tpch/sf=1/dm=5/tpch.benchmark.in
+++ b/benchmark/tpch/sf=1/dm=5/tpch.benchmark.in
@@ -99,7 +99,8 @@ ATTACH '' AS my_datalake (
 
 
 run
-set enable_external_file_cache=false;
+SET debug_fs_delay_mean_ms=5;
+SET enable_external_file_cache=false;
 USE my_datalake.tpch_sf1_dm5;
 pragma tpch(${QUERY_NUMBER_PADDED});
 

--- a/benchmark/tpch/sf=1/tpch.benchmark.in
+++ b/benchmark/tpch/sf=1/tpch.benchmark.in
@@ -63,8 +63,9 @@ COPY FROM DATABASE mem TO my_datalake;
 USE my_datalake;
 DETACH mem;
 
-run 
-set enable_external_file_cache=false;
+run
+SET debug_fs_delay_mean_ms=5;
+SET enable_external_file_cache=false;
 pragma tpch(${QUERY_NUMBER_PADDED});
 
 result duckdb/extension/tpch/dbgen/answers/sf${sf}/q${QUERY_NUMBER_PADDED}.csv sf=${sf}

--- a/benchmark/tpch/sf=1/tpch.benchmark.in
+++ b/benchmark/tpch/sf=1/tpch.benchmark.in
@@ -64,7 +64,7 @@ USE my_datalake;
 DETACH mem;
 
 run
-SET debug_fs_delay_mean_ms=5;
+SET debug_fs_delay_mean_ms=3;
 SET enable_external_file_cache=false;
 pragma tpch(${QUERY_NUMBER_PADDED});
 


### PR DESCRIPTION
Original PR by Tom (#1282 )
Adds delays to make the reduction of requests more impactful on the regression tests.