### PR TITLE
iceberg_rewrite_data_files: add min_file_size_bytes and max_file_size_bytes

### DIFF
--- a/src/function/metadata/iceberg_rewrite_data_files.cpp
+++ b/src/function/metadata/iceberg_rewrite_data_files.cpp
@@ -40,29 +40,27 @@ static QualifiedName ParseRewriteTableName(const string &identifier) {
 	return QualifiedName {parts[0], parts[1], parts[2]};
 }
 
-static int64_t ParseTargetFileSizeBytes(const Value &value) {
+static int64_t ParseByteSizeNamedParameter(const Value &value, const char *parameter_name) {
 	idx_t parsed_value;
 	if (value.type().id() == LogicalTypeId::VARCHAR) {
 		auto error = StringUtil::TryParseFormattedBytes(StringValue::Get(value), parsed_value);
 		if (!error.empty()) {
-			throw InvalidInputException("iceberg_rewrite_data_files: invalid 'target_file_size_bytes': %s", error);
+			throw InvalidInputException("iceberg_rewrite_data_files: invalid '%s': %s", parameter_name, error);
 		}
 	} else {
 		auto numeric_value = value.DefaultCastAs(LogicalType::BIGINT).GetValue<int64_t>();
 		if (numeric_value < MIN_TARGET_FILE_SIZE_BYTES) {
-			throw InvalidInputException(
-			    "iceberg_rewrite_data_files: 'target_file_size_bytes' must be >= %lld bytes, got %lld",
-			    MIN_TARGET_FILE_SIZE_BYTES, numeric_value);
+			throw InvalidInputException("iceberg_rewrite_data_files: '%s' must be >= %lld bytes, got %lld",
+			                            parameter_name, MIN_TARGET_FILE_SIZE_BYTES, numeric_value);
 		}
 		return numeric_value;
 	}
 	if (parsed_value < static_cast<idx_t>(MIN_TARGET_FILE_SIZE_BYTES)) {
-		throw InvalidInputException(
-		    "iceberg_rewrite_data_files: 'target_file_size_bytes' must be >= %lld bytes, got %llu",
-		    MIN_TARGET_FILE_SIZE_BYTES, static_cast<unsigned long long>(parsed_value));
+		throw InvalidInputException("iceberg_rewrite_data_files: '%s' must be >= %lld bytes, got %llu", parameter_name,
+		                            MIN_TARGET_FILE_SIZE_BYTES, static_cast<unsigned long long>(parsed_value));
 	}
 	if (parsed_value > static_cast<idx_t>(NumericLimits<int64_t>::Maximum())) {
-		throw InvalidInputException("iceberg_rewrite_data_files: 'target_file_size_bytes' is too large");
+		throw InvalidInputException("iceberg_rewrite_data_files: '%s' is too large", parameter_name);
 	}
 	return static_cast<int64_t>(parsed_value);
 }
@@ -75,7 +73,11 @@ static RewriteDataFilesPlanInput ParseRewritePlanInput(TableFunctionBindInput &i
 		auto opt = StringUtil::Lower(kv.first.GetIdentifierName());
 		auto &val = kv.second;
 		if (opt == "target_file_size_bytes") {
-			result.target_file_size_bytes = ParseTargetFileSizeBytes(val);
+			result.target_file_size_bytes = ParseByteSizeNamedParameter(val, "target_file_size_bytes");
+		} else if (opt == "min_file_size_bytes") {
+			result.min_file_size_bytes = ParseByteSizeNamedParameter(val, "min_file_size_bytes");
+		} else if (opt == "max_file_size_bytes") {
+			result.max_file_size_bytes = ParseByteSizeNamedParameter(val, "max_file_size_bytes");
 		} else if (opt == "min_input_files") {
 			auto value = val.GetValue<int64_t>();
 			if (value < 1) {
@@ -86,6 +88,12 @@ static RewriteDataFilesPlanInput ParseRewritePlanInput(TableFunctionBindInput &i
 		} else if (opt == "rewrite_all") {
 			result.rewrite_all = BooleanValue::Get(val);
 		}
+	}
+	if (result.min_file_size_bytes && result.max_file_size_bytes &&
+	    result.min_file_size_bytes.value() > result.max_file_size_bytes.value()) {
+		throw InvalidInputException(
+		    "iceberg_rewrite_data_files: 'min_file_size_bytes' (%lld) must be <= 'max_file_size_bytes' (%lld)",
+		    result.min_file_size_bytes.value(), result.max_file_size_bytes.value());
 	}
 	return result;
 }
@@ -172,6 +180,8 @@ TableFunctionSet IcebergFunctions::GetIcebergRewriteDataFilesFunction() {
 	TableFunction function("iceberg_rewrite_data_files", {LogicalType::VARCHAR}, nullptr);
 	function.bind_operator = RewriteDataFilesBindOperator;
 	function.named_parameters["target_file_size_bytes"] = LogicalType::ANY;
+	function.named_parameters["min_file_size_bytes"] = LogicalType::ANY;
+	function.named_parameters["max_file_size_bytes"] = LogicalType::ANY;
 	function.named_parameters["min_input_files"] = LogicalType::BIGINT;
 	function.named_parameters["rewrite_all"] = LogicalType::BOOLEAN;
 	function_set.AddFunction(function);

--- a/src/include/maintenance/rewrite_data_files_planner.hpp
+++ b/src/include/maintenance/rewrite_data_files_planner.hpp
@@ -37,6 +37,10 @@ struct RewritePlan {
 struct RewriteDataFilesPlanInput {
 	QualifiedName table_name;
 	optional<int64_t> target_file_size_bytes;
+	//! Optional override; defaults to 75% of the resolved target file size.
+	optional<int64_t> min_file_size_bytes;
+	//! Optional override; defaults to 180% of the resolved target file size.
+	optional<int64_t> max_file_size_bytes;
 	int64_t min_input_files = 5;
 	bool rewrite_all = false;
 };

--- a/src/include/maintenance/rewrite_data_files_planner.hpp
+++ b/src/include/maintenance/rewrite_data_files_planner.hpp
@@ -25,7 +25,8 @@ struct RewritePlan {
 	QualifiedName table_name;
 	int64_t starting_snapshot_id = -1;
 	int64_t starting_sequence_number = 0;
-	int64_t target_file_size_bytes = 134217728;
+	//! Iceberg spec default for write.target-file-size-bytes (same as IcebergCopyOptions::file_size_bytes).
+	int64_t target_file_size_bytes = 512LL * 1024 * 1024;
 	//! Keep the loaded metadata alive until commit.
 	shared_ptr<IcebergTable> table_info;
 	//! All live DATA files considered during planning.

--- a/src/maintenance/rewrite_data_files_planner.cpp
+++ b/src/maintenance/rewrite_data_files_planner.cpp
@@ -19,7 +19,8 @@ namespace duckdb {
 
 namespace {
 
-constexpr int64_t DEFAULT_TARGET_FILE_SIZE_BYTES = 134217728;
+//! Iceberg spec default for write.target-file-size-bytes (same as IcebergCopyOptions::file_size_bytes).
+constexpr int64_t DEFAULT_TARGET_FILE_SIZE_BYTES = 512LL * 1024 * 1024;
 constexpr int64_t MIN_TARGET_FILE_SIZE_BYTES = 100;
 
 static int64_t ParseTargetFileSizeProperty(const string &value, const string &property) {

--- a/src/maintenance/rewrite_data_files_planner.cpp
+++ b/src/maintenance/rewrite_data_files_planner.cpp
@@ -57,21 +57,46 @@ static int64_t ResolveTargetFileSizeBytes(const RewriteDataFilesPlanInput &input
 	return DEFAULT_TARGET_FILE_SIZE_BYTES;
 }
 
-void GroupCandidates(RewritePlan &plan, int64_t target_file_size_bytes, int64_t min_input_files, bool rewrite_all) {
+//! Spark SizeBasedFileRewriter defaults: min = 75% of target, max = 180% of target.
+static int64_t ResolveMinFileSizeBytes(const RewriteDataFilesPlanInput &input, int64_t target_file_size_bytes) {
+	if (input.min_file_size_bytes) {
+		return input.min_file_size_bytes.value();
+	}
+	return (target_file_size_bytes * 3) / 4;
+}
+
+static int64_t ResolveMaxFileSizeBytes(const RewriteDataFilesPlanInput &input, int64_t target_file_size_bytes) {
+	if (input.max_file_size_bytes) {
+		return input.max_file_size_bytes.value();
+	}
+	return (target_file_size_bytes * 9) / 5;
+}
+
+void GroupCandidates(RewritePlan &plan, const RewriteDataFilesPlanInput &input) {
 	if (plan.candidates.empty()) {
 		return;
 	}
 
+	const auto min_file_size_bytes = ResolveMinFileSizeBytes(input, plan.target_file_size_bytes);
+	const auto max_file_size_bytes = ResolveMaxFileSizeBytes(input, plan.target_file_size_bytes);
+	if (min_file_size_bytes > max_file_size_bytes) {
+		throw InvalidInputException("iceberg_rewrite_data_files: resolved 'min_file_size_bytes' (%lld) must be <= "
+		                            "'max_file_size_bytes' (%lld)",
+		                            min_file_size_bytes, max_file_size_bytes);
+	}
+
 	std::map<string, vector<RewriteCandidate>> per_partition;
 	for (auto &cand : plan.candidates) {
-		if (!rewrite_all && cand.file_size_in_bytes >= target_file_size_bytes) {
+		//! Match Spark: rewrite undersized or oversized files; leave the band alone.
+		if (!input.rewrite_all && cand.file_size_in_bytes >= min_file_size_bytes &&
+		    cand.file_size_in_bytes <= max_file_size_bytes) {
 			continue;
 		}
 		per_partition[rewrite_planner_internal::PartitionBucketKey(cand.partition_info)].push_back(cand);
 	}
 
 	for (auto &kv : per_partition) {
-		if (!rewrite_all && static_cast<int64_t>(kv.second.size()) < min_input_files) {
+		if (!input.rewrite_all && static_cast<int64_t>(kv.second.size()) < input.min_input_files) {
 			continue;
 		}
 		for (auto &cand : kv.second) {
@@ -197,7 +222,7 @@ RewritePlan PlanRewrite(ClientContext &context, const RewriteDataFilesPlanInput 
 		return plan;
 	}
 
-	GroupCandidates(plan, plan.target_file_size_bytes, input.min_input_files, input.rewrite_all);
+	GroupCandidates(plan, input);
 
 	return plan;
 }

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_min_max_file_size.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_min_max_file_size.test
@@ -102,6 +102,13 @@ call iceberg_rewrite_data_files(
 5	1	<REGEX>:[1-9][0-9]*
 
 query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_min_max_size')
+where content = 'DATA' and status <> 'DELETED';
+----
+1
+
+query I
 select count(*) from my_datalake.default.rewrite_min_max_size;
 ----
 10

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_min_max_file_size.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_min_max_file_size.test
@@ -1,0 +1,110 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_min_max_file_size.test
+# description: rewrite_data_files selects undersized or oversized files via min/max file size
+# group: [maintenance]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+statement ok
+drop table if exists my_datalake.default.rewrite_min_max_size;
+
+statement ok
+create table my_datalake.default.rewrite_min_max_size (id INTEGER, payload VARCHAR);
+
+statement ok
+insert into my_datalake.default.rewrite_min_max_size values (1, 'a1'), (2, 'b1');
+
+statement ok
+insert into my_datalake.default.rewrite_min_max_size values (3, 'a2'), (4, 'b2');
+
+statement ok
+insert into my_datalake.default.rewrite_min_max_size values (5, 'a3'), (6, 'b3');
+
+statement ok
+insert into my_datalake.default.rewrite_min_max_size values (7, 'a4'), (8, 'b4');
+
+statement ok
+insert into my_datalake.default.rewrite_min_max_size values (9, 'a5'), (10, 'b5');
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_min_max_size')
+where content = 'DATA' and status <> 'DELETED';
+----
+5
+
+# Band that contains every live file: nothing is undersized or oversized.
+query III
+call iceberg_rewrite_data_files(
+	'my_datalake.default.rewrite_min_max_size',
+	min_file_size_bytes => 100,
+	max_file_size_bytes => 1000000000,
+	min_input_files => 1
+);
+----
+0	0	0
+
+# Files are larger than a tiny max, so they are oversized candidates.
+query III
+call iceberg_rewrite_data_files(
+	'my_datalake.default.rewrite_min_max_size',
+	min_file_size_bytes => 100,
+	max_file_size_bytes => 100,
+	min_input_files => 5
+);
+----
+5	1	<REGEX>:[1-9][0-9]*
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_min_max_size')
+where content = 'DATA' and status <> 'DELETED';
+----
+1
+
+statement ok
+drop table if exists my_datalake.default.rewrite_min_max_size;
+
+statement ok
+create table my_datalake.default.rewrite_min_max_size (id INTEGER, payload VARCHAR);
+
+statement ok
+insert into my_datalake.default.rewrite_min_max_size values (1, 'a1'), (2, 'b1');
+
+statement ok
+insert into my_datalake.default.rewrite_min_max_size values (3, 'a2'), (4, 'b2');
+
+statement ok
+insert into my_datalake.default.rewrite_min_max_size values (5, 'a3'), (6, 'b3');
+
+statement ok
+insert into my_datalake.default.rewrite_min_max_size values (7, 'a4'), (8, 'b4');
+
+statement ok
+insert into my_datalake.default.rewrite_min_max_size values (9, 'a5'), (10, 'b5');
+
+# Files are smaller than a large min, so they are undersized candidates.
+query III
+call iceberg_rewrite_data_files(
+	'my_datalake.default.rewrite_min_max_size',
+	min_file_size_bytes => 1000000,
+	max_file_size_bytes => 1000000000,
+	min_input_files => 5
+);
+----
+5	1	<REGEX>:[1-9][0-9]*
+
+query I
+select count(*) from my_datalake.default.rewrite_min_max_size;
+----
+10
+
+statement ok
+drop table if exists my_datalake.default.rewrite_min_max_size;

--- a/test/sql/local/maintenance/rewrite_data_files_validation.test
+++ b/test/sql/local/maintenance/rewrite_data_files_validation.test
@@ -64,6 +64,25 @@ SELECT * FROM iceberg_rewrite_data_files('a.b.c', min_input_files => 0);
 'min_input_files' must be >= 1
 
 statement error
+SELECT * FROM iceberg_rewrite_data_files('a.b.c', min_file_size_bytes => 99);
+----
+'min_file_size_bytes' must be >= 100 bytes
+
+statement error
+SELECT * FROM iceberg_rewrite_data_files('a.b.c', max_file_size_bytes => '50B');
+----
+'max_file_size_bytes' must be >= 100 bytes
+
+statement error
+SELECT * FROM iceberg_rewrite_data_files(
+    'a.b.c',
+    min_file_size_bytes => 1000,
+    max_file_size_bytes => 500
+);
+----
+'min_file_size_bytes' (1000) must be <= 'max_file_size_bytes' (500)
+
+statement error
 SELECT * FROM iceberg_rewrite_data_files(
     'cat.sch.tbl',
     target_file_size_bytes => '256MiB',


### PR DESCRIPTION
Align config with Spark's `SizeBasedFileRewriter` defaults (75%/180% of target) and allow overrides via `min_file_size_bytes` and `max_file_size_bytes`.

## Source

https://iceberg.apache.org/docs/latest/spark-procedures/#general-options

Option | Descrition | Details
-- | -- | --
min-file-size-bytes | 75% of target file size | Files under this threshold will be considered for rewriting regardless of any other criteria
max-file-size-bytes | 180% of target file size | Files with sizes above this threshold will be considered for rewriting regardless of any other criteria

