### PR TITLE
Fix parallel Avro manifest publication race

### DIFF
--- a/src/include/planning/metadata_io/avro/iceberg_avro_multi_file_list.hpp
+++ b/src/include/planning/metadata_io/avro/iceberg_avro_multi_file_list.hpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/mutex.hpp"
 
 #include "core/metadata/iceberg_table_metadata.hpp"
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
@@ -72,11 +73,16 @@ public:
 	virtual ~IcebergManifestFileScanInfo();
 
 	idx_t GetManifestIndex(idx_t scan_index) const;
+	mutex &GetManifestLock(idx_t manifest_index);
 
 public:
 	vector<IcebergManifestListEntry> &manifest_files;
 	//! Maps the compact multi-file scan index to the owning manifest-list entry.
 	vector<idx_t> manifest_indexes;
+	//! A manifest Avro file can now be scanned by multiple workers, one per Avro block.
+	//! Serialize writes to each owning manifest-list entry while retaining parallelism
+	//! between different manifest files.
+	vector<unique_ptr<mutex>> manifest_locks;
 	const IcebergOptions &options;
 	FileSystem &fs;
 	string iceberg_path;

--- a/src/planning/metadata_io/avro/iceberg_avro_multi_file_list.cpp
+++ b/src/planning/metadata_io/avro/iceberg_avro_multi_file_list.cpp
@@ -31,6 +31,10 @@ IcebergManifestFileScanInfo::IcebergManifestFileScanInfo(
 		}
 	}
 	manifest_indexes = std::move(manifest_indexes_p);
