### PR TITLE
Support Iceberg REST catalog remote request signing

### DIFF
--- a/make/catalogs/lakekeeper.mk
+++ b/make/catalogs/lakekeeper.mk
@@ -25,6 +25,17 @@ lakekeeper-configure-auth:
 	docker compose exec -T keycloak /opt/keycloak/bin/kcadm.sh update realms/iceberg \
 		-s sslRequired=NONE)
 
+lakekeeper-remote-signing:
+	@echo "Creating the Lakekeeper warehouse used by the remote signing tests..."
+	cp scripts/lakekeeper/remote_signing_setup.py .catalogs/lakekeeper/examples/access-control-simple/notebooks/
+	(cd .catalogs/lakekeeper/examples/access-control-simple && \
+	docker compose run --rm --no-deps \
+		-e SPARK_LOCAL_DIRS='$(LAKEKEEPER_SPARK_LOCAL_DIR)' \
+		jupyter bash -lc '\
+			rm -rf "$$SPARK_LOCAL_DIRS" /tmp/blockmgr-* /tmp/spark-* && \
+			mkdir -p "$$SPARK_LOCAL_DIRS" && \
+			python /home/jovyan/examples/remote_signing_setup.py')
+
 lakekeeper: lakekeeper-clone lakekeeper-stop
 	$(call stop_active_catalog)
 	@echo "Starting Lakekeeper catalog..."
@@ -41,6 +52,7 @@ lakekeeper: lakekeeper-clone lakekeeper-stop
 			jupyter nbconvert --to notebook --execute --output-dir=/tmp /home/jovyan/examples/01-Bootstrap.ipynb && \
 			jupyter nbconvert --to notebook --execute --output-dir=/tmp /home/jovyan/examples/02-Create-Warehouse.ipynb && \
 			jupyter nbconvert --to notebook --execute --output-dir=/tmp /home/jovyan/examples/03-01-Spark.ipynb'
+	$(MAKE) lakekeeper-remote-signing
 	$(call set_active_catalog,lakekeeper)
 
 lakekeeper-data: lakekeeper

--- a/scripts/lakekeeper/remote_signing_setup.py
+++ b/scripts/lakekeeper/remote_signing_setup.py
@@ -1,0 +1,110 @@
+"""Create the Lakekeeper warehouse the remote signing tests read from.
+
+Runs inside the Lakekeeper example 'jupyter' container, so all service names are the ones
+of the docker compose network. The warehouse disables STS, which makes Lakekeeper answer a
+'remote-signing' access delegation request with signer information instead of credentials.
+"""
+
+import pandas as pd
+import pyspark
+import requests
+from pyspark.conf import SparkConf
+from pyspark.sql import SparkSession
+
+MANAGEMENT_URL = "http://lakekeeper:8181/management"
+CATALOG_URL = "http://lakekeeper:8181/catalog"
+KEYCLOAK_TOKEN_URL = "http://keycloak:8080/realms/iceberg/protocol/openid-connect/token"
+
+WAREHOUSE = "demo_remote_signing"
+NAMESPACE = "remote_signing"
+TABLE = "remote_signing_table"
+
+CLIENT_ID = "spark"
+CLIENT_SECRET = "2OR3eRvYfSZzzZ16MlPd95jhLnOaLM52"
+ICEBERG_VERSION = "1.10.0"
+
+
+def get_access_token() -> str:
+    response = requests.post(
+        url=KEYCLOAK_TOKEN_URL,
+        data={
+            "grant_type": "client_credentials",
+            "client_id": CLIENT_ID,
+            "client_secret": CLIENT_SECRET,
+            "scope": "lakekeeper",
+        },
+        headers={"Content-type": "application/x-www-form-urlencoded"},
+    )
+    response.raise_for_status()
+    return response.json()["access_token"]
+
+
+def create_warehouse(access_token: str) -> None:
+    response = requests.post(
+        url=f"{MANAGEMENT_URL}/v1/warehouse",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={
+            "warehouse-name": WAREHOUSE,
+            "storage-profile": {
+                "type": "s3",
+                "bucket": "examples",
+                "key-prefix": "remote-signing-warehouse",
+                "endpoint": "http://minio:9000",
+                "region": "local-01",
+                "path-style-access": True,
+                "flavor": "s3-compat",
+                "sts-enabled": False,
+                "remote-signing-enabled": True,
+            },
+            "storage-credential": {
+                "type": "s3",
+                "credential-type": "access-key",
+                "aws-access-key-id": "minio-root-user",
+                "aws-secret-access-key": "minio-root-password",
+            },
+        },
+    )
+    if response.status_code == 409:
+        print(f"Warehouse '{WAREHOUSE}' already exists")
+        return
+    response.raise_for_status()
+    print(f"Created warehouse '{WAREHOUSE}'")
+
+
+def seed_table() -> None:
+    spark_minor_version = ".".join(pyspark.__version__.split(".")[:2])
+    conf = {
+        "spark.jars.packages": (
+            f"org.apache.iceberg:iceberg-spark-runtime-{spark_minor_version}_2.12:{ICEBERG_VERSION},"
+            f"org.apache.iceberg:iceberg-aws-bundle:{ICEBERG_VERSION}"
+        ),
+        "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+        "spark.sql.catalog.lakekeeper": "org.apache.iceberg.spark.SparkCatalog",
+        "spark.sql.catalog.lakekeeper.type": "rest",
+        "spark.sql.catalog.lakekeeper.uri": CATALOG_URL,
+        "spark.sql.catalog.lakekeeper.credential": f"{CLIENT_ID}:{CLIENT_SECRET}",
+        "spark.sql.catalog.lakekeeper.warehouse": WAREHOUSE,
+        "spark.sql.catalog.lakekeeper.scope": "lakekeeper",
+        "spark.sql.catalog.lakekeeper.oauth2-server-uri": KEYCLOAK_TOKEN_URL,
+        "spark.sql.catalog.lakekeeper.header.X-Iceberg-Access-Delegation": "remote-signing",
+    }
+
+    spark_config = SparkConf().setMaster("local").setAppName("Iceberg-REST-Remote-Signing")
+    for key, value in conf.items():
+        spark_config = spark_config.set(key, value)
+    spark = SparkSession.builder.config(conf=spark_config).getOrCreate()
+
+    spark.sql("USE lakekeeper")
+    spark.sql(f"CREATE NAMESPACE IF NOT EXISTS {NAMESPACE}")
+    data = pd.DataFrame(
+        [[1, "a-string", 2.2], [2, "another-string", 3.3], [3, "a-third-string", 4.4]],
+        columns=["id", "strings", "floats"],
+    )
+    spark.createDataFrame(data).writeTo(f"{NAMESPACE}.{TABLE}").createOrReplace()
+    print(f"Seeded '{WAREHOUSE}.{NAMESPACE}.{TABLE}'")
+    spark.stop()
+
+
+if __name__ == "__main__":
+    create_warehouse(get_access_token())
+    seed_table()

--- a/src/catalog/rest/api/catalog_api.cpp
+++ b/src/catalog/rest/api/catalog_api.cpp
@@ -197,9 +197,7 @@ static unique_ptr<HTTPResponse> GetTableMetadata(ClientContext &context, Iceberg
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent(table));
 
 	HTTPHeaders headers(*context.db);
-	if (catalog.attach_options.access_mode == IRCAccessDelegationMode::VENDED_CREDENTIALS) {
-		headers.Insert("X-Iceberg-Access-Delegation", "vended-credentials");
-	}
+	ICUtils::AddAccessDelegationHeader(headers, catalog.attach_options.access_mode);
 	return catalog.auth_handler->Request(RequestType::GET_REQUEST, context, url_builder, headers);
 }
 
@@ -215,9 +213,7 @@ static unique_ptr<HTTPResponse> LoadCredentials(ClientContext &context, IcebergC
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent("credentials"));
 
 	HTTPHeaders headers(*context.db);
