### PR TITLE
Fix iceberg_bucket UUID hashing to use RFC 4122 big-endian bytes

### DIFF
--- a/scripts/data_generators/tests/default/bucket_partitioned_uuid/__init__.py
+++ b/scripts/data_generators/tests/default/bucket_partitioned_uuid/__init__.py
@@ -1,0 +1,36 @@
+from scripts.data_generators.tests.base import IcebergTest
+import pathlib
+
+
+@IcebergTest.register()
+class Test(IcebergTest):
+    """Bucket-partitioned UUID table.
+
+    Spark SQL has no UUID type, so the table cannot be created with `CREATE TABLE ... (val UUID)`.
+    Instead the table is created through the Iceberg Java API (reached through the Spark catalog),
+    after which Spark can insert into it using the string representation of the UUIDs.
+    """
+
+    def __init__(self):
+        path = pathlib.PurePath(__file__)
+        super().__init__(__file__)
+
+    def setup(self, con):
+        spark = con.con
+        jvm = spark.sparkContext._jvm
+        gateway = spark.sparkContext._gateway
+
+        types = jvm.org.apache.iceberg.types.Types
+        fields = gateway.new_array(types.NestedField, 2)
+        fields[0] = types.NestedField.required(1, "id", types.IntegerType.get())
+        fields[1] = types.NestedField.optional(2, "val", types.UUIDType.get())
+        schema = jvm.org.apache.iceberg.Schema(fields)
+        spec = jvm.org.apache.iceberg.PartitionSpec.builderFor(schema).bucket("val", 32).build()
+
+        spark_catalog = spark._jsparkSession.sessionState().catalogManager().catalog(con.catalog)
+        iceberg_catalog = spark_catalog.icebergCatalog()
+        identifier = jvm.org.apache.iceberg.catalog.TableIdentifier.parse(self.qualified_name)
+
+        properties = jvm.java.util.HashMap()
+        properties.put("format-version", "2")
+        iceberg_catalog.createTable(identifier, schema, spec, properties)

