### PR TITLE
Prevent std::terminate when manifest-read tasks fail during scan state destruction

### DIFF
--- a/src/planning/scan_plan/iceberg_scan_plan_state.cpp
+++ b/src/planning/scan_plan/iceberg_scan_plan_state.cpp
@@ -34,8 +34,14 @@ IcebergScanPlanState::IcebergScanPlanState(ClientContext &context_p, shared_ptr<
 
 IcebergScanPlanState::~IcebergScanPlanState() {
 	if (data_manifest_read_state) {
-		//! FIXME: this could throw if the tasks encountered an error.
-		data_manifest_read_state->executor.WorkOnTasks();
+		try {
+			data_manifest_read_state->executor.WorkOnTasks();
+		} catch (...) {
+			//! WorkOnTasks rethrows errors pushed by the manifest-read tasks. Destructors are implicitly
+			//! noexcept (and this one can run while another exception is already unwinding), so letting the
+			//! error escape calls std::terminate and aborts the whole process. Errors are still surfaced on
+			//! the regular scan path (TryGetNextBatch/FinishScanTasks); here they can only be swallowed.
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

When a manifest-read task fails on a background worker (for example a storage error while opening a manifest `.avro` file), the whole process can abort with SIGABRT instead of failing the query:

```
terminate called after throwing an instance of 'duckdb::Exception'
  what():  {"exception_type":"IO","exception_message":"AzureStorageFileSystem open file
'abfss://.../metadata/xxx-m0.avro' failed with code 'NoAuthenticationInformation', ..."}
```

For embedders (e.g. Python) this is unrecoverable: the exception never reaches the host application.

## Root cause

`~IcebergScanPlanState()` drains the manifest-read executor with `WorkOnTasks()`, which rethrows any error the tasks pushed — the existing `FIXME` in the code already called this out:

```cpp
IcebergScanPlanState::~IcebergScanPlanState() {
	if (data_manifest_read_state) {
		//! FIXME: this could throw if the tasks encountered an error.
		data_manifest_read_state->executor.WorkOnTasks();
	}
}
```

Destructors are implicitly `noexcept`, and this one can also run while another exception is already unwinding (the scan plan state is shared across filter-pushdown clones, so the last release can happen on an arbitrary thread during query teardown). Either way, the rethrow calls `std::terminate`.

We hit this in production with an hourly ETL reading Iceberg tables over `abfss://`: a transient storage error (duckdb/duckdb-azure#183) turned into a process abort several times a day. Reproduced on v1.5 and the same code is present on main.

## Change

Wrap the `WorkOnTasks()` drain in the destructor in try/catch. Errors are still surfaced on the regular scan path (`TryGetNextBatch` / `FinishScanTasks`); the destructor is the only place where they cannot be propagated safely.

## Testing

- Builds cleanly on main.
- Equivalent patch applied to a v1.5-based build and validated on the production workload above: the same storage error now surfaces as a regular catchable query error instead of SIGABRT.
- The race is timing-dependent, so no deterministic regression test is included; the change is limited to exception handling in a destructor.