-	if (catalog.attach_options.access_mode == IRCAccessDelegationMode::VENDED_CREDENTIALS) {
-		headers.Insert("X-Iceberg-Access-Delegation", "vended-credentials");
-	}
+	ICUtils::AddAccessDelegationHeader(headers, catalog.attach_options.access_mode);
 	return catalog.auth_handler->Request(RequestType::GET_REQUEST, context, url_builder, headers);
 }
 
@@ -281,9 +277,7 @@ IRCAPI::GetNamespace(ClientContext &context, IcebergCatalog &catalog, const Iceb
 	    IRCPathComponent::NamespaceComponent(schema.namespace_items, catalog.namespace_separator));
 
 	HTTPHeaders headers(*context.db);
-	if (catalog.attach_options.access_mode == IRCAccessDelegationMode::VENDED_CREDENTIALS) {
-		headers.Insert("X-Iceberg-Access-Delegation", "vended-credentials");
-	}
+	ICUtils::AddAccessDelegationHeader(headers, catalog.attach_options.access_mode);
 	auto result = catalog.auth_handler->Request(RequestType::GET_REQUEST, context, url_builder, headers);
 
 	if (result->status != HTTPStatusCode::OK_200) {
@@ -320,9 +314,7 @@ vector<rest_api_objects::TableIdentifier> IRCAPI::GetTables(ClientContext &conte
 		}
 
 		HTTPHeaders headers(*context.db);
-		if (catalog.attach_options.access_mode == IRCAccessDelegationMode::VENDED_CREDENTIALS) {
-			headers.Insert("X-Iceberg-Access-Delegation", "vended-credentials");
-		}
+		ICUtils::AddAccessDelegationHeader(headers, catalog.attach_options.access_mode);
 		auto response = catalog.auth_handler->Request(RequestType::GET_REQUEST, context, url_builder, headers);
 		if (!response->Success()) {
 			if (response->status == HTTPStatusCode::Forbidden_403 ||
@@ -591,9 +583,7 @@ rest_api_objects::LoadTableResult IRCAPI::CommitNewTable(ClientContext &context,
 		HTTPHeaders headers(*context.db);
 		headers.Insert("Content-Type", "application/json");
 		// if you are creating a table with stage create, you need vended credentials
-		if (catalog.attach_options.access_mode == IRCAccessDelegationMode::VENDED_CREDENTIALS) {
-			headers.Insert("X-Iceberg-Access-Delegation", "vended-credentials");
-		}
+		ICUtils::AddAccessDelegationHeader(headers, catalog.attach_options.access_mode);
 		LogPostBody(context, url_builder, create_table_json);
 		auto response =
 		    catalog.auth_handler->Request(RequestType::POST_REQUEST, context, url_builder, headers, create_table_json);

--- a/src/catalog/rest/api/catalog_utils.cpp
+++ b/src/catalog/rest/api/catalog_utils.cpp
@@ -4,6 +4,19 @@
 
 namespace duckdb {
 
+void ICUtils::AddAccessDelegationHeader(HTTPHeaders &headers, IRCAccessDelegationMode access_mode) {
+	switch (access_mode) {
+	case IRCAccessDelegationMode::VENDED_CREDENTIALS:
+		headers.Insert("X-Iceberg-Access-Delegation", "vended-credentials");
+		break;
+	case IRCAccessDelegationMode::REMOTE_SIGNING:
+		headers.Insert("X-Iceberg-Access-Delegation", "remote-signing");
+		break;
+	default:
+		break;
+	}
+}
+
 JSONValue ICUtils::GetErrorMessage(const string &api_result, unique_ptr<JSONDocument> &out_doc) {
 	JSONParseError parse_error;
 	out_doc = JSONDocument::TryParse(api_result.c_str(), api_result.size(), parse_error);

--- a/src/catalog/rest/catalog_entry/table/iceberg_table.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table.cpp
@@ -498,7 +498,44 @@ static void AddHTTPSecretsToOptions(SecretEntry &http_secret_entry, case_insensi
 	                            : http_kv_secret.TryGetValue("verify_ssl").DefaultCastAs(LogicalType::BOOLEAN);
 }
 
+bool IcebergTable::RegisterRemoteSigning() const {
+	//! Catalogs advertise remote signing whenever their storage profile supports it, so honoring it has to
+	//! stay opt-in: an attach that manages its own credentials must keep reaching storage directly
+	if (catalog.attach_options.access_mode != IRCAccessDelegationMode::REMOTE_SIGNING) {
+		return false;
+	}
+	if (!catalog.remote_signing) {
+		return false;
+	}
+	auto location = table_metadata.GetLocation();
+	if (!IcebergRemoteSigningConfig::IsSupportedLocation(location)) {
+		return false;
+	}
+	IcebergRemoteSigningTarget target;
+	if (!IcebergRemoteSigningConfig::TryParse(config, catalog.base_uri, catalog.GetName().GetIdentifierName(),
+	                                          target)) {
+		return false;
+	}
+	catalog.remote_signing->RegisterTarget(location, target);
+	auto data_path = table_metadata.table_properties.find("write.data.path");
+	if (data_path != table_metadata.table_properties.end() &&
+	    IcebergRemoteSigningConfig::IsSupportedLocation(data_path->second)) {
+		catalog.remote_signing->RegisterTarget(data_path->second, target);
+	}
+	return true;
+}
+
 void IcebergTable::LoadCredentials(ClientContext &context) const {
+	if (catalog.attach_options.access_mode == IRCAccessDelegationMode::REMOTE_SIGNING) {
+		if (!RegisterRemoteSigning() && IcebergRemoteSigningConfig::IsSupportedLocation(table_metadata.GetLocation())) {
+			throw InvalidConfigurationException(
+			    "'%s' is attached with access_delegation_mode 'remote_signing', but the catalog returned no remote "
+			    "signing information for table '%s'. Remote signing has to be enabled for the storage profile the "
+			    "table lives in.",
+			    catalog.GetName().GetIdentifierName(), name);
+		}
+		return;
+	}
 	if (catalog.attach_options.access_mode != IRCAccessDelegationMode::VENDED_CREDENTIALS) {
 		// assume secret already exists
 		return;
@@ -507,6 +544,9 @@ void IcebergTable::LoadCredentials(ClientContext &context) const {
 }
 
 void IcebergTable::LoadCredentials(ClientContext &context, IRCAPITableCredentials table_credentials) const {
+	if (RegisterRemoteSigning()) {
+		return;
+	}
 	auto &secret_manager = SecretManager::Get(context);
 
 	auto &transaction = IcebergTransaction::Get(context, catalog);

--- a/src/function/metadata/iceberg_load_table_response.cpp
+++ b/src/function/metadata/iceberg_load_table_response.cpp
@@ -53,9 +53,7 @@ static unique_ptr<HTTPResponse> MakeRequest(ClientContext &context, const Iceber
 	url_builder.AddPathComponent(IRCPathComponent::RegularComponent(ic_table_entry.name.GetIdentifierName()));
 
 	HTTPHeaders headers(*context.db);
-	if (ic_catalog.attach_options.access_mode == IRCAccessDelegationMode::VENDED_CREDENTIALS) {
-		headers.Insert("X-Iceberg-Access-Delegation", "vended-credentials");
-	}
+	ICUtils::AddAccessDelegationHeader(headers, ic_catalog.attach_options.access_mode);
 	unique_ptr<HTTPResponse> response =
 	    ic_catalog.auth_handler->Request(RequestType::GET_REQUEST, context, url_builder, headers);
 	if (!response->Success()) {

--- a/src/iceberg_attach.cpp
+++ b/src/iceberg_attach.cpp
@@ -298,12 +298,14 @@ unique_ptr<Catalog> IcebergAttach::Attach(optional_ptr<StorageExtensionInfo> sto
 	if (!access_mode_string.empty()) {
 		if (access_mode_string == "vended_credentials") {
 			attach_options.access_mode = IRCAccessDelegationMode::VENDED_CREDENTIALS;
+		} else if (access_mode_string == "remote_signing") {
+			attach_options.access_mode = IRCAccessDelegationMode::REMOTE_SIGNING;
 		} else if (access_mode_string == "none") {
 			attach_options.access_mode = IRCAccessDelegationMode::NONE;
 		} else {
-			throw InvalidInputException(
-			    "Unrecognized access mode '%s'. Supported options are 'vended_credentials' and 'none'",
-			    access_mode_string);
+			throw InvalidInputException("Unrecognized access mode '%s'. Supported options are 'vended_credentials', "
+			                            "'remote_signing' and 'none'",
+			                            access_mode_string);
 		}
 	}
 	if (attach_options.authorization_type == IcebergAuthorizationType::INVALID) {
@@ -348,6 +350,9 @@ unique_ptr<Catalog> IcebergAttach::Attach(optional_ptr<StorageExtensionInfo> sto
 	D_ASSERT(auth_handler);
 	auto catalog =
 	    make_uniq<IcebergCatalog>(db, options.access_mode, std::move(auth_handler), attach_options, default_schema);
+	if (storage_info) {
+		catalog->remote_signing = dynamic_cast<IcebergStorageExtensionInfo &>(*storage_info).remote_signing;
+	}
 	//! Remember the normalized attach options so that a later ATTACH OR REPLACE can detect when they change.
 	catalog->SetAttachOptions(options.options);
 	catalog->GetConfig(context, endpoint_type);

--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -29,6 +29,7 @@
 #include "function/copy/iceberg_copy_function.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"
 #include "planning/iceberg_optimizer.hpp"
+#include "storage/remote_signing/iceberg_remote_signed_file_system.hpp"
 
 namespace duckdb {
 
@@ -65,9 +66,10 @@ static unique_ptr<TransactionManager> CreateTransactionManager(optional_ptr<Stor
 
 class IRCStorageExtension : public StorageExtension {
 public:
-	IRCStorageExtension() {
+	explicit IRCStorageExtension(shared_ptr<IcebergRemoteSigningRegistry> remote_signing) {
 		attach = IcebergAttach::Attach;
 		create_transaction_manager = CreateTransactionManager;
+		storage_info = make_shared_ptr<IcebergStorageExtensionInfo>(std::move(remote_signing));
 	}
 };
 
@@ -158,7 +160,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	auto &log_manager = instance.GetLogManager();
 	log_manager.RegisterLogType(make_uniq<IcebergLogType>());
-	StorageExtension::Register(config, "iceberg", make_shared_ptr<IRCStorageExtension>());
+	auto remote_signing = make_shared_ptr<IcebergRemoteSigningRegistry>();
+	instance.GetFileSystem().RegisterSubSystem(make_uniq<IcebergRemoteSignedFileSystem>(remote_signing));
+	StorageExtension::Register(config, "iceberg", make_shared_ptr<IRCStorageExtension>(std::move(remote_signing)));
 	OptimizerExtension::Register(config, IcebergOptimizer::Create());
 }
 

--- a/src/include/catalog/rest/api/catalog_utils.hpp
+++ b/src/include/catalog/rest/api/catalog_utils.hpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/json_document.hpp"
 
 #include "catalog/rest/api/catalog_api.hpp"
+#include "iceberg_attach.hpp"
 
 namespace duckdb {
 class IcebergSchemaEntry;
@@ -14,6 +15,8 @@ class ICUtils {
 public:
 	static JSONValue GetErrorMessage(const string &api_result, unique_ptr<JSONDocument> &out_doc);
 	static unique_ptr<JSONDocument> APIResultToDoc(const string &api_result);
+	//! Tell the catalog which form of storage access delegation this attach expects
+	static void AddAccessDelegationHeader(HTTPHeaders &headers, IRCAccessDelegationMode access_mode);
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/catalog_entry/table/iceberg_table.hpp
+++ b/src/include/catalog/rest/catalog_entry/table/iceberg_table.hpp
@@ -28,6 +28,9 @@ public:
 public:
 	void LoadCredentials(ClientContext &context) const;
 	void LoadCredentials(ClientContext &context, IRCAPITableCredentials table_credentials) const;
+	//! Make the storage locations of this table reachable through the catalog's remote signing endpoint,
+	//! returns false when the catalog did not vend remote signing information for it
+	bool RegisterRemoteSigning() const;
 	optional_ptr<CatalogEntry> GetLatestSchema();
 	idx_t GetIcebergVersion() const;
 	optional_ptr<CatalogEntry> GetSchemaVersion(optional_ptr<BoundAtClause> at);

--- a/src/include/catalog/rest/iceberg_catalog.hpp
+++ b/src/include/catalog/rest/iceberg_catalog.hpp
@@ -14,6 +14,7 @@
 #include "rest_catalog/objects/load_table_result.hpp"
 #include "catalog/rest/storage/iceberg_authorization.hpp"
 #include "common/iceberg_utils.hpp"
+#include "storage/remote_signing/iceberg_remote_signing.hpp"
 
 namespace duckdb {
 
@@ -180,6 +181,8 @@ public:
 	//! attach options
 	IcebergAttachOptions attach_options;
 	Identifier default_schema;
+	//! Storage locations this catalog signs requests for, shared with the file system that reads them
+	shared_ptr<IcebergRemoteSigningRegistry> remote_signing;
 
 private:
 	//! warehouse

--- a/src/include/iceberg_attach.hpp
+++ b/src/include/iceberg_attach.hpp
@@ -13,7 +13,7 @@ enum class IcebergEndpointType : uint8_t { AWS_S3TABLES, AWS_GLUE, INVALID };
 
 enum class IcebergAuthorizationType : uint8_t { OAUTH2, SIGV4, NONE, INVALID };
 
-enum class IRCAccessDelegationMode : uint8_t { NONE, VENDED_CREDENTIALS };
+enum class IRCAccessDelegationMode : uint8_t { NONE, VENDED_CREDENTIALS, REMOTE_SIGNING };
 
 struct IcebergAttachOptions {
 	string catalog_uri;

--- a/src/include/storage/remote_signing/iceberg_remote_signed_file_system.hpp
+++ b/src/include/storage/remote_signing/iceberg_remote_signed_file_system.hpp
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/remote_signing/iceberg_remote_signed_file_system.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/file_system.hpp"
+
+#include "storage/remote_signing/iceberg_remote_signing.hpp"
+
+namespace duckdb {
+
+class IcebergRemoteSignedFileSystem;
+
+class IcebergRemoteSignedFileHandle : public FileHandle {
+public:
+	IcebergRemoteSignedFileHandle(IcebergRemoteSignedFileSystem &fs, const OpenFileInfo &file, FileOpenFlags flags,
+	                              IcebergRemoteSigningTarget target, string http_url, string host,
+	                              weak_ptr<ClientContext> context);
+
+public:
+	void Close() override {
+	}
+
+public:
+	IcebergRemoteSigningTarget target;
+	string http_url;
+	string host;
+	weak_ptr<ClientContext> context;
+	idx_t length = 0;
+	idx_t file_offset = 0;
+	timestamp_t last_modified;
+	string etag;
+	//! Set for the files Iceberg asks to be downloaded in full (manifests and manifest lists), which are
+	//! read in many small sequential chunks that would otherwise each become a range request
+	bool fully_downloaded = false;
+	string body;
+};
+
+//! Reads Iceberg data below a table location whose REST catalog delegates storage access through
+//! remote request signing instead of vending credentials
+class IcebergRemoteSignedFileSystem : public FileSystem {
+public:
+	static constexpr const char *NAME = "IcebergRemoteSignedFileSystem";
+
+public:
+	explicit IcebergRemoteSignedFileSystem(shared_ptr<IcebergRemoteSigningRegistry> registry_p)
+	    : registry(std::move(registry_p)) {
+	}
+
+public:
+	string GetName() const override {
+		return NAME;
+	}
+	bool CanHandleFile(const string &fpath) override;
+	//! Take priority over httpfs for the table locations that require remote signing, independent of
+	//! the order in which the two extensions were loaded
+	bool IsManuallySet() override {
+		return true;
+	}
+
+	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
+	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
+	int64_t GetFileSize(FileHandle &handle) override;
+	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
+	string GetVersionTag(FileHandle &handle) override;
+	FileType GetFileType(FileHandle &handle) override;
+	FileMetadata Stats(FileHandle &handle) override;
+	bool FileExists(const string &filename, optional_ptr<FileOpener> opener) override;
+	bool DirectoryExists(const string &directory, optional_ptr<FileOpener> opener) override;
+	void CreateDirectory(const string &directory, optional_ptr<FileOpener> opener) override;
+	//! Nothing can be written through this file system, so there is never anything to clean up. Cleanup
+	//! runs while an error is already in flight, where throwing would hide the error that caused it.
+	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener) override;
+	bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener) override;
+	void RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener) override;
+	void Seek(FileHandle &handle, idx_t location) override;
+	idx_t SeekPosition(FileHandle &handle) override;
+	bool CanSeek() override {
+		return true;
+	}
+	bool OnDiskFile(FileHandle &handle) override {
+		return false;
+	}
+	void Reset(FileHandle &handle) override;
+	string PathSeparator(const string &path) override {
+		return "/";
+	}
+
+protected:
+	unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
+	                                        optional_ptr<FileOpener> opener) override;
+	bool SupportsOpenFileExtended() const override {
+		return true;
+	}
+
+private:
+	void DownloadFully(IcebergRemoteSignedFileHandle &handle);
+
+private:
+	shared_ptr<IcebergRemoteSigningRegistry> registry;
+};
+
+} // namespace duckdb

--- a/src/include/storage/remote_signing/iceberg_remote_signer.hpp
+++ b/src/include/storage/remote_signing/iceberg_remote_signer.hpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/remote_signing/iceberg_remote_signer.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/http_util.hpp"
+#include "duckdb/main/client_context.hpp"
+
+#include "storage/remote_signing/iceberg_remote_signing.hpp"
+
+namespace duckdb {
+
+class IcebergRemoteSigner {
+public:
+	//! Translate an s3://, s3a:// or s3n:// path into the HTTP url the object is reachable at
+	static string ToHttpUrl(const IcebergRemoteSigningTarget &target, const string &path, string &host);
+	//! Ask the catalog to sign a request, reusing a cached signature when one is still valid
+	static IcebergSignedRequest Sign(ClientContext &context, IcebergRemoteSigningRegistry &registry,
+	                                 const IcebergRemoteSigningTarget &target, RequestType request_type,
+	                                 const string &http_url, const string &host);
+};
+
+} // namespace duckdb

--- a/src/include/storage/remote_signing/iceberg_remote_signing.hpp
+++ b/src/include/storage/remote_signing/iceberg_remote_signing.hpp
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/remote_signing/iceberg_remote_signing.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/atomic.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/http_util.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/storage/storage_extension.hpp"
+
+namespace duckdb {
+
+//! Everything needed to turn an s3 path below a table location into a signed HTTP request
+struct IcebergRemoteSigningTarget {
+	string catalog_name;
+	string signer_url;
+	string region;
+	//! Host (and optional port) of the S3 endpoint, without a scheme
+	string host;
+	//! Path the S3 endpoint is served under, empty for the common case of a bare host
+	string path_prefix;
+	bool use_ssl = true;
+	bool path_style_access = false;
+};
+
+struct IcebergRemoteSigningConfig {
+	//! The endpoint used when the catalog does not report one, as defined by the Iceberg REST spec
+	static constexpr const char *DEFAULT_SIGNER_ENDPOINT = "v1/aws/s3/sign";
+
+	//! Whether remote signing can be used for this storage location
+	static bool IsSupportedLocation(const string &location);
+	//! Read the remote signing properties out of the 'config' of a LoadTableResult
+	static bool TryParse(const case_insensitive_map_t<string> &config, const string &catalog_uri,
+	                     const string &catalog_name, IcebergRemoteSigningTarget &result);
+};
+
+struct IcebergSignedRequest {
+	string url;
+	HTTPHeaders headers;
+};
+
+//! Signing targets and cached signatures, scoped to a single DatabaseInstance
+class IcebergRemoteSigningRegistry {
+public:
+	//! Signatures are reused for this long, matching the Iceberg S3V4RestSignerClient cache
+	static constexpr int64_t SIGNATURE_CACHE_MS = 30000;
+	//! Expired signatures are swept once the cache grows past this many entries
+	static constexpr idx_t SIGNATURE_CACHE_SWEEP_SIZE = 1024;
+
+public:
+	void RegisterTarget(const string &location, IcebergRemoteSigningTarget target);
+	bool TryGetTarget(const string &path, IcebergRemoteSigningTarget &result);
+	//! Lock-free pre-check, so file systems that are never used stay off the file-open hot path
+	bool Empty() const {
+		return !has_targets;
+	}
+
+	bool TryGetSignature(const string &cache_key, IcebergSignedRequest &result);
+	void PutSignature(const string &cache_key, const IcebergSignedRequest &signature);
+
+private:
+	struct CachedSignature {
+		timestamp_t expires_at;
+		IcebergSignedRequest signature;
+	};
+
+private:
+	atomic<bool> has_targets {false};
+	mutex lock;
+	unordered_map<string, IcebergRemoteSigningTarget> targets;
+	unordered_map<string, CachedSignature> signatures;
+};
+
+struct IcebergStorageExtensionInfo : public StorageExtensionInfo {
+	explicit IcebergStorageExtensionInfo(shared_ptr<IcebergRemoteSigningRegistry> remote_signing_p)
+	    : remote_signing(std::move(remote_signing_p)) {
+	}
+
+	shared_ptr<IcebergRemoteSigningRegistry> remote_signing;
+};
+
+} // namespace duckdb

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(remote_signing)
 add_subdirectory(statistics)
 
 set(ALL_OBJECT_FILES

--- a/src/storage/remote_signing/CMakeLists.txt
+++ b/src/storage/remote_signing/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(
+  iceberg_storage_remote_signing OBJECT
+  iceberg_remote_signed_file_system.cpp iceberg_remote_signer.cpp
+  iceberg_remote_signing.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_storage_remote_signing>
+    PARENT_SCOPE)

--- a/src/storage/remote_signing/iceberg_remote_signed_file_system.cpp
+++ b/src/storage/remote_signing/iceberg_remote_signed_file_system.cpp
@@ -1,0 +1,303 @@
+#include "storage/remote_signing/iceberg_remote_signed_file_system.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/exception/http_exception.hpp"
+#include "duckdb/common/file_opener.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/function/scalar/strftime_format.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
+
+#include "storage/remote_signing/iceberg_remote_signer.hpp"
+
+#include <cstring>
+
+namespace duckdb {
+
+IcebergRemoteSignedFileHandle::IcebergRemoteSignedFileHandle(IcebergRemoteSignedFileSystem &fs,
+                                                             const OpenFileInfo &file, FileOpenFlags flags,
+                                                             IcebergRemoteSigningTarget target_p, string http_url_p,
+                                                             string host_p, weak_ptr<ClientContext> context_p)
+    : FileHandle(fs, file.path, flags), target(std::move(target_p)), http_url(std::move(http_url_p)),
+      host(std::move(host_p)), context(std::move(context_p)), last_modified(timestamp_t(0)) {
+}
+
+static bool IsS3Path(const string &path) {
+	return StringUtil::StartsWith(path, "s3://") || StringUtil::StartsWith(path, "s3a://") ||
+	       StringUtil::StartsWith(path, "s3n://");
+}
+
+bool IcebergRemoteSignedFileSystem::CanHandleFile(const string &fpath) {
+	if (!IsS3Path(fpath)) {
+		return false;
+	}
+	IcebergRemoteSigningTarget target;
+	return registry->TryGetTarget(fpath, target);
+}
+
+static ClientContext &GetContext(IcebergRemoteSignedFileHandle &handle) {
+	auto context = handle.context.lock();
+	if (!context) {
+		throw IOException("Cannot access '%s': the client context it was opened with is gone, so the Iceberg catalog "
+		                  "can no longer be asked to sign requests for it",
+		                  handle.path);
+	}
+	return *context;
+}
+
+using SignedRequestCallback =
+    std::function<unique_ptr<HTTPResponse>(HTTPUtil &, const string &, HTTPHeaders &, HTTPParams &)>;
+
+static unique_ptr<HTTPResponse> RunSignedRequest(IcebergRemoteSigningRegistry &registry,
+                                                 IcebergRemoteSignedFileHandle &handle, RequestType request_type,
+                                                 const HTTPHeaders &extra_headers,
+                                                 const SignedRequestCallback &callback) {
+	auto &context = GetContext(handle);
+	auto &http_util = HTTPUtil::Get(*context.db);
+
+	auto signature =
+	    IcebergRemoteSigner::Sign(context, registry, handle.target, request_type, handle.http_url, handle.host);
+	auto headers = signature.headers;
+	for (auto &entry : extra_headers) {
+		headers.Insert(entry.first, entry.second);
+	}
+	auto params = http_util.InitializeParameters(context, signature.url);
+	return callback(http_util, signature.url, headers, *params);
+}
+
+static void CheckResponse(optional_ptr<HTTPResponse> response, const string &path, const char *operation) {
+	if (!response) {
+		throw IOException("Iceberg remote signed request while %s '%s' did not return a response", operation, path);
+	}
+	if (response->HasRequestError()) {
+		throw IOException("Iceberg remote signed request while %s '%s' failed: %s", operation, path,
+		                  response->GetRequestError());
+	}
+	if (response->status != HTTPStatusCode::OK_200 && response->status != HTTPStatusCode::PartialContent_206) {
+		throw HTTPException(*response, "Iceberg remote signed request while %s '%s' returned status %d: %s", operation,
+		                    path, static_cast<int>(response->status), response->body);
+	}
+}
+
+void IcebergRemoteSignedFileSystem::DownloadFully(IcebergRemoteSignedFileHandle &handle) {
+	auto response =
+	    RunSignedRequest(*registry, handle, RequestType::GET_REQUEST, HTTPHeaders(),
+	                     [](HTTPUtil &http_util, const string &url, HTTPHeaders &headers, HTTPParams &params) {
+		                     GetRequestInfo get_request(url, headers, params, nullptr, nullptr);
+		                     unique_ptr<HTTPClient> client;
+		                     return http_util.Request(get_request, client);
+	                     });
+	CheckResponse(response.get(), handle.path, "downloading");
+	handle.body = std::move(response->body);
+	handle.length = handle.body.size();
+	handle.fully_downloaded = true;
+}
+
+unique_ptr<FileHandle> IcebergRemoteSignedFileSystem::OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
+                                                                       optional_ptr<FileOpener> opener) {
+	if (flags.OpenForWriting()) {
+		throw NotImplementedException(
+		    "Cannot write to '%s': the Iceberg REST catalog delegates access to this location through remote request "
+		    "signing, which the iceberg extension only implements for reads",
+		    file.path);
+	}
+	auto context = FileOpener::TryGetClientContext(opener);
+	if (!context) {
+		throw IOException("Cannot open '%s': no client context is available to sign the request with", file.path);
+	}
+	IcebergRemoteSigningTarget target;
+	if (!registry->TryGetTarget(file.path, target)) {
+		throw IOException("No Iceberg remote signing configuration is registered for '%s'", file.path);
+	}
+
+	string host;
+	auto http_url = IcebergRemoteSigner::ToHttpUrl(target, file.path, host);
+	auto handle = make_uniq<IcebergRemoteSignedFileHandle>(*this, file, flags, std::move(target), std::move(http_url),
+	                                                       std::move(host), context->shared_from_this());
+
+	if (file.extended_info) {
+		auto &options = file.extended_info->options;
+		auto etag = options.find("etag");
+		if (etag != options.end()) {
+			handle->etag = StringValue::Get(etag->second);
+		}
+		auto force_full_download = options.find("force_full_download");
+		if (force_full_download != options.end() && force_full_download->second.GetValue<bool>()) {
+			DownloadFully(*handle);
+			return std::move(handle);
+		}
+		//! Iceberg records the size of the files it points at, which lets the HEAD request be skipped
+		auto file_size = options.find("file_size");
+		if (file_size != options.end()) {
+			handle->length = NumericCast<idx_t>(file_size->second.GetValue<uint64_t>());
+			return std::move(handle);
+		}
+	}
+
+	auto response =
+	    RunSignedRequest(*registry, *handle, RequestType::HEAD_REQUEST, HTTPHeaders(),
+	                     [](HTTPUtil &http_util, const string &url, HTTPHeaders &headers, HTTPParams &params) {
+		                     HeadRequestInfo head_request(url, headers, params);
+		                     unique_ptr<HTTPClient> client;
+		                     return http_util.Request(head_request, client);
+	                     });
+	CheckResponse(response.get(), file.path, "opening");
+
+	if (response->HasHeader("Content-Length")) {
+		auto content_length = response->GetHeaderValue("Content-Length");
+		uint64_t length = 0;
+		if (!TryCast::Operation<string_t, uint64_t>(string_t(content_length), length)) {
+			throw IOException("Iceberg remote signed HEAD request for '%s' returned an unparseable Content-Length "
+			                  "header: %s",
+			                  file.path, content_length);
+		}
+		handle->length = NumericCast<idx_t>(length);
+	}
+	if (response->HasHeader("ETag")) {
+		handle->etag = response->GetHeaderValue("ETag");
+	}
+	if (response->HasHeader("Last-Modified")) {
+		StrpTimeFormat::ParseResult parse_result;
+		timestamp_t last_modified;
+		if (StrpTimeFormat::TryParse("%a, %d %h %Y %T %Z", response->GetHeaderValue("Last-Modified"), parse_result) &&
+		    parse_result.TryToTimestamp(last_modified)) {
+			handle->last_modified = last_modified;
+		}
+	}
+	return std::move(handle);
+}
+
+void IcebergRemoteSignedFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	if (nr_bytes == 0) {
+		return;
+	}
+	auto &signed_handle = handle.Cast<IcebergRemoteSignedFileHandle>();
+	auto buffer_out = static_cast<data_ptr_t>(buffer);
+	auto buffer_out_len = NumericCast<idx_t>(nr_bytes);
+
+	if (signed_handle.fully_downloaded) {
+		if (location > signed_handle.length || buffer_out_len > signed_handle.length - location) {
+			throw IOException("Cannot read %llu bytes at offset %llu from '%s', which is %llu bytes", buffer_out_len,
+			                  location, signed_handle.path, signed_handle.length);
+		}
+		memcpy(buffer_out, signed_handle.body.data() + location, buffer_out_len);
+		return;
+	}
+
+	HTTPHeaders range_header;
+	range_header.Insert("Range", StringUtil::Format("bytes=%llu-%llu", location, location + buffer_out_len - 1));
+
+	idx_t bytes_written = 0;
+	bool collect_body = false;
+	auto response = RunSignedRequest(
+	    *registry, signed_handle, RequestType::GET_REQUEST, range_header,
+	    [&](HTTPUtil &http_util, const string &url, HTTPHeaders &headers, HTTPParams &params) {
+		    GetRequestInfo get_request(
+		        url, headers, params,
+		        [&](const HTTPResponse &response) {
+			        //! A retried request restarts the body, so the output buffer restarts with it
+			        bytes_written = 0;
+			        collect_body = response.status == HTTPStatusCode::OK_200 ||
+			                       response.status == HTTPStatusCode::PartialContent_206;
+			        return true;
+		        },
+		        [&](const_data_ptr_t data, idx_t data_length) {
+			        if (!collect_body) {
+				        return true;
+			        }
+			        if (bytes_written + data_length > buffer_out_len) {
+				        throw IOException("Iceberg remote signed range request for '%s' returned more than the "
+				                          "requested %llu bytes",
+				                          signed_handle.path, buffer_out_len);
+			        }
+			        memcpy(buffer_out + bytes_written, data, data_length);
+			        bytes_written += data_length;
+			        return true;
+		        });
+		    unique_ptr<HTTPClient> client;
+		    return http_util.Request(get_request, client);
+	    });
+	CheckResponse(response.get(), signed_handle.path, "reading");
+
+	if (bytes_written != buffer_out_len) {
+		throw IOException("Iceberg remote signed range request for '%s' returned %llu bytes, expected %llu",
+		                  signed_handle.path, bytes_written, buffer_out_len);
+	}
+}
+
+int64_t IcebergRemoteSignedFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &signed_handle = handle.Cast<IcebergRemoteSignedFileHandle>();
+	if (signed_handle.file_offset >= signed_handle.length) {
+		return 0;
+	}
+	auto max_read = MinValue<idx_t>(NumericCast<idx_t>(nr_bytes), signed_handle.length - signed_handle.file_offset);
+	Read(handle, buffer, NumericCast<int64_t>(max_read), signed_handle.file_offset);
+	signed_handle.file_offset += max_read;
+	return NumericCast<int64_t>(max_read);
+}
+
+int64_t IcebergRemoteSignedFileSystem::GetFileSize(FileHandle &handle) {
+	return NumericCast<int64_t>(handle.Cast<IcebergRemoteSignedFileHandle>().length);
+}
+
+timestamp_t IcebergRemoteSignedFileSystem::GetLastModifiedTime(FileHandle &handle) {
+	return handle.Cast<IcebergRemoteSignedFileHandle>().last_modified;
+}
+
+string IcebergRemoteSignedFileSystem::GetVersionTag(FileHandle &handle) {
+	return handle.Cast<IcebergRemoteSignedFileHandle>().etag;
+}
+
+FileType IcebergRemoteSignedFileSystem::GetFileType(FileHandle &handle) {
+	return FileType::FILE_TYPE_REGULAR;
+}
+
+FileMetadata IcebergRemoteSignedFileSystem::Stats(FileHandle &handle) {
+	auto &signed_handle = handle.Cast<IcebergRemoteSignedFileHandle>();
+	FileMetadata result;
+	result.file_size = NumericCast<int64_t>(signed_handle.length);
+	result.last_modification_time = signed_handle.last_modified;
+	result.file_type = FileType::FILE_TYPE_REGULAR;
+	return result;
+}
+
+bool IcebergRemoteSignedFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {
+	try {
+		return OpenFile(filename, FileFlags::FILE_FLAGS_READ, opener) != nullptr;
+	} catch (...) {
+		return false;
+	}
+}
+
+bool IcebergRemoteSignedFileSystem::DirectoryExists(const string &directory, optional_ptr<FileOpener> opener) {
+	return true;
+}
+
+void IcebergRemoteSignedFileSystem::CreateDirectory(const string &directory, optional_ptr<FileOpener> opener) {
+}
+
+void IcebergRemoteSignedFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
+}
+
+bool IcebergRemoteSignedFileSystem::TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
+	return false;
+}
+
+void IcebergRemoteSignedFileSystem::RemoveFiles(const vector<string> &filenames, optional_ptr<FileOpener> opener) {
+}
+
+void IcebergRemoteSignedFileSystem::Seek(FileHandle &handle, idx_t location) {
+	handle.Cast<IcebergRemoteSignedFileHandle>().file_offset = location;
+}
+
+idx_t IcebergRemoteSignedFileSystem::SeekPosition(FileHandle &handle) {
+	return handle.Cast<IcebergRemoteSignedFileHandle>().file_offset;
+}
+
+void IcebergRemoteSignedFileSystem::Reset(FileHandle &handle) {
+	handle.Cast<IcebergRemoteSignedFileHandle>().file_offset = 0;
+}
+
+} // namespace duckdb

--- a/src/storage/remote_signing/iceberg_remote_signer.cpp
+++ b/src/storage/remote_signing/iceberg_remote_signer.cpp
@@ -1,0 +1,160 @@
+#include "storage/remote_signing/iceberg_remote_signer.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/enum_util.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/exception/http_exception.hpp"
+#include "duckdb/common/json_document.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/logging/logger.hpp"
+
+#include "catalog/rest/api/url_utils.hpp"
+#include "catalog/rest/iceberg_catalog.hpp"
+#include "iceberg_logging.hpp"
+
+namespace duckdb {
+
+static const char *ToMethodString(RequestType request_type) {
+	switch (request_type) {
+	case RequestType::GET_REQUEST:
+		return "GET";
+	case RequestType::HEAD_REQUEST:
+		return "HEAD";
+	case RequestType::PUT_REQUEST:
+		return "PUT";
+	case RequestType::POST_REQUEST:
+		return "POST";
+	case RequestType::DELETE_REQUEST:
+		return "DELETE";
+	default:
+		throw NotImplementedException("Iceberg remote signing does not support requests of type %s",
+		                              EnumUtil::ToString(request_type));
+	}
+}
+
+static void SplitS3Path(const string &path, string &bucket, string &key) {
+	auto scheme_end = path.find("://");
+	if (scheme_end == string::npos) {
+		throw InvalidInputException("Expected an S3 path, got '%s'", path);
+	}
+	auto bucket_start = scheme_end + 3;
+	auto bucket_end = path.find('/', bucket_start);
+	if (bucket_end == string::npos) {
+		throw InvalidInputException("S3 path '%s' does not contain a key", path);
+	}
+	bucket = path.substr(bucket_start, bucket_end - bucket_start);
+	key = path.substr(bucket_end + 1);
+}
+
+string IcebergRemoteSigner::ToHttpUrl(const IcebergRemoteSigningTarget &target, const string &path, string &host) {
+	string bucket;
+	string key;
+	SplitS3Path(path, bucket, key);
+
+	//! The signer computes the canonical request over the url as it is sent, so the key has to be
+	//! percent-encoded here and left untouched afterwards
+	auto encoded_key = StringUtil::URLEncode(key, false);
+	const char *scheme = target.use_ssl ? "https://" : "http://";
+	if (target.path_style_access) {
+		host = target.host;
+		return StringUtil::Format("%s%s%s/%s/%s", scheme, host, target.path_prefix, bucket, encoded_key);
+	}
+	host = bucket + "." + target.host;
+	return StringUtil::Format("%s%s%s/%s", scheme, host, target.path_prefix, encoded_key);
+}
+
+static string BuildSignRequestBody(const IcebergRemoteSigningTarget &target, const char *method, const string &url,
+                                   const string &host) {
+	JSONWriter writer;
+	auto root = writer.CreateObject();
+	root.AddString("region", target.region);
+	root.AddString("uri", url);
+	root.AddString("method", method);
+
+	auto headers = writer.CreateObject();
+	auto host_values = writer.CreateArray();
+	host_values.AppendString(host);
+	headers.Add("Host", host_values);
+	root.Add("headers", headers);
+
+	root.Add("properties", writer.CreateObject());
+	root.Add("body", writer.CreateNull());
+	writer.SetRoot(root);
+	return writer.ToString();
+}
+
+static IcebergSignedRequest ParseSignResponse(const string &body, const string &fallback_url) {
+	auto doc = JSONDocument::Parse(body.c_str(), body.size());
+	auto root = doc->GetRoot();
+	if (!root.IsObject()) {
+		throw HTTPException(StringUtil::Format("Iceberg remote signing response is not a JSON object: %s", body));
+	}
+
+	IcebergSignedRequest result;
+	auto uri = root.GetMember("uri");
+	result.url = uri.IsValid() && uri.IsString() ? uri.GetString() : fallback_url;
+
+	auto headers = root.GetMember("headers");
+	if (!headers.IsValid() || !headers.IsObject()) {
+		throw HTTPException(StringUtil::Format("Iceberg remote signing response does not contain 'headers': %s", body));
+	}
+	headers.IterateObject([&result](const string &key, JSONValue value) {
+		//! The signer reports its own caching policy through Cache-Control, it is not part of the signature
+		if (StringUtil::CIEquals(key, "Cache-Control")) {
+			return;
+		}
+		if (value.IsString()) {
+			result.headers.Insert(key, value.GetString());
+			return;
+		}
+		if (!value.IsArray()) {
+			return;
+		}
+		value.IterateArray([&result, &key](JSONValue element) {
+			if (element.IsString()) {
+				result.headers.Insert(key, element.GetString());
+			}
+		});
+	});
+	return result;
+}
+
+IcebergSignedRequest IcebergRemoteSigner::Sign(ClientContext &context, IcebergRemoteSigningRegistry &registry,
+                                               const IcebergRemoteSigningTarget &target, RequestType request_type,
+                                               const string &http_url, const string &host) {
+	auto method = ToMethodString(request_type);
+	auto cache_key = StringUtil::Format("%s %s %s", target.signer_url, method, http_url);
+
+	IcebergSignedRequest cached;
+	if (registry.TryGetSignature(cache_key, cached)) {
+		return cached;
+	}
+
+	auto &catalog = Catalog::GetCatalog(context, Identifier(target.catalog_name));
+	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
+
+	auto body = BuildSignRequestBody(target, method, http_url, host);
+	auto endpoint_builder = IRCEndpointBuilder::FromURL(target.signer_url);
+	HTTPHeaders headers(*context.db);
+	headers.Insert("Content-Type", "application/json");
+
+	DUCKDB_LOG(context, IcebergLogType, "Requesting an S3 signature from %s for %s %s", target.signer_url, method,
+	           http_url);
+	auto response =
+	    ic_catalog.auth_handler->Request(RequestType::POST_REQUEST, context, endpoint_builder, headers, body);
+	if (!response) {
+		throw HTTPException(
+		    StringUtil::Format("Failed to sign %s %s through the Iceberg catalog signer at %s: no response", method,
+		                       http_url, target.signer_url));
+	}
+	if (response->status != HTTPStatusCode::OK_200) {
+		throw HTTPException(*response, "Failed to sign %s %s through the Iceberg catalog signer at %s: %s", method,
+		                    http_url, target.signer_url, response->body);
+	}
+
+	auto signature = ParseSignResponse(response->body, http_url);
+	registry.PutSignature(cache_key, signature);
+	return signature;
+}
+
+} // namespace duckdb

--- a/src/storage/remote_signing/iceberg_remote_signing.cpp
+++ b/src/storage/remote_signing/iceberg_remote_signing.cpp
@@ -1,0 +1,148 @@
+#include "storage/remote_signing/iceberg_remote_signing.hpp"
+
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/timestamp.hpp"
+
+#include "catalog/rest/api/url_utils.hpp"
+
+namespace duckdb {
+
+static string GetConfigValue(const case_insensitive_map_t<string> &config, const vector<string> &keys) {
+	for (auto &key : keys) {
+		auto entry = config.find(key);
+		if (entry != config.end() && !entry->second.empty()) {
+			return entry->second;
+		}
+	}
+	return string();
+}
+
+//! Mirrors RESTUtil.resolveEndpoint: an absolute endpoint replaces the signer uri instead of extending it
+static string ResolveSignerUrl(const string &uri, const string &endpoint) {
+	auto lower_endpoint = StringUtil::Lower(endpoint);
+	if (StringUtil::StartsWith(lower_endpoint, "http://") || StringUtil::StartsWith(lower_endpoint, "https://")) {
+		return endpoint;
+	}
+	auto base = uri;
+	StringUtil::RTrim(base, "/");
+	if (base.empty()) {
+		throw InvalidConfigurationException(
+		    "Iceberg remote signing is enabled for this table, but no signer uri could be resolved");
+	}
+	idx_t path_start = 0;
+	while (path_start < endpoint.size() && endpoint[path_start] == '/') {
+		path_start++;
+	}
+	return AddHttpHostIfMissing(base + "/" + endpoint.substr(path_start));
+}
+
+bool IcebergRemoteSigningConfig::IsSupportedLocation(const string &location) {
+	return StringUtil::StartsWith(location, "s3://") || StringUtil::StartsWith(location, "s3a://") ||
+	       StringUtil::StartsWith(location, "s3n://");
+}
+
+bool IcebergRemoteSigningConfig::TryParse(const case_insensitive_map_t<string> &config, const string &catalog_uri,
+                                          const string &catalog_name, IcebergRemoteSigningTarget &result) {
+	auto enabled = GetConfigValue(config, {"s3.remote-signing-enabled", "remote-signing-enabled"});
+	if (!StringUtil::CIEquals(enabled, "true")) {
+		return false;
+	}
+
+	auto signer_uri = GetConfigValue(config, {"signer.uri", "s3.signer.uri"});
+	if (signer_uri.empty()) {
+		signer_uri = catalog_uri;
+	}
+	auto signer_endpoint = GetConfigValue(config, {"signer.endpoint", "s3.signer.endpoint"});
+	if (signer_endpoint.empty()) {
+		signer_endpoint = DEFAULT_SIGNER_ENDPOINT;
+	}
+
+	result.catalog_name = catalog_name;
+	result.signer_url = ResolveSignerUrl(signer_uri, signer_endpoint);
+	result.region = GetConfigValue(config, {"s3.region", "client.region", "region"});
+	if (result.region.empty()) {
+		throw InvalidConfigurationException("Iceberg remote signing is enabled for this table, but the catalog did "
+		                                    "not report the 's3.region' that requests have to be signed for");
+	}
+	result.path_style_access = StringUtil::CIEquals(GetConfigValue(config, {"s3.path-style-access"}), "true");
+
+	auto endpoint = GetConfigValue(config, {"s3.endpoint"});
+	if (endpoint.empty()) {
+		result.host = StringUtil::Format("s3.%s.amazonaws.com", result.region);
+		return true;
+	}
+
+	if (StringUtil::StartsWith(StringUtil::Lower(endpoint), "http://")) {
+		result.use_ssl = false;
+	}
+	auto authority = StripScheme(endpoint);
+	StringUtil::RTrim(authority, "/");
+	auto path_start = authority.find('/');
+	if (path_start != string::npos) {
+		result.path_prefix = authority.substr(path_start);
+		authority = authority.substr(0, path_start);
+	}
+	result.host = authority;
+	return true;
+}
+
+void IcebergRemoteSigningRegistry::RegisterTarget(const string &location, IcebergRemoteSigningTarget target) {
+	auto prefix = location;
+	if (!StringUtil::EndsWith(prefix, "/")) {
+		prefix += "/";
+	}
+	lock_guard<mutex> guard(lock);
+	targets[prefix] = std::move(target);
+	has_targets = true;
+}
+
+bool IcebergRemoteSigningRegistry::TryGetTarget(const string &path, IcebergRemoteSigningTarget &result) {
+	if (Empty()) {
+		return false;
+	}
+	lock_guard<mutex> guard(lock);
+	idx_t longest_match = 0;
+	bool found = false;
+	for (auto &entry : targets) {
+		if (entry.first.size() <= longest_match || !StringUtil::StartsWith(path, entry.first)) {
+			continue;
+		}
+		longest_match = entry.first.size();
+		result = entry.second;
+		found = true;
+	}
+	return found;
+}
+
+bool IcebergRemoteSigningRegistry::TryGetSignature(const string &cache_key, IcebergSignedRequest &result) {
+	lock_guard<mutex> guard(lock);
+	auto entry = signatures.find(cache_key);
+	if (entry == signatures.end()) {
+		return false;
+	}
+	if (Timestamp::GetCurrentTimestamp() >= entry->second.expires_at) {
+		signatures.erase(entry);
+		return false;
+	}
+	result = entry->second.signature;
+	return true;
+}
+
+void IcebergRemoteSigningRegistry::PutSignature(const string &cache_key, const IcebergSignedRequest &signature) {
+	auto now = Timestamp::GetCurrentTimestamp();
+	CachedSignature cached;
+	cached.expires_at = Timestamp::FromEpochMs(Timestamp::GetEpochMs(now) + SIGNATURE_CACHE_MS);
+	cached.signature = signature;
+
+	lock_guard<mutex> guard(lock);
+	//! Every file gets its own entry and is rarely signed twice, so expired entries have to be swept
+	//! instead of being evicted on lookup
+	if (signatures.size() >= SIGNATURE_CACHE_SWEEP_SIZE) {
+		for (auto it = signatures.begin(); it != signatures.end();) {
+			it = now >= it->second.expires_at ? signatures.erase(it) : std::next(it);
+		}
+	}
+	signatures[cache_key] = std::move(cached);
+}
+
+} // namespace duckdb

--- a/test/sql/local/catalog_custom_setup/nessie/test_nessie.test
+++ b/test/sql/local/catalog_custom_setup/nessie/test_nessie.test
@@ -43,7 +43,7 @@ attach '' as my_datalake (
     SECRET 'my_secret'
 );
 ----
-<REGEX>:.*Unrecognized access mode.*Supported options are 'vended_credentials' and 'none'.*
+<REGEX>:.*Unrecognized access mode.*Supported options are 'vended_credentials', 'remote_signing' and 'none'.*
 
 statement ok
 call enable_logging(level='debug');

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/lakekeeper/test_remote_signing.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/lakekeeper/test_remote_signing.test
@@ -1,0 +1,112 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_specifc/lakekeeper/test_remote_signing.test
+# group: [lakekeeper]
+
+require httpfs
+
+require avro
+
+require parquet
+
+require iceberg
+
+require-env CATALOG_TEST_CONFIG_SETUP lakekeeper
+
+statement ok
+set enable_logging=true;
+
+statement ok
+set logging_level='debug';
+
+statement ok
+call enable_logging(['Iceberg', 'HTTP']);
+
+# 'demo_remote_signing' is created with sts-enabled = false, so the catalog can only delegate
+# access through remote request signing. No S3 credentials exist in this process.
+statement ok
+attach 'demo_remote_signing' as remote_signing_catalog (
+	type ICEBERG,
+	URI 'http://localhost:8181/catalog',
+	SECRET 'my_secret',
+	ACCESS_DELEGATION_MODE 'remote_signing'
+);
+
+query III
+select * from remote_signing_catalog.remote_signing.remote_signing_table order by id;
+----
+1	a-string	2.2
+2	another-string	3.3
+3	a-third-string	4.4
+
+query II
+select count(*), sum(id) from remote_signing_catalog.remote_signing.remote_signing_table;
+----
+3	6
+
+query I
+select strings from remote_signing_catalog.remote_signing.remote_signing_table where id = 2;
+----
+another-string
+
+query I
+select count(*) from duckdb_secrets() where type = 's3';
+----
+0
+
+# The metadata of the table lives on the same storage and is read through the signer as well
+query I
+select count(*) > 0 from iceberg_metadata(remote_signing_catalog.remote_signing.remote_signing_table);
+----
+true
+
+statement error
+insert into remote_signing_catalog.remote_signing.remote_signing_table values (4, 'a-fourth-string', 5.5);
+----
+<REGEX>:.*remote request signing.*
+
+# Data files are immutable once their snapshot is committed, which is why the multi file list marks
+# them as not needing cache validation. Without that the caching layer finds no version tag to
+# validate against and bypasses the external file cache for every read.
+statement ok
+set enable_external_file_cache=true;
+
+statement ok
+select count(*) from remote_signing_catalog.remote_signing.remote_signing_table;
+
+query I
+select count(*) > 0 from duckdb_external_file_cache()
+where path like 's3://examples/remote-signing-warehouse/%.parquet' and loaded;
+----
+true
+
+# A signature covers an object, not a byte range, so all reads of a file share one. Turning the
+# external file cache off forces the repeated storage requests that would otherwise be served from
+# memory, so a signature cache that stopped working becomes visible below.
+statement ok
+set enable_external_file_cache=false;
+
+statement ok
+select count(*), sum(id) from remote_signing_catalog.remote_signing.remote_signing_table;
+
+query I
+select count(*) > 0 from duckdb_logs() where type = 'Iceberg' and message like 'Requesting an S3 signature%';
+----
+true
+
+statement ok
+call truncate_duckdb_logs();
+
+statement ok
+select count(*), sum(id) from remote_signing_catalog.remote_signing.remote_signing_table;
+
+# The same objects are read again
+query I
+select count(*) > 0 from duckdb_logs_parsed('HTTP')
+where request.type = 'GET' and request.url like '%remote-signing-warehouse%';
+----
+true
+
+# but every one of them is signed already, so the catalog is not asked again
+query I
+select count(*) from duckdb_logs() where type = 'Iceberg' and message like 'Requesting an S3 signature%';
+----
+0


### PR DESCRIPTION
Adds support for the `remote-signing` storage access delegation mode, so Iceberg tables can be read from object stores that have no STS endpoint and therefore can't vend credentials. Closes #670.

## Why a separate filesystem

With remote signing the client never holds storage credentials: it POSTs the request details to the catalog's signer endpoint and gets back the `Authorization`, `x-amz-date` and `x-amz-content-sha256` headers to replay against the object store. `httpfs`'s `S3FileSystem` computes SigV4 locally and has no hook to substitute a signer, so this adds an iceberg-owned filesystem that claims only the storage locations the catalog told us to sign for. Everything else keeps going through `httpfs`.

I guess creating a parallel S3 filesystem long-term is undesireable. If you'd take a pluggable request-signer hook in `S3FileSystem` ( the way the AWS SDKs and PyIceberg implement this ) I'm happy to redo it that way, and it would give us connection pooling and multipart uploads for free. This PR is the version that needs no changes outside this repo.

## Honoring it only when asked

`ACCESS_DELEGATION_MODE 'remote_signing'` sends `X-Iceberg-Access-Delegation: remote-signing`, and signing is used only when the attach asked for it.

That gating matters. Catalogs report `s3.remote-signing-enabled` whenever their storage profile *supports* signing, not when the client chose it — Nessie advertises it unconditionally. Treating the flag alone as consent hijacks storage access from an attach that manages its own credentials, and the existing Nessie tests catch it.

## Details worth a look

- The signer URL comes from `signer.uri`/`signer.endpoint`, falling back to the deprecated `s3.signer.*` aliases and then to the catalog URI plus the spec default `v1/aws/s3/sign`. An absolute `signer.endpoint` replaces the URI rather than extending it, matching `RESTUtil.resolveEndpoint`.
- Region is required, since it's what the request is signed for.
- The sign request goes through the catalog's existing auth handler, so OAuth2 / SigV4 / none all work unchanged.
- Object keys are percent-encoded before signing and left untouched afterwards, because the signer computes the canonical request over the URL as it is sent.
- Signatures are cached per `(signer, method, url)` for 30s, matching `S3V4RestSignerClient`. `Cache-Control` is dropped from the applied headers.
- `X-Iceberg-Access-Delegation` was written inline at six call sites; those now go through `ICUtils::AddAccessDelegationHeader`.

## Reads only

Writes fail with an explicit error rather than a signature rejection. The cleanup entry points (`RemoveFile`, `CreateDirectory`) are no-ops instead of throwing, since they run while a write error is already in flight and nothing can be written through this filesystem anyway.

Reads use signed ranged GETs. `force_full_download`, which Iceberg sets on manifests and manifest lists, is honored with a single whole-object GET, and the `HEAD` for the file size is skipped when Iceberg already reported `file_size`. The external file cache and the parquet reader's prefetch coalescing both sit above the filesystem, so they keep working unchanged.

## Testing

`make lakekeeper` now also creates a `demo_remote_signing` warehouse with `sts-enabled: false` and `remote-signing-enabled: true` and seeds a table into it, via the Spark client already used for the other Lakekeeper fixtures. With STS off the catalog can only answer with signing information, so the test can't quietly pass on vended credentials instead.

`test_remote_signing.test` attaches that warehouse, reads the table, asserts that no S3 secret exists in the process, reads the table metadata, and asserts the write path errors. It also pins two behaviours that otherwise hold only implicitly, where nothing would fail if they stopped working: that data file reads participate in the external file cache, and that a signature is reused across all reads of an object rather than fetched per read.

The Nessie setup test was updated for the new access-mode error message.

## Known gaps

- Writes need PUT and multipart-upload support in the new filesystem.
- No HTTP connection reuse. The filesystem default-constructs a client per request and never returns it through `HTTPUtil::CloseClient`, so every request pays a fresh handshake.
- `FileSystem::TryGetNetworkThroughput` isn't implemented, so the parquet prefetch cost model stays unmeasured and the coalescing gap stays at its 16 KiB default. Largely masked by the external file cache's 2 MiB blocks, so it matters most when that cache is off.

## AI Disclaimer

I wrote this code with extensive help of AI next to my own effort. I'm happy to spend more time on this if you think the quality is not good enough. Thanks for taking the time to check it 