### PR TITLE
iceberg_rewrite_data_files: Add `max_files_to_rewrite` parameter

### DIFF
--- a/src/function/metadata/iceberg_rewrite_data_files.cpp
+++ b/src/function/metadata/iceberg_rewrite_data_files.cpp
@@ -85,6 +85,16 @@ static RewriteDataFilesPlanInput ParseRewritePlanInput(TableFunctionBindInput &i
 				                            value);
 			}
 			result.min_input_files = value;
+		} else if (opt == "max_files_to_rewrite") {
+			if (val.IsNull()) {
+				throw InvalidInputException("iceberg_rewrite_data_files: 'max_files_to_rewrite' cannot be NULL");
+			}
+			auto value = val.GetValue<int64_t>();
+			if (value < 1) {
+				throw InvalidInputException("iceberg_rewrite_data_files: 'max_files_to_rewrite' must be >= 1, got %lld",
+				                            value);
+			}
+			result.max_files_to_rewrite = value;
 		} else if (opt == "rewrite_all") {
 			result.rewrite_all = BooleanValue::Get(val);
 		}
@@ -183,6 +193,7 @@ TableFunctionSet IcebergFunctions::GetIcebergRewriteDataFilesFunction() {
 	function.named_parameters["min_file_size_bytes"] = LogicalType::ANY;
 	function.named_parameters["max_file_size_bytes"] = LogicalType::ANY;
 	function.named_parameters["min_input_files"] = LogicalType::BIGINT;
+	function.named_parameters["max_files_to_rewrite"] = LogicalType::BIGINT;
 	function.named_parameters["rewrite_all"] = LogicalType::BOOLEAN;
 	function_set.AddFunction(function);
 	return function_set;

--- a/src/include/maintenance/rewrite_data_files_planner.hpp
+++ b/src/include/maintenance/rewrite_data_files_planner.hpp
@@ -53,7 +53,7 @@ struct RewriteDataFilesPlanInput {
 	bool rewrite_all = false;
 };
 
-RewritePlan PlanRewrite(ClientContext &context, const RewriteDataFilesPlanInput &input);
+RewritePlan PlanRewrite(ClientContext &context, RewriteDataFilesPlanInput input);
 
 namespace rewrite_planner_internal {
 

--- a/src/include/maintenance/rewrite_data_files_planner.hpp
+++ b/src/include/maintenance/rewrite_data_files_planner.hpp
@@ -55,11 +55,4 @@ struct RewriteDataFilesPlanInput {
 
 RewritePlan PlanRewrite(ClientContext &context, RewriteDataFilesPlanInput input);
 
-namespace rewrite_planner_internal {
-
-//! Canonical partition key used by the bin-packer.
-string PartitionBucketKey(const vector<IcebergPartitionInfo> &partition_info);
-
-} // namespace rewrite_planner_internal
-
 } // namespace duckdb

--- a/src/include/maintenance/rewrite_data_files_planner.hpp
+++ b/src/include/maintenance/rewrite_data_files_planner.hpp
@@ -21,6 +21,13 @@ struct RewriteCandidate {
 	vector<IcebergPartitionInfo> partition_info;
 };
 
+struct PartitionRewriteBucket {
+	vector<RewriteCandidate> retained;
+	//! Counted over every eligible file, so max_files_to_rewrite cannot change the gating decision below.
+	int64_t eligible_count = 0;
+	int64_t eligible_bytes = 0;
+};
+
 struct RewritePlan {
 	QualifiedName table_name;
 	int64_t starting_snapshot_id = -1;
@@ -29,8 +36,6 @@ struct RewritePlan {
 	int64_t target_file_size_bytes = 512LL * 1024 * 1024;
 	//! Keep the loaded metadata alive until commit.
 	shared_ptr<IcebergTable> table_info;
-	//! All live DATA files considered during planning.
-	vector<RewriteCandidate> candidates;
 	//! Files selected for rewrite after per-partition size / min_input_files gating.
 	vector<RewriteCandidate> selected_candidates;
 };
@@ -43,6 +48,8 @@ struct RewriteDataFilesPlanInput {
 	//! Optional override; defaults to 180% of the resolved target file size.
 	optional<int64_t> max_file_size_bytes;
 	int64_t min_input_files = 5;
+	//! Optional upper bound on how many eligible files will be rewritten.
+	optional<int64_t> max_files_to_rewrite;
 	bool rewrite_all = false;
 };
 

--- a/src/include/maintenance/rewrite_data_files_planner.hpp
+++ b/src/include/maintenance/rewrite_data_files_planner.hpp
@@ -21,7 +21,7 @@ struct RewriteCandidate {
 	vector<IcebergPartitionInfo> partition_info;
 };
 
-struct PartitionRewriteBucket {
+struct RewriteBucket {
 	vector<RewriteCandidate> retained;
 	//! Counted over every eligible file, so max_files_to_rewrite cannot change the gating decision below.
 	int64_t eligible_count = 0;

--- a/src/maintenance/rewrite_data_files_planner.cpp
+++ b/src/maintenance/rewrite_data_files_planner.cpp
@@ -74,7 +74,7 @@ static int64_t ResolveMaxFileSizeBytes(const RewriteDataFilesPlanInput &input, i
 }
 
 bool BucketQualifies(const RewriteBucket &bucket, const RewriteDataFilesPlanInput &input,
-                        int64_t target_file_size_bytes) {
+                     int64_t target_file_size_bytes) {
 	if (input.rewrite_all) {
 		return true;
 	}

--- a/src/maintenance/rewrite_data_files_planner.cpp
+++ b/src/maintenance/rewrite_data_files_planner.cpp
@@ -23,7 +23,7 @@ namespace {
 constexpr int64_t DEFAULT_TARGET_FILE_SIZE_BYTES = 512LL * 1024 * 1024;
 constexpr int64_t MIN_TARGET_FILE_SIZE_BYTES = 100;
 
-static int64_t ParseTargetFileSizeProperty(const string &value, const string &property) {
+int64_t ParseTargetFileSizeProperty(const string &value, const string &property) {
 	idx_t parsed_value;
 	if (!TryCast::Operation<string_t, idx_t>(string_t(value), parsed_value)) {
 		auto error = StringUtil::TryParseFormattedBytes(value, parsed_value);
@@ -41,8 +41,7 @@ static int64_t ParseTargetFileSizeProperty(const string &value, const string &pr
 	return static_cast<int64_t>(parsed_value);
 }
 
-static int64_t ResolveTargetFileSizeBytes(const RewriteDataFilesPlanInput &input,
-                                          const IcebergTableMetadata &metadata) {
+int64_t ResolveTargetFileSizeBytes(const RewriteDataFilesPlanInput &input, const IcebergTableMetadata &metadata) {
 	if (input.target_file_size_bytes) {
 		return input.target_file_size_bytes.value();
 	}
@@ -59,14 +58,14 @@ static int64_t ResolveTargetFileSizeBytes(const RewriteDataFilesPlanInput &input
 }
 
 //! Spark SizeBasedFileRewriter defaults: min = 75% of target, max = 180% of target.
-static int64_t ResolveMinFileSizeBytes(const RewriteDataFilesPlanInput &input, int64_t target_file_size_bytes) {
+int64_t ResolveMinFileSizeBytes(const RewriteDataFilesPlanInput &input, int64_t target_file_size_bytes) {
 	if (input.min_file_size_bytes) {
 		return input.min_file_size_bytes.value();
 	}
 	return (target_file_size_bytes * 3) / 4;
 }
 
-static int64_t ResolveMaxFileSizeBytes(const RewriteDataFilesPlanInput &input, int64_t target_file_size_bytes) {
+int64_t ResolveMaxFileSizeBytes(const RewriteDataFilesPlanInput &input, int64_t target_file_size_bytes) {
 	if (input.max_file_size_bytes) {
 		return input.max_file_size_bytes.value();
 	}
@@ -206,29 +205,7 @@ void CollectUnpartitionedCandidates(RewriteBucket &bucket, const vector<IcebergM
 	}
 }
 
-void CollectPartitionedCandidates(std::map<string, RewriteBucket> &per_partition,
-                                  const vector<IcebergManifestListEntry> &manifest_files,
-                                  const RewriteDataFilesPlanInput &input, int32_t default_spec_id) {
-	for (const auto &list_entry : manifest_files) {
-		if (list_entry.file.content != IcebergManifestContentType::DATA) {
-			continue;
-		}
-		AssertCurrentPartitionSpec(list_entry, default_spec_id);
-		for (const auto &entry : list_entry.GetManifestEntries()) {
-			auto cand = TryMakeRewriteCandidate(entry);
-			if (!cand) {
-				continue;
-			}
-			auto &bucket = per_partition[rewrite_planner_internal::PartitionBucketKey(cand->partition_info)];
-			ConsiderCandidate(bucket, std::move(*cand), input);
-		}
-	}
-}
-
-} // namespace
-
-namespace rewrite_planner_internal {
-
+//! Canonical partition key used by the bin-packer.
 string PartitionBucketKey(const vector<IcebergPartitionInfo> &partition_info) {
 	if (partition_info.empty()) {
 		return "";
@@ -254,7 +231,26 @@ string PartitionBucketKey(const vector<IcebergPartitionInfo> &partition_info) {
 	return out;
 }
 
-} // namespace rewrite_planner_internal
+void CollectPartitionedCandidates(std::map<string, RewriteBucket> &per_partition,
+                                  const vector<IcebergManifestListEntry> &manifest_files,
+                                  const RewriteDataFilesPlanInput &input, int32_t default_spec_id) {
+	for (const auto &list_entry : manifest_files) {
+		if (list_entry.file.content != IcebergManifestContentType::DATA) {
+			continue;
+		}
+		AssertCurrentPartitionSpec(list_entry, default_spec_id);
+		for (const auto &entry : list_entry.GetManifestEntries()) {
+			auto cand = TryMakeRewriteCandidate(entry);
+			if (!cand) {
+				continue;
+			}
+			auto &bucket = per_partition[PartitionBucketKey(cand->partition_info)];
+			ConsiderCandidate(bucket, std::move(*cand), input);
+		}
+	}
+}
+
+} // namespace
 
 RewritePlan PlanRewrite(ClientContext &context, RewriteDataFilesPlanInput input) {
 	RewritePlan plan;

--- a/src/maintenance/rewrite_data_files_planner.cpp
+++ b/src/maintenance/rewrite_data_files_planner.cpp
@@ -156,11 +156,7 @@ void SelectCandidates(RewritePlan &plan, const RewriteDataFilesPlanInput &input,
 }
 
 void AssertCurrentPartitionSpec(const IcebergManifestListEntry &list_entry, int32_t default_spec_id) {
-	//! Guard against partition spec evolution: if a manifest was written
-	//! under a different partition spec, its partition tuples may not match
-	//! the current default spec. Mixing specs in one rewrite group would
-	//! produce incorrect manifest metadata. Reject until multi-spec support
-	//! is implemented.
+	//! Guard against partition spec evolution: reject until multi-spec support is implemented.
 	if (list_entry.file.partition_spec_id != default_spec_id) {
 		throw NotImplementedException(
 		    "iceberg_rewrite_data_files: table has data files written under partition spec %d "

--- a/src/maintenance/rewrite_data_files_planner.cpp
+++ b/src/maintenance/rewrite_data_files_planner.cpp
@@ -73,45 +73,75 @@ static int64_t ResolveMaxFileSizeBytes(const RewriteDataFilesPlanInput &input, i
 	return (target_file_size_bytes * 9) / 5;
 }
 
-void GroupCandidates(RewritePlan &plan, const RewriteDataFilesPlanInput &input) {
-	if (plan.candidates.empty()) {
+bool PartitionQualifies(const PartitionRewriteBucket &bucket, const RewriteDataFilesPlanInput &input,
+                        int64_t target_file_size_bytes) {
+	if (input.rewrite_all) {
+		return true;
+	}
+	//! Spark SizeBasedFileRewriter: rewrite when the group has enough files,
+	//! or at least two files whose total size already meets the target.
+	if (bucket.eligible_count >= input.min_input_files) {
+		return true;
+	}
+	return bucket.eligible_count >= 2 && bucket.eligible_bytes >= target_file_size_bytes;
+}
+
+void ConsiderCandidate(PartitionRewriteBucket &bucket, RewriteCandidate cand, const RewriteDataFilesPlanInput &input,
+                       int64_t min_file_size_bytes, int64_t max_file_size_bytes) {
+	//! Match Spark: rewrite undersized or oversized files; leave the band alone.
+	if (!input.rewrite_all && cand.file_size_in_bytes >= min_file_size_bytes &&
+	    cand.file_size_in_bytes <= max_file_size_bytes) {
 		return;
 	}
-
-	const auto min_file_size_bytes = ResolveMinFileSizeBytes(input, plan.target_file_size_bytes);
-	const auto max_file_size_bytes = ResolveMaxFileSizeBytes(input, plan.target_file_size_bytes);
-	if (min_file_size_bytes > max_file_size_bytes) {
-		throw InvalidInputException("iceberg_rewrite_data_files: resolved 'min_file_size_bytes' (%lld) must be <= "
-		                            "'max_file_size_bytes' (%lld)",
-		                            min_file_size_bytes, max_file_size_bytes);
+	bucket.eligible_count++;
+	bucket.eligible_bytes += cand.file_size_in_bytes;
+	if (input.max_files_to_rewrite &&
+	    bucket.retained.size() >= static_cast<idx_t>(input.max_files_to_rewrite.value())) {
+		//! Partition already has a Spark-style subList prefix; keep counting so gating stays cap-independent.
+		return;
 	}
+	bucket.retained.push_back(std::move(cand));
+}
 
-	std::map<string, vector<RewriteCandidate>> per_partition;
-	for (auto &cand : plan.candidates) {
-		//! Match Spark: rewrite undersized or oversized files; leave the band alone.
-		if (!input.rewrite_all && cand.file_size_in_bytes >= min_file_size_bytes &&
-		    cand.file_size_in_bytes <= max_file_size_bytes) {
+bool UnpartitionedCollectionComplete(const std::map<string, PartitionRewriteBucket> &per_partition,
+                                     const RewriteDataFilesPlanInput &input, int64_t target_file_size_bytes) {
+	if (!input.max_files_to_rewrite) {
+		return false;
+	}
+	auto it = per_partition.find("");
+	if (it == per_partition.end()) {
+		return false;
+	}
+	auto &bucket = it->second;
+	if (bucket.retained.size() < static_cast<idx_t>(input.max_files_to_rewrite.value())) {
+		return false;
+	}
+	return PartitionQualifies(bucket, input, target_file_size_bytes);
+}
+
+void SelectCandidates(RewritePlan &plan, const RewriteDataFilesPlanInput &input,
+                      std::map<string, PartitionRewriteBucket> &per_partition) {
+	idx_t remaining = NumericLimits<idx_t>::Maximum();
+	const bool capped = input.max_files_to_rewrite.has_value();
+	if (capped) {
+		remaining = NumericCast<idx_t>(input.max_files_to_rewrite.value());
+	}
+	for (auto &kv : per_partition) {
+		if (capped && remaining == 0) {
+			return;
+		}
+		auto &bucket = kv.second;
+		if (!PartitionQualifies(bucket, input, plan.target_file_size_bytes)) {
 			continue;
 		}
-		per_partition[rewrite_planner_internal::PartitionBucketKey(cand.partition_info)].push_back(cand);
-	}
-
-	for (auto &kv : per_partition) {
-		if (!input.rewrite_all) {
-			int64_t total_bytes = 0;
-			for (auto &cand : kv.second) {
-				total_bytes += cand.file_size_in_bytes;
+		for (auto &cand : bucket.retained) {
+			if (capped && remaining == 0) {
+				return;
 			}
-			//! Spark SizeBasedFileRewriter: rewrite when the group has enough files,
-			//! or at least two files whose total size already meets the target.
-			const bool enough_files = static_cast<int64_t>(kv.second.size()) >= input.min_input_files;
-			const bool enough_bytes = kv.second.size() >= 2 && total_bytes >= plan.target_file_size_bytes;
-			if (!enough_files && !enough_bytes) {
-				continue;
-			}
-		}
-		for (auto &cand : kv.second) {
 			plan.selected_candidates.push_back(std::move(cand));
+			if (capped) {
+				remaining--;
+			}
 		}
 	}
 }
@@ -194,7 +224,17 @@ RewritePlan PlanRewrite(ClientContext &context, const RewriteDataFilesPlanInput 
 		return plan;
 	}
 
+	const auto min_file_size_bytes = ResolveMinFileSizeBytes(input, plan.target_file_size_bytes);
+	const auto max_file_size_bytes = ResolveMaxFileSizeBytes(input, plan.target_file_size_bytes);
+	if (min_file_size_bytes > max_file_size_bytes) {
+		throw InvalidInputException("iceberg_rewrite_data_files: resolved 'min_file_size_bytes' (%lld) must be <= "
+		                            "'max_file_size_bytes' (%lld)",
+		                            min_file_size_bytes, max_file_size_bytes);
+	}
+
 	auto default_spec_id = table_metadata.default_spec_id;
+	const bool unpartitioned = !table_metadata.HasPartitionSpec();
+	std::map<string, PartitionRewriteBucket> per_partition;
 
 	for (const auto &list_entry : manifest_files) {
 		if (list_entry.file.content != IcebergManifestContentType::DATA) {
@@ -212,6 +252,12 @@ RewritePlan PlanRewrite(ClientContext &context, const RewriteDataFilesPlanInput 
 			    list_entry.file.partition_spec_id, default_spec_id);
 		}
 
+		if (unpartitioned && UnpartitionedCollectionComplete(per_partition, input, plan.target_file_size_bytes)) {
+			//! Cap and group gating are already satisfied; remaining DATA manifests
+			//! are still checked above for partition spec evolution.
+			continue;
+		}
+
 		for (const auto &entry : list_entry.GetManifestEntries()) {
 			if (entry.status == IcebergManifestEntryStatusType::DELETED) {
 				continue;
@@ -225,15 +271,15 @@ RewritePlan PlanRewrite(ClientContext &context, const RewriteDataFilesPlanInput 
 			cand.file_size_in_bytes = entry.data_file.file_size_in_bytes;
 			cand.record_count = entry.data_file.record_count;
 			cand.partition_info = entry.data_file.partition_info;
-			plan.candidates.push_back(std::move(cand));
+			auto &bucket = per_partition[rewrite_planner_internal::PartitionBucketKey(cand.partition_info)];
+			ConsiderCandidate(bucket, std::move(cand), input, min_file_size_bytes, max_file_size_bytes);
+			if (unpartitioned && UnpartitionedCollectionComplete(per_partition, input, plan.target_file_size_bytes)) {
+				break;
+			}
 		}
 	}
 
-	if (plan.candidates.empty()) {
-		return plan;
-	}
-
-	GroupCandidates(plan, input);
+	SelectCandidates(plan, input, per_partition);
 
 	return plan;
 }

--- a/src/maintenance/rewrite_data_files_planner.cpp
+++ b/src/maintenance/rewrite_data_files_planner.cpp
@@ -86,11 +86,10 @@ bool BucketQualifies(const RewriteBucket &bucket, const RewriteDataFilesPlanInpu
 	return bucket.eligible_count >= 2 && bucket.eligible_bytes >= target_file_size_bytes;
 }
 
-void ConsiderCandidate(RewriteBucket &bucket, RewriteCandidate cand, const RewriteDataFilesPlanInput &input,
-                       int64_t min_file_size_bytes, int64_t max_file_size_bytes) {
+void ConsiderCandidate(RewriteBucket &bucket, RewriteCandidate cand, const RewriteDataFilesPlanInput &input) {
 	//! Match Spark: rewrite undersized or oversized files; leave the band alone.
-	if (!input.rewrite_all && cand.file_size_in_bytes >= min_file_size_bytes &&
-	    cand.file_size_in_bytes <= max_file_size_bytes) {
+	if (!input.rewrite_all && cand.file_size_in_bytes >= input.min_file_size_bytes.value() &&
+	    cand.file_size_in_bytes <= input.max_file_size_bytes.value()) {
 		return;
 	}
 	bucket.eligible_count++;
@@ -187,7 +186,6 @@ optional<RewriteCandidate> TryMakeRewriteCandidate(const IcebergManifestEntry &e
 
 void CollectUnpartitionedCandidates(RewriteBucket &bucket, const vector<IcebergManifestListEntry> &manifest_files,
                                     const RewriteDataFilesPlanInput &input, int32_t default_spec_id,
-                                    int64_t min_file_size_bytes, int64_t max_file_size_bytes,
                                     int64_t target_file_size_bytes) {
 	for (const auto &list_entry : manifest_files) {
 		if (list_entry.file.content != IcebergManifestContentType::DATA) {
@@ -204,7 +202,7 @@ void CollectUnpartitionedCandidates(RewriteBucket &bucket, const vector<IcebergM
 			if (!cand) {
 				continue;
 			}
-			ConsiderCandidate(bucket, std::move(*cand), input, min_file_size_bytes, max_file_size_bytes);
+			ConsiderCandidate(bucket, std::move(*cand), input);
 			if (UnpartitionedCollectionComplete(bucket, input, target_file_size_bytes)) {
 				break;
 			}
@@ -214,8 +212,7 @@ void CollectUnpartitionedCandidates(RewriteBucket &bucket, const vector<IcebergM
 
 void CollectPartitionedCandidates(std::map<string, RewriteBucket> &per_partition,
                                   const vector<IcebergManifestListEntry> &manifest_files,
-                                  const RewriteDataFilesPlanInput &input, int32_t default_spec_id,
-                                  int64_t min_file_size_bytes, int64_t max_file_size_bytes) {
+                                  const RewriteDataFilesPlanInput &input, int32_t default_spec_id) {
 	for (const auto &list_entry : manifest_files) {
 		if (list_entry.file.content != IcebergManifestContentType::DATA) {
 			continue;
@@ -227,7 +224,7 @@ void CollectPartitionedCandidates(std::map<string, RewriteBucket> &per_partition
 				continue;
 			}
 			auto &bucket = per_partition[rewrite_planner_internal::PartitionBucketKey(cand->partition_info)];
-			ConsiderCandidate(bucket, std::move(*cand), input, min_file_size_bytes, max_file_size_bytes);
+			ConsiderCandidate(bucket, std::move(*cand), input);
 		}
 	}
 }
@@ -263,7 +260,7 @@ string PartitionBucketKey(const vector<IcebergPartitionInfo> &partition_info) {
 
 } // namespace rewrite_planner_internal
 
-RewritePlan PlanRewrite(ClientContext &context, const RewriteDataFilesPlanInput &input) {
+RewritePlan PlanRewrite(ClientContext &context, RewriteDataFilesPlanInput input) {
 	RewritePlan plan;
 	plan.table_name = input.table_name;
 
@@ -271,6 +268,13 @@ RewritePlan PlanRewrite(ClientContext &context, const RewriteDataFilesPlanInput 
 	auto &table_info = *table_info_ptr;
 	auto &table_metadata = table_info.table_metadata;
 	plan.target_file_size_bytes = ResolveTargetFileSizeBytes(input, table_metadata);
+	input.min_file_size_bytes = ResolveMinFileSizeBytes(input, plan.target_file_size_bytes);
+	input.max_file_size_bytes = ResolveMaxFileSizeBytes(input, plan.target_file_size_bytes);
+	if (input.min_file_size_bytes.value() > input.max_file_size_bytes.value()) {
+		throw InvalidInputException("iceberg_rewrite_data_files: resolved 'min_file_size_bytes' (%lld) must be <= "
+		                            "'max_file_size_bytes' (%lld)",
+		                            input.min_file_size_bytes.value(), input.max_file_size_bytes.value());
+	}
 	plan.table_info = std::move(table_info_ptr);
 
 	if (table_metadata.iceberg_version >= 3) {
@@ -310,25 +314,15 @@ RewritePlan PlanRewrite(ClientContext &context, const RewriteDataFilesPlanInput 
 		return plan;
 	}
 
-	const auto min_file_size_bytes = ResolveMinFileSizeBytes(input, plan.target_file_size_bytes);
-	const auto max_file_size_bytes = ResolveMaxFileSizeBytes(input, plan.target_file_size_bytes);
-	if (min_file_size_bytes > max_file_size_bytes) {
-		throw InvalidInputException("iceberg_rewrite_data_files: resolved 'min_file_size_bytes' (%lld) must be <= "
-		                            "'max_file_size_bytes' (%lld)",
-		                            min_file_size_bytes, max_file_size_bytes);
-	}
-
 	auto default_spec_id = table_metadata.default_spec_id;
 	const bool unpartitioned = !table_metadata.HasPartitionSpec();
 	if (unpartitioned) {
 		RewriteBucket bucket;
-		CollectUnpartitionedCandidates(bucket, manifest_files, input, default_spec_id, min_file_size_bytes,
-		                               max_file_size_bytes, plan.target_file_size_bytes);
+		CollectUnpartitionedCandidates(bucket, manifest_files, input, default_spec_id, plan.target_file_size_bytes);
 		SelectCandidates(plan, input, bucket);
 	} else {
 		std::map<string, RewriteBucket> per_partition;
-		CollectPartitionedCandidates(per_partition, manifest_files, input, default_spec_id, min_file_size_bytes,
-		                             max_file_size_bytes);
+		CollectPartitionedCandidates(per_partition, manifest_files, input, default_spec_id);
 		SelectCandidates(plan, input, per_partition);
 	}
 

--- a/src/maintenance/rewrite_data_files_planner.cpp
+++ b/src/maintenance/rewrite_data_files_planner.cpp
@@ -170,18 +170,19 @@ void AssertCurrentPartitionSpec(const IcebergManifestListEntry &list_entry, int3
 	}
 }
 
-bool TryMakeRewriteCandidate(const IcebergManifestEntry &entry, RewriteCandidate &cand) {
+optional<RewriteCandidate> TryMakeRewriteCandidate(const IcebergManifestEntry &entry) {
 	if (entry.status == IcebergManifestEntryStatusType::DELETED) {
-		return false;
+		return nullopt;
 	}
 	if (entry.data_file.content != IcebergManifestEntryContentType::DATA) {
-		return false;
+		return nullopt;
 	}
+	RewriteCandidate cand;
 	cand.file_path = entry.data_file.file_path;
 	cand.file_size_in_bytes = entry.data_file.file_size_in_bytes;
 	cand.record_count = entry.data_file.record_count;
 	cand.partition_info = entry.data_file.partition_info;
-	return true;
+	return cand;
 }
 
 void CollectUnpartitionedCandidates(RewriteBucket &bucket, const vector<IcebergManifestListEntry> &manifest_files,
@@ -199,11 +200,11 @@ void CollectUnpartitionedCandidates(RewriteBucket &bucket, const vector<IcebergM
 			continue;
 		}
 		for (const auto &entry : list_entry.GetManifestEntries()) {
-			RewriteCandidate cand;
-			if (!TryMakeRewriteCandidate(entry, cand)) {
+			auto cand = TryMakeRewriteCandidate(entry);
+			if (!cand) {
 				continue;
 			}
-			ConsiderCandidate(bucket, std::move(cand), input, min_file_size_bytes, max_file_size_bytes);
+			ConsiderCandidate(bucket, std::move(*cand), input, min_file_size_bytes, max_file_size_bytes);
 			if (UnpartitionedCollectionComplete(bucket, input, target_file_size_bytes)) {
 				break;
 			}
@@ -221,12 +222,12 @@ void CollectPartitionedCandidates(std::map<string, RewriteBucket> &per_partition
 		}
 		AssertCurrentPartitionSpec(list_entry, default_spec_id);
 		for (const auto &entry : list_entry.GetManifestEntries()) {
-			RewriteCandidate cand;
-			if (!TryMakeRewriteCandidate(entry, cand)) {
+			auto cand = TryMakeRewriteCandidate(entry);
+			if (!cand) {
 				continue;
 			}
-			auto &bucket = per_partition[rewrite_planner_internal::PartitionBucketKey(cand.partition_info)];
-			ConsiderCandidate(bucket, std::move(cand), input, min_file_size_bytes, max_file_size_bytes);
+			auto &bucket = per_partition[rewrite_planner_internal::PartitionBucketKey(cand->partition_info)];
+			ConsiderCandidate(bucket, std::move(*cand), input, min_file_size_bytes, max_file_size_bytes);
 		}
 	}
 }

--- a/src/maintenance/rewrite_data_files_planner.cpp
+++ b/src/maintenance/rewrite_data_files_planner.cpp
@@ -1,6 +1,5 @@
 #include "maintenance/rewrite_data_files_planner.hpp"
 
-#include "duckdb/common/assert.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
@@ -74,7 +73,7 @@ static int64_t ResolveMaxFileSizeBytes(const RewriteDataFilesPlanInput &input, i
 	return (target_file_size_bytes * 9) / 5;
 }
 
-bool PartitionQualifies(const PartitionRewriteBucket &bucket, const RewriteDataFilesPlanInput &input,
+bool PartitionQualifies(const RewriteBucket &bucket, const RewriteDataFilesPlanInput &input,
                         int64_t target_file_size_bytes) {
 	if (input.rewrite_all) {
 		return true;
@@ -87,7 +86,7 @@ bool PartitionQualifies(const PartitionRewriteBucket &bucket, const RewriteDataF
 	return bucket.eligible_count >= 2 && bucket.eligible_bytes >= target_file_size_bytes;
 }
 
-void ConsiderCandidate(PartitionRewriteBucket &bucket, RewriteCandidate cand, const RewriteDataFilesPlanInput &input,
+void ConsiderCandidate(RewriteBucket &bucket, RewriteCandidate cand, const RewriteDataFilesPlanInput &input,
                        int64_t min_file_size_bytes, int64_t max_file_size_bytes) {
 	//! Match Spark: rewrite undersized or oversized files; leave the band alone.
 	if (!input.rewrite_all && cand.file_size_in_bytes >= min_file_size_bytes &&
@@ -104,46 +103,130 @@ void ConsiderCandidate(PartitionRewriteBucket &bucket, RewriteCandidate cand, co
 	bucket.retained.push_back(std::move(cand));
 }
 
-bool UnpartitionedCollectionComplete(const std::map<string, PartitionRewriteBucket> &per_partition,
-                                     const RewriteDataFilesPlanInput &input, int64_t target_file_size_bytes) {
+bool UnpartitionedCollectionComplete(const RewriteBucket &bucket, const RewriteDataFilesPlanInput &input,
+                                     int64_t target_file_size_bytes) {
 	if (!input.max_files_to_rewrite) {
 		return false;
 	}
-	if (per_partition.empty()) {
-		return false;
-	}
-	//! Unpartitioned tables have a single rewrite bucket; do not look up partition value "".
-	D_ASSERT(per_partition.size() == 1);
-	auto &bucket = per_partition.begin()->second;
 	if (bucket.retained.size() < static_cast<idx_t>(input.max_files_to_rewrite.value())) {
 		return false;
 	}
 	return PartitionQualifies(bucket, input, target_file_size_bytes);
 }
 
-void SelectCandidates(RewritePlan &plan, const RewriteDataFilesPlanInput &input,
-                      std::map<string, PartitionRewriteBucket> &per_partition) {
-	idx_t remaining = NumericLimits<idx_t>::Maximum();
-	const bool capped = input.max_files_to_rewrite.has_value();
-	if (capped) {
-		remaining = NumericCast<idx_t>(input.max_files_to_rewrite.value());
+void SelectFromBucket(RewritePlan &plan, RewriteBucket &bucket, const RewriteDataFilesPlanInput &input,
+                      idx_t &remaining, bool capped) {
+	if (!PartitionQualifies(bucket, input, plan.target_file_size_bytes)) {
+		return;
 	}
+	for (auto &cand : bucket.retained) {
+		if (capped && remaining == 0) {
+			return;
+		}
+		plan.selected_candidates.push_back(std::move(cand));
+		if (capped) {
+			remaining--;
+		}
+	}
+}
+
+idx_t RemainingRewriteCap(const RewriteDataFilesPlanInput &input, bool &capped) {
+	capped = input.max_files_to_rewrite.has_value();
+	if (capped) {
+		return NumericCast<idx_t>(input.max_files_to_rewrite.value());
+	}
+	return NumericLimits<idx_t>::Maximum();
+}
+
+void SelectCandidates(RewritePlan &plan, const RewriteDataFilesPlanInput &input, RewriteBucket &bucket) {
+	bool capped;
+	idx_t remaining = RemainingRewriteCap(input, capped);
+	SelectFromBucket(plan, bucket, input, remaining, capped);
+}
+
+void SelectCandidates(RewritePlan &plan, const RewriteDataFilesPlanInput &input,
+                      std::map<string, RewriteBucket> &per_partition) {
+	bool capped;
+	idx_t remaining = RemainingRewriteCap(input, capped);
 	for (auto &kv : per_partition) {
 		if (capped && remaining == 0) {
 			return;
 		}
-		auto &bucket = kv.second;
-		if (!PartitionQualifies(bucket, input, plan.target_file_size_bytes)) {
+		SelectFromBucket(plan, kv.second, input, remaining, capped);
+	}
+}
+
+void AssertCurrentPartitionSpec(const IcebergManifestListEntry &list_entry, int32_t default_spec_id) {
+	//! Guard against partition spec evolution: if a manifest was written
+	//! under a different partition spec, its partition tuples may not match
+	//! the current default spec. Mixing specs in one rewrite group would
+	//! produce incorrect manifest metadata. Reject until multi-spec support
+	//! is implemented.
+	if (list_entry.file.partition_spec_id != default_spec_id) {
+		throw NotImplementedException(
+		    "iceberg_rewrite_data_files: table has data files written under partition spec %d "
+		    "but current default spec is %d; partition spec evolution is not yet supported",
+		    list_entry.file.partition_spec_id, default_spec_id);
+	}
+}
+
+bool TryMakeRewriteCandidate(const IcebergManifestEntry &entry, RewriteCandidate &cand) {
+	if (entry.status == IcebergManifestEntryStatusType::DELETED) {
+		return false;
+	}
+	if (entry.data_file.content != IcebergManifestEntryContentType::DATA) {
+		return false;
+	}
+	cand.file_path = entry.data_file.file_path;
+	cand.file_size_in_bytes = entry.data_file.file_size_in_bytes;
+	cand.record_count = entry.data_file.record_count;
+	cand.partition_info = entry.data_file.partition_info;
+	return true;
+}
+
+void CollectUnpartitionedCandidates(RewriteBucket &bucket, const vector<IcebergManifestListEntry> &manifest_files,
+                                    const RewriteDataFilesPlanInput &input, int32_t default_spec_id,
+                                    int64_t min_file_size_bytes, int64_t max_file_size_bytes,
+                                    int64_t target_file_size_bytes) {
+	for (const auto &list_entry : manifest_files) {
+		if (list_entry.file.content != IcebergManifestContentType::DATA) {
 			continue;
 		}
-		for (auto &cand : bucket.retained) {
-			if (capped && remaining == 0) {
-				return;
+		AssertCurrentPartitionSpec(list_entry, default_spec_id);
+		if (UnpartitionedCollectionComplete(bucket, input, target_file_size_bytes)) {
+			//! Cap and group gating are already satisfied; remaining DATA manifests
+			//! are still checked above for partition spec evolution.
+			continue;
+		}
+		for (const auto &entry : list_entry.GetManifestEntries()) {
+			RewriteCandidate cand;
+			if (!TryMakeRewriteCandidate(entry, cand)) {
+				continue;
 			}
-			plan.selected_candidates.push_back(std::move(cand));
-			if (capped) {
-				remaining--;
+			ConsiderCandidate(bucket, std::move(cand), input, min_file_size_bytes, max_file_size_bytes);
+			if (UnpartitionedCollectionComplete(bucket, input, target_file_size_bytes)) {
+				break;
 			}
+		}
+	}
+}
+
+void CollectPartitionedCandidates(std::map<string, RewriteBucket> &per_partition,
+                                  const vector<IcebergManifestListEntry> &manifest_files,
+                                  const RewriteDataFilesPlanInput &input, int32_t default_spec_id,
+                                  int64_t min_file_size_bytes, int64_t max_file_size_bytes) {
+	for (const auto &list_entry : manifest_files) {
+		if (list_entry.file.content != IcebergManifestContentType::DATA) {
+			continue;
+		}
+		AssertCurrentPartitionSpec(list_entry, default_spec_id);
+		for (const auto &entry : list_entry.GetManifestEntries()) {
+			RewriteCandidate cand;
+			if (!TryMakeRewriteCandidate(entry, cand)) {
+				continue;
+			}
+			auto &bucket = per_partition[rewrite_planner_internal::PartitionBucketKey(cand.partition_info)];
+			ConsiderCandidate(bucket, std::move(cand), input, min_file_size_bytes, max_file_size_bytes);
 		}
 	}
 }
@@ -236,52 +319,17 @@ RewritePlan PlanRewrite(ClientContext &context, const RewriteDataFilesPlanInput 
 
 	auto default_spec_id = table_metadata.default_spec_id;
 	const bool unpartitioned = !table_metadata.HasPartitionSpec();
-	std::map<string, PartitionRewriteBucket> per_partition;
-
-	for (const auto &list_entry : manifest_files) {
-		if (list_entry.file.content != IcebergManifestContentType::DATA) {
-			continue;
-		}
-		//! Guard against partition spec evolution: if a manifest was written
-		//! under a different partition spec, its partition tuples may not match
-		//! the current default spec. Mixing specs in one rewrite group would
-		//! produce incorrect manifest metadata. Reject until multi-spec support
-		//! is implemented.
-		if (list_entry.file.partition_spec_id != default_spec_id) {
-			throw NotImplementedException(
-			    "iceberg_rewrite_data_files: table has data files written under partition spec %d "
-			    "but current default spec is %d; partition spec evolution is not yet supported",
-			    list_entry.file.partition_spec_id, default_spec_id);
-		}
-
-		if (unpartitioned && UnpartitionedCollectionComplete(per_partition, input, plan.target_file_size_bytes)) {
-			//! Cap and group gating are already satisfied; remaining DATA manifests
-			//! are still checked above for partition spec evolution.
-			continue;
-		}
-
-		for (const auto &entry : list_entry.GetManifestEntries()) {
-			if (entry.status == IcebergManifestEntryStatusType::DELETED) {
-				continue;
-			}
-			if (entry.data_file.content != IcebergManifestEntryContentType::DATA) {
-				continue;
-			}
-
-			RewriteCandidate cand;
-			cand.file_path = entry.data_file.file_path;
-			cand.file_size_in_bytes = entry.data_file.file_size_in_bytes;
-			cand.record_count = entry.data_file.record_count;
-			cand.partition_info = entry.data_file.partition_info;
-			auto &bucket = per_partition[rewrite_planner_internal::PartitionBucketKey(cand.partition_info)];
-			ConsiderCandidate(bucket, std::move(cand), input, min_file_size_bytes, max_file_size_bytes);
-			if (unpartitioned && UnpartitionedCollectionComplete(per_partition, input, plan.target_file_size_bytes)) {
-				break;
-			}
-		}
+	if (unpartitioned) {
+		RewriteBucket bucket;
+		CollectUnpartitionedCandidates(bucket, manifest_files, input, default_spec_id, min_file_size_bytes,
+		                               max_file_size_bytes, plan.target_file_size_bytes);
+		SelectCandidates(plan, input, bucket);
+	} else {
+		std::map<string, RewriteBucket> per_partition;
+		CollectPartitionedCandidates(per_partition, manifest_files, input, default_spec_id, min_file_size_bytes,
+		                             max_file_size_bytes);
+		SelectCandidates(plan, input, per_partition);
 	}
-
-	SelectCandidates(plan, input, per_partition);
 
 	return plan;
 }

--- a/src/maintenance/rewrite_data_files_planner.cpp
+++ b/src/maintenance/rewrite_data_files_planner.cpp
@@ -1,5 +1,6 @@
 #include "maintenance/rewrite_data_files_planner.hpp"
 
+#include "duckdb/common/assert.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
@@ -108,11 +109,12 @@ bool UnpartitionedCollectionComplete(const std::map<string, PartitionRewriteBuck
 	if (!input.max_files_to_rewrite) {
 		return false;
 	}
-	auto it = per_partition.find("");
-	if (it == per_partition.end()) {
+	if (per_partition.empty()) {
 		return false;
 	}
-	auto &bucket = it->second;
+	//! Unpartitioned tables have a single rewrite bucket; do not look up partition value "".
+	D_ASSERT(per_partition.size() == 1);
+	auto &bucket = per_partition.begin()->second;
 	if (bucket.retained.size() < static_cast<idx_t>(input.max_files_to_rewrite.value())) {
 		return false;
 	}

--- a/src/maintenance/rewrite_data_files_planner.cpp
+++ b/src/maintenance/rewrite_data_files_planner.cpp
@@ -73,7 +73,7 @@ static int64_t ResolveMaxFileSizeBytes(const RewriteDataFilesPlanInput &input, i
 	return (target_file_size_bytes * 9) / 5;
 }
 
-bool PartitionQualifies(const RewriteBucket &bucket, const RewriteDataFilesPlanInput &input,
+bool BucketQualifies(const RewriteBucket &bucket, const RewriteDataFilesPlanInput &input,
                         int64_t target_file_size_bytes) {
 	if (input.rewrite_all) {
 		return true;
@@ -111,12 +111,12 @@ bool UnpartitionedCollectionComplete(const RewriteBucket &bucket, const RewriteD
 	if (bucket.retained.size() < static_cast<idx_t>(input.max_files_to_rewrite.value())) {
 		return false;
 	}
-	return PartitionQualifies(bucket, input, target_file_size_bytes);
+	return BucketQualifies(bucket, input, target_file_size_bytes);
 }
 
 void SelectFromBucket(RewritePlan &plan, RewriteBucket &bucket, const RewriteDataFilesPlanInput &input,
                       idx_t &remaining, bool capped) {
-	if (!PartitionQualifies(bucket, input, plan.target_file_size_bytes)) {
+	if (!BucketQualifies(bucket, input, plan.target_file_size_bytes)) {
 		return;
 	}
 	for (auto &cand : bucket.retained) {

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_max_files_to_rewrite.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_max_files_to_rewrite.test
@@ -1,0 +1,167 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_max_files_to_rewrite.test
+# description: max_files_to_rewrite caps how many eligible files are compacted
+# group: [maintenance]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+statement ok
+drop table if exists my_datalake.default.rewrite_max_files;
+
+statement ok
+create table my_datalake.default.rewrite_max_files (id INTEGER, payload VARCHAR);
+
+statement ok
+insert into my_datalake.default.rewrite_max_files values (1, 'a1'), (2, 'b1');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files values (3, 'a2'), (4, 'b2');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files values (5, 'a3'), (6, 'b3');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files values (7, 'a4'), (8, 'b4');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files values (9, 'a5'), (10, 'b5');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files values (11, 'a6'), (12, 'b6');
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_max_files')
+where content = 'DATA' and status <> 'DELETED';
+----
+6
+
+# Six eligible files, but only rewrite three of them.
+query III
+call iceberg_rewrite_data_files(
+	'my_datalake.default.rewrite_max_files',
+	min_input_files => 5,
+	max_files_to_rewrite => 3
+);
+----
+3	1	<REGEX>:[1-9][0-9]*
+
+# One new file plus the three untouched originals.
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_max_files')
+where content = 'DATA' and status <> 'DELETED';
+----
+4
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_max_files')
+where content = 'DATA' and status = 'DELETED';
+----
+3
+
+query I
+select count(*) from my_datalake.default.rewrite_max_files;
+----
+12
+
+statement ok
+drop table if exists my_datalake.default.rewrite_max_files;
+
+statement ok
+drop table if exists my_datalake.default.rewrite_max_files_part;
+
+statement ok
+create table my_datalake.default.rewrite_max_files_part (id INTEGER, category VARCHAR, payload VARCHAR)
+partitioned by (category);
+
+statement ok
+insert into my_datalake.default.rewrite_max_files_part values (1, 'a', 'a1'), (2, 'b', 'b1');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files_part values (3, 'a', 'a2'), (4, 'b', 'b2');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files_part values (5, 'a', 'a3'), (6, 'b', 'b3');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files_part values (7, 'a', 'a4'), (8, 'b', 'b4');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files_part values (9, 'a', 'a5'), (10, 'b', 'b5');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files_part values (11, 'a', 'a6'), (12, 'b', 'b6');
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_max_files_part')
+where content = 'DATA' and status <> 'DELETED';
+----
+12
+
+# Both partitions qualify (6 >= min_input_files). The global cap of 3 is filled
+# from the first partition key (category=a), leaving category=b untouched.
+query III
+call iceberg_rewrite_data_files(
+	'my_datalake.default.rewrite_max_files_part',
+	min_input_files => 5,
+	max_files_to_rewrite => 3
+);
+----
+3	1	<REGEX>:[1-9][0-9]*
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_max_files_part')
+where content = 'DATA' and status <> 'DELETED';
+----
+10
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_max_files_part')
+where content = 'DATA' and status <> 'DELETED'
+  and file_path like '%/category=a/%';
+----
+4
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_max_files_part')
+where content = 'DATA' and status <> 'DELETED'
+  and file_path like '%/category=b/%';
+----
+6
+
+query I
+select count(*) from my_datalake.default.rewrite_max_files_part;
+----
+12
+
+query III
+select id, category, payload from my_datalake.default.rewrite_max_files_part order by id;
+----
+1	a	a1
+2	b	b1
+3	a	a2
+4	b	b2
+5	a	a3
+6	b	b3
+7	a	a4
+8	b	b4
+9	a	a5
+10	b	b5
+11	a	a6
+12	b	b6
+
+statement ok
+drop table if exists my_datalake.default.rewrite_max_files_part;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_temporal_partitions.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_temporal_partitions.test
@@ -1,0 +1,334 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/rewrite_data_files_temporal_partitions.test
+# description: rewrite_data_files compaction for day() and month() partition transforms
+# group: [maintenance]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# ---- DAY transform: full compact ----
+
+statement ok
+drop table if exists my_datalake.default.rewrite_day;
+
+statement ok
+create table my_datalake.default.rewrite_day (id INTEGER, ts TIMESTAMP, payload VARCHAR)
+partitioned by (day(ts));
+
+statement ok
+insert into my_datalake.default.rewrite_day values
+	(1, '2021-06-15 10:00:00'::TIMESTAMP, 'a1'),
+	(2, '2021-06-16 10:00:00'::TIMESTAMP, 'b1');
+
+statement ok
+insert into my_datalake.default.rewrite_day values
+	(3, '2021-06-15 11:00:00'::TIMESTAMP, 'a2'),
+	(4, '2021-06-16 11:00:00'::TIMESTAMP, 'b2');
+
+statement ok
+insert into my_datalake.default.rewrite_day values
+	(5, '2021-06-15 12:00:00'::TIMESTAMP, 'a3'),
+	(6, '2021-06-16 12:00:00'::TIMESTAMP, 'b3');
+
+statement ok
+insert into my_datalake.default.rewrite_day values
+	(7, '2021-06-15 13:00:00'::TIMESTAMP, 'a4'),
+	(8, '2021-06-16 13:00:00'::TIMESTAMP, 'b4');
+
+statement ok
+insert into my_datalake.default.rewrite_day values
+	(9, '2021-06-15 14:00:00'::TIMESTAMP, 'a5'),
+	(10, '2021-06-16 14:00:00'::TIMESTAMP, 'b5');
+
+statement ok
+insert into my_datalake.default.rewrite_day values
+	(11, '2021-06-15 15:00:00'::TIMESTAMP, 'a6'),
+	(12, '2021-06-16 15:00:00'::TIMESTAMP, 'b6');
+
+query I
+select count(*) from my_datalake.default.rewrite_day;
+----
+12
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_day')
+where content = 'DATA' and status <> 'DELETED';
+----
+12
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_day')
+where content = 'DATA' and status <> 'DELETED'
+  and file_path like '%/day_ts_2=%';
+----
+12
+
+query III
+call iceberg_rewrite_data_files('my_datalake.default.rewrite_day');
+----
+12	2	<REGEX>:[1-9][0-9]*
+
+query I
+select count(*) from my_datalake.default.rewrite_day;
+----
+12
+
+query III
+select id, ts, payload from my_datalake.default.rewrite_day order by id;
+----
+1	2021-06-15 10:00:00	a1
+2	2021-06-16 10:00:00	b1
+3	2021-06-15 11:00:00	a2
+4	2021-06-16 11:00:00	b2
+5	2021-06-15 12:00:00	a3
+6	2021-06-16 12:00:00	b3
+7	2021-06-15 13:00:00	a4
+8	2021-06-16 13:00:00	b4
+9	2021-06-15 14:00:00	a5
+10	2021-06-16 14:00:00	b5
+11	2021-06-15 15:00:00	a6
+12	2021-06-16 15:00:00	b6
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_day')
+where content = 'DATA' and status <> 'DELETED';
+----
+2
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_day')
+where content = 'DATA' and status <> 'DELETED'
+  and file_path like '%/day_ts_2=%';
+----
+2
+
+query III
+call iceberg_rewrite_data_files('my_datalake.default.rewrite_day');
+----
+0	0	0
+
+statement ok
+drop table if exists my_datalake.default.rewrite_day;
+
+# ---- MONTH transform: full compact ----
+
+statement ok
+drop table if exists my_datalake.default.rewrite_month;
+
+statement ok
+create table my_datalake.default.rewrite_month (id INTEGER, ts TIMESTAMP, payload VARCHAR)
+partitioned by (month(ts));
+
+statement ok
+insert into my_datalake.default.rewrite_month values
+	(1, '2021-01-15 10:00:00'::TIMESTAMP, 'a1'),
+	(2, '2021-02-15 10:00:00'::TIMESTAMP, 'b1');
+
+statement ok
+insert into my_datalake.default.rewrite_month values
+	(3, '2021-01-16 11:00:00'::TIMESTAMP, 'a2'),
+	(4, '2021-02-16 11:00:00'::TIMESTAMP, 'b2');
+
+statement ok
+insert into my_datalake.default.rewrite_month values
+	(5, '2021-01-17 12:00:00'::TIMESTAMP, 'a3'),
+	(6, '2021-02-17 12:00:00'::TIMESTAMP, 'b3');
+
+statement ok
+insert into my_datalake.default.rewrite_month values
+	(7, '2021-01-18 13:00:00'::TIMESTAMP, 'a4'),
+	(8, '2021-02-18 13:00:00'::TIMESTAMP, 'b4');
+
+statement ok
+insert into my_datalake.default.rewrite_month values
+	(9, '2021-01-19 14:00:00'::TIMESTAMP, 'a5'),
+	(10, '2021-02-19 14:00:00'::TIMESTAMP, 'b5');
+
+statement ok
+insert into my_datalake.default.rewrite_month values
+	(11, '2021-01-20 15:00:00'::TIMESTAMP, 'a6'),
+	(12, '2021-02-20 15:00:00'::TIMESTAMP, 'b6');
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_month')
+where content = 'DATA' and status <> 'DELETED';
+----
+12
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_month')
+where content = 'DATA' and status <> 'DELETED'
+  and file_path like '%/month_ts_2=%';
+----
+12
+
+query III
+call iceberg_rewrite_data_files('my_datalake.default.rewrite_month');
+----
+12	2	<REGEX>:[1-9][0-9]*
+
+query I
+select count(*) from my_datalake.default.rewrite_month;
+----
+12
+
+query III
+select id, ts, payload from my_datalake.default.rewrite_month order by id;
+----
+1	2021-01-15 10:00:00	a1
+2	2021-02-15 10:00:00	b1
+3	2021-01-16 11:00:00	a2
+4	2021-02-16 11:00:00	b2
+5	2021-01-17 12:00:00	a3
+6	2021-02-17 12:00:00	b3
+7	2021-01-18 13:00:00	a4
+8	2021-02-18 13:00:00	b4
+9	2021-01-19 14:00:00	a5
+10	2021-02-19 14:00:00	b5
+11	2021-01-20 15:00:00	a6
+12	2021-02-20 15:00:00	b6
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_month')
+where content = 'DATA' and status <> 'DELETED';
+----
+2
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_month')
+where content = 'DATA' and status <> 'DELETED'
+  and file_path like '%/month_ts_2=%';
+----
+2
+
+query III
+call iceberg_rewrite_data_files('my_datalake.default.rewrite_month');
+----
+0	0	0
+
+statement ok
+drop table if exists my_datalake.default.rewrite_month;
+
+# ---- DAY transform: max_files_to_rewrite fills the first day key ----
+
+statement ok
+drop table if exists my_datalake.default.rewrite_max_files_day;
+
+statement ok
+create table my_datalake.default.rewrite_max_files_day (id INTEGER, ts TIMESTAMP, payload VARCHAR)
+partitioned by (day(ts));
+
+statement ok
+insert into my_datalake.default.rewrite_max_files_day values
+	(1, '2021-06-15 10:00:00'::TIMESTAMP, 'a1'),
+	(2, '2021-06-16 10:00:00'::TIMESTAMP, 'b1');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files_day values
+	(3, '2021-06-15 11:00:00'::TIMESTAMP, 'a2'),
+	(4, '2021-06-16 11:00:00'::TIMESTAMP, 'b2');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files_day values
+	(5, '2021-06-15 12:00:00'::TIMESTAMP, 'a3'),
+	(6, '2021-06-16 12:00:00'::TIMESTAMP, 'b3');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files_day values
+	(7, '2021-06-15 13:00:00'::TIMESTAMP, 'a4'),
+	(8, '2021-06-16 13:00:00'::TIMESTAMP, 'b4');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files_day values
+	(9, '2021-06-15 14:00:00'::TIMESTAMP, 'a5'),
+	(10, '2021-06-16 14:00:00'::TIMESTAMP, 'b5');
+
+statement ok
+insert into my_datalake.default.rewrite_max_files_day values
+	(11, '2021-06-15 15:00:00'::TIMESTAMP, 'a6'),
+	(12, '2021-06-16 15:00:00'::TIMESTAMP, 'b6');
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_max_files_day')
+where content = 'DATA' and status <> 'DELETED';
+----
+12
+
+# Both day partitions qualify (6 >= min_input_files). The global cap of 3 is filled
+# from the lexicographically first day key (2021-06-15), leaving 2021-06-16 untouched.
+query III
+call iceberg_rewrite_data_files(
+	'my_datalake.default.rewrite_max_files_day',
+	min_input_files => 5,
+	max_files_to_rewrite => 3
+);
+----
+3	1	<REGEX>:[1-9][0-9]*
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_max_files_day')
+where content = 'DATA' and status <> 'DELETED';
+----
+10
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_max_files_day')
+where content = 'DATA' and status <> 'DELETED'
+  and (
+	file_path like '%/day_ts_2=' || date_diff('day', DATE '1970-01-01', DATE '2021-06-15')::VARCHAR || '/%'
+	or file_path like '%/day_ts_2=2021-06-15/%'
+  );
+----
+4
+
+query I
+select count(*)
+from iceberg_metadata('my_datalake.default.rewrite_max_files_day')
+where content = 'DATA' and status <> 'DELETED'
+  and (
+	file_path like '%/day_ts_2=' || date_diff('day', DATE '1970-01-01', DATE '2021-06-16')::VARCHAR || '/%'
+	or file_path like '%/day_ts_2=2021-06-16/%'
+  );
+----
+6
+
+query I
+select count(*) from my_datalake.default.rewrite_max_files_day;
+----
+12
+
+query III
+select id, ts, payload from my_datalake.default.rewrite_max_files_day order by id;
+----
+1	2021-06-15 10:00:00	a1
+2	2021-06-16 10:00:00	b1
+3	2021-06-15 11:00:00	a2
+4	2021-06-16 11:00:00	b2
+5	2021-06-15 12:00:00	a3
+6	2021-06-16 12:00:00	b3
+7	2021-06-15 13:00:00	a4
+8	2021-06-16 13:00:00	b4
+9	2021-06-15 14:00:00	a5
+10	2021-06-16 14:00:00	b5
+11	2021-06-15 15:00:00	a6
+12	2021-06-16 15:00:00	b6
+
+statement ok
+drop table if exists my_datalake.default.rewrite_max_files_day;

--- a/test/sql/local/maintenance/rewrite_data_files_validation.test
+++ b/test/sql/local/maintenance/rewrite_data_files_validation.test
@@ -64,6 +64,16 @@ SELECT * FROM iceberg_rewrite_data_files('a.b.c', min_input_files => 0);
 'min_input_files' must be >= 1
 
 statement error
+SELECT * FROM iceberg_rewrite_data_files('a.b.c', max_files_to_rewrite => 0);
+----
+'max_files_to_rewrite' must be >= 1
+
+statement error
+SELECT * FROM iceberg_rewrite_data_files('cat.sch.tbl', max_files_to_rewrite => NULL);
+----
+'max_files_to_rewrite' cannot be NULL
+
+statement error
 SELECT * FROM iceberg_rewrite_data_files('a.b.c', min_file_size_bytes => 99);
 ----
 'min_file_size_bytes' must be >= 100 bytes


### PR DESCRIPTION
Adds the Spark-compatible `max_files_to_rewrite` parameter to `iceberg_rewrite_data_files`, an upper bound on how many eligible data files a single call will compact.

Without it, compaction is all-or-nothing: a table-wide rewrite touches every eligible file in one commit. The cap lets callers break that into smaller, incremental, resumable batches, which keeps each commit cheap and bounds the blast radius if something goes wrong.

```sql
call iceberg_rewrite_data_files('my_datalake.default.events', max_files_to_rewrite => 100);
```

## Source

https://iceberg.apache.org/docs/latest/spark-procedures/#general-options


max-files-to-rewrite | null | This option sets an upper limit on the number of eligible files that will be rewritten. If this option is not specified, all eligible files will be rewritten.
-- | -- | --

# LLM Notes

## Behavior

The cap bounds how many files are rewritten. It never changes *which* partitions are considered worth rewriting.

That distinction is the core of the change. A partition qualifies for rewrite based on the size and count of **all** its eligible files, and only after it qualifies does the cap limit how many of those files this call actually takes. A low cap can therefore leave a partition partly compacted, but it can never cause a partition to be skipped that would otherwise have been selected.

`max_files_to_rewrite` is rejected at bind time when it is `NULL` or below `1`. When it is omitted, planning and selection behave exactly as before.

## Implementation notes

**Planning no longer materializes every live data file.** `PlanRewrite` used to collect all live DATA files into `RewritePlan::candidates` and group them in a second pass. Candidates are now bucketed by partition key as they are read from the manifests, and `RewritePlan::candidates` is removed. For an unpartitioned table, planning can also stop scanning once the cap and the gating thresholds are both satisfied, rather than always walking every manifest entry. Manifests are still checked for partition spec evolution even after that early exit.

**Gating is evaluated against the full eligible set, not the capped prefix.** Each partition bucket tracks `eligible_count` and `eligible_bytes` across every eligible file, separately from the `retained` prefix that the cap truncates. This is what makes the guarantee above hold. The rule lives in a single `PartitionQualifies` helper shared by the selection loop and the unpartitioned early-exit check, so the two cannot drift apart.

This matters because of how it interacts with the `enough_bytes` rule from #1339, which landed on `main` while this branch was open. That rule selects a partition holding at least two files whose combined size already meets the target, even when the file count is below `min_input_files`. Had gating been evaluated against the cap-truncated prefix instead of the full eligible set, a low cap could have suppressed a partition that should have been rewritten.

## Limitations compared to Spark

Spark's `RewriteDataFiles` bin-packs eligible files into ordered *file groups* and truncates that list. This implementation has no equivalent grouping step: every selected file across every qualifying partition feeds a single `COPY`. Two consequences follow.

* **The cap is filled in partition-key order, not by benefit.** Partitions are visited in sorted key order and the budget is consumed greedily by the first qualifying ones; within a partition, files are taken in manifest-scan order. Spark orders its file groups before truncating, so it can spend a small cap where compaction pays off most. Here a low cap deterministically lands on the lexicographically-first partitions.
* **A partition is never split across calls in a size-aware way.** There is no way to bin-pack one very large partition into several groups and take the cap from more than one of them.

The ordering is at least deterministic, so repeated capped calls make steady forward progress rather than revisiting the same files.
