### PR TITLE
[Dev] Remove Flatten from `IcebergMultiFileReader::FinalizeChunk`

### DIFF
--- a/src/planning/iceberg_multi_file_reader.cpp
+++ b/src/planning/iceberg_multi_file_reader.cpp
@@ -552,9 +552,6 @@ void IcebergMultiFileReader::FinalizeChunk(ClientContext &context, const MultiFi
 		idx_t count = filter_executor.SelectExpression(equality_delete_chunk, sel_vec);
 		output_chunk.Slice(sel_vec, count);
 	}
-	//! FIXME: dictionary vectors cause problems in 'GroupedAggregateHashTable::TryAddDictionaryGroups'
-	//! side-step the issue by flattening for now
-	output_chunk.Flatten();
 }
 
 bool IcebergMultiFileReader::ParseOption(const Identifier &key, const Value &val, MultiFileOptions &options,


### PR DESCRIPTION
Test to determine if https://github.com/duckdblabs/duckdb-internal/issues/9462 is resolved

I believe this was fixed as a side effect of https://github.com/duckdb/duckdb/pull/22230 introducing `ht_offsets_valid` to `GroupedAggregateHashTable::UpdateAggregates`