### PR TITLE
Extract delete-planning helpers (no behaviour change)

### DIFF
--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -527,11 +527,11 @@ PhysicalOperator &IcebergDelete::PlanDelete(ClientContext &context, PhysicalPlan
 
 PhysicalOperator &IcebergCatalog::PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op,
                                              PhysicalOperator &plan) {
-	return PlanDeleteInternal(context, planner, op, plan);
+	return PlanDeleteOperation(context, planner, op, plan);
 }
 
-PhysicalOperator &IcebergCatalog::PlanDeleteInternal(ClientContext &context, PhysicalPlanGenerator &planner,
-                                                     LogicalDelete &op, PhysicalOperator &plan) {
+PhysicalOperator &IcebergCatalog::PlanDeleteOperation(ClientContext &context, PhysicalPlanGenerator &planner,
+                                                      LogicalDelete &op, PhysicalOperator &plan) {
 	if (op.return_chunk) {
 		throw BinderException("RETURNING clause not yet supported for deletion from Iceberg table");
 	}

--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -527,6 +527,11 @@ PhysicalOperator &IcebergDelete::PlanDelete(ClientContext &context, PhysicalPlan
 
 PhysicalOperator &IcebergCatalog::PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op,
                                              PhysicalOperator &plan) {
+	return PlanDeleteInternal(context, planner, op, plan);
+}
+
+PhysicalOperator &IcebergCatalog::PlanDeleteInternal(ClientContext &context, PhysicalPlanGenerator &planner,
+                                                     LogicalDelete &op, PhysicalOperator &plan) {
 	if (op.return_chunk) {
 		throw BinderException("RETURNING clause not yet supported for deletion from Iceberg table");
 	}

--- a/src/execution/operator/merge_into/iceberg_merge_into.cpp
+++ b/src/execution/operator/merge_into/iceberg_merge_into.cpp
@@ -213,7 +213,9 @@ static unique_ptr<MergeIntoOperator> IcebergPlanMergeIntoAction(IcebergCatalog &
 			delete_op.expressions.push_back(std::move(ref));
 		}
 		delete_op.bound_constraints = std::move(bound_constraints);
-		result->op = catalog.PlanDelete(context, planner, delete_op, child_plan);
+		//! MERGE shares this scan with its other actions, so it plans its delete action through the shared
+		//! internal path rather than the standalone PlanDelete entry point.
+		result->op = catalog.PlanDeleteInternal(context, planner, delete_op, child_plan);
 		break;
 	}
 	case MergeActionType::MERGE_INSERT: {

--- a/src/execution/operator/merge_into/iceberg_merge_into.cpp
+++ b/src/execution/operator/merge_into/iceberg_merge_into.cpp
@@ -214,8 +214,8 @@ static unique_ptr<MergeIntoOperator> IcebergPlanMergeIntoAction(IcebergCatalog &
 		}
 		delete_op.bound_constraints = std::move(bound_constraints);
 		//! MERGE shares this scan with its other actions, so it plans its delete action through the shared
-		//! internal path rather than the standalone PlanDelete entry point.
-		result->op = catalog.PlanDeleteInternal(context, planner, delete_op, child_plan);
+		//! PlanDeleteOperation path rather than the standalone PlanDelete entry point.
+		result->op = catalog.PlanDeleteOperation(context, planner, delete_op, child_plan);
 		break;
 	}
 	case MergeActionType::MERGE_INSERT: {

--- a/src/include/catalog/rest/iceberg_catalog.hpp
+++ b/src/include/catalog/rest/iceberg_catalog.hpp
@@ -144,10 +144,10 @@ public:
 	                                    PhysicalOperator &plan) override;
 	PhysicalOperator &PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op,
 	                             PhysicalOperator &plan) override;
-	//! Shared delete-planning body. PlanDelete forwards here; MERGE plans its delete action through this too,
-	//! so both entry points share one implementation.
-	PhysicalOperator &PlanDeleteInternal(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op,
-	                                     PhysicalOperator &plan);
+	//! Shared delete-planning body both PlanDelete and MERGE build on; only PlanDelete additionally opts the
+	//! standalone DELETE into metadata-only deletes, so MERGE must plan its delete action through here directly.
+	PhysicalOperator &PlanDeleteOperation(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op,
+	                                      PhysicalOperator &plan);
 	PhysicalOperator &PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
 	                             PhysicalOperator &plan) override;
 	PhysicalOperator &PlanMergeInto(ClientContext &context, PhysicalPlanGenerator &planner, LogicalMergeInto &op,

--- a/src/include/catalog/rest/iceberg_catalog.hpp
+++ b/src/include/catalog/rest/iceberg_catalog.hpp
@@ -144,6 +144,10 @@ public:
 	                                    PhysicalOperator &plan) override;
 	PhysicalOperator &PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op,
 	                             PhysicalOperator &plan) override;
