### PR TITLE
Evict cached tables that the REST listing no longer contains

### DIFF
--- a/src/catalog/rest/api/catalog_api.cpp
+++ b/src/catalog/rest/api/catalog_api.cpp
@@ -303,13 +303,10 @@ IRCAPI::GetNamespace(ClientContext &context, IcebergCatalog &catalog, const Iceb
 	return ret;
 }
 
-vector<rest_api_objects::TableIdentifier> IRCAPI::GetTables(ClientContext &context, IcebergCatalog &catalog,
-                                                            const IcebergSchemaEntry &schema, bool *listing_complete) {
+optional<vector<rest_api_objects::TableIdentifier>> IRCAPI::GetTables(ClientContext &context, IcebergCatalog &catalog,
+                                                                      const IcebergSchemaEntry &schema) {
 	vector<rest_api_objects::TableIdentifier> all_identifiers;
 	string page_token;
-	if (listing_complete) {
-		*listing_complete = true;
-	}
 
 	do {
 		auto url_builder = catalog.GetBaseUrl();
@@ -336,12 +333,8 @@ vector<rest_api_objects::TableIdentifier> IRCAPI::GetTables(ClientContext &conte
 				// results.
 				DUCKDB_LOG_WARNING(context, "GET %s returned status code %s", url_builder.GetURLEncoded(),
 				                   EnumUtil::ToString(response->status));
-				// return empty result if user cannot list tables for a schema.
-				if (listing_complete) {
-					*listing_complete = false;
-				}
-				vector<rest_api_objects::TableIdentifier> ret;
-				return ret;
+				// no listing if the user cannot list tables for a schema.
+				return nullopt;
 			}
 			auto url = url_builder.GetURLEncoded();
 			ThrowException(url, *response, "GET");

--- a/src/catalog/rest/api/catalog_api.cpp
+++ b/src/catalog/rest/api/catalog_api.cpp
@@ -304,9 +304,12 @@ IRCAPI::GetNamespace(ClientContext &context, IcebergCatalog &catalog, const Iceb
 }
 
 vector<rest_api_objects::TableIdentifier> IRCAPI::GetTables(ClientContext &context, IcebergCatalog &catalog,
-                                                            const IcebergSchemaEntry &schema) {
+                                                            const IcebergSchemaEntry &schema, bool *listing_complete) {
 	vector<rest_api_objects::TableIdentifier> all_identifiers;
 	string page_token;
+	if (listing_complete) {
+		*listing_complete = true;
+	}
 
 	do {
 		auto url_builder = catalog.GetBaseUrl();
@@ -334,6 +337,9 @@ vector<rest_api_objects::TableIdentifier> IRCAPI::GetTables(ClientContext &conte
 				DUCKDB_LOG_WARNING(context, "GET %s returned status code %s", url_builder.GetURLEncoded(),
 				                   EnumUtil::ToString(response->status));
 				// return empty result if user cannot list tables for a schema.
+				if (listing_complete) {
+					*listing_complete = false;
+				}
 				vector<rest_api_objects::TableIdentifier> ret;
 				return ret;
 			}

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -177,17 +177,16 @@ void IcebergTableSet::LoadEntriesInternal(ClientContext &context) {
 		return;
 	}
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
-	bool listing_complete = true;
-	auto tables = IRCAPI::GetTables(context, ic_catalog, schema, &listing_complete);
-	case_insensitive_set_t listed;
-	for (auto &table : tables) {
-		listed.insert(table.name);
-		entries.emplace(table.name, make_shared_ptr<IcebergTable>(ic_catalog, schema, table.name));
-	}
-	// 'entries' outlives the transaction, so a table dropped through another engine stays
-	// cached unless the listing is treated as authoritative and absent names are removed.
-	// Entries created in this transaction live on the transaction, not here, so they are safe.
-	if (listing_complete) {
+	auto tables = IRCAPI::GetTables(context, ic_catalog, schema);
+	// A refused listing says nothing about which tables exist, so the cache is left untouched.
+	if (tables) {
+		case_insensitive_set_t listed;
+		for (auto &table : *tables) {
+			listed.insert(table.name);
+			entries.emplace(table.name, make_shared_ptr<IcebergTable>(ic_catalog, schema, table.name));
+		}
+		// 'entries' outlives the transaction, so drop the names the listing no longer reports.
+		// Tables created in this transaction live on the transaction, not here, so they are safe.
 		for (auto it = entries.begin(); it != entries.end();) {
 			if (listed.find(it->first) == listed.end()) {
 				it = entries.erase(it);

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -177,9 +177,24 @@ void IcebergTableSet::LoadEntriesInternal(ClientContext &context) {
 		return;
 	}
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
-	auto tables = IRCAPI::GetTables(context, ic_catalog, schema);
+	bool listing_complete = true;
+	auto tables = IRCAPI::GetTables(context, ic_catalog, schema, &listing_complete);
+	case_insensitive_set_t listed;
 	for (auto &table : tables) {
+		listed.insert(table.name);
 		entries.emplace(table.name, make_shared_ptr<IcebergTable>(ic_catalog, schema, table.name));
+	}
+	// 'entries' outlives the transaction, so a table dropped through another engine stays
+	// cached unless the listing is treated as authoritative and absent names are removed.
+	// Entries created in this transaction live on the transaction, not here, so they are safe.
+	if (listing_complete) {
+		for (auto it = entries.begin(); it != entries.end();) {
+			if (listed.find(it->first) == listed.end()) {
+				it = entries.erase(it);
+			} else {
+				++it;
+			}
+		}
 	}
 	iceberg_transaction.listed_schemas.insert(schema.name.GetIdentifierName());
 }

--- a/src/include/catalog/rest/api/catalog_api.hpp
+++ b/src/include/catalog/rest/api/catalog_api.hpp
@@ -66,11 +66,9 @@ public:
 class IRCAPI {
 public:
 	static const string API_VERSION_1;
-	//! When 'listing_complete' is given it is set to false if the catalog refused the listing,
-	//! which is reported as an empty result and must not be read as "the schema is empty".
-	static vector<rest_api_objects::TableIdentifier> GetTables(ClientContext &context, IcebergCatalog &catalog,
-	                                                           const IcebergSchemaEntry &schema,
-	                                                           bool *listing_complete = nullptr);
+	//! Returns 'nullopt' if the catalog refused the listing, which must not be read as "the schema is empty".
+	static optional<vector<rest_api_objects::TableIdentifier>>
+	GetTables(ClientContext &context, IcebergCatalog &catalog, const IcebergSchemaEntry &schema);
 	static bool VerifyResponse(ClientContext &context, IcebergCatalog &catalog, IRCEndpointBuilder &url_builder,
 	                           bool execute_head);
 	static bool VerifySchemaExistence(ClientContext &context, IcebergCatalog &catalog, const string &schema);

--- a/src/include/catalog/rest/api/catalog_api.hpp
+++ b/src/include/catalog/rest/api/catalog_api.hpp
@@ -66,8 +66,11 @@ public:
 class IRCAPI {
 public:
 	static const string API_VERSION_1;
+	//! When 'listing_complete' is given it is set to false if the catalog refused the listing,
+	//! which is reported as an empty result and must not be read as "the schema is empty".
 	static vector<rest_api_objects::TableIdentifier> GetTables(ClientContext &context, IcebergCatalog &catalog,
-	                                                           const IcebergSchemaEntry &schema);
+	                                                           const IcebergSchemaEntry &schema,
+	                                                           bool *listing_complete = nullptr);
 	static bool VerifyResponse(ClientContext &context, IcebergCatalog &catalog, IRCEndpointBuilder &url_builder,
 	                           bool execute_head);
 	static bool VerifySchemaExistence(ClientContext &context, IcebergCatalog &catalog, const string &schema);

--- a/test/sql/local/catalog_custom_setup/fixture/dropped_table_removed_from_listing.test
+++ b/test/sql/local/catalog_custom_setup/fixture/dropped_table_removed_from_listing.test
@@ -1,0 +1,90 @@
+# name: test/sql/local/catalog_custom_setup/fixture/dropped_table_removed_from_listing.test
+# description: A table dropped through another catalog client must disappear from an existing attachment's listing
+# group: [fixture]
+
+require-env FIXTURE_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require core_functions
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+# Two attachments to the same REST catalog, each with its own catalog state, so a drop
+# through 'writer_catalog' only reaches 'reader_catalog' via the list-tables endpoint.
+statement ok
+ATTACH OR REPLACE '' AS writer_catalog (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    URI 'http://127.0.0.1:8181'
+);
+
+statement ok
+ATTACH OR REPLACE '' AS reader_catalog (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    URI 'http://127.0.0.1:8181'
+);
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS writer_catalog.default;
+
+statement ok
+DROP TABLE IF EXISTS writer_catalog.default.listing_prune_dropped;
+
+statement ok
+DROP TABLE IF EXISTS writer_catalog.default.listing_prune_kept;
+
+statement ok
+CREATE TABLE writer_catalog.default.listing_prune_dropped (id INTEGER);
+
+statement ok
+CREATE TABLE writer_catalog.default.listing_prune_kept (id INTEGER);
+
+# Cache both names in 'reader_catalog'; without this there is no stale entry to survive.
+query I
+SELECT table_name FROM duckdb_tables()
+WHERE database_name = 'reader_catalog' AND schema_name = 'default'
+  AND table_name IN ('listing_prune_dropped', 'listing_prune_kept')
+ORDER BY table_name;
+----
+listing_prune_dropped
+listing_prune_kept
+
+statement ok
+DROP TABLE writer_catalog.default.listing_prune_dropped;
+
+# 'reader_catalog' never saw the DROP, so it must pick the removal up from the listing.
+# The sibling must survive: the listing is authoritative, not a blanket cache clear.
+query I
+SELECT table_name FROM duckdb_tables()
+WHERE database_name = 'reader_catalog' AND schema_name = 'default'
+  AND table_name IN ('listing_prune_dropped', 'listing_prune_kept')
+ORDER BY table_name;
+----
+listing_prune_kept
+
+# The dropped table must also be gone for a direct lookup, not just a listing.
+statement error
+SELECT * FROM reader_catalog.default.listing_prune_dropped;
+----
+<REGEX>:.*listing_prune_dropped.*
+
+statement ok
+DROP TABLE IF EXISTS writer_catalog.default.listing_prune_kept;


### PR DESCRIPTION
## Problem

This shows up primarily with long-lived DuckDB processes, such as the Quack server, where a single `ATTACH` can stay alive for hours or days.

The REST catalog listing is refreshed for each transaction, but `IcebergTableSet::entries` is scoped to the `ATTACH`. The refreshed results are merged with the existing cache using `entries.emplace()`, so tables removed by another writer are never evicted.

```text
Quack server / embedded DuckDB
        │
        │ long-lived ATTACH
        ▼
IcebergTableSet::entries
        │
        │ new transaction
        ▼
     GetTables()
        │
        │ current REST listing
        ▼
    entries.emplace()
        │
        └── stale entries remain
```

This is more noticeable in the Quack server because the DuckDB process and `ATTACH` can remain alive for a long time. A dropped table can therefore continue to appear in listings until the connection is detached or restarted.

With an embedded DuckDB process that is frequently recreated, the stale cache is naturally discarded with the process, so the issue is much less visible.

## Fix

Treat the REST listing as authoritative and evict cached entries that are no longer returned:

```text
GetTables()
    │
    ▼
current catalog listing
    │
    ├── add new entries
    ├── keep existing entries
    └── evict entries no longer listed
```

`GetTables()` can return an empty vector for 401/403/404, so an empty result does not necessarily mean the schema is empty. A `listing_complete` flag is therefore used to distinguish a complete empty listing from an incomplete one, and eviction only happens for complete listings.

## Result

The existing ATTACH-scoped cache is preserved, but long-lived processes such as the Quack server now converge with the REST catalog when tables are removed externally.
