### PR TITLE
Add metadata-only snapshot expiration 

### DIFF
--- a/src/catalog/rest/api/table_update.cpp
+++ b/src/catalog/rest/api/table_update.cpp
@@ -2,6 +2,8 @@
 #include "duckdb/common/exception.hpp"
 #include "catalog/rest/iceberg_table_set.hpp"
 
+#include <algorithm>
+
 namespace duckdb {
 
 AddSchemaUpdate::AddSchemaUpdate(shared_ptr<IcebergTableSchema> schema_p, optional_idx last_column_id_p)
@@ -80,7 +82,7 @@ void AssertCurrentSchemaIdRequirement::CreateRequirement(DatabaseInstance &db, C
 	req.assert_current_schema_id->current_schema_id = current_schema_id;
 }
 
-AssertRefSnapshotId::AssertRefSnapshotId(int64_t snapshot_id)
+AssertRefSnapshotId::AssertRefSnapshotId(optional<int64_t> snapshot_id)
     : IcebergTableRequirement(IcebergTableRequirementType::ASSERT_REF_SNAPSHOT_ID), snapshot_id(snapshot_id) {
 }
 
@@ -252,6 +254,30 @@ void RemoveProperties::CreateUpdate(DatabaseInstance &db, ClientContext &context
 	req.remove_properties_update = rest_api_objects::RemovePropertiesUpdate();
 	req.remove_properties_update->base_update.action = "remove-properties";
 	req.remove_properties_update->removals = properties;
+}
+
+static void SortAndRemoveDuplicates(vector<int64_t> &values) {
+	std::sort(values.begin(), values.end());
+	values.erase(std::unique(values.begin(), values.end()), values.end());
+}
+
+RemoveSnapshots::RemoveSnapshots(vector<int64_t> snapshot_ids_p)
+    : IcebergTableUpdate(IcebergTableUpdateType::REMOVE_SNAPSHOTS), snapshot_ids(std::move(snapshot_ids_p)) {
+	SortAndRemoveDuplicates(snapshot_ids);
+}
+
+void RemoveSnapshots::AddSnapshotIds(const vector<int64_t> &snapshot_ids_p) {
+	snapshot_ids.insert(snapshot_ids.end(), snapshot_ids_p.begin(), snapshot_ids_p.end());
+	SortAndRemoveDuplicates(snapshot_ids);
+}
+
+void RemoveSnapshots::CreateUpdate(DatabaseInstance &db, ClientContext &context,
+                                   IcebergCommitState &commit_state) const {
+	commit_state.table_change.updates.push_back(rest_api_objects::TableUpdate());
+	auto &update = commit_state.table_change.updates.back();
+	update.remove_snapshots_update = rest_api_objects::RemoveSnapshotsUpdate();
+	update.remove_snapshots_update->base_update.action = "remove-snapshots";
+	update.remove_snapshots_update->snapshot_ids = snapshot_ids;
 }
 
 SetLocation::SetLocation(string location)

--- a/src/catalog/rest/transaction/iceberg_transaction_data.cpp
+++ b/src/catalog/rest/transaction/iceberg_transaction_data.cpp
@@ -17,6 +17,21 @@
 
 namespace duckdb {
 
+static bool HasTableUpdate(const vector<unique_ptr<IcebergTableUpdate>> &updates, IcebergTableUpdateType type) {
+	for (const auto &update : updates) {
+		if (update->type == type) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static void VerifyNoSnapshotExpiration(const vector<unique_ptr<IcebergTableUpdate>> &updates, const char *operation) {
+	if (HasTableUpdate(updates, IcebergTableUpdateType::REMOVE_SNAPSHOTS)) {
+		throw TransactionException("%s cannot be combined with snapshot expiration in the same transaction", operation);
+	}
+}
+
 static void LoadMissingManifestCounts(ClientContext &context, const IcebergTableMetadata &metadata,
                                       const IcebergSnapshotScanInfo &snapshot_info,
                                       IcebergManifestListEntry &manifest_list_entry) {
@@ -138,6 +153,21 @@ bool IcebergTransactionData::ContainsDelete() const {
 	return false;
 }
 
+void IcebergTransactionData::VerifySnapshotExpirationAllowed() const {
+	//! These updates are not all materialized in the metadata used by the expiration planner.
+	if (HasTableUpdate(updates, IcebergTableUpdateType::ADD_SNAPSHOT)) {
+		throw TransactionException("Snapshot expiration cannot follow data changes in the same transaction");
+	}
+	if (HasTableUpdate(updates, IcebergTableUpdateType::SET_SNAPSHOT_REF)) {
+		throw TransactionException(
+		    "Snapshot expiration cannot be combined with snapshot rollback in the same transaction");
+	}
+	if (HasTableUpdate(updates, IcebergTableUpdateType::SET_PROPERTIES) ||
+	    HasTableUpdate(updates, IcebergTableUpdateType::REMOVE_PROPERTIES)) {
+		throw TransactionException("Snapshot expiration cannot follow table property changes in the same transaction");
+	}
+}
+
 bool IcebergTransactionData::IsFileInvalidated(const string &file_path) const {
 	return manifest_deletes.IsInvalidated(file_path);
 }
@@ -194,6 +224,7 @@ void IcebergTransactionData::AddSnapshot(IcebergSnapshotOperationType operation,
                                          IcebergManifestDeletes &&altered_manifests) {
 	//! NOTE: Lock has to be held to make sure the rows are assigned the correct row ids
 	lock_guard<mutex> guard(lock);
+	VerifyNoSnapshotExpiration(updates, "Data changes");
 
 	//! Generate a new snapshot id
 	auto &table_metadata = table_info.table_metadata;
@@ -256,6 +287,7 @@ void IcebergTransactionData::AddDeleteSnapshot(partitioned_manifest_entry_map_t 
                                                IcebergManifestDeletes &&altered_manifests) {
 	//! NOTE: Lock has to be held to make sure the rows are assigned the correct row ids
 	lock_guard<mutex> guard(lock);
+	VerifyNoSnapshotExpiration(updates, "Data changes");
 
 	auto &table_metadata = table_info.table_metadata;
 	CacheExistingManifestList(guard, table_metadata);
@@ -276,6 +308,7 @@ void IcebergTransactionData::AddUpdateSnapshot(partitioned_manifest_entry_map_t 
                                                IcebergManifestDeletes &&altered_manifests) {
 	//! NOTE: Lock has to be held to make sure the rows are assigned the correct row ids
 	lock_guard<mutex> guard(lock);
+	VerifyNoSnapshotExpiration(updates, "Data changes");
 
 	//! Generate a new snapshot id
 	auto &table_metadata = table_info.table_metadata;
@@ -372,11 +405,27 @@ void IcebergTransactionData::TableSetDefaultSpec() {
 }
 
 void IcebergTransactionData::TableSetProperties(const case_insensitive_map_t<string> &properties) {
+	VerifyNoSnapshotExpiration(updates, "Table property changes");
 	updates.push_back(make_uniq<SetProperties>(properties));
 }
 
 void IcebergTransactionData::TableRemoveProperties(const vector<string> &properties) {
+	VerifyNoSnapshotExpiration(updates, "Table property changes");
 	updates.push_back(make_uniq<RemoveProperties>(properties));
+}
+
+void IcebergTransactionData::TableRemoveSnapshots(const vector<int64_t> &snapshot_ids) {
+	for (auto &update : updates) {
+		if (update->type == IcebergTableUpdateType::REMOVE_SNAPSHOTS) {
+			update->Cast<RemoveSnapshots>().AddSnapshotIds(snapshot_ids);
+			return;
+		}
+	}
+	updates.push_back(make_uniq<RemoveSnapshots>(snapshot_ids));
+	//! The standard requirement detects changes to main, but cannot detect a
+	//! concurrently created ref or retention-only policy changes.
+	auto &metadata = table_info.table_metadata;
+	requirements.push_back(make_uniq<AssertRefSnapshotId>(metadata.current_snapshot_id));
 }
 
 void IcebergTransactionData::TableSetLocation() {
@@ -403,6 +452,7 @@ static bool IsAncestorOfCurrentSnapshot(const IcebergTableMetadata &metadata, in
 }
 
 void IcebergTransactionData::TableRollbackToSnapshot(int64_t snapshot_id) {
+	VerifyNoSnapshotExpiration(updates, "Snapshot rollback");
 	auto &metadata = table_info.table_metadata;
 	auto target = metadata.FindSnapshotByIdInternal(snapshot_id);
 	if (!target) {

--- a/src/core/metadata/iceberg_table_metadata.cpp
+++ b/src/core/metadata/iceberg_table_metadata.cpp
@@ -377,6 +377,18 @@ IcebergTableMetadata IcebergTableMetadata::FromTableMetadata(const rest_api_obje
 			res.snapshots.emplace(snapshot.snapshot_id, IcebergSnapshot::ParseSnapshot(snapshot, res));
 		}
 	}
+	if (table_metadata.refs) {
+		res.snapshot_refs_present = true;
+		for (auto &entry : table_metadata.refs->additional_properties) {
+			const auto &ref = entry.second;
+			if (entry.first == "main") {
+				res.main_snapshot_ref = IcebergMainSnapshotReference {
+				    ref.type, ref.snapshot_id, ref.max_snapshot_age_ms, ref.min_snapshots_to_keep};
+			} else if (!res.unsupported_snapshot_ref || entry.first < *res.unsupported_snapshot_ref) {
+				res.unsupported_snapshot_ref = entry.first;
+			}
+		}
+	}
 	if (table_metadata.snapshot_log) {
 		res.snapshot_log.reserve(table_metadata.snapshot_log->value.size());
 		for (auto &entry : table_metadata.snapshot_log->value) {
@@ -490,6 +502,9 @@ IcebergTableMetadata IcebergTableMetadata::Copy() const {
 	res.partition_specs = partition_specs;
 	res.sort_specs = sort_specs;
 	res.snapshots = snapshots;
+	res.snapshot_refs_present = snapshot_refs_present;
+	res.main_snapshot_ref = main_snapshot_ref;
+	res.unsupported_snapshot_ref = unsupported_snapshot_ref;
 	res.snapshot_log = snapshot_log;
 	res.mappings = mappings;
 	res.write_data_path = write_data_path;

--- a/src/function/iceberg_functions.cpp
+++ b/src/function/iceberg_functions.cpp
@@ -24,6 +24,7 @@ vector<TableFunctionSet> IcebergFunctions::GetTableFunctions(ExtensionLoader &lo
 	functions.push_back(RemoveIcebergSchemaPropertiesFunctions());
 	functions.push_back(GetIcebergToDuckLakeFunction());
 	functions.push_back(GetIcebergLoadTableResponseFunction());
+	functions.push_back(GetIcebergExpireSnapshotsFunction());
 	functions.push_back(GetIcebergRewriteDataFilesFunction());
 	functions.push_back(GetIcebergRollbackToSnapshotFunction());
 

--- a/src/function/metadata/CMakeLists.txt
+++ b/src/function/metadata/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
   iceberg_function_metadata OBJECT
   iceberg_column_stats.cpp
+  iceberg_expire_snapshots.cpp
   iceberg_load_table_response.cpp
   iceberg_metadata.cpp
   iceberg_partition_stats.cpp

--- a/src/function/metadata/iceberg_expire_snapshots.cpp
+++ b/src/function/metadata/iceberg_expire_snapshots.cpp
@@ -1,0 +1,121 @@
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/planner/binder.hpp"
+
+#include "catalog/rest/iceberg_catalog.hpp"
+#include "function/iceberg_functions.hpp"
+#include "maintenance/expire_snapshots_operator.hpp"
+#include "maintenance/expire_snapshots_planner.hpp"
+#include "maintenance/maintenance_table_loader.hpp"
+
+namespace duckdb {
+
+namespace {
+
+constexpr const char *EXPIRE_SNAPSHOTS_NAME = "iceberg_expire_snapshots";
+
+QualifiedName ParseExpireSnapshotsTableName(const Value &identifier_value) {
+	if (identifier_value.IsNull()) {
+		throw InvalidInputException("%s: table identifier cannot be NULL", EXPIRE_SNAPSHOTS_NAME);
+	}
+	auto identifier = StringValue::Get(identifier_value);
+	if (identifier.empty() || identifier.front() == '.' || identifier.back() == '.') {
+		throw InvalidInputException("%s: table identifier '%s' has an empty component", EXPIRE_SNAPSHOTS_NAME,
+		                            identifier);
+	}
+	auto parts = QualifiedName::ParseComponents(identifier);
+	if (parts.size() != 3) {
+		throw InvalidInputException("%s: table identifier must be 'catalog.schema.table', got '%s'",
+		                            EXPIRE_SNAPSHOTS_NAME, identifier);
+	}
+	for (const auto &part : parts) {
+		if (part.empty()) {
+			throw InvalidInputException("%s: table identifier '%s' has an empty component", EXPIRE_SNAPSHOTS_NAME,
+			                            identifier);
+		}
+	}
+	return QualifiedName {parts[0], parts[1], parts[2]};
+}
+
+ExpireSnapshotsPlanInput BindExpireSnapshotsArguments(TableFunctionBindInput &input) {
+	ExpireSnapshotsPlanInput result;
+	result.table_name = ParseExpireSnapshotsTableName(input.inputs[0]);
+
+	for (const auto &entry : input.named_parameters) {
+		auto option = StringUtil::Lower(entry.first.GetIdentifierName());
+		auto &value = entry.second;
+		if (value.IsNull()) {
+			if (option == "older_than" || option == "retain_last") {
+				continue;
+			}
+			throw InvalidInputException("%s: '%s' cannot be NULL", EXPIRE_SNAPSHOTS_NAME, option);
+		}
+		if (option == "older_than") {
+			auto older_than = value.GetValue<timestamp_t>();
+			if (!older_than.IsFinite()) {
+				throw InvalidInputException("%s: 'older_than' must be a finite timestamp", EXPIRE_SNAPSHOTS_NAME);
+			}
+			result.older_than = older_than;
+		} else if (option == "retain_last") {
+			auto retain_last = value.GetValue<int64_t>();
+			if (retain_last < 1) {
+				throw InvalidInputException("%s: 'retain_last' must be >= 1, got %lld", EXPIRE_SNAPSHOTS_NAME,
+				                            retain_last);
+			}
+			result.retain_last = retain_last;
+		} else if (option == "snapshot_ids") {
+			if (value.type().id() != LogicalTypeId::LIST) {
+				throw InvalidInputException("%s: 'snapshot_ids' must be a list of integers, got %s",
+				                            EXPIRE_SNAPSHOTS_NAME, value.type().ToString());
+			}
+			auto &children = ListValue::GetChildren(value);
+			result.snapshot_ids.reserve(children.size());
+			for (const auto &child : children) {
+				if (child.IsNull()) {
+					throw InvalidInputException("%s: 'snapshot_ids' entries cannot be NULL", EXPIRE_SNAPSHOTS_NAME);
+				}
+				if (!child.type().IsIntegral()) {
+					throw InvalidInputException("%s: 'snapshot_ids' entries must be integers, got %s",
+					                            EXPIRE_SNAPSHOTS_NAME, child.type().ToString());
+				}
+				result.snapshot_ids.push_back(child.DefaultCastAs(LogicalType::BIGINT).GetValue<int64_t>());
+			}
+		}
+	}
+	return result;
+}
+
+unique_ptr<LogicalOperator> ExpireSnapshotsBindOperator(ClientContext &context, TableFunctionBindInput &input,
+                                                        TableIndex bind_index, vector<Identifier> &return_names) {
+	if (!input.binder) {
+		throw InternalException("%s: bind_operator called without a binder", EXPIRE_SNAPSHOTS_NAME);
+	}
+	auto plan_input = BindExpireSnapshotsArguments(input);
+	//! Prepared maintenance statements must resolve the catalog again before execution.
+	input.binder->SetAlwaysRequireRebind();
+	auto &catalog = GetMaintenanceIcebergCatalog(context, plan_input.table_name, EXPIRE_SNAPSHOTS_NAME);
+	DatabaseModificationType modification;
+	modification |= DatabaseModificationType::ALTER_TABLE;
+	input.binder->GetStatementProperties().RegisterDBModify(catalog, context, modification);
+
+	return_names = {"deleted_snapshots", "retained_snapshots"};
+	return make_uniq<LogicalExpireSnapshots>(bind_index.index, std::move(plan_input));
+}
+
+} // namespace
+
+TableFunctionSet IcebergFunctions::GetIcebergExpireSnapshotsFunction() {
+	TableFunctionSet function_set(EXPIRE_SNAPSHOTS_NAME);
+	TableFunction function(EXPIRE_SNAPSHOTS_NAME, {LogicalType::VARCHAR}, nullptr);
+	function.bind_operator = ExpireSnapshotsBindOperator;
+	function.named_parameters["older_than"] = LogicalType::TIMESTAMP;
+	function.named_parameters["retain_last"] = LogicalType::BIGINT;
+	function.named_parameters["snapshot_ids"] = LogicalType::ANY;
+	function_set.AddFunction(function);
+	return function_set;
+}
+
+} // namespace duckdb

--- a/src/include/catalog/rest/api/table_update.hpp
+++ b/src/include/catalog/rest/api/table_update.hpp
@@ -60,10 +60,10 @@ struct AssertCurrentSchemaIdRequirement : public IcebergTableRequirement {
 struct AssertRefSnapshotId : public IcebergTableRequirement {
 	static constexpr const IcebergTableRequirementType TYPE = IcebergTableRequirementType::ASSERT_REF_SNAPSHOT_ID;
 
-	explicit AssertRefSnapshotId(int64_t snapshot_id);
+	explicit AssertRefSnapshotId(optional<int64_t> snapshot_id);
 	void CreateRequirement(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state);
 
-	int64_t snapshot_id;
+	optional<int64_t> snapshot_id;
 };
 
 //! The table's last assigned column id (a.k.a last_column_id) must match the requirement's `last-assigned-field-id`
@@ -175,6 +175,18 @@ struct RemoveProperties : public IcebergTableUpdate {
 	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
 
 	vector<string> properties;
+};
+
+//! Remove snapshots from metadata through REST "remove-snapshots".
+//! This update does not delete data or metadata files.
+struct RemoveSnapshots : public IcebergTableUpdate {
+	static constexpr const IcebergTableUpdateType TYPE = IcebergTableUpdateType::REMOVE_SNAPSHOTS;
+
+	explicit RemoveSnapshots(vector<int64_t> snapshot_ids);
+	void AddSnapshotIds(const vector<int64_t> &snapshot_ids);
+	void CreateUpdate(DatabaseInstance &db, ClientContext &context, IcebergCommitState &commit_state) const override;
+
+	vector<int64_t> snapshot_ids;
 };
 
 struct SetLocation : public IcebergTableUpdate {

--- a/src/include/catalog/rest/transaction/iceberg_transaction.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction.hpp
@@ -46,6 +46,12 @@ public:
 	void SetStatus(IcebergTableStatus value) {
 		status = value;
 	}
+	bool IsExpirationMetadataInitialized() const {
+		return expiration_metadata_initialized;
+	}
+	void MarkExpirationMetadataInitialized() {
+		expiration_metadata_initialized = true;
+	}
 
 private:
 	//! The catalog state is retained as the source for lazily materializing transaction-local state.
@@ -54,6 +60,8 @@ private:
 	//! entries.
 	unique_ptr<IcebergTable> transaction_table;
 	IcebergTableStatus status;
+	//! True only when snapshot expiration force-refreshed and pinned this state.
+	bool expiration_metadata_initialized = false;
 };
 
 struct SchemaPropertyUpdates {

--- a/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
+++ b/src/include/catalog/rest/transaction/iceberg_transaction_data.hpp
@@ -30,6 +30,7 @@ public:
 	bool RetryStateMatches(const IcebergTable &table_info) const;
 	//! Whether this transaction stages a DELETE snapshot; gates the commit-retry safety check.
 	bool ContainsDelete() const;
+	void VerifySnapshotExpirationAllowed() const;
 	bool IsFileInvalidated(const string &file_path) const;
 
 	void AddSnapshot(IcebergSnapshotOperationType operation, vector<IcebergManifestEntry> &&data_files,
@@ -54,6 +55,7 @@ public:
 	void TableSetDefaultSpec();
 	void TableSetProperties(const case_insensitive_map_t<string> &properties);
 	void TableRemoveProperties(const vector<string> &properties);
+	void TableRemoveSnapshots(const vector<int64_t> &snapshot_ids);
 	void TableSetLocation();
 	//! Roll main back to an ancestor snapshot (Spark rollback_to_snapshot semantics).
 	void TableRollbackToSnapshot(int64_t snapshot_id);

--- a/src/include/core/metadata/iceberg_table_metadata.hpp
+++ b/src/include/core/metadata/iceberg_table_metadata.hpp
@@ -31,6 +31,14 @@ public:
 	timestamp_ms_t timestamp_ms;
 };
 
+//! Copyable subset of the generated REST reference needed by main-only expiration.
+struct IcebergMainSnapshotReference {
+	string type;
+	int64_t snapshot_id;
+	optional<int64_t> max_snapshot_age_ms;
+	optional<int32_t> min_snapshots_to_keep;
+};
+
 //! A structure to store "LoadTableResult" information that changes as a transaction goes on
 //! Everything is parsed from a load table result, but if a transaction changes a schema, those schema
 //! updates are reflected here and never within the catalog that lives beyond transactions
@@ -131,6 +139,12 @@ public:
 	unordered_map<int32_t, IcebergSortOrder> sort_specs;
 	//! snapshot_id -> snapshot
 	unordered_map<int64_t, IcebergSnapshot> snapshots;
+	//! Distinguishes an absent refs field (legacy implicit main) from an explicit empty map.
+	bool snapshot_refs_present = false;
+	//! The main branch policy used by main-only snapshot expiration.
+	optional<IcebergMainSnapshotReference> main_snapshot_ref;
+	//! Lexicographically first non-main name, retained for deterministic fail-closed validation.
+	optional<string> unsupported_snapshot_ref;
 	//! History of refs.main per Iceberg spec "snapshot-log": (snapshot_id, raw millis)
 	//! pairs recording each change to current-snapshot-id, sorted ascending by ms.
 	//! Used for spec-compliant point-in-time resolution; side-branch commits are absent.

--- a/src/include/function/iceberg_functions.hpp
+++ b/src/include/function/iceberg_functions.hpp
@@ -38,6 +38,7 @@ private:
 	static TableFunctionSet GetIcebergSchemaPropertiesFunctions();
 	static TableFunctionSet SetIcebergSchemaPropertiesFunctions();
 	static TableFunctionSet RemoveIcebergSchemaPropertiesFunctions();
+	static TableFunctionSet GetIcebergExpireSnapshotsFunction();
 	static TableFunctionSet GetIcebergRewriteDataFilesFunction();
 	static TableFunctionSet GetIcebergRollbackToSnapshotFunction();
 };

--- a/src/include/maintenance/expire_snapshots_operator.hpp
+++ b/src/include/maintenance/expire_snapshots_operator.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
+#include "duckdb/planner/operator/logical_extension_operator.hpp"
+
+#include "maintenance/expire_snapshots_planner.hpp"
+
+namespace duckdb {
+
+struct LogicalExpireSnapshots : public LogicalExtensionOperator {
+public:
+	LogicalExpireSnapshots(idx_t bind_index, ExpireSnapshotsPlanInput input);
+
+	idx_t bind_index;
+	ExpireSnapshotsPlanInput input;
+
+	PhysicalOperator &CreatePlan(ClientContext &context, PhysicalPlanGenerator &planner) override;
+	vector<ColumnBinding> GetColumnBindings() override;
+	vector<TableIndex> GetTableIndex() const override;
+	string GetName() const override;
+	bool SupportSerialization() const override {
+		return false;
+	}
+
+protected:
+	void ResolveTypes() override;
+};
+
+class PhysicalExpireSnapshots : public PhysicalOperator {
+public:
+	PhysicalExpireSnapshots(PhysicalPlan &physical_plan, ExpireSnapshotsPlanInput input, idx_t estimated_cardinality);
+
+	ExpireSnapshotsPlanInput input;
+
+	bool IsSource() const override {
+		return true;
+	}
+
+	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override;
+	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
+	                                 OperatorSourceInput &input) const override;
+
+	string GetName() const override;
+	InsertionOrderPreservingMap<string> ParamsToString() const override;
+};
+
+} // namespace duckdb

--- a/src/include/maintenance/expire_snapshots_planner.hpp
+++ b/src/include/maintenance/expire_snapshots_planner.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "duckdb/common/optional.hpp"
+#include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/parser/qualified_name.hpp"
+
+namespace duckdb {
+
+struct IcebergTableMetadata;
+
+struct ExpireSnapshotsPlanInput {
+	QualifiedName table_name;
+	optional<timestamp_t> older_than;
+	optional<int64_t> retain_last;
+	vector<int64_t> snapshot_ids;
+};
+
+struct ExpireSnapshotsPlan {
+	vector<int64_t> to_expire;
+	int64_t retained_snapshots = 0;
+};
+
+//! Select snapshots to remove without mutating table metadata.
+ExpireSnapshotsPlan PlanSnapshotExpiration(const IcebergTableMetadata &metadata, const ExpireSnapshotsPlanInput &input,
+                                           timestamp_ms_t now);
+
+} // namespace duckdb

--- a/src/include/maintenance/maintenance_table_loader.hpp
+++ b/src/include/maintenance/maintenance_table_loader.hpp
@@ -6,11 +6,15 @@
 
 namespace duckdb {
 
+class IcebergCatalog;
 struct IcebergTable;
 
+IcebergCatalog &GetMaintenanceIcebergCatalog(ClientContext &context, const QualifiedName &table_name,
+                                             const string &function_name);
+
 //! Load metadata into a new table-information instance instead of reusing an
-//! already-filled catalog entry.
+//! already-filled catalog entry. Set force_refresh to bypass the catalog cache.
 shared_ptr<IcebergTable> ReloadIcebergTableShared(ClientContext &context, const QualifiedName &table_name,
-                                                  const string &function_name);
+                                                  const string &function_name, bool force_refresh = false);
 
 } // namespace duckdb

--- a/src/maintenance/CMakeLists.txt
+++ b/src/maintenance/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(
   iceberg_maintenance OBJECT
+  expire_snapshots_operator.cpp expire_snapshots_planner.cpp
   maintenance_table_loader.cpp rewrite_data_files_executor.cpp
   rewrite_data_files_operator.cpp rewrite_data_files_planner.cpp)
 set(ALL_OBJECT_FILES

--- a/src/maintenance/expire_snapshots_operator.cpp
+++ b/src/maintenance/expire_snapshots_operator.cpp
@@ -1,0 +1,181 @@
+#include "maintenance/expire_snapshots_operator.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/timestamp.hpp"
+
+#include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
+#include "catalog/rest/api/catalog_api.hpp"
+#include "catalog/rest/iceberg_catalog.hpp"
+#include "catalog/rest/transaction/iceberg_transaction.hpp"
+#include "catalog/rest/transaction/iceberg_transaction_data.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
+#include "maintenance/maintenance_table_loader.hpp"
+
+namespace duckdb {
+
+namespace {
+
+constexpr const char *EXPIRE_SNAPSHOTS_NAME = "iceberg_expire_snapshots";
+
+vector<LogicalType> ExpireSnapshotsResultTypes() {
+	return {LogicalType::BIGINT, LogicalType::BIGINT};
+}
+
+IcebergTable &LoadTransactionVisibleTable(ClientContext &context, const QualifiedName &table_name,
+                                          IcebergCatalog &catalog, IcebergTransaction &transaction) {
+	auto namespace_items = IRCAPI::ParseSchemaName(table_name.Schema().GetIdentifierName());
+	auto table_key = IcebergTable::GetTableKey(catalog, namespace_items, table_name.Name().GetIdentifierName());
+	auto transaction_state = transaction.GetLatestTableState(table_key);
+	if (!transaction_state) {
+		//! The first expiration access bypasses MAX_TABLE_STALENESS. Pin that
+		//! result even for a no-op so later calls do not mix in catalog state.
+		auto catalog_table = ReloadIcebergTableShared(context, table_name, EXPIRE_SNAPSHOTS_NAME, true);
+		transaction_state = transaction.SetCatalogTableState(std::move(catalog_table));
+		//! Materialize the transaction-visible copy before planning. This honors
+		//! metadata-log time travel and guarantees staging reuses the same object.
+		transaction_state->GetOrCreateTransactionInfo(transaction);
+		transaction_state->MarkExpirationMetadataInitialized();
+	}
+	if (!transaction_state->IsAlive()) {
+		throw TransactionException("Iceberg table '%s' was dropped or renamed in this transaction",
+		                           table_name.Name().GetIdentifierName());
+	}
+	if (!transaction_state->IsExpirationMetadataInitialized()) {
+		auto &table = transaction_state->GetInfo();
+		if (table.transaction_data) {
+			table.transaction_data->VerifySnapshotExpirationAllowed();
+		}
+		throw TransactionException(
+		    "%s: table '%s' was already accessed in this transaction; run expiration in a new transaction",
+		    EXPIRE_SNAPSHOTS_NAME, table_name.ToString());
+	}
+	return transaction_state->GetInfo();
+}
+
+void ValidateGCEnabled(const IcebergTableMetadata &metadata) {
+	auto &properties = metadata.GetTableProperties();
+	auto entry = properties.find("gc.enabled");
+	if (entry == properties.end() || StringUtil::CIEquals(entry->second, "true")) {
+		return;
+	}
+	if (StringUtil::CIEquals(entry->second, "false")) {
+		throw InvalidInputException("%s: cannot run when table property 'gc.enabled' is false", EXPIRE_SNAPSHOTS_NAME);
+	}
+	throw InvalidInputException("%s: invalid value '%s' for table property 'gc.enabled': expected 'true' or 'false'",
+	                            EXPIRE_SNAPSHOTS_NAME, entry->second);
+}
+
+void ApplyExpirationToTransactionMetadata(IcebergTableMetadata &metadata, const vector<int64_t> &snapshot_ids) {
+	for (auto snapshot_id : snapshot_ids) {
+		metadata.snapshots.erase(snapshot_id);
+	}
+
+	//! Remove the full prefix through the newest expired log entry. Keeping an
+	//! older entry would let timestamp lookup cross a gap and return the wrong state.
+	idx_t retained_log_start = 0;
+	for (idx_t i = 0; i < metadata.snapshot_log.size(); i++) {
+		if (!metadata.snapshots.count(metadata.snapshot_log[i].first)) {
+			retained_log_start = i + 1;
+		}
+	}
+	metadata.snapshot_log.erase(metadata.snapshot_log.begin(), metadata.snapshot_log.begin() + retained_log_start);
+}
+
+ExpireSnapshotsPlan ExecuteSnapshotExpiration(ClientContext &context, const ExpireSnapshotsPlanInput &input) {
+	auto &catalog = GetMaintenanceIcebergCatalog(context, input.table_name, EXPIRE_SNAPSHOTS_NAME);
+	auto &transaction = IcebergTransaction::Get(context, catalog);
+	//! Planning and staging must use the same transaction-visible table state.
+	auto &visible_table = LoadTransactionVisibleTable(context, input.table_name, catalog, transaction);
+	if (visible_table.transaction_data) {
+		visible_table.transaction_data->VerifySnapshotExpirationAllowed();
+	}
+	auto now = timestamp_ms_t(Timestamp::GetEpochMs(Timestamp::GetCurrentTimestamp()));
+	auto plan = PlanSnapshotExpiration(visible_table.table_metadata, input, now);
+	ValidateGCEnabled(visible_table.table_metadata);
+
+	if (plan.to_expire.empty()) {
+		return plan;
+	}
+
+	ApplyTableUpdate(visible_table, transaction, [&](IcebergTable &table) {
+		auto &transaction_data = table.GetOrCreateTransactionData(transaction);
+		transaction_data.TableRemoveSnapshots(plan.to_expire);
+		//! Mirror the staged update so another call in this transaction replans
+		//! from the remaining snapshots.
+		ApplyExpirationToTransactionMetadata(table.table_metadata, plan.to_expire);
+	});
+	return plan;
+}
+
+struct ExpireSnapshotsGlobalSourceState : public GlobalSourceState {
+	idx_t MaxThreads() override {
+		return 1;
+	}
+
+	bool emitted = false;
+};
+
+} // namespace
+
+LogicalExpireSnapshots::LogicalExpireSnapshots(idx_t bind_index_p, ExpireSnapshotsPlanInput input_p)
+    : LogicalExtensionOperator(), bind_index(bind_index_p), input(std::move(input_p)) {
+	SetEstimatedCardinality(1);
+}
+
+void LogicalExpireSnapshots::ResolveTypes() {
+	types = ExpireSnapshotsResultTypes();
+}
+
+vector<ColumnBinding> LogicalExpireSnapshots::GetColumnBindings() {
+	return GenerateColumnBindings(TableIndex(bind_index), 2);
+}
+
+vector<TableIndex> LogicalExpireSnapshots::GetTableIndex() const {
+	return {TableIndex(bind_index)};
+}
+
+string LogicalExpireSnapshots::GetName() const {
+	return "ICEBERG_EXPIRE_SNAPSHOTS";
+}
+
+PhysicalOperator &LogicalExpireSnapshots::CreatePlan(ClientContext &context, PhysicalPlanGenerator &planner) {
+	return planner.Make<PhysicalExpireSnapshots>(std::move(input), estimated_cardinality);
+}
+
+PhysicalExpireSnapshots::PhysicalExpireSnapshots(PhysicalPlan &physical_plan, ExpireSnapshotsPlanInput input_p,
+                                                 idx_t estimated_cardinality)
+    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, ExpireSnapshotsResultTypes(),
+                       estimated_cardinality),
+      input(std::move(input_p)) {
+}
+
+unique_ptr<GlobalSourceState> PhysicalExpireSnapshots::GetGlobalSourceState(ClientContext &context) const {
+	return make_uniq<ExpireSnapshotsGlobalSourceState>();
+}
+
+SourceResultType PhysicalExpireSnapshots::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
+                                                          OperatorSourceInput &source_input) const {
+	auto &state = source_input.global_state.Cast<ExpireSnapshotsGlobalSourceState>();
+	if (state.emitted) {
+		return SourceResultType::FINISHED;
+	}
+	state.emitted = true;
+
+	auto plan = ExecuteSnapshotExpiration(context.client, input);
+	chunk.data[0].Append(Value::BIGINT(static_cast<int64_t>(plan.to_expire.size())));
+	chunk.data[1].Append(Value::BIGINT(plan.retained_snapshots));
+	return SourceResultType::FINISHED;
+}
+
+string PhysicalExpireSnapshots::GetName() const {
+	return "ICEBERG_EXPIRE_SNAPSHOTS";
+}
+
+InsertionOrderPreservingMap<string> PhysicalExpireSnapshots::ParamsToString() const {
+	InsertionOrderPreservingMap<string> result;
+	result["Table"] = input.table_name.ToString();
+	return result;
+}
+
+} // namespace duckdb

--- a/src/maintenance/expire_snapshots_planner.cpp
+++ b/src/maintenance/expire_snapshots_planner.cpp
@@ -1,0 +1,256 @@
+#include "maintenance/expire_snapshots_planner.hpp"
+
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/limits.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/interval.hpp"
+#include "duckdb/common/unordered_set.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace duckdb {
+
+namespace {
+
+constexpr int64_t DEFAULT_MAX_SNAPSHOT_AGE_MS = 5LL * 24 * 60 * 60 * 1000;
+constexpr int64_t DEFAULT_MIN_SNAPSHOTS_TO_KEEP = 1;
+constexpr const char *MAX_SNAPSHOT_AGE_PROPERTY = "history.expire.max-snapshot-age-ms";
+constexpr const char *MIN_SNAPSHOTS_TO_KEEP_PROPERTY = "history.expire.min-snapshots-to-keep";
+
+struct SnapshotRetentionPolicy {
+	timestamp_ms_t cutoff;
+	int64_t min_snapshots_to_keep;
+};
+
+int64_t GetBoundedIntegerTableProperty(const IcebergTableMetadata &metadata, const string &name, int64_t default_value,
+                                       int64_t minimum_value, int64_t maximum_value) {
+	const auto &properties = metadata.GetTableProperties();
+	const auto entry = properties.find(name);
+	if (entry == properties.end()) {
+		return default_value;
+	}
+
+	const auto &value = entry->second;
+	if (value.empty() || StringUtil::CharacterIsSpace(value.front())) {
+		throw InvalidInputException("Invalid value '%s' for table property '%s': expected an integer", value, name);
+	}
+
+	int64_t result;
+	size_t parsed_characters = 0;
+	try {
+		result = std::stoll(value, &parsed_characters);
+	} catch (const std::invalid_argument &) {
+		throw InvalidInputException("Invalid value '%s' for table property '%s': expected an integer", value, name);
+	} catch (const std::out_of_range &) {
+		throw InvalidInputException("Invalid value '%s' for table property '%s': expected an integer", value, name);
+	}
+	if (parsed_characters != value.size()) {
+		throw InvalidInputException("Invalid value '%s' for table property '%s': expected an integer", value, name);
+	}
+	if (result < minimum_value) {
+		throw InvalidInputException("Invalid value '%s' for table property '%s': expected a value >= %lld", value, name,
+		                            minimum_value);
+	}
+	if (result > maximum_value) {
+		throw InvalidInputException("Invalid value '%s' for table property '%s': expected a value <= %lld", value, name,
+		                            maximum_value);
+	}
+	return result;
+}
+
+timestamp_ms_t SubtractAge(timestamp_ms_t now, int64_t age_ms) {
+	D_ASSERT(age_ms >= 0);
+	if (now.value < timestamp_ms_t::ninfinity().value + age_ms) {
+		return timestamp_ms_t::ninfinity();
+	}
+	return timestamp_ms_t(now.value - age_ms);
+}
+
+constexpr int64_t CeilMicrosecondsToMilliseconds(int64_t microseconds) {
+	return microseconds / Interval::MICROS_PER_MSEC + (microseconds % Interval::MICROS_PER_MSEC > 0 ? 1 : 0);
+}
+
+static_assert(CeilMicrosecondsToMilliseconds(-1001) == -1 && CeilMicrosecondsToMilliseconds(-1000) == -1 &&
+                  CeilMicrosecondsToMilliseconds(-999) == 0 && CeilMicrosecondsToMilliseconds(999) == 1 &&
+                  CeilMicrosecondsToMilliseconds(1000) == 1 && CeilMicrosecondsToMilliseconds(1001) == 2,
+              "timestamp cutoffs must use mathematical ceil");
+
+timestamp_ms_t GetExpirationCutoff(timestamp_t timestamp) {
+	//! Snapshot timestamps have millisecond precision. Round the SQL timestamp up
+	//! so `snapshot_time < older_than` stays strict for sub-millisecond inputs.
+	return timestamp_ms_t(CeilMicrosecondsToMilliseconds(timestamp.value));
+}
+
+SnapshotRetentionPolicy ResolveGlobalPolicy(const IcebergTableMetadata &metadata, const ExpireSnapshotsPlanInput &input,
+                                            timestamp_ms_t now) {
+	SnapshotRetentionPolicy result;
+	if (input.older_than) {
+		result.cutoff = GetExpirationCutoff(*input.older_than);
+	} else {
+		const auto max_snapshot_age_ms = GetBoundedIntegerTableProperty(
+		    metadata, MAX_SNAPSHOT_AGE_PROPERTY, DEFAULT_MAX_SNAPSHOT_AGE_MS, 0, NumericLimits<int64_t>::Maximum());
+		result.cutoff = SubtractAge(now, max_snapshot_age_ms);
+	}
+
+	if (input.retain_last) {
+		result.min_snapshots_to_keep = *input.retain_last;
+	} else {
+		result.min_snapshots_to_keep =
+		    GetBoundedIntegerTableProperty(metadata, MIN_SNAPSHOTS_TO_KEEP_PROPERTY, DEFAULT_MIN_SNAPSHOTS_TO_KEEP, 1,
+		                                   NumericLimits<int32_t>::Maximum());
+	}
+	return result;
+}
+
+void ApplyMainRetention(const IcebergTableMetadata &metadata, int64_t main_snapshot_id,
+                        const SnapshotRetentionPolicy &policy, unordered_set<int64_t> &to_expire) {
+	int64_t depth = 0;
+	bool retention_prefix_open = true;
+	unordered_set<int64_t> seen;
+	seen.reserve(metadata.snapshots.size());
+	auto snapshot_id = main_snapshot_id;
+	while (true) {
+		const auto snapshot = metadata.FindSnapshotByIdInternal(snapshot_id);
+		if (!snapshot) {
+			break;
+		}
+		if (!seen.insert(snapshot_id).second) {
+			throw InvalidConfigurationException("Cycle detected in snapshot ancestry at snapshot %lld", snapshot_id);
+		}
+		const bool retain =
+		    retention_prefix_open && (depth < policy.min_snapshots_to_keep || snapshot->timestamp_ms >= policy.cutoff);
+		if (retain) {
+			to_expire.erase(snapshot_id);
+		} else {
+			//! Keep walking after the prefix closes so newer timestamps cannot reopen it
+			//! and cycles in older ancestry are still detected.
+			retention_prefix_open = false;
+			to_expire.insert(snapshot_id);
+		}
+		depth++;
+		if (!snapshot->parent_snapshot_id) {
+			break;
+		}
+		//! A previous expiration may have removed the parent.
+		snapshot_id = *snapshot->parent_snapshot_id;
+	}
+}
+
+void ValidateMainOnlyMetadata(const IcebergTableMetadata &metadata) {
+	if (metadata.unsupported_snapshot_ref) {
+		throw NotImplementedException(
+		    "iceberg_expire_snapshots currently supports only the main branch; found unsupported snapshot reference "
+		    "\"%s\"",
+		    *metadata.unsupported_snapshot_ref);
+	}
+
+	if (metadata.current_snapshot_id && !metadata.FindSnapshotByIdInternal(*metadata.current_snapshot_id)) {
+		throw InvalidConfigurationException("current-snapshot-id points to unknown snapshot %lld",
+		                                    *metadata.current_snapshot_id);
+	}
+	if (!metadata.main_snapshot_ref) {
+		if (metadata.snapshot_refs_present && metadata.current_snapshot_id) {
+			throw InvalidConfigurationException("Snapshot refs must contain 'main' when current-snapshot-id is set");
+		}
+		return;
+	}
+
+	const auto &main_ref = *metadata.main_snapshot_ref;
+	if (main_ref.type != "branch") {
+		throw InvalidConfigurationException("Snapshot ref 'main' must be a branch");
+	}
+	if (!metadata.current_snapshot_id) {
+		throw InvalidConfigurationException("Snapshot ref 'main' requires current-snapshot-id");
+	}
+	if (main_ref.snapshot_id != *metadata.current_snapshot_id) {
+		throw InvalidConfigurationException("Snapshot ref 'main' does not match current-snapshot-id");
+	}
+	if (main_ref.max_snapshot_age_ms && *main_ref.max_snapshot_age_ms < 1) {
+		throw InvalidConfigurationException("Invalid max-snapshot-age-ms for snapshot ref 'main': expected a positive "
+		                                    "integer");
+	}
+	if (main_ref.min_snapshots_to_keep && *main_ref.min_snapshots_to_keep < 1) {
+		throw InvalidConfigurationException(
+		    "Invalid min-snapshots-to-keep for snapshot ref 'main': expected a positive "
+		    "integer");
+	}
+}
+
+SnapshotRetentionPolicy ResolveMainPolicy(const IcebergTableMetadata &metadata,
+                                          const SnapshotRetentionPolicy &global_policy, timestamp_ms_t now) {
+	auto result = global_policy;
+	if (!metadata.main_snapshot_ref) {
+		return result;
+	}
+
+	const auto &main_ref = *metadata.main_snapshot_ref;
+	if (main_ref.min_snapshots_to_keep) {
+		result.min_snapshots_to_keep = *main_ref.min_snapshots_to_keep;
+	}
+	if (main_ref.max_snapshot_age_ms) {
+		result.cutoff = SubtractAge(now, *main_ref.max_snapshot_age_ms);
+	}
+	return result;
+}
+
+void ApplyGlobalAgePolicy(const IcebergTableMetadata &metadata, timestamp_ms_t cutoff,
+                          unordered_set<int64_t> &to_expire) {
+	//! Apply the global age policy as if snapshots were unreferenced.
+	//! Main ancestry retention below overrides this initial classification.
+	for (const auto &entry : metadata.snapshots) {
+		if (entry.second.timestamp_ms < cutoff) {
+			to_expire.insert(entry.first);
+		}
+	}
+}
+
+void ApplyExplicitSnapshotIds(const IcebergTableMetadata &metadata, const vector<int64_t> &snapshot_ids,
+                              unordered_set<int64_t> &to_expire) {
+	//! Explicit IDs override age and count retention, but never current main.
+	for (auto snapshot_id : snapshot_ids) {
+		if (!metadata.FindSnapshotByIdInternal(snapshot_id)) {
+			throw InvalidInputException("iceberg_expire_snapshots: snapshot %lld does not exist", snapshot_id);
+		}
+		if (metadata.current_snapshot_id && snapshot_id == *metadata.current_snapshot_id) {
+			throw InvalidInputException("iceberg_expire_snapshots: cannot expire snapshot %lld because it is still "
+			                            "referenced",
+			                            snapshot_id);
+		}
+		to_expire.insert(snapshot_id);
+	}
+}
+
+} // namespace
+
+ExpireSnapshotsPlan PlanSnapshotExpiration(const IcebergTableMetadata &metadata, const ExpireSnapshotsPlanInput &input,
+                                           timestamp_ms_t now) {
+	ValidateMainOnlyMetadata(metadata);
+
+	const auto global_policy = ResolveGlobalPolicy(metadata, input, now);
+	const auto main_policy = ResolveMainPolicy(metadata, global_policy, now);
+
+	unordered_set<int64_t> to_expire;
+	to_expire.reserve(metadata.snapshots.size());
+	ApplyGlobalAgePolicy(metadata, global_policy.cutoff, to_expire);
+	if (metadata.current_snapshot_id) {
+		//! Validation guarantees that an explicit refs.main targets current;
+		//! otherwise current is the implicit main head.
+		ApplyMainRetention(metadata, *metadata.current_snapshot_id, main_policy, to_expire);
+	}
+	ApplyExplicitSnapshotIds(metadata, input.snapshot_ids, to_expire);
+
+	vector<int64_t> result_ids(to_expire.begin(), to_expire.end());
+	std::sort(result_ids.begin(), result_ids.end());
+	D_ASSERT(result_ids.size() <= metadata.snapshots.size());
+
+	ExpireSnapshotsPlan result;
+	result.retained_snapshots =
+	    static_cast<int64_t>(metadata.snapshots.size()) - static_cast<int64_t>(result_ids.size());
+	result.to_expire = std::move(result_ids);
+	return result;
+}
+
+} // namespace duckdb

--- a/src/maintenance/maintenance_table_loader.cpp
+++ b/src/maintenance/maintenance_table_loader.cpp
@@ -17,12 +17,7 @@ namespace {
 
 static IcebergSchemaEntry &LoadIcebergSchema(ClientContext &context, const QualifiedName &table_name,
                                              const string &function_name) {
-	auto &catalog = Catalog::GetCatalog(context, table_name.Catalog());
-	if (catalog.GetCatalogType() != "iceberg") {
-		throw InvalidInputException("%s: catalog '%s' is not an Iceberg catalog (type='%s')", function_name,
-		                            table_name.Catalog().GetIdentifierName(), catalog.GetCatalogType());
-	}
-	auto &iceberg_catalog = catalog.Cast<IcebergCatalog>();
+	auto &iceberg_catalog = GetMaintenanceIcebergCatalog(context, table_name, function_name);
 
 	auto &schema_set = iceberg_catalog.GetSchemas();
 	schema_set.LoadEntries(context);
@@ -37,14 +32,26 @@ static IcebergSchemaEntry &LoadIcebergSchema(ClientContext &context, const Quali
 
 } // namespace
 
+IcebergCatalog &GetMaintenanceIcebergCatalog(ClientContext &context, const QualifiedName &table_name,
+                                             const string &function_name) {
+	auto &catalog = Catalog::GetCatalog(context, table_name.Catalog());
+	if (catalog.GetCatalogType() != "iceberg") {
+		throw InvalidInputException("%s: catalog '%s' is not an Iceberg catalog (type='%s')", function_name,
+		                            table_name.Catalog().GetIdentifierName(), catalog.GetCatalogType());
+	}
+	return catalog.Cast<IcebergCatalog>();
+}
+
 shared_ptr<IcebergTable> ReloadIcebergTableShared(ClientContext &context, const QualifiedName &table_name,
-                                                  const string &function_name) {
+                                                  const string &function_name, bool force_refresh) {
 	auto &iceberg_schema = LoadIcebergSchema(context, table_name, function_name);
 	auto &tables = iceberg_schema.tables;
 	auto table_name_string = table_name.Name().GetIdentifierName();
 	auto table_info = make_shared_ptr<IcebergTable>(iceberg_schema.ParentCatalog().Cast<IcebergCatalog>(),
 	                                                iceberg_schema, table_name_string);
-	if (!tables.FillEntry(context, *table_info)) {
+	if (force_refresh) {
+		table_info->RefreshFromCatalog(context);
+	} else if (!tables.FillEntry(context, *table_info)) {
 		throw InvalidInputException("%s: table '%s' not found in schema '%s.%s'", function_name, table_name_string,
 		                            table_name.Catalog().GetIdentifierName(), table_name.Schema().GetIdentifierName());
 	}

--- a/test/configs/nessie.json
+++ b/test/configs/nessie.json
@@ -169,6 +169,14 @@
 			]
 		},
 		{
+			"reason": "Nessie sets gc.enabled=false and rejects external snapshot management through remove-snapshots.",
+			"paths": [
+				"test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/expire_snapshots_commit.test",
+				"test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/expire_snapshots_conflict.test",
+				"test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/expire_snapshots_properties.test"
+			]
+		},
+		{
 			"reason": "Inserting into nessie triggers Relassert error that does not reproduce locally",
 			"paths": [
 				"test/sql/local/catalog_test_config_setup/catalog_agnostic/file_properties/test_parquet_options_physical_properties.test"

--- a/test/python/test_expire_snapshots.py
+++ b/test/python/test_expire_snapshots.py
@@ -1,0 +1,897 @@
+import json
+from contextlib import contextmanager
+from functools import partial
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from time import sleep
+from uuid import uuid4
+
+import pytest
+
+from conftest import is_active_catalog
+from duckdb_unittest import DuckDBUnittestRunner
+
+
+JAVA_FIXTURE_ONLY = pytest.mark.skipif(
+    not is_active_catalog("fixture"),
+    reason="Requires Apache Iceberg Java REST fixture metadata registration/update behavior",
+)
+NESSIE_UNSUPPORTED = pytest.mark.skipif(
+    is_active_catalog("nessie"),
+    reason="Nessie sets gc.enabled=false and rejects external snapshot management through remove-snapshots",
+)
+
+
+@pytest.fixture
+def duckdb_runner(unittest_binary, unittest_test_config, print_unittest_stdin):
+    return partial(
+        DuckDBUnittestRunner,
+        unittest_binary,
+        test_config=unittest_test_config,
+        print_stdin=print_unittest_stdin,
+    )
+
+
+def _drop_table_if_exists(catalog, identifier):
+    if catalog.table_exists(identifier):
+        catalog.drop_table(identifier)
+
+
+def _expire_query(table_name, *options):
+    arguments = ", ".join((f"'{table_name}'", *options))
+    return f"SELECT * FROM iceberg_expire_snapshots({arguments})"
+
+
+def _check_expiration(test, table_name, expected, *options, connection=None):
+    test.query("II", _expire_query(table_name, *options), [expected], connection=connection)
+
+
+def _timestamp_time_travel_query(table_name, timestamp_ms):
+    return f"SELECT count(*) FROM {table_name} AT (TIMESTAMP => make_timestamp_ms({timestamp_ms}))"
+
+
+@contextmanager
+def _serve_table_metadata(metadata_location, metadata):
+    class MetadataHandler(BaseHTTPRequestHandler):
+        def do_HEAD(self):
+            self.send_response(200)
+            self.end_headers()
+
+        def do_GET(self):
+            if self.path.startswith("/v1/config"):
+                self._respond({"defaults": {}, "overrides": {}})
+            elif "/namespaces/" in self.path and "/tables/" in self.path:
+                self._respond({"metadata-location": metadata_location, "metadata": metadata, "config": {}})
+            else:
+                self._respond({}, status=404)
+
+        def _respond(self, body, status=200):
+            encoded = json.dumps(body, separators=(",", ":")).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def log_message(self, format, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), MetadataHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_port
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+def _attach_metadata_catalog(test, catalog_name, port):
+    test.statement_ok(
+        f"""
+        ATTACH '' AS {catalog_name} (
+            TYPE ICEBERG,
+            URI 'http://127.0.0.1:{port}',
+            AUTHORIZATION_TYPE 'none'
+        )
+        """
+    )
+
+
+@pytest.fixture
+def seeded_table(rest_catalog, duckdb_runner):
+    identifiers = []
+
+    def seed(identifier, count, *, distinct_timestamps=False):
+        _drop_table_if_exists(rest_catalog, identifier)
+        identifiers.append(identifier)
+        table_name = f"my_datalake.{identifier}"
+        if distinct_timestamps:
+            with duckdb_runner() as test:
+                test.statement_ok(f"CREATE TABLE {table_name} (id INTEGER)")
+            for value in range(1, count + 1):
+                with duckdb_runner() as test:
+                    test.statement_ok(f"INSERT INTO {table_name} VALUES ({value})")
+                # REST commits normally take longer than a millisecond, but make
+                # the timestamp-gap regression independent of that latency.
+                sleep(0.01)
+        else:
+            with duckdb_runner() as test:
+                test.statement_ok(f"CREATE TABLE {table_name} (id INTEGER)")
+                for value in range(1, count + 1):
+                    test.statement_ok(f"INSERT INTO {table_name} VALUES ({value})")
+        return rest_catalog.load_table(identifier), table_name
+
+    yield seed
+
+    for identifier in identifiers:
+        _drop_table_if_exists(rest_catalog, identifier)
+
+
+def _ordered_snapshots(table):
+    return sorted(table.metadata.snapshots, key=lambda snapshot: snapshot.sequence_number)
+
+
+@pytest.fixture
+def registered_metadata_table(rest_catalog, seeded_table):
+    registered_identifiers = []
+
+    def register(source_identifier, target_identifier, snapshot_count, mutate_metadata):
+        source_table, _ = seeded_table(source_identifier, snapshot_count)
+        _drop_table_if_exists(rest_catalog, target_identifier)
+        metadata = source_table.metadata.model_dump(mode="json", by_alias=True, exclude_none=True)
+        mutate_metadata(metadata)
+
+        metadata_directory = source_table.metadata_location.rsplit("/", 1)[0]
+        metadata_location = f"{metadata_directory}/synthetic-{uuid4()}.metadata.json"
+        with source_table.io.new_output(metadata_location).create() as output_stream:
+            output_stream.write(json.dumps(metadata, separators=(",", ":")).encode("utf-8"))
+
+        registered_identifiers.append(target_identifier)
+        table = rest_catalog.register_table(target_identifier, metadata_location)
+        return table, f"my_datalake.{target_identifier}"
+
+    yield register
+
+    for identifier in registered_identifiers:
+        _drop_table_if_exists(rest_catalog, identifier)
+
+
+@NESSIE_UNSUPPORTED
+class TestExpireSnapshots:
+    def test_cutoff_precision(self, seeded_table, duckdb_runner):
+        table, table_name = seeded_table("default.expire_snapshots_main_only", 5)
+        snapshots = _ordered_snapshots(table)
+        oldest_timestamp_ms = min(snapshot.timestamp_ms for snapshot in snapshots)
+        snapshots_before_cutoff = sum(
+            snapshot.timestamp_ms == oldest_timestamp_ms
+            and snapshot.snapshot_id != table.current_snapshot().snapshot_id
+            for snapshot in snapshots
+        )
+
+        with duckdb_runner() as test:
+            test.statement_ok("BEGIN")
+            _check_expiration(
+                test,
+                table_name,
+                (0, 5),
+                "retain_last => 1",
+                f"older_than => make_timestamp_ms({oldest_timestamp_ms})",
+            )
+            _check_expiration(
+                test,
+                table_name,
+                (snapshots_before_cutoff, 5 - snapshots_before_cutoff),
+                "retain_last => 1",
+                f"older_than => make_timestamp_ms({oldest_timestamp_ms}) + interval 1 microsecond",
+            )
+            test.statement_ok("ROLLBACK")
+
+    @JAVA_FIXTURE_ONLY
+    def test_non_main_refs_report_first_name_without_staging(
+        self,
+        registered_metadata_table,
+        duckdb_runner,
+    ):
+        def add_non_main_refs(metadata):
+            current_id = metadata["current-snapshot-id"]
+            metadata["refs"]["zeta"] = {"snapshot-id": current_id, "type": "branch"}
+            metadata["refs"]["alpha"] = {"snapshot-id": current_id, "type": "tag"}
+
+        _, table_name = registered_metadata_table(
+            "default.expire_snapshots_non_main_noop_source",
+            "default.expire_snapshots_non_main_noop",
+            1,
+            add_non_main_refs,
+        )
+
+        with duckdb_runner() as test:
+            test.statement_ok("CALL enable_logging('Iceberg')")
+            test.statement_ok("CALL truncate_duckdb_logs()")
+            test.statement_ok("BEGIN")
+            test.statement_error(
+                _expire_query(table_name, "retain_last => 10"),
+                'found unsupported snapshot reference "alpha"',
+            )
+            # DuckDB aborts an explicit transaction after a statement error.
+            # Rolling it back must not reveal a staged metadata mutation or POST.
+            test.statement_ok("ROLLBACK")
+            test.query("I", f"SELECT count(*) FROM iceberg_snapshots({table_name})", [(1,)])
+            test.query(
+                "I",
+                """
+                SELECT count(*)
+                FROM duckdb_logs()
+                WHERE type = 'Iceberg'
+                  AND message LIKE 'POST % body=%'
+                """,
+                [(0,)],
+            )
+
+    @pytest.mark.parametrize(
+        ("shape", "expected_error"),
+        (
+            ("main-is-tag", "Snapshot ref 'main' must be a branch"),
+            ("main-current-mismatch", "does not match current-snapshot-id"),
+            ("main-without-current", "requires current-snapshot-id"),
+            ("current-unknown", "current-snapshot-id points to unknown snapshot"),
+            ("main-max-age-zero", "Invalid max-snapshot-age-ms"),
+            ("main-min-count-zero", "Invalid min-snapshots-to-keep"),
+        ),
+    )
+    def test_invalid_explicit_main_metadata(
+        self,
+        shape,
+        expected_error,
+        seeded_table,
+        duckdb_runner,
+    ):
+        sql_shape = shape.replace("-", "_")
+        table, _ = seeded_table(f"default.expire_snapshots_{sql_shape}_source", 2)
+        metadata = table.metadata.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+        def make_main_invalid(metadata):
+            if shape == "main-is-tag":
+                metadata["refs"]["main"]["type"] = "tag"
+            elif shape == "main-current-mismatch":
+                snapshots = sorted(metadata["snapshots"], key=lambda snapshot: snapshot["sequence-number"])
+                metadata["refs"]["main"]["snapshot-id"] = snapshots[0]["snapshot-id"]
+            elif shape == "main-without-current":
+                metadata.pop("current-snapshot-id", None)
+            elif shape == "current-unknown":
+                unknown_id = max(snapshot["snapshot-id"] for snapshot in metadata["snapshots"]) + 1
+                metadata["current-snapshot-id"] = unknown_id
+                metadata["refs"]["main"]["snapshot-id"] = unknown_id
+            elif shape == "main-max-age-zero":
+                metadata["refs"]["main"]["max-snapshot-age-ms"] = 0
+            else:
+                metadata["refs"]["main"]["min-snapshots-to-keep"] = 0
+
+        make_main_invalid(metadata)
+        with _serve_table_metadata(table.metadata_location, metadata) as port:
+            with duckdb_runner() as test:
+                _attach_metadata_catalog(test, "invalid_datalake", port)
+                test.statement_error(
+                    _expire_query("invalid_datalake.default.invalid_main"),
+                    expected_error,
+                )
+
+    def test_empty_refs_with_current_is_rejected_without_staging(self, seeded_table, duckdb_runner):
+        table, _ = seeded_table("default.expire_snapshots_empty_refs_source", 2)
+        metadata = table.metadata.model_dump(mode="json", by_alias=True, exclude_none=True)
+        metadata["refs"] = {}
+
+        with _serve_table_metadata(table.metadata_location, metadata) as port:
+            with duckdb_runner() as test:
+                test.statement_ok("CALL enable_logging('Iceberg')")
+                test.statement_ok("CALL truncate_duckdb_logs()")
+                _attach_metadata_catalog(test, "empty_refs_datalake", port)
+                test.statement_error(
+                    _expire_query("empty_refs_datalake.default.empty_refs"),
+                    "Snapshot refs must contain 'main'",
+                )
+                test.query(
+                    "I",
+                    "SELECT count(*) FROM iceberg_snapshots(empty_refs_datalake.default.empty_refs)",
+                    [(2,)],
+                )
+                test.query(
+                    "I",
+                    """
+                    SELECT count(*)
+                    FROM duckdb_logs()
+                    WHERE type = 'Iceberg'
+                      AND message LIKE 'POST % body=%'
+                    """,
+                    [(0,)],
+                )
+
+    def test_empty_refs_without_current_is_accepted(self, seeded_table, duckdb_runner):
+        table, _ = seeded_table("default.expire_snapshots_empty_refs_no_current_source", 2)
+        metadata = table.metadata.model_dump(mode="json", by_alias=True, exclude_none=True)
+        metadata.pop("current-snapshot-id", None)
+        metadata["refs"] = {}
+        metadata["snapshot-log"] = []
+
+        with _serve_table_metadata(table.metadata_location, metadata) as port:
+            with duckdb_runner() as test:
+                _attach_metadata_catalog(test, "empty_refs_no_current_datalake", port)
+                _check_expiration(
+                    test,
+                    "empty_refs_no_current_datalake.default.empty_refs_no_current",
+                    (0, 2),
+                    "retain_last => 10",
+                    "older_than => TIMESTAMP '1970-01-01'",
+                )
+
+    @JAVA_FIXTURE_ONLY
+    def test_non_monotonic_main_retention_prefix(self, registered_metadata_table, duckdb_runner):
+        def set_non_monotonic_timestamps(metadata):
+            snapshots = sorted(metadata["snapshots"], key=lambda snapshot: snapshot["sequence-number"])
+            for snapshot, timestamp_ms in zip(snapshots, (200, 100, 300)):
+                snapshot["timestamp-ms"] = timestamp_ms
+
+        _, table_name = registered_metadata_table(
+            "default.expire_snapshots_prefix_source",
+            "default.expire_snapshots_prefix",
+            3,
+            set_non_monotonic_timestamps,
+        )
+
+        with duckdb_runner() as test:
+            test.statement_ok("BEGIN")
+            _check_expiration(
+                test,
+                table_name,
+                (2, 1),
+                "retain_last => 1",
+                "older_than => make_timestamp_ms(150)",
+            )
+            test.query("I", f"SELECT count(*) FROM iceberg_snapshots({table_name})", [(1,)])
+            test.statement_ok("ROLLBACK")
+
+    @JAVA_FIXTURE_ONLY
+    def test_cycle_detected_after_retention_prefix_closes(self, registered_metadata_table, duckdb_runner):
+        def create_cycle_after_expired_snapshot(metadata):
+            snapshots = sorted(metadata["snapshots"], key=lambda snapshot: snapshot["sequence-number"])
+            for snapshot, timestamp_ms in zip(snapshots, (200, 100, 300)):
+                snapshot["timestamp-ms"] = timestamp_ms
+            snapshots[0]["parent-snapshot-id"] = snapshots[1]["snapshot-id"]
+
+        _, table_name = registered_metadata_table(
+            "default.expire_snapshots_cycle_source",
+            "default.expire_snapshots_cycle",
+            3,
+            create_cycle_after_expired_snapshot,
+        )
+
+        with duckdb_runner() as test:
+            test.statement_error(
+                _expire_query(
+                    table_name,
+                    "retain_last => 1",
+                    "older_than => make_timestamp_ms(150)",
+                ),
+                "Cycle detected in snapshot ancestry",
+            )
+            test.query("I", f"SELECT count(*) FROM iceberg_snapshots({table_name})", [(3,)])
+
+    @JAVA_FIXTURE_ONLY
+    def test_legacy_implicit_main_commit_and_requirement(self, registered_metadata_table, duckdb_runner):
+        def remove_refs(metadata):
+            metadata.pop("refs", None)
+
+        table, table_name = registered_metadata_table(
+            "default.expire_snapshots_legacy_source",
+            "default.expire_snapshots_legacy",
+            3,
+            remove_refs,
+        )
+        current_id = table.current_snapshot().snapshot_id
+
+        with duckdb_runner() as test:
+            test.statement_error(
+                _expire_query(table_name, f"snapshot_ids => [{current_id}]"),
+                "still referenced",
+            )
+            test.statement_ok("CALL enable_logging('Iceberg')")
+            test.statement_ok("CALL truncate_duckdb_logs()")
+            _check_expiration(
+                test,
+                table_name,
+                (2, 1),
+                "retain_last => 1",
+                "older_than => TIMESTAMP '2999-01-01'",
+            )
+            test.query(
+                "III",
+                f"""
+                WITH commit_log AS (
+                    SELECT message
+                    FROM duckdb_logs()
+                    WHERE type = 'Iceberg'
+                      AND message LIKE 'POST % body=%'
+                    ORDER BY timestamp DESC
+                    LIMIT 1
+                )
+                SELECT
+                    list_count(regexp_extract_all(message, '"type":"assert-ref-snapshot-id"')),
+                    list_count(regexp_extract_all(message, '"ref":"main"')),
+                    CAST(contains(message, '"snapshot-id":{current_id}') AS INTEGER)
+                FROM commit_log
+                """,
+                [(1, 1, 1)],
+            )
+            test.query("I", f"SELECT count(*) FROM iceberg_snapshots({table_name})", [(1,)])
+            test.query("I", f"SELECT count(*) FROM {table_name} AT (VERSION => {current_id})", [(3,)])
+
+        table.refresh()
+        assert {snapshot.snapshot_id for snapshot in table.metadata.snapshots} == {current_id}
+
+    @JAVA_FIXTURE_ONLY
+    def test_explicit_id_removes_recent_unreferenced_snapshot(self, registered_metadata_table, duckdb_runner):
+        def remove_main(metadata):
+            metadata.pop("current-snapshot-id", None)
+            metadata.pop("refs", None)
+            metadata["snapshot-log"] = []
+
+        table, table_name = registered_metadata_table(
+            "default.expire_snapshots_no_current_explicit_source",
+            "default.expire_snapshots_no_current_explicit",
+            1,
+            remove_main,
+        )
+        snapshot_id = table.metadata.snapshots[0].snapshot_id
+
+        with duckdb_runner() as test:
+            _check_expiration(
+                test,
+                table_name,
+                (1, 0),
+                f"snapshot_ids => [{snapshot_id}]",
+                "retain_last => 10",
+                "older_than => TIMESTAMP '1970-01-01'",
+            )
+
+        table.refresh()
+        assert not table.metadata.snapshots
+
+    @JAVA_FIXTURE_ONLY
+    def test_no_current_snapshots_use_global_cutoff_and_null_main_requirement(
+        self,
+        registered_metadata_table,
+        duckdb_runner,
+    ):
+        def remove_main(metadata):
+            metadata.pop("current-snapshot-id", None)
+            metadata.pop("refs", None)
+            metadata["snapshot-log"] = []
+            snapshots = sorted(metadata["snapshots"], key=lambda snapshot: snapshot["sequence-number"])
+            snapshots[0]["timestamp-ms"] = 100
+            snapshots[1]["timestamp-ms"] = 200
+
+        table, table_name = registered_metadata_table(
+            "default.expire_snapshots_no_current_source",
+            "default.expire_snapshots_no_current",
+            2,
+            remove_main,
+        )
+        snapshots = _ordered_snapshots(table)
+        old_id = snapshots[0].snapshot_id
+        recent_id = snapshots[1].snapshot_id
+        assert table.current_snapshot() is None
+
+        with duckdb_runner() as test:
+            test.statement_ok("CALL enable_logging('Iceberg')")
+            test.statement_ok("CALL truncate_duckdb_logs()")
+            _check_expiration(
+                test,
+                table_name,
+                (1, 1),
+                "retain_last => 10",
+                "older_than => make_timestamp_ms(150)",
+            )
+            test.query(
+                "IIIII",
+                f"""
+                WITH commit_log AS (
+                    SELECT message
+                    FROM duckdb_logs()
+                    WHERE type = 'Iceberg'
+                      AND message LIKE 'POST % body=%'
+                    ORDER BY timestamp DESC
+                    LIMIT 1
+                )
+                SELECT
+                    list_count(regexp_extract_all(message, '"action":"remove-snapshots"')),
+                    list_count(regexp_extract_all(message, '"type":"assert-ref-snapshot-id"')),
+                    list_count(regexp_extract_all(message, '"ref":"main"')),
+                    list_count(regexp_extract_all(message, '"snapshot-id":null')),
+                    CAST(contains(message, '"snapshot-ids":[{old_id}]') AS INTEGER)
+                FROM commit_log
+                """,
+                [(1, 1, 1, 1, 1)],
+            )
+
+        table.refresh()
+        assert table.current_snapshot() is None
+        assert {snapshot.snapshot_id for snapshot in table.metadata.snapshots} == {recent_id}
+
+    def test_main_min_snapshot_count_retains_globally_old_ancestor(self, seeded_table, duckdb_runner):
+        table, table_name = seeded_table("default.expire_snapshots_main_min_count", 3)
+        snapshots = _ordered_snapshots(table)
+        current_id = snapshots[-1].snapshot_id
+        table.manage_snapshots().create_branch(current_id, "main", min_snapshots_to_keep=2).commit()
+
+        with duckdb_runner() as test:
+            _check_expiration(
+                test,
+                table_name,
+                (1, 2),
+                "older_than => TIMESTAMP '2999-01-01'",
+                "retain_last => 1",
+            )
+
+        table.refresh()
+        assert {snapshot.snapshot_id for snapshot in table.metadata.snapshots} == {
+            snapshots[-2].snapshot_id,
+            current_id,
+        }
+
+    def test_main_max_snapshot_age_overrides_global_cutoff(self, seeded_table, duckdb_runner):
+        table, table_name = seeded_table("default.expire_snapshots_main_max_age", 3)
+        snapshots = _ordered_snapshots(table)
+        current_id = snapshots[-1].snapshot_id
+
+        table.manage_snapshots().create_branch(
+            current_id,
+            "main",
+            max_snapshot_age_ms=1,
+            min_snapshots_to_keep=1,
+        ).commit()
+        sleep(0.01)
+
+        with duckdb_runner() as test:
+            _check_expiration(
+                test,
+                table_name,
+                (2, 1),
+                "older_than => TIMESTAMP '1970-01-01'",
+                "retain_last => 3",
+            )
+
+        table.refresh()
+        assert {snapshot.snapshot_id for snapshot in table.metadata.snapshots} == {current_id}
+
+    @JAVA_FIXTURE_ONLY
+    def test_retained_main_child_with_missing_parent(self, registered_metadata_table, duckdb_runner):
+        def remove_middle_parent(metadata):
+            snapshots = sorted(metadata["snapshots"], key=lambda snapshot: snapshot["sequence-number"])
+            missing_parent_id = snapshots[1]["snapshot-id"]
+            metadata["snapshots"] = [
+                snapshot for snapshot in metadata["snapshots"] if snapshot["snapshot-id"] != missing_parent_id
+            ]
+
+        table, table_name = registered_metadata_table(
+            "default.expire_snapshots_missing_parent_source",
+            "default.expire_snapshots_missing_parent",
+            3,
+            remove_middle_parent,
+        )
+        current_id = table.current_snapshot().snapshot_id
+
+        with duckdb_runner() as test:
+            _check_expiration(
+                test,
+                table_name,
+                (1, 1),
+                "retain_last => 1",
+                "older_than => TIMESTAMP '2999-01-01'",
+            )
+
+        table.refresh()
+        assert {snapshot.snapshot_id for snapshot in table.metadata.snapshots} == {current_id}
+
+    def test_side_effect_execution_boundary(self, seeded_table, duckdb_runner):
+        table, table_name = seeded_table("default.expire_snapshots_execution_boundary", 3)
+        snapshots = _ordered_snapshots(table)
+        expiring_id = snapshots[0].snapshot_id
+        expiration_query = _expire_query(
+            table_name,
+            f"snapshot_ids => [{expiring_id}]",
+            "retain_last => 3",
+        )
+
+        with duckdb_runner() as test:
+            # Binding and planning do not execute the source operator. A source
+            # eliminated before it is pulled does not stage an update either.
+            test.statement_ok(f"PREPARE expire_boundary AS {expiration_query}")
+            test.statement_ok(f"EXPLAIN {expiration_query}")
+            test.query("I", f"SELECT count(*) FROM ({expiration_query} LIMIT 0)", [(0,)])
+            test.query("I", f"SELECT count(*) FROM ({expiration_query} WHERE false)", [(0,)])
+
+        table.refresh()
+        assert {snapshot.snapshot_id for snapshot in table.metadata.snapshots} == {
+            snapshot.snapshot_id for snapshot in snapshots
+        }
+
+        with duckdb_runner() as test:
+            test.query("I", f"SELECT count(*) FROM ({expiration_query})", [(1,)])
+
+        table.refresh()
+        assert {snapshot.snapshot_id for snapshot in table.metadata.snapshots} == {
+            snapshots[1].snapshot_id,
+            snapshots[2].snapshot_id,
+        }
+
+    def test_explain_analyze_executes_expiration(self, seeded_table, duckdb_runner):
+        table, table_name = seeded_table("default.expire_snapshots_explain_analyze", 3)
+        snapshots = _ordered_snapshots(table)
+        expiring_id = snapshots[0].snapshot_id
+        expiration_query = _expire_query(
+            table_name,
+            f"snapshot_ids => [{expiring_id}]",
+            "retain_last => 3",
+        )
+
+        with duckdb_runner() as test:
+            test.statement_ok(f"EXPLAIN ANALYZE {expiration_query}")
+
+        table.refresh()
+        assert {snapshot.snapshot_id for snapshot in table.metadata.snapshots} == {
+            snapshots[1].snapshot_id,
+            snapshots[2].snapshot_id,
+        }
+
+    def test_downstream_failure_rolls_back_staged_expiration(self, seeded_table, duckdb_runner):
+        table, table_name = seeded_table("default.expire_snapshots_downstream_failure", 3)
+        snapshots = _ordered_snapshots(table)
+        expiring_id = snapshots[0].snapshot_id
+        expiration_query = _expire_query(
+            table_name,
+            f"snapshot_ids => [{expiring_id}]",
+            "retain_last => 3",
+        )
+
+        with duckdb_runner() as test:
+            test.statement_ok("CALL enable_logging('Iceberg')")
+            test.statement_ok("CALL truncate_duckdb_logs()")
+            test.statement_ok("BEGIN")
+            test.statement_error(
+                f"""
+                SELECT error('forced downstream failure after source row '
+                             || CAST(deleted_snapshots AS VARCHAR))
+                FROM ({expiration_query})
+                """,
+                "forced downstream failure after source row",
+            )
+            # Committing an aborted DuckDB transaction performs an implicit rollback.
+            test.statement_ok("COMMIT")
+            test.query("I", f"SELECT count(*) FROM iceberg_snapshots({table_name})", [(3,)])
+            test.query(
+                "I",
+                """
+                SELECT count(*)
+                FROM duckdb_logs()
+                WHERE type = 'Iceberg'
+                  AND message LIKE 'POST % body=%'
+                """,
+                [(0,)],
+            )
+
+        table.refresh()
+        assert {snapshot.snapshot_id for snapshot in table.metadata.snapshots} == {
+            snapshot.snapshot_id for snapshot in snapshots
+        }
+
+    def test_standard_rest_requirement_surface(self, seeded_table, duckdb_runner):
+        table, table_name = seeded_table("default.expire_snapshots_requirements", 5)
+        snapshots = _ordered_snapshots(table)
+        first_expiring_id = snapshots[0].snapshot_id
+        second_expiring_id = snapshots[1].snapshot_id
+        current_id = snapshots[-1].snapshot_id
+        expected_snapshot_ids = ",".join(
+            str(snapshot_id) for snapshot_id in sorted((first_expiring_id, second_expiring_id))
+        )
+
+        with duckdb_runner() as test:
+            test.statement_ok("CALL enable_logging('Iceberg')")
+            test.statement_ok("CALL truncate_duckdb_logs()")
+            test.statement_ok("BEGIN")
+            _check_expiration(
+                test,
+                table_name,
+                (1, 4),
+                f"snapshot_ids => [{first_expiring_id}]",
+                "retain_last => 5",
+            )
+            _check_expiration(
+                test,
+                table_name,
+                (1, 3),
+                f"snapshot_ids => [{second_expiring_id}]",
+                "retain_last => 5",
+            )
+            test.statement_ok("COMMIT")
+            test.query(
+                "IIIIIII",
+                f"""
+                WITH commit_log AS (
+                    SELECT message
+                    FROM duckdb_logs()
+                    WHERE type = 'Iceberg'
+                      AND message LIKE 'POST % body=%'
+                    ORDER BY timestamp DESC
+                    LIMIT 1
+                )
+                SELECT
+                    list_count(regexp_extract_all(message, '"action":"remove-snapshots"')),
+                    list_count(string_split(regexp_extract(message, '"snapshot-ids":\\[([^]]*)\\]', 1), ',')),
+                    list_count(regexp_extract_all(message, '"type":"assert-ref-snapshot-id"')),
+                    list_count(regexp_extract_all(message, '"ref":"main"')),
+                    list_count(regexp_extract_all(message, '"type":"assert-table-uuid"')),
+                    list_count(regexp_extract_all(message, '"type":"assert-')),
+                    CAST(
+                        contains(message, '"snapshot-id":{current_id}')
+                        AND contains(message, '"snapshot-ids":[{expected_snapshot_ids}]')
+                        AS INTEGER
+                    )
+                FROM commit_log
+                """,
+                [(1, 2, 1, 1, 1, 2, 1)],
+            )
+
+        table.refresh()
+        assert {snapshot.snapshot_id for snapshot in table.metadata.snapshots} == {
+            snapshots[2].snapshot_id,
+            snapshots[3].snapshot_id,
+            snapshots[4].snapshot_id,
+        }
+
+    def test_rollback_expires_abandoned_history(self, seeded_table, duckdb_runner):
+        table, table_name = seeded_table("default.expire_snapshots_rollback", 3)
+        snapshots = _ordered_snapshots(table)
+        rollback_id = snapshots[1].snapshot_id
+
+        with duckdb_runner() as test:
+            test.statement_ok(f"CALL iceberg_rollback_to_snapshot('{table_name}', {rollback_id})")
+
+        table.refresh()
+        assert table.metadata.snapshot_log[-2].snapshot_id == snapshots[2].snapshot_id
+        assert table.metadata.snapshot_log[-1].snapshot_id == rollback_id
+        abandoned_timestamp_ms = table.metadata.snapshot_log[-2].timestamp_ms
+        rollback_timestamp_ms = table.metadata.snapshot_log[-1].timestamp_ms
+
+        with duckdb_runner() as test:
+            test.query("I", _timestamp_time_travel_query(table_name, abandoned_timestamp_ms), [(3,)])
+            test.statement_ok("BEGIN")
+            _check_expiration(test, table_name, (2, 1), "retain_last => 1", "older_than => TIMESTAMP '2999-01-01'")
+            # Truncating through the expired log entry prevents fallback to an older main state.
+            test.query("I", _timestamp_time_travel_query(table_name, abandoned_timestamp_ms), [(0,)])
+            test.query("I", _timestamp_time_travel_query(table_name, rollback_timestamp_ms), [(2,)])
+            test.statement_ok("COMMIT")
+            test.query("I", _timestamp_time_travel_query(table_name, abandoned_timestamp_ms), [(0,)])
+            test.query("I", _timestamp_time_travel_query(table_name, rollback_timestamp_ms), [(2,)])
+            test.query("II", f"SELECT count(*), sum(id) FROM {table_name}", [(2, 3)])
+
+        table.refresh()
+        assert {snapshot.snapshot_id for snapshot in table.metadata.snapshots} == {rollback_id}
+        assert [entry.snapshot_id for entry in table.metadata.snapshot_log] == [rollback_id]
+
+    def test_duplicate_snapshot_log_id_trims_through_last_occurrence(self, seeded_table, duckdb_runner):
+        table, table_name = seeded_table(
+            "default.expire_snapshots_duplicate_log",
+            2,
+            distinct_timestamps=True,
+        )
+        initial_snapshots = _ordered_snapshots(table)
+        first_id = initial_snapshots[0].snapshot_id
+        retained_id = initial_snapshots[1].snapshot_id
+
+        with duckdb_runner() as test:
+            test.statement_ok(f"CALL iceberg_rollback_to_snapshot('{table_name}', {first_id})")
+        sleep(0.01)
+        with duckdb_runner() as test:
+            test.statement_ok(f"INSERT INTO {table_name} VALUES (3)")
+
+        table.refresh()
+        current_id = table.current_snapshot().snapshot_id
+        log_ids = [entry.snapshot_id for entry in table.metadata.snapshot_log]
+        assert log_ids[-4:] == [first_id, retained_id, first_id, current_id]
+        retained_log_timestamp_ms = next(
+            entry.timestamp_ms for entry in table.metadata.snapshot_log if entry.snapshot_id == retained_id
+        )
+
+        with duckdb_runner() as test:
+            test.query("I", _timestamp_time_travel_query(table_name, retained_log_timestamp_ms), [(2,)])
+            test.statement_ok("BEGIN")
+            _check_expiration(
+                test,
+                table_name,
+                (1, 2),
+                f"snapshot_ids => [{first_id}]",
+                "retain_last => 10",
+            )
+            # The last S1 occurrence is after S2, so trimming only through the
+            # first S1 would incorrectly leave a timestamp lookup across the gap.
+            test.query("I", _timestamp_time_travel_query(table_name, retained_log_timestamp_ms), [(0,)])
+            test.query(
+                "II",
+                f"SELECT count(*), sum(id) FROM {table_name} AT (VERSION => {retained_id})",
+                [(2, 3)],
+            )
+            # The local mirror is already trimmed. A repeated call is a no-op,
+            # but the first call's update remains pending and is committed.
+            _check_expiration(
+                test,
+                table_name,
+                (0, 2),
+                "retain_last => 10",
+            )
+            test.statement_ok("COMMIT")
+            test.query("I", _timestamp_time_travel_query(table_name, retained_log_timestamp_ms), [(0,)])
+            test.query(
+                "II",
+                f"SELECT count(*), sum(id) FROM {table_name} AT (VERSION => {retained_id})",
+                [(2, 3)],
+            )
+
+        table.refresh()
+        assert {snapshot.snapshot_id for snapshot in table.metadata.snapshots} == {retained_id, current_id}
+        assert [entry.snapshot_id for entry in table.metadata.snapshot_log] == [current_id]
+
+    def test_snapshot_log_gap_is_a_history_boundary(self, seeded_table, duckdb_runner):
+        table, table_name = seeded_table("default.expire_snapshots_log_gap", 3, distinct_timestamps=True)
+        snapshots = _ordered_snapshots(table)
+        first_id = snapshots[0].snapshot_id
+        missing_id = snapshots[1].snapshot_id
+        current_id = snapshots[2].snapshot_id
+        missing_timestamp_ms = snapshots[1].timestamp_ms
+        assert missing_timestamp_ms < snapshots[2].timestamp_ms
+
+        with duckdb_runner() as test:
+            test.statement_ok("BEGIN")
+            _check_expiration(
+                test,
+                table_name,
+                (1, 2),
+                f"snapshot_ids => [{missing_id}]",
+                "retain_last => 3",
+            )
+            # S2 is the newest log entry at this timestamp. Its absence is a
+            # boundary; timestamp lookup must not cross the gap and return S1.
+            test.query("I", _timestamp_time_travel_query(table_name, missing_timestamp_ms), [(0,)])
+            test.query("II", f"SELECT count(*), sum(id) FROM {table_name} AT (VERSION => {first_id})", [(1, 1)])
+            test.statement_ok("COMMIT")
+            test.query("I", _timestamp_time_travel_query(table_name, missing_timestamp_ms), [(0,)])
+            test.query("II", f"SELECT count(*), sum(id) FROM {table_name} AT (VERSION => {first_id})", [(1, 1)])
+
+        table.refresh()
+        assert {snapshot.snapshot_id for snapshot in table.metadata.snapshots} == {first_id, current_id}
+        assert missing_id not in {snapshot.snapshot_id for snapshot in table.metadata.snapshots}
+
+    def test_concurrent_expiration_of_disjoint_snapshots(self, seeded_table, duckdb_runner):
+        table, table_name = seeded_table("default.expire_snapshots_concurrent", 4)
+        snapshots = _ordered_snapshots(table)
+
+        with duckdb_runner() as test:
+            for connection, snapshot in zip(("con1", "con2"), snapshots[:2]):
+                test.statement_ok("BEGIN", connection=connection)
+                _check_expiration(
+                    test,
+                    table_name,
+                    (1, 3),
+                    f"snapshot_ids => [{snapshot.snapshot_id}]",
+                    "retain_last => 4",
+                    connection=connection,
+                )
+
+            test.statement_ok("COMMIT", connection="con1")
+            test.statement_ok("COMMIT", connection="con2")
+
+        table.refresh()
+        assert {snapshot.snapshot_id for snapshot in table.metadata.snapshots} == {
+            snapshots[2].snapshot_id,
+            snapshots[3].snapshot_id,
+        }

--- a/test/sql/local/catalog_custom_setup/fixture/expire_snapshots_stale_cache.test
+++ b/test/sql/local/catalog_custom_setup/fixture/expire_snapshots_stale_cache.test
@@ -1,0 +1,268 @@
+# name: test/sql/local/catalog_custom_setup/fixture/expire_snapshots_stale_cache.test
+# description: expire_snapshots refreshes metadata instead of planning from a valid stale cache entry
+# group: [fixture]
+
+require-env FIXTURE_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+CREATE SECRET (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL 0
+);
+
+statement ok
+ATTACH OR REPLACE '' AS my_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    URI 'http://127.0.0.1:8181',
+    MAX_TABLE_STALENESS '10 minutes'
+);
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS my_datalake.default;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.expire_snapshots_stale_cache;
+
+statement ok
+CREATE TABLE my_datalake.default.expire_snapshots_stale_cache (id INTEGER);
+
+statement ok
+INSERT INTO my_datalake.default.expire_snapshots_stale_cache VALUES (1);
+
+statement ok
+INSERT INTO my_datalake.default.expire_snapshots_stale_cache VALUES (2);
+
+# Populate the default connection's staleness cache at S2.
+query I
+SELECT count(*) FROM iceberg_snapshots(my_datalake.default.expire_snapshots_stale_cache);
+----
+2
+
+# A separate attached catalog advances the REST table to S3 without evicting
+# the default connection's cache.
+statement ok con2
+ATTACH '' AS external_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    URI 'http://127.0.0.1:8181'
+);
+
+statement ok con2
+INSERT INTO external_datalake.default.expire_snapshots_stale_cache VALUES (3);
+
+# A planner using cached S2 would select only one ID and then conflict on main.
+# The destructive operator force-refreshes S3 and expires both older snapshots.
+query II
+SELECT * FROM iceberg_expire_snapshots(
+    'my_datalake.default.expire_snapshots_stale_cache',
+    retain_last => 1,
+    older_than => TIMESTAMP '2999-01-01'
+);
+----
+2	1
+
+query I
+SELECT count(*) FROM iceberg_snapshots(my_datalake.default.expire_snapshots_stale_cache);
+----
+1
+
+query II
+SELECT count(*), sum(id) FROM my_datalake.default.expire_snapshots_stale_cache;
+----
+3	6
+
+# Once the first expiration call pins fresh metadata in a transaction, a later
+# no-op uses that state and does not issue another table GET.
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+CALL truncate_duckdb_logs();
+
+statement ok
+BEGIN;
+
+query II
+SELECT * FROM iceberg_expire_snapshots(
+    'my_datalake.default.expire_snapshots_stale_cache',
+    retain_last => 1,
+    older_than => TIMESTAMP '2999-01-01'
+);
+----
+0	1
+
+query II
+SELECT * FROM iceberg_expire_snapshots(
+    'my_datalake.default.expire_snapshots_stale_cache',
+    retain_last => 1,
+    older_than => TIMESTAMP '2999-01-01'
+);
+----
+0	1
+
+query I
+SELECT count(*)
+FROM duckdb_logs_parsed('HTTP')
+WHERE request.type = 'GET'
+  AND request.url LIKE '%/v1/namespaces/default/tables/expire_snapshots_stale_cache%';
+----
+1
+
+statement ok
+ROLLBACK;
+
+# A normal read can pin a cached table state before expiration sees the table.
+# Expiration fails closed instead of replacing that transaction view or planning
+# from metadata whose freshness it cannot establish.
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.expire_snapshots_preexisting_state;
+
+statement ok
+CREATE TABLE my_datalake.default.expire_snapshots_preexisting_state (id INTEGER);
+
+statement ok
+INSERT INTO my_datalake.default.expire_snapshots_preexisting_state VALUES (1);
+
+statement ok
+INSERT INTO my_datalake.default.expire_snapshots_preexisting_state VALUES (2);
+
+# Populate the default catalog cache at S2.
+query I
+SELECT count(*) FROM iceberg_snapshots(my_datalake.default.expire_snapshots_preexisting_state);
+----
+2
+
+# Advance the REST table to S3 without evicting the default catalog cache.
+statement ok con2
+INSERT INTO external_datalake.default.expire_snapshots_preexisting_state VALUES (3);
+
+statement ok
+CALL truncate_duckdb_logs();
+
+statement ok
+BEGIN;
+
+# This ordinary table scan both observes cached S2 and establishes transaction-local state.
+query I
+SELECT count(*) FROM my_datalake.default.expire_snapshots_preexisting_state;
+----
+2
+
+statement error
+SELECT * FROM iceberg_expire_snapshots(
+    'my_datalake.default.expire_snapshots_preexisting_state',
+    retain_last => 1,
+    older_than => TIMESTAMP '2999-01-01'
+);
+----
+<REGEX>:.*already accessed in this transaction.*new transaction.*
+
+# Committing an aborted transaction performs an implicit rollback.
+statement ok
+COMMIT;
+
+# No expiration commit reached the server.
+query I
+SELECT count(*)
+FROM duckdb_logs_parsed('HTTP')
+WHERE request.type = 'POST'
+  AND request.url LIKE '%/v1/namespaces/default/tables/expire_snapshots_preexisting_state%';
+----
+0
+
+query I
+SELECT count(*) FROM iceberg_snapshots(external_datalake.default.expire_snapshots_preexisting_state);
+----
+3
+
+# A new transaction has no pinned table state, so expiration force-refreshes S3.
+query II
+SELECT * FROM iceberg_expire_snapshots(
+    'my_datalake.default.expire_snapshots_preexisting_state',
+    retain_last => 1,
+    older_than => TIMESTAMP '2999-01-01'
+);
+----
+2	1
+
+query I
+SELECT count(*) FROM iceberg_snapshots(external_datalake.default.expire_snapshots_preexisting_state);
+----
+1
+
+# A force refresh may discover metadata committed after this transaction began.
+# With metadata-log isolation enabled, planning and staging must both use the
+# transaction-start copy derived from that refreshed metadata.
+statement ok
+SET iceberg_use_metadata_log = true;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.expire_snapshots_metadata_log;
+
+statement ok
+CREATE TABLE my_datalake.default.expire_snapshots_metadata_log (id INTEGER);
+
+statement ok
+INSERT INTO my_datalake.default.expire_snapshots_metadata_log VALUES (1);
+
+statement ok
+INSERT INTO my_datalake.default.expire_snapshots_metadata_log VALUES (2);
+
+statement ok
+BEGIN;
+
+statement ok con2
+INSERT INTO external_datalake.default.expire_snapshots_metadata_log VALUES (3);
+
+# The refresh sees S3, but the transaction-visible copy is S2. Both the plan
+# and local mirror therefore expire only S1.
+query II
+SELECT * FROM iceberg_expire_snapshots(
+    'my_datalake.default.expire_snapshots_metadata_log',
+    retain_last => 1,
+    older_than => TIMESTAMP '2999-01-01'
+);
+----
+1	1
+
+query I
+SELECT count(*) FROM iceberg_snapshots(my_datalake.default.expire_snapshots_metadata_log);
+----
+1
+
+statement ok
+ROLLBACK;
+
+query I
+SELECT count(*) FROM iceberg_snapshots(external_datalake.default.expire_snapshots_metadata_log);
+----
+3
+
+statement ok
+SET iceberg_use_metadata_log = false;
+
+statement ok
+DROP TABLE my_datalake.default.expire_snapshots_metadata_log;
+
+statement ok
+DROP TABLE my_datalake.default.expire_snapshots_preexisting_state;
+
+statement ok
+DROP TABLE my_datalake.default.expire_snapshots_stale_cache;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/expire_snapshots_commit.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/expire_snapshots_commit.test
@@ -1,0 +1,271 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/expire_snapshots_commit.test
+# description: expire_snapshots selection, transaction visibility, and REST metadata commit
+# group: [maintenance]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.expire_snapshots_commit;
+
+statement ok
+create table my_datalake.default.expire_snapshots_commit (id INTEGER);
+
+query II
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit');
+----
+0	0
+
+statement ok
+insert into my_datalake.default.expire_snapshots_commit values (1);
+
+query II
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit', retain_last => 1, older_than => timestamp '2999-01-01');
+----
+0	1
+
+foreach value 2 3 4
+
+statement ok
+insert into my_datalake.default.expire_snapshots_commit values ({value});
+
+endloop
+
+statement ok
+prepare expire_snapshots_prepared as
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit', retain_last => 1, older_than => timestamp '2999-01-01');
+
+statement ok
+begin;
+
+query II
+execute expire_snapshots_prepared;
+----
+3	1
+
+statement ok
+rollback;
+
+statement ok
+insert into my_datalake.default.expire_snapshots_commit values (5);
+
+# Execution resolves the current catalog entry instead of retaining a bind-time pointer.
+statement ok
+begin;
+
+query II
+execute expire_snapshots_prepared;
+----
+4	1
+
+statement ok
+rollback;
+
+statement ok
+set variable current_snapshot = (select arg_max(snapshot_id, sequence_number) from iceberg_snapshots(my_datalake.default.expire_snapshots_commit));
+
+statement error
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit', snapshot_ids => [getvariable('current_snapshot')]);
+----
+still referenced
+
+statement ok
+set variable oldest_snapshot = (select arg_min(snapshot_id, sequence_number) from iceberg_snapshots(my_datalake.default.expire_snapshots_commit));
+
+# Explicit IDs override age and retain_last, are de-duplicated, and must exist.
+statement ok
+begin;
+
+query II
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit', snapshot_ids => [getvariable('oldest_snapshot'), getvariable('oldest_snapshot')], retain_last => 10);
+----
+1	4
+
+statement ok
+rollback;
+
+statement error
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit', snapshot_ids => [-1]);
+----
+snapshot -1 does not exist
+
+# Expiration and rollback both change the snapshot graph or its main ref, so a
+# transaction cannot combine them in either order.
+statement ok
+set variable rollback_snapshot = (
+    select snapshot_id
+    from iceberg_snapshots(my_datalake.default.expire_snapshots_commit)
+    order by sequence_number desc
+    offset 1 limit 1
+);
+
+statement ok
+begin;
+
+query II
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit', snapshot_ids => [getvariable('oldest_snapshot')], retain_last => 10);
+----
+1	4
+
+statement error
+call iceberg_rollback_to_snapshot('my_datalake.default.expire_snapshots_commit', getvariable('rollback_snapshot'));
+----
+cannot be combined with snapshot expiration
+
+statement ok
+rollback;
+
+statement ok
+begin;
+
+statement ok
+call iceberg_rollback_to_snapshot('my_datalake.default.expire_snapshots_commit', getvariable('rollback_snapshot'));
+
+statement error
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit', snapshot_ids => [getvariable('oldest_snapshot')], retain_last => 10);
+----
+cannot be combined with snapshot rollback
+
+statement ok
+rollback;
+
+query I
+select count(*) from iceberg_snapshots(my_datalake.default.expire_snapshots_commit);
+----
+5
+
+# Transaction-visible metadata must not expose a locally dropped table.
+statement ok
+begin;
+
+statement ok
+drop table my_datalake.default.expire_snapshots_commit;
+
+statement error
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit');
+----
+dropped or renamed in this transaction
+
+statement ok
+rollback;
+
+# A pending data snapshot is not materialized in transaction-local metadata, so
+# expiration cannot plan after a data change.
+statement ok
+begin;
+
+statement ok
+insert into my_datalake.default.expire_snapshots_commit values (6);
+
+statement error
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit', retain_last => 1, older_than => timestamp '2999-01-01');
+----
+cannot follow data changes
+
+statement ok
+rollback;
+
+# Once expiration is staged, later data changes are rejected as well so the
+# transaction has one consistent snapshot-graph operation model.
+statement ok
+begin;
+
+query II
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit', snapshot_ids => [getvariable('oldest_snapshot')], retain_last => 10);
+----
+1	4
+
+statement error
+insert into my_datalake.default.expire_snapshots_commit values (6);
+----
+cannot be combined with snapshot expiration
+
+statement ok
+rollback;
+
+# Property updates can change the retention plan, so they cannot share a transaction with expiration.
+statement ok
+begin;
+
+statement ok
+call set_iceberg_table_properties(my_datalake.default.expire_snapshots_commit, {'gc.enabled': 'false'});
+
+statement error
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit');
+----
+cannot follow table property changes
+
+statement ok
+rollback;
+
+statement ok
+begin;
+
+query II
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit', snapshot_ids => [getvariable('oldest_snapshot')], retain_last => 10);
+----
+1	4
+
+statement error
+call set_iceberg_table_properties(my_datalake.default.expire_snapshots_commit, {'gc.enabled': 'false'});
+----
+Table property changes cannot be combined with snapshot expiration
+
+statement ok
+rollback;
+
+query II
+select count(*), sum(id) from my_datalake.default.expire_snapshots_commit;
+----
+5	15
+
+# Consecutive calls plan against transaction-visible metadata produced by the
+# previous call. Committing the transaction removes all four selected snapshots.
+statement ok
+begin;
+
+query II
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit', snapshot_ids => [getvariable('oldest_snapshot')], retain_last => 10);
+----
+1	4
+
+query II
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_commit', retain_last => 1, older_than => timestamp '2999-01-01');
+----
+3	1
+
+statement ok
+commit;
+
+query I
+select count(*) from iceberg_snapshots(my_datalake.default.expire_snapshots_commit);
+----
+1
+
+query II
+select count(*), sum(id) from my_datalake.default.expire_snapshots_commit AT (VERSION => getvariable('current_snapshot'));
+----
+5	15
+
+statement error
+select * from my_datalake.default.expire_snapshots_commit AT (VERSION => getvariable('oldest_snapshot'));
+----
+snapshot
+
+# Expiration removes metadata, never data files.
+query II
+select count(*), sum(id) from my_datalake.default.expire_snapshots_commit;
+----
+5	15
+
+statement ok
+drop table my_datalake.default.expire_snapshots_commit;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/expire_snapshots_conflict.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/expire_snapshots_conflict.test
@@ -1,0 +1,63 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/expire_snapshots_conflict.test
+# description: expire_snapshots rejects a main-ref CAS conflict without partial expiry
+# group: [maintenance]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.expire_snapshots_conflict;
+
+statement ok
+create table my_datalake.default.expire_snapshots_conflict (id INTEGER);
+
+foreach value 1 2 3
+
+statement ok
+insert into my_datalake.default.expire_snapshots_conflict values ({value});
+
+endloop
+
+statement ok con1
+begin;
+
+query II con1
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_conflict', retain_last => 1, older_than => timestamp '2999-01-01');
+----
+2	1
+
+statement ok con2
+begin;
+
+statement ok con2
+insert into my_datalake.default.expire_snapshots_conflict values (4);
+
+statement ok con2
+commit;
+
+statement error con1
+commit;
+----
+<REGEX>:.*TransactionContext Error.*Conflict_409.*
+
+query II
+select count(*), sum(id) from my_datalake.default.expire_snapshots_conflict;
+----
+4	10
+
+query I
+select count(*) from iceberg_snapshots(my_datalake.default.expire_snapshots_conflict);
+----
+4
+
+statement ok
+drop table my_datalake.default.expire_snapshots_conflict;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/expire_snapshots_properties.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/expire_snapshots_properties.test
@@ -1,0 +1,137 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/maintenance/expire_snapshots_properties.test
+# description: expire_snapshots table-property defaults and validation
+# group: [maintenance]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+drop table if exists my_datalake.default.expire_snapshots_properties;
+
+statement ok
+create table my_datalake.default.expire_snapshots_properties (id INTEGER);
+
+foreach value 1 2 3 4
+
+statement ok
+insert into my_datalake.default.expire_snapshots_properties values ({value});
+
+endloop
+
+# Omitted arguments use table properties; explicit arguments take precedence.
+statement ok
+call set_iceberg_table_properties(my_datalake.default.expire_snapshots_properties, {'history.expire.max-snapshot-age-ms': '9223372036854775807', 'history.expire.min-snapshots-to-keep': '2'});
+
+query II
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_properties', retain_last => 1);
+----
+0	4
+
+statement ok
+begin;
+
+query II
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_properties', older_than => timestamp '2999-01-01');
+----
+2	2
+
+statement ok
+rollback;
+
+statement ok
+call set_iceberg_table_properties(my_datalake.default.expire_snapshots_properties, {'history.expire.max-snapshot-age-ms': '1ms', 'history.expire.min-snapshots-to-keep': 'not-an-integer'});
+
+statement ok
+begin;
+
+query II
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_properties', older_than => timestamp '2999-01-01', retain_last => 1);
+----
+3	1
+
+statement ok
+rollback;
+
+statement error
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_properties', retain_last => 1);
+----
+history.expire.max-snapshot-age-ms
+
+statement error
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_properties', older_than => timestamp '2999-01-01');
+----
+history.expire.min-snapshots-to-keep
+
+# Representative lower bounds cover strict integer and range parsing.
+statement ok
+call set_iceberg_table_properties(my_datalake.default.expire_snapshots_properties, {'history.expire.max-snapshot-age-ms': '-1', 'history.expire.min-snapshots-to-keep': '1'});
+
+statement error
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_properties', retain_last => 1);
+----
+expected a value >= 0
+
+statement ok
+call set_iceberg_table_properties(my_datalake.default.expire_snapshots_properties, {'history.expire.max-snapshot-age-ms': '1', 'history.expire.min-snapshots-to-keep': '0'});
+
+statement error
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_properties', older_than => timestamp '2999-01-01');
+----
+expected a value >= 1
+
+# Overflow and the INT32-backed retain-count upper bound are rejected.
+statement ok
+call set_iceberg_table_properties(my_datalake.default.expire_snapshots_properties, {'history.expire.max-snapshot-age-ms': '9223372036854775808', 'history.expire.min-snapshots-to-keep': '2147483648'});
+
+statement error
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_properties', retain_last => 1);
+----
+expected an integer
+
+statement error
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_properties', older_than => timestamp '2999-01-01');
+----
+expected a value <= 2147483647
+
+# gc.enabled is case-insensitive and validated strictly.
+statement ok
+call set_iceberg_table_properties(my_datalake.default.expire_snapshots_properties, {'history.expire.max-snapshot-age-ms': '1', 'history.expire.min-snapshots-to-keep': '1', 'gc.enabled': 'TRUE'});
+
+statement ok
+begin;
+
+query II
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_properties', older_than => timestamp '2999-01-01', retain_last => 1);
+----
+3	1
+
+statement ok
+rollback;
+
+statement ok
+call set_iceberg_table_properties(my_datalake.default.expire_snapshots_properties, {'gc.enabled': 'not-a-boolean'});
+
+statement error
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_properties');
+----
+expected 'true' or 'false'
+
+statement ok
+call set_iceberg_table_properties(my_datalake.default.expire_snapshots_properties, {'gc.enabled': 'false'});
+
+statement error
+select * from iceberg_expire_snapshots('my_datalake.default.expire_snapshots_properties');
+----
+table property 'gc.enabled' is false
+
+statement ok
+drop table my_datalake.default.expire_snapshots_properties;

--- a/test/sql/local/maintenance/expire_snapshots_validation.test
+++ b/test/sql/local/maintenance/expire_snapshots_validation.test
@@ -1,0 +1,79 @@
+# name: test/sql/local/maintenance/expire_snapshots_validation.test
+# description: bind-time validation for iceberg_expire_snapshots
+# group: [maintenance]
+
+require avro
+
+require parquet
+
+require iceberg
+
+statement error
+select * from iceberg_expire_snapshots(NULL);
+----
+table identifier cannot be NULL
+
+statement error
+select * from iceberg_expire_snapshots('');
+----
+has an empty component
+
+foreach table_name bad a.b a.b.c.d .b.c a..c a.b.c.
+
+statement error
+select * from iceberg_expire_snapshots('{table_name}');
+----
+table identifier
+
+endloop
+
+statement error
+select * from iceberg_expire_snapshots('a.b.c', retain_last => 0);
+----
+'retain_last' must be >= 1
+
+statement error
+select * from iceberg_expire_snapshots('a.b.c', snapshot_ids => 1);
+----
+'snapshot_ids' must be a list of integers
+
+statement error
+select * from iceberg_expire_snapshots('a.b.c', snapshot_ids => [1.5]);
+----
+'snapshot_ids' entries must be integers
+
+statement error
+select * from iceberg_expire_snapshots('a.b.c', snapshot_ids => [1, NULL]);
+----
+'snapshot_ids' entries cannot be NULL
+
+statement error
+select * from iceberg_expire_snapshots('a.b.c', snapshot_ids => NULL);
+----
+'snapshot_ids' cannot be NULL
+
+foreach timestamp infinity -infinity
+
+statement error
+select * from iceberg_expire_snapshots('a.b.c', older_than => timestamp '{timestamp}');
+----
+'older_than' must be a finite timestamp
+
+endloop
+
+# Optional NULLs are omitted and quoted identifier components remain valid.
+statement error
+select * from iceberg_expire_snapshots('"missing-catalog"."missing-schema"."missing-table"', older_than => NULL, retain_last => NULL);
+----
+Catalog "missing-catalog" does not exist
+
+statement ok
+create table expire_snapshots_not_iceberg (id INTEGER);
+
+statement error
+select * from iceberg_expire_snapshots('memory.main.expire_snapshots_not_iceberg');
+----
+not an Iceberg catalog
+
+statement ok
+drop table expire_snapshots_not_iceberg;


### PR DESCRIPTION
Hi DuckDB team, 

As we discussed before, I’d like to contribute to the development of Iceberg maintenance functions. Here is our implementation of iceberg_expire_snapshots.

It may not be fully mature yet, and we’d really appreciate any feedback or suggestions!

## Summary

This change adds `iceberg_expire_snapshots`, a metadata-only table function
for expiring snapshots according to the current `main` branch and Iceberg
snapshot-retention settings.

```sql
FROM iceberg_expire_snapshots(
    'catalog.schema.table',
    older_than => TIMESTAMP '2026-01-01',
    retain_last => 1,
    snapshot_ids => [101, 102]
);
```

The operation removes snapshot entries from table metadata. It does not delete
data files, delete files, manifests, manifest lists, metadata JSON, or any
other physical file.

## Design

The initial implementation supports only tables with no snapshot references
other than `main`. A non-main branch or tag is rejected before staging.

Retention is planned in three steps:

1. Apply the global cutoff to all snapshots as an initial classification.
2. Walk main ancestry and apply its retained-prefix policy. The prefix remains
   open while either the minimum-count or age rule retains a snapshot. Once it
   closes, older ancestors cannot re-enter it, including when timestamps are
   non-monotonic.
3. Apply explicit snapshot IDs, then sort and deduplicate the result.

Retention precedence is:

```text
global cutoff: older_than > max-snapshot-age table property > default
global count:  retain_last > min-snapshots table property > default
main policy:   matching refs.main setting > corresponding global value
```

Snapshots outside main ancestry, including history abandoned by rollback, use
the global cutoff.

Metadata without `refs`, or with `refs: null`, uses the current snapshot as an
implicit main branch. An explicitly empty refs map with a current snapshot is
rejected.

## Transactions and REST commits

The commit uses standard Iceberg REST objects only:

- one sorted and deduplicated `remove-snapshots` update;
- one `assert-ref-snapshot-id` requirement for `main`; and
- the existing `assert-table-uuid` requirement.


## Limitations

Standard REST requirements cannot assert that the complete refs map, main
retention fields, table retention properties, or `gc.enabled` remained
unchanged after planning. In particular, a concurrently created non-main ref
may not be detected by this main-only request surface. This implementation
does not add private REST requirements.

For example, T1 may plan to remove S1 before T2 creates `release -> S1`. The
Apache Iceberg Java REST fixture currently accepts T1's
requirement-compatible commit and removes the newly created `release` ref while
applying `remove-snapshots`. Another catalog may instead reject the commit.