+	manifest_locks.reserve(manifest_files.size());
+	for (idx_t manifest_idx = 0; manifest_idx < manifest_files.size(); manifest_idx++) {
+		manifest_locks.push_back(make_uniq<mutex>());
+	}
 	unordered_set<int32_t> partition_spec_ids;
 	for (auto manifest_idx : manifest_indexes) {
 		if (manifest_idx >= manifest_files.size()) {
@@ -56,6 +60,13 @@ idx_t IcebergManifestFileScanInfo::GetManifestIndex(idx_t scan_index) const {
 		throw InternalException("Manifest scan index %llu is out of bounds", scan_index);
 	}
 	return manifest_indexes[scan_index];
+}
+
+mutex &IcebergManifestFileScanInfo::GetManifestLock(idx_t manifest_index) {
+	if (manifest_index >= manifest_locks.size()) {
+		throw InternalException("Manifest lock index %llu is out of bounds", manifest_index);
+	}
+	return *manifest_locks[manifest_index];
 }
 
 IcebergAvroMultiFileList::IcebergAvroMultiFileList(shared_ptr<IcebergAvroScanInfo> info, vector<OpenFileInfo> paths)

--- a/src/planning/metadata_io/avro/iceberg_avro_multi_file_reader.cpp
+++ b/src/planning/metadata_io/avro/iceberg_avro_multi_file_reader.cpp
@@ -603,11 +603,13 @@ ReaderInitializeType IcebergAvroMultiFileReader::InitializeReader(
 			auto file_idx = manifest_scan_info.GetManifestIndex(reader_data.reader->file_list_idx.GetIndex());
 			lock_guard<mutex> manifest_guard(manifest_scan_info.GetManifestLock(file_idx));
 			auto &manifest_list_entry = manifest_scan_info.manifest_files[file_idx];
-			auto manifest_path = manifest_list_entry.file.manifest_path.empty()
-			                         ? reader_data.reader->GetFileName()
-			                         : manifest_list_entry.file.manifest_path;
-			manifest_list_entry.manifest_metadata.emplace(
-			    ParseManifestMetadata(reader_data.reader->GetMetadata(), manifest_path));
+			if (!manifest_list_entry.manifest_metadata) {
+				auto manifest_path = manifest_list_entry.file.manifest_path.empty()
+				                         ? reader_data.reader->GetFileName()
+				                         : manifest_list_entry.file.manifest_path;
+				manifest_list_entry.manifest_metadata.emplace(
+				    ParseManifestMetadata(reader_data.reader->GetMetadata(), manifest_path));
+			}
 		}
 		for (auto &partition_spec : avro_scan_info.metadata.partition_specs) {
 			for (auto &spec_field : partition_spec.second.fields) {
@@ -649,14 +651,10 @@ void IcebergAvroMultiFileReader::FinalizeChunk(ClientContext &context, const Mul
 		auto manifest_file_idx = manifest_scan_info.GetManifestIndex(reader.file_list_idx.GetIndex());
 		auto &manifest_file = manifest_scan_info.manifest_files[manifest_file_idx];
 
-		auto manifest_metadata = [&]() {
-			lock_guard<mutex> manifest_guard(manifest_scan_info.GetManifestLock(manifest_file_idx));
-			if (!manifest_file.manifest_metadata) {
-				throw InternalException("Manifest metadata was not initialized for '%s'",
-				                        manifest_file.file.manifest_path);
-			}
-			return *manifest_file.manifest_metadata;
-		}();
+		//! InitializeReader publishes this immutable value under the per-manifest lock
+		//! before this reader can produce chunks.
+		D_ASSERT(manifest_file.manifest_metadata);
+		auto &manifest_metadata = *manifest_file.manifest_metadata;
 		auto spec_id = manifest_metadata.partition_spec_id;
 		auto partition_spec_p = metadata.FindPartitionSpecById(spec_id);
 		if (!partition_spec_p) {

--- a/src/planning/metadata_io/avro/iceberg_avro_multi_file_reader.cpp
+++ b/src/planning/metadata_io/avro/iceberg_avro_multi_file_reader.cpp
@@ -601,6 +601,7 @@ ReaderInitializeType IcebergAvroMultiFileReader::InitializeReader(
 		if (avro_scan_info.type == AvroScanInfoType::MANIFEST_FILE) {
 			auto &manifest_scan_info = avro_scan_info.Cast<IcebergManifestFileScanInfo>();
 			auto file_idx = manifest_scan_info.GetManifestIndex(reader_data.reader->file_list_idx.GetIndex());
+			lock_guard<mutex> manifest_guard(manifest_scan_info.GetManifestLock(file_idx));
 			auto &manifest_list_entry = manifest_scan_info.manifest_files[file_idx];
 			auto manifest_path = manifest_list_entry.file.manifest_path.empty()
 			                         ? reader_data.reader->GetFileName()
@@ -648,7 +649,14 @@ void IcebergAvroMultiFileReader::FinalizeChunk(ClientContext &context, const Mul
 		auto manifest_file_idx = manifest_scan_info.GetManifestIndex(reader.file_list_idx.GetIndex());
 		auto &manifest_file = manifest_scan_info.manifest_files[manifest_file_idx];
 
-		auto &manifest_metadata = *manifest_file.manifest_metadata;
+		auto manifest_metadata = [&]() {
+			lock_guard<mutex> manifest_guard(manifest_scan_info.GetManifestLock(manifest_file_idx));
+			if (!manifest_file.manifest_metadata) {
+				throw InternalException("Manifest metadata was not initialized for '%s'",
+				                        manifest_file.file.manifest_path);
+			}
+			return *manifest_file.manifest_metadata;
+		}();
 		auto spec_id = manifest_metadata.partition_spec_id;
 		auto partition_spec_p = metadata.FindPartitionSpecById(spec_id);
 		if (!partition_spec_p) {
@@ -660,10 +668,26 @@ void IcebergAvroMultiFileReader::FinalizeChunk(ClientContext &context, const Mul
 
 		IcebergManifestReaderInput input(manifest_metadata, partition_spec, metadata.iceberg_version);
 
+		vector<IcebergManifestEntry> decoded_entries;
+		manifest_file::ManifestReader::ReadChunk(output_chunk, manifest_scan_info.partition_field_id_to_type, input,
+		                                         decoded_entries);
+
+		lock_guard<mutex> manifest_guard(manifest_scan_info.GetManifestLock(manifest_file_idx));
 		auto &manifest_entries = manifest_file.GetOrCreateManifestEntries();
 		idx_t start_index = manifest_entries.size();
-		manifest_file::ManifestReader::ReadChunk(output_chunk, manifest_scan_info.partition_field_id_to_type, input,
-		                                         manifest_entries);
+		if (manifest_scan_info.read_state) {
+			//! Streaming consumers retain references into this vector after publication. LoadManifestList
+			//! reserves the exact manifest-list file count before it enables this path, so exceeding the
+			//! reserved capacity means the advertised count was wrong; appending would invalidate those
+			//! references.
+			if (decoded_entries.size() > manifest_entries.capacity() - manifest_entries.size()) {
+				throw InvalidConfigurationException("Manifest '%s' contains more entries than its manifest-list counts",
+				                                    manifest_file.file.manifest_path);
+			}
+		}
+		for (auto &entry : decoded_entries) {
+			manifest_entries.push_back(std::move(entry));
+		}
 		if (manifest_scan_info.read_state) {
 			auto &read_state = *manifest_scan_info.read_state;
 			read_state.PushBatch(ManifestReadBatch(manifest_file_idx, start_index, manifest_entries.size()));


### PR DESCRIPTION
After #1304, multiple Avro blocks from one manifest can be decoded concurrently. Decode chunks privately and serialize metadata and entry publication per manifest so workers cannot mutate the same shared vector at once.

This was causing a segmentation fault for me