### PR TITLE
Reject NULL snapshot_id in iceberg_rollback_to_snapshot

### DIFF
--- a/src/function/metadata/iceberg_rollback_to_snapshot.cpp
+++ b/src/function/metadata/iceberg_rollback_to_snapshot.cpp
@@ -58,6 +58,10 @@ static unique_ptr<FunctionData> IcebergRollbackToSnapshotBind(ClientContext &con
                                                               vector<Identifier> &names) {
 	auto ret = make_uniq<IcebergRollbackToSnapshotBindData>();
 
+	if (input.inputs[1].IsNull()) {
+		throw InvalidInputException("iceberg_rollback_to_snapshot: snapshot_id cannot be NULL");
+	}
+
 	auto input_string = input.inputs[0].ToString();
 	VerifyInputIsNotAFile(context, input_string);
 	auto parts = QualifiedName::ParseComponents(input_string);

--- a/test/sql/local/maintenance/rollback_to_snapshot_validation.test
+++ b/test/sql/local/maintenance/rollback_to_snapshot_validation.test
@@ -37,3 +37,8 @@ statement error
 SELECT * FROM iceberg_rollback_to_snapshot('cat.sch.tbl', 1);
 ----
 Catalog "cat" does not exist
+
+statement error
+SELECT * FROM iceberg_rollback_to_snapshot('cat.sch.tbl', NULL);
+----
+snapshot_id cannot be NULL


### PR DESCRIPTION

- Guard `iceberg_rollback_to_snapshot` bind against a NULL `snapshot_id` so callers get `InvalidInputException` instead of an `INTERNAL Error` from `Value::GetValue`.
- Add a bind-time validation test covering the NULL case.