### PR TITLE
Log when a SigV4 catalog secret refresh fails

### DIFF
--- a/src/catalog/rest/storage/authorization/sigv4.cpp
+++ b/src/catalog/rest/storage/authorization/sigv4.cpp
@@ -183,10 +183,7 @@ void SIGV4Authorization::MaybeRefreshSecret(ClientContext &context) {
 		(void)secret_manager.CreateSecret(context, refresh_input);
 		last_refresh_time = std::chrono::steady_clock::now();
 	} catch (std::exception &ex) {
-		// Leave last_refresh_time alone so the next call retries. Log it: the request is about
-		// to be signed with a credential that may already have expired, and without this the
-		// only symptom is a confusing authorization failure from the catalog. Log the resolved
-		// name rather than `secret`, which is empty when the catalog matched a secret by scope.
+		// Leave last_refresh_time alone so the next call retries with the same credentials.
 		DUCKDB_LOG_DEBUG(context, "Iceberg SigV4 secret '%s' was not updated, refresh failed: %s", refresh_input.name,
 		                 ex.what());
 	}

--- a/src/catalog/rest/storage/authorization/sigv4.cpp
+++ b/src/catalog/rest/storage/authorization/sigv4.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/logging/logger.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/main/setting_info.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -181,8 +182,13 @@ void SIGV4Authorization::MaybeRefreshSecret(ClientContext &context) {
 		auto &secret_manager = context.db->GetSecretManager();
 		(void)secret_manager.CreateSecret(context, refresh_input);
 		last_refresh_time = std::chrono::steady_clock::now();
-	} catch (std::exception &) {
-		// Leave last_refresh_time alone so the next call retries
+	} catch (std::exception &ex) {
+		// Leave last_refresh_time alone so the next call retries. Log it: the request is about
+		// to be signed with a credential that may already have expired, and without this the
+		// only symptom is a confusing authorization failure from the catalog. Log the resolved
+		// name rather than `secret`, which is empty when the catalog matched a secret by scope.
+		DUCKDB_LOG_DEBUG(context, "Iceberg SigV4 secret '%s' was not updated, refresh failed: %s", refresh_input.name,
+		                 ex.what());
 	}
 }
 


### PR DESCRIPTION
Follow-up to @Tmonster's last nit on #1051, which merged without it.

`MaybeRefreshSecret` swallowed the exception, so a refresh failing on every interval left no trace — the only symptom was a confusing authorization failure from the catalog, which is exactly the case that is hard to diagnose in a long-running process.

Logs the resolved secret name rather than the `secret` attach option: that option is empty when the catalog matched a secret by scope, which is the common case (verified — it logged `secret ''` before this).

Verified by making a refresh actually fail (emptying the credentials file the `config` chain reads, then forcing expiry):

```
DEBUG: Iceberg SigV4 secret 's' was not updated, refresh failed:
  {"exception_type":"Invalid Configuration","exception_message":"Secret Validation Failure: ..."}
```

`sigv4_mock` tests still pass (39 assertions).