+	//! Shared delete-planning body. PlanDelete forwards here; MERGE plans its delete action through this too,
+	//! so both entry points share one implementation.
+	PhysicalOperator &PlanDeleteInternal(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op,
+	                                     PhysicalOperator &plan);
 	PhysicalOperator &PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
 	                             PhysicalOperator &plan) override;
 	PhysicalOperator &PlanMergeInto(ClientContext &context, PhysicalPlanGenerator &planner, LogicalMergeInto &op,

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -34,6 +34,7 @@ class IcebergScanPlanProvider;
 struct IcebergScanPlanContext;
 struct IcebergMultiFileList;
 struct IcebergMultiFileReader;
+struct IcebergDeleteFileReference;
 
 struct IcebergMultiFileList : public MultiFileList {
 public:
@@ -81,6 +82,12 @@ private:
 	IcebergMultiFileList(shared_ptr<IcebergScanPlanState> shared_state);
 
 	void InitializeView(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
+
+	//! The delete-manifest entries that apply to a data file, after manifest pruning and the per-entry
+	//! filter and data-file checks. Must be called without holding the shared lock - reading the delete
+	//! manifests takes it.
+	vector<IcebergDeleteFileReference>
+	ResolveApplicableDeleteFiles(const BoundIcebergManifestEntry &data_manifest_entry) const;
 
 	bool HasTransactionData() const;
 	//! Reorder (and prune, when a LIMIT is present) the materialized data files by the

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -615,8 +615,9 @@ void IcebergMultiFileList::StartDataManifestScan(annotated_lock_guard<annotated_
 	GetScanPlanProvider().StartDataManifestScan(data_manifest_matches, table_filters.FilterCount());
 }
 
-IcebergDeletePlan IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_manifest_entry) const {
-	IcebergDeletePlan result;
+vector<IcebergDeleteFileReference>
+IcebergMultiFileList::ResolveApplicableDeleteFiles(const BoundIcebergManifestEntry &data_manifest_entry) const {
+	vector<IcebergDeleteFileReference> result;
 	if (!has_matching_delete_manifests.load()) {
 		return result;
 	}
@@ -637,6 +638,42 @@ IcebergDeletePlan IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifes
 	D_ASSERT(provider);
 	provider->ReadDeleteManifests(manifest_indexes, table_filters.FilterCount());
 
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
+	auto delete_context = GetDeletePlanningContext();
+	auto data_partition_values = IcebergFilePruner::PartitionValueMap(data_manifest_entry.entry.data_file);
+	for (auto delete_file : provider->GetDeleteFiles(manifest_indexes)) {
+		if (delete_file.manifest_idx >= delete_manifests.size()) {
+			throw InternalException("Delete manifest index %llu is out of bounds for %llu manifests",
+			                        delete_file.manifest_idx, delete_manifests.size());
+		}
+		auto &manifest_entries = delete_manifests[delete_file.manifest_idx].entry.GetManifestEntries();
+		if (delete_file.entry_idx >= manifest_entries.size()) {
+			throw InternalException("Delete manifest entry index %llu is out of bounds for manifest %llu",
+			                        delete_file.entry_idx, delete_file.manifest_idx);
+		}
+		auto &delete_entry = manifest_entries[delete_file.entry_idx];
+		if (!IcebergDeletePlanner::DeleteEntryMatchesFilters(delete_context, delete_file.manifest_idx, delete_entry)) {
+			continue;
+		}
+		if (!IcebergDeletePlanner::DeleteEntryAppliesToDataFile(delete_context, delete_file.manifest_idx, delete_entry,
+		                                                        data_manifest_entry, data_partition_values)) {
+			continue;
+		}
+		result.push_back(delete_file);
+	}
+	return result;
+}
+
+IcebergDeletePlan IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_manifest_entry) const {
+	IcebergDeletePlan result;
+	if (!has_matching_delete_manifests.load()) {
+		return result;
+	}
+
+	auto applicable_delete_files = ResolveApplicableDeleteFiles(data_manifest_entry);
+
+	optional_ptr<IcebergScanPlanProvider> provider;
 	vector<IcebergDeleteScanEntry> scan_entries;
 	vector<shared_ptr<IcebergDeleteFileLoadState>> required_loads;
 	vector<shared_ptr<IcebergDeleteFileLoadState>> new_loads;
@@ -644,32 +681,14 @@ IcebergDeletePlan IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifes
 	{
 		annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
 		annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
-		auto delete_files = provider->GetDeleteFiles(manifest_indexes);
+		provider = scan_plan_provider.get();
+		if (!provider) {
+			return result;
+		}
 		delete_context = make_uniq<IcebergDeletePlanningContext>(GetDeletePlanningContext());
-		auto data_partition_values = IcebergFilePruner::PartitionValueMap(data_manifest_entry.entry.data_file);
 		unordered_set<IcebergDeleteFileLoadState *> seen_loads;
-		for (auto delete_file : delete_files) {
-			if (delete_file.manifest_idx >= delete_manifests.size()) {
-				throw InternalException("Delete manifest index %llu is out of bounds for %llu manifests",
-				                        delete_file.manifest_idx, delete_manifests.size());
-			}
+		for (auto delete_file : applicable_delete_files) {
 			auto &delete_manifest = delete_manifests[delete_file.manifest_idx].entry;
-			auto &manifest_entries = delete_manifest.GetManifestEntries();
-			if (delete_file.entry_idx >= manifest_entries.size()) {
-				throw InternalException("Delete manifest entry index %llu is out of bounds for manifest %llu",
-				                        delete_file.entry_idx, delete_file.manifest_idx);
-			}
-			auto &delete_entry = manifest_entries[delete_file.entry_idx];
-			if (!IcebergDeletePlanner::DeleteEntryMatchesFilters(*delete_context, delete_file.manifest_idx,
-			                                                     delete_entry)) {
-				continue;
-			}
-			if (!IcebergDeletePlanner::DeleteEntryAppliesToDataFile(*delete_context, delete_file.manifest_idx,
-			                                                        delete_entry, data_manifest_entry,
-			                                                        data_partition_values)) {
-				continue;
-			}
-
 			auto &load = provider->GetDeleteFileLoad(delete_file);
 			if (!load) {
 				load = make_shared_ptr<IcebergDeleteFileLoadState>();

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -683,7 +683,9 @@ IcebergDeletePlan IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifes
 		annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
 		provider = scan_plan_provider.get();
 		if (!provider) {
-			return result;
+			//! ResolveApplicableDeleteFiles ran InitializeView, which creates the provider, so it is always
+			//! set here - a null is a broken invariant, not a "nothing to do".
+			throw InternalException("scan_plan_provider is not initialized in ProcessDeletes");
 		}
 		delete_context = make_uniq<IcebergDeletePlanningContext>(GetDeletePlanningContext());
 		unordered_set<IcebergDeleteFileLoadState *> seen_loads;

--- a/src/planning/pruning/iceberg_file_pruner.cpp
+++ b/src/planning/pruning/iceberg_file_pruner.cpp
@@ -9,6 +9,33 @@
 
 namespace duckdb {
 
+namespace {
+
+//! How many of a column's values in a data file are NULL, from the counts its manifest entry carries. An absent
+//! null count tells us nothing, so assume both kinds of row are present.
+void ApplyNullCounts(const IcebergDataFile &data_file, int32_t column_id, IcebergPredicateStats &stats) {
+	optional<int64_t> value_count;
+	optional<int64_t> null_count;
+	auto value_counts_it = data_file.value_counts.find(column_id);
+	if (value_counts_it != data_file.value_counts.end()) {
+		value_count = value_counts_it->second;
+	}
+	auto null_counts_it = data_file.null_value_counts.find(column_id);
+	if (null_counts_it != data_file.null_value_counts.end()) {
+		null_count = null_counts_it->second;
+	}
+
+	if (null_count) {
+		stats.has_null = *null_count > 0;
+		stats.has_not_null = value_count ? *value_count - *null_count > 0 : true;
+	} else {
+		stats.has_null = true;
+		stats.has_not_null = value_count ? *value_count > 0 : true;
+	}
+}
+
+} // namespace
+
 bool IcebergFilePruner::FilePartitionMatchesFilter(const IcebergDataFile &data_file,
                                                    const IcebergManifestFile &manifest_file) const {
 	if (data_file.partition_info.empty()) {
@@ -136,24 +163,7 @@ bool IcebergFilePruner::FileMatchesFilter(const IcebergManifestFile &manifest_fi
 			stats = IcebergPredicateStats::DeserializeBounds(lower_bound, upper_bound, column.name, column.type);
 		}
 
-		optional<int64_t> value_count;
-		optional<int64_t> null_count;
-		auto value_counts_it = data_file.value_counts.find(column_id);
-		if (value_counts_it != data_file.value_counts.end()) {
-			value_count = value_counts_it->second;
-		}
-		auto null_counts_it = data_file.null_value_counts.find(column_id);
-		if (null_counts_it != data_file.null_value_counts.end()) {
-			null_count = null_counts_it->second;
-		}
-
-		if (null_count) {
-			stats.has_null = *null_count > 0;
-			stats.has_not_null = value_count ? *value_count - *null_count > 0 : true;
-		} else {
-			stats.has_null = true;
-			stats.has_not_null = value_count ? *value_count > 0 : true;
-		}
+		ApplyNullCounts(data_file, column_id, stats);
 
 		auto nan_counts_it = data_file.nan_value_counts.find(column_id);
 		stats.has_nan = nan_counts_it == data_file.nan_value_counts.end() || nan_counts_it->second > 0;


### PR DESCRIPTION
Pure-refactor prep for #1287, split out at @Tishj's request so that PR's diff is more reviewable.

Three behaviour-preserving extractions, one per commit:

1. **`ResolveApplicableDeleteFiles`** — lift the delete-file resolution loop (the
   manifest-index bounds checks, `DeleteEntryMatchesFilters`,
   `DeleteEntryAppliesToDataFile`) out of `ProcessDeletes` into a method returning
   the applicable delete-file references. `ProcessDeletes` iterates that list to
   build its loads.
2. **`ApplyNullCounts`** — move the per-column value/null-count derivation in
   `FileMatchesFilter` into a file-local helper.
3. **`PlanDeleteInternal`** — split the delete-planning body out of `PlanDelete`
   (which now forwards to it), and route MERGE's delete action through it too, so
   the standalone DELETE and MERGE entry points share one implementation.

No behaviour change. These are the code moves #1287 currently carries; once this
merges, #1287 rebases on top and shrinks to just the new metadata-only-DELETE
logic.

Verified locally with a release build.