--- a/scripts/data_generators/tests/default/bucket_partitioned_uuid/test.sql
+++ b/scripts/data_generators/tests/default/bucket_partitioned_uuid/test.sql
@@ -1,0 +1,18 @@
+-- The table itself is created through the Iceberg Java API in __init__.py, because Spark SQL
+-- has no UUID type. Spark accepts the string representation of a UUID when inserting.
+INSERT INTO default.bucket_partitioned_uuid
+VALUES
+    (1,  'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+    (2,  'b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22'),
+    (3,  'c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a33'),
+    (4,  'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a44'),
+    (5,  'e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a55'),
+    (6,  'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a66'),
+    (7,  'a6eebc99-9c0b-4ef8-bb6d-6bb9bd380a77'),
+    (8,  'b7eebc99-9c0b-4ef8-bb6d-6bb9bd380a88'),
+    (9,  'c8eebc99-9c0b-4ef8-bb6d-6bb9bd380a99'),
+    (10, 'd9eebc99-9c0b-4ef8-bb6d-6bb9bd380aaa'),
+    (11, 'f79c3e09-677c-4bbd-a479-3f349cb785e7'),
+    (12, '00000000-0000-0000-0000-000000000000'),
+    (13, 'ffffffff-ffff-ffff-ffff-ffffffffffff'),
+    (14, NULL)

--- a/src/core/expression/iceberg_hash.cpp
+++ b/src/core/expression/iceberg_hash.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/hugeint.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/uuid.hpp"
 
 namespace duckdb {
 
@@ -220,15 +221,11 @@ int32_t IcebergHash::HashTimestampTzNs(timestamp_tz_ns_t t) {
 }
 
 //! Hash UUID value (Iceberg spec: 16 big-endian bytes, MSB first)
-//! DuckDB stores UUID as hugeint_t: upper (int64, most-significant) + lower (uint64, least-significant)
 int32_t IcebergHash::HashUUID(hugeint_t uuid) {
 	uint8_t bytes[16];
-	for (int i = 0; i < 8; i++) {
-		bytes[i] = static_cast<uint8_t>(uuid.upper >> (56 - i * 8));
-	}
-	for (int i = 0; i < 8; i++) {
-		bytes[8 + i] = static_cast<uint8_t>(uuid.lower >> (56 - i * 8));
-	}
+	// BaseUUID::ToBlob converts DuckDB's internal representation (MSB flipped for hugeint_t ordering) back to the RFC
+	// 4122 big-endian byte layout required by the Iceberg spec.
+	BaseUUID::ToBlob(uuid, bytes);
 	return Murmur3Hash32(bytes, 16, SEED);
 }
 

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/functions/test_iceberg_bucket.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/functions/test_iceberg_bucket.test
@@ -36,6 +36,11 @@ SELECT iceberg_bucket(16, NULL);
 ----
 NULL
 
+query I
+SELECT iceberg_bucket(16, NULL::UUID);
+----
+NULL
+
 # ---- Return type is always INTEGER ----
 
 query I
@@ -80,6 +85,11 @@ INTEGER
 
 query I
 SELECT typeof(iceberg_bucket(16, '\x01\x02'::BLOB));
+----
+INTEGER
+
+query I
+SELECT typeof(iceberg_bucket(16, 'f79c3e09-677c-4bbd-a479-3f349cb785e7'::UUID));
 ----
 INTEGER
 
@@ -130,6 +140,25 @@ SELECT
 	iceberg_bucket(16, '2017-11-16T14:31:08.000001001-08:00'::TIMESTAMPTZ_NS);
 ----
 7	6
+
+# Spec Appendix B test vector: hash(uuid("f79c3e09-677c-4bbd-a479-3f349cb785e7")) = 1488055340
+# hash = 1488055340  =>  (& 0x7FFFFFFF) % 16 = 12
+query I
+SELECT iceberg_bucket(16, 'f79c3e09-677c-4bbd-a479-3f349cb785e7'::UUID);
+----
+12
+
+# hash = 1488055340  =>  (& 0x7FFFFFFF) % 100 = 40
+query I
+SELECT iceberg_bucket(100, 'f79c3e09-677c-4bbd-a479-3f349cb785e7'::UUID);
+----
+40
+
+# N = INT32 max exposes the (sign-discarded) hash value itself
+query I
+SELECT iceberg_bucket(2147483647, 'f79c3e09-677c-4bbd-a479-3f349cb785e7'::UUID);
+----
+1488055340
 
 # ---- Result is always in range [0, num_buckets) ----
 

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/bucket/test_bucket_uuid_spark_parity.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/bucket/test_bucket_uuid_spark_parity.test
@@ -1,0 +1,167 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/bucket/test_bucket_uuid_spark_parity.test
+# description: Verify DuckDB and Spark hash UUIDs into the same buckets (bucket(32, val))
+# group: [bucket]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# 'bucket_partitioned_uuid' is written by Spark (scripts/data_generators/tests/default/bucket_partitioned_uuid).
+# This test writes the exact same UUID values with DuckDB and compares the bucket that each UUID
+# ended up in, as recorded in the partition column of the avro manifest files.
+
+statement ok
+create schema if not exists my_datalake.default;
+
+statement ok
+drop table if exists my_datalake.default.test_bucket_uuid_spark_parity;
+
+statement ok
+CREATE TABLE my_datalake.default.test_bucket_uuid_spark_parity (id int, val uuid)
+PARTITIONED BY (bucket(32, val));
+
+statement ok
+insert into my_datalake.default.test_bucket_uuid_spark_parity values
+    (1,  'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+    (2,  'b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22'),
+    (3,  'c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a33'),
+    (4,  'd3eebc99-9c0b-4ef8-bb6d-6bb9bd380a44'),
+    (5,  'e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a55'),
+    (6,  'f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a66'),
+    (7,  'a6eebc99-9c0b-4ef8-bb6d-6bb9bd380a77'),
+    (8,  'b7eebc99-9c0b-4ef8-bb6d-6bb9bd380a88'),
+    (9,  'c8eebc99-9c0b-4ef8-bb6d-6bb9bd380a99'),
+    (10, 'd9eebc99-9c0b-4ef8-bb6d-6bb9bd380aaa'),
+    (11, 'f79c3e09-677c-4bbd-a479-3f349cb785e7'),
+    (12, '00000000-0000-0000-0000-000000000000'),
+    (13, 'ffffffff-ffff-ffff-ffff-ffffffffffff'),
+    (14, NULL);
+
+# Both tables contain the same values
+query II nosort uuid_values
+select id, val from my_datalake.default.bucket_partitioned_uuid order by id;
+----
+
+query II nosort uuid_values
+select id, val from my_datalake.default.test_bucket_uuid_spark_parity order by id;
+----
+
+# Start transaction to keep necessary credentials in scope
+statement ok
+begin
+
+statement ok
+set variable spark_manifest = (select manifest_path from iceberg_metadata(my_datalake.default.bucket_partitioned_uuid) order by manifest_sequence_number desc limit 1);
+
+statement ok
+set variable duckdb_manifest = (select manifest_path from iceberg_metadata(my_datalake.default.test_bucket_uuid_spark_parity) order by manifest_sequence_number desc limit 1);
+
+# The partition column of the manifest entries holds the bucket that Iceberg assigned to each file.
+# The partition field is accessed by position because Spark names it 'val_bucket' while DuckDB
+# names it 'bucket_32__val_2'.
+statement ok
+create table spark_file_partitions as
+select file_path, struct_extract_at(partition, 1) as bucket_id
+from (select unnest(data_file) from read_avro(getvariable('spark_manifest')));
+
+statement ok
+create table duckdb_file_partitions as
+select file_path, struct_extract_at(partition, 1) as bucket_id
+from (select unnest(data_file) from read_avro(getvariable('duckdb_manifest')));
+
+# Map every UUID to the bucket of the file it was written to
+statement ok
+create table spark_uuid_buckets as
+select t.id, t.val, p.bucket_id
+from my_datalake.default.bucket_partitioned_uuid t
+join spark_file_partitions p on t.filename = p.file_path;
+
+statement ok
+create table duckdb_uuid_buckets as
+select t.id, t.val, p.bucket_id
+from my_datalake.default.test_bucket_uuid_spark_parity t
+join duckdb_file_partitions p on t.filename = p.file_path;
+
+statement ok
+commit
+
+# Every row was matched to a manifest entry
+query I
+select count(*) from spark_uuid_buckets;
+----
+14
+
+query I
+select count(*) from duckdb_uuid_buckets;
+----
+14
+
+# The partition values written by Spark
+query III
+select id, val, bucket_id from spark_uuid_buckets order by id;
+----
+1	a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11	26
+2	b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22	15
+3	c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a33	26
+4	d3eebc99-9c0b-4ef8-bb6d-6bb9bd380a44	5
+5	e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a55	28
+6	f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a66	2
+7	a6eebc99-9c0b-4ef8-bb6d-6bb9bd380a77	17
+8	b7eebc99-9c0b-4ef8-bb6d-6bb9bd380a88	14
+9	c8eebc99-9c0b-4ef8-bb6d-6bb9bd380a99	16
+10	d9eebc99-9c0b-4ef8-bb6d-6bb9bd380aaa	22
+11	f79c3e09-677c-4bbd-a479-3f349cb785e7	12
+12	00000000-0000-0000-0000-000000000000	24
+13	ffffffff-ffff-ffff-ffff-ffffffffffff	14
+14	NULL	NULL
+
+# The partition values written by DuckDB have to be identical
+query III
+select id, val, bucket_id from duckdb_uuid_buckets order by id;
+----
+1	a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11	26
+2	b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22	15
+3	c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a33	26
+4	d3eebc99-9c0b-4ef8-bb6d-6bb9bd380a44	5
+5	e4eebc99-9c0b-4ef8-bb6d-6bb9bd380a55	28
+6	f5eebc99-9c0b-4ef8-bb6d-6bb9bd380a66	2
+7	a6eebc99-9c0b-4ef8-bb6d-6bb9bd380a77	17
+8	b7eebc99-9c0b-4ef8-bb6d-6bb9bd380a88	14
+9	c8eebc99-9c0b-4ef8-bb6d-6bb9bd380a99	16
+10	d9eebc99-9c0b-4ef8-bb6d-6bb9bd380aaa	22
+11	f79c3e09-677c-4bbd-a479-3f349cb785e7	12
+12	00000000-0000-0000-0000-000000000000	24
+13	ffffffff-ffff-ffff-ffff-ffffffffffff	14
+14	NULL	NULL
+
+# Symmetric difference between the two mappings has to be empty
+query I
+select count(*) from (
+    (select val, bucket_id from spark_uuid_buckets except select val, bucket_id from duckdb_uuid_buckets)
+    union all
+    (select val, bucket_id from duckdb_uuid_buckets except select val, bucket_id from spark_uuid_buckets)
+);
+----
+0
+
+# The iceberg_bucket function agrees with the buckets Spark wrote
+query I
+select count(*) from spark_uuid_buckets where bucket_id is distinct from iceberg_bucket(32, val);
+----
+0
+
+# Both writers produced the same set of occupied buckets
+query I
+select count(*) from (
+    (select distinct bucket_id from spark_file_partitions except select distinct bucket_id from duckdb_file_partitions)
+    union all
+    (select distinct bucket_id from duckdb_file_partitions except select distinct bucket_id from spark_file_partitions)
+);
+----
+0


### PR DESCRIPTION
Fixes #1325

## Problem

`iceberg_bucket` on UUID values hashes DuckDB's internal `hugeint_t` representation. DuckDB stores UUIDs with the MSB of the upper 64 bits flipped so they sort correctly as signed int128 (see `BaseUUID::FromString` / `ToString`). Hashing that representation disagrees with the Iceberg spec, which requires hashing the RFC 4122 big-endian bytes ([Appendix B, note 4](https://iceberg.apache.org/spec/#appendix-b-32-bit-hash-requirements)).

Spec test vector: `hash(uuid "f79c3e09-677c-4bbd-a479-3f349cb785e7") = 1488055340`. Before this change DuckDB produced `2132039410`. Integer and string hashing already match the spec vectors, so only the UUID byte serialization was wrong.

## Fix

Convert with `BaseUUID::ToBlob` before hashing — the same utility the Parquet writer (`ParquetUUIDOperator::Operation`) uses for the identical conversion.

This single change fixes all three paths that share `IcebergHash::HashUUID`: the `iceberg_bucket` scalar function, partition value computation on writes (`iceberg_insert.cpp` binds the same scalar function), and bucket predicate pushdown when pruning files on reads (`BucketTransform::ApplyTransform` → `IcebergHash::BucketValue`).

Note that this changes the bucket values produced for UUIDs (they were spec-incorrect); see #1325 for the impact on existing tables.

## Testing

Added the spec test vector for UUID to `test_iceberg_bucket.test` (NULL handling, return type, bucket values, and the raw 31-bit hash value).