### PR TITLE
Bump duckdb to 3be83b480f

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: iceberg
-      duckdb_version: 1da80a4a3adef9053fb665864734debf1407a521
+      duckdb_version: 3be83b480fe0c05b35ddf3a5458ba50ce3f2b389 
       ci_tools_version: main
       exclude_archs: 'windows_amd64_mingw'
       extra_toolchains: 'python3'
@@ -29,7 +29,7 @@ jobs:
     secrets: inherit
     with:
       extension_name: iceberg
-      duckdb_version: 1da80a4a3adef9053fb665864734debf1407a521
+      duckdb_version: 13be83b480fe0c05b35ddf3a5458ba50ce3f2b389
       ci_tools_version: main
       exclude_archs: 'windows_amd64_mingw'
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
@@ -40,6 +40,6 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
     with:
       extension_name: iceberg
-      duckdb_version: 1da80a4a3adef9053fb665864734debf1407a521
+      duckdb_version: 13be83b480fe0c05b35ddf3a5458ba50ce3f2b389 
       ci_tools_version: main
       format_checks: 'format'

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -26,18 +26,17 @@ duckdb_extension_load(iceberg
 if (NOT EMSCRIPTEN)
   duckdb_extension_load(tpch)
   duckdb_extension_load(icu)
-#  duckdb_extension_load(ducklake
-#        LOAD_TESTS
-#        GIT_URL https://github.com/duckdb/ducklake
-#        GIT_TAG a92abf755a7b4e2f3e410f8b89c72b990a0698da
-#)
+  #  duckdb_extension_load(ducklake
+  #        LOAD_TESTS
+  #        GIT_URL https://github.com/duckdb/ducklake
+  #        GIT_TAG a92abf755a7b4e2f3e410f8b89c72b990a0698da
+  #)
 
   if (NOT MINGW)
     duckdb_extension_load(aws
             LOAD_TESTS
             GIT_URL https://github.com/duckdb/duckdb-aws
-            GIT_TAG 9126ffd679dc7649402da9c1c02da37dafe6c54b
-            APPLY_PATCHES
+            GIT_TAG 6c044194df8f9fa6ebc4365aa11c75095c1d5ef2
     )
   endif()
 endif()

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -26,11 +26,11 @@ duckdb_extension_load(iceberg
 if (NOT EMSCRIPTEN)
   duckdb_extension_load(tpch)
   duckdb_extension_load(icu)
-  #  duckdb_extension_load(ducklake
-  #        LOAD_TESTS
-  #        GIT_URL https://github.com/duckdb/ducklake
-  #        GIT_TAG a92abf755a7b4e2f3e410f8b89c72b990a0698da
-  #)
+#  duckdb_extension_load(ducklake
+#        LOAD_TESTS
+#        GIT_URL https://github.com/duckdb/ducklake
+#        GIT_TAG a92abf755a7b4e2f3e410f8b89c72b990a0698da
+#)
 
   if (NOT MINGW)
     duckdb_extension_load(aws

--- a/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
+++ b/src/catalog/rest/catalog_entry/schema/iceberg_schema_entry.cpp
@@ -576,15 +576,17 @@ void IcebergSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) 
 			}
 
 			if (StringUtil::CIEquals(key, "format-version")) {
-				if (!val.DefaultTryCastAs(LogicalType::INTEGER, true)) {
+				auto casted_val = val.DefaultTryCastAs(LogicalType::INTEGER, nullptr, true);
+				if (!casted_val) {
 					throw InvalidInputException("Can't cast 'format-version' property (%s) to INTEGER", val.ToString());
 				}
-				new_format_version = val.GetValue<int32_t>();
+				new_format_version = casted_val->GetValue<int32_t>();
 			} else {
-				if (!val.DefaultTryCastAs(LogicalType::VARCHAR, true)) {
+				auto casted_val = val.DefaultTryCastAs(LogicalType::VARCHAR, nullptr, true);
+				if (!casted_val) {
 					throw InvalidInputException("Can't cast '%s' property (%s) to VARCHAR", key, val.ToString());
 				}
-				new_properties[key] = val.GetValue<string>();
+				new_properties[key] = casted_val->GetValue<string>();
 			}
 		}
 

--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -210,11 +210,12 @@ static Value ParseTableProperty(TableFunctionBinder &binder, ClientContext &cont
 	if (val.IsNull()) {
 		throw BinderException("NULL is not supported as a valid option for '%s'", property_name);
 	}
-	if (!val.DefaultTryCastAs(type, true)) {
+	auto casted_val = val.DefaultTryCastAs(type, nullptr, true);
+	if (!casted_val) {
 		throw InvalidInputException("Can't cast '%s' property (%s) to %s", property_name, val.ToString(),
 		                            type.ToString());
 	}
-	return val;
+	return std::move(*casted_val);
 }
 
 shared_ptr<IcebergTable> IcebergTableSet::CreateEntryInternal(const string &name, IcebergTable &&table,

--- a/src/common/iceberg_utils.cpp
+++ b/src/common/iceberg_utils.cpp
@@ -51,7 +51,7 @@ idx_t IcebergUtils::ParseByteSizeOptionallyFormatted(const string &input) {
 	}
 }
 
-CopyFunctionCatalogEntry &IcebergUtils::GetCopyFunction(ClientContext &context, const string &name) {
+CopyFunctionCatalogEntry &IcebergUtils::GetCopyFunction(ClientContext &context, const Identifier &name) {
 	// Logic is partially duplicated from Catalog::AutoLoadExtensionByCatalogEntry(db, CatalogType::COPY_FUNCTION_ENTRY,
 	// name), but that do not offer enough control
 	auto &db = *context.db;
@@ -65,7 +65,7 @@ CopyFunctionCatalogEntry &IcebergUtils::GetCopyFunction(ClientContext &context, 
 	auto &system_catalog = Catalog::GetSystemCatalog(db);
 
 	auto entry = system_catalog.GetEntry<CopyFunctionCatalogEntry>(
-	    context, QualifiedName(system_catalog.GetName(), Identifier::DefaultSchema(), Identifier(name)),
+	    context, QualifiedName(system_catalog.GetName(), Identifier::DefaultSchema(), name),
 	    OnEntryNotFound::RETURN_NULL);
 	if (!entry) {
 		throw MissingExtensionException(

--- a/src/core/expression/iceberg_hash.cpp
+++ b/src/core/expression/iceberg_hash.cpp
@@ -324,8 +324,7 @@ Value IcebergHash::TruncateValue(const Value &v, idx_t width) {
 	}
 	case LogicalTypeId::DECIMAL: {
 		// Truncate the unscaled integer value, preserving type (scale/precision)
-		auto scaled = v.Copy();
-		scaled.Reinterpret(LogicalType::BIGINT);
+		auto scaled = v.WithType(LogicalType::BIGINT);
 		auto val = scaled.GetValue<int64_t>();
 		auto result = val - (((val % W) + W) % W);
 		return Value::DECIMAL(result, DecimalType::GetWidth(v.type()), DecimalType::GetScale(v.type()));

--- a/src/core/metadata/manifest/iceberg_manifest.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest.cpp
@@ -525,13 +525,13 @@ static void WritePartitionValue(Vector &vector, idx_t row_idx, const Value &valu
 		FlatVector::SetNull(vector, row_idx, true);
 		return;
 	}
-	Value cast_value;
 	string error_message;
-	if (!value.DefaultTryCastAs(vector.GetType(), cast_value, &error_message, true)) {
+	auto cast_value = value.DefaultTryCastAs(vector.GetType(), &error_message, true);
+	if (!cast_value) {
 		throw InvalidInputException("Could not cast partition value %s to %s", value.type().ToString(),
 		                            vector.GetType().ToString());
 	}
-	vector.SetValue(row_idx, cast_value);
+	vector.SetValue(row_idx, *cast_value);
 }
 
 static void WritePartitionStructRow(Vector &partition_vector, idx_t row_idx, const IcebergDataFile &data_file,

--- a/src/execution/helpers/equality_delete_helpers.cpp
+++ b/src/execution/helpers/equality_delete_helpers.cpp
@@ -336,16 +336,16 @@ bool IcebergDelete::TryGetEqualityDeletePredicates(ClientContext &context, Icebe
 		predicate.column_name = column_definition->name;
 		predicate.type = column_definition->type;
 		for (auto &raw_value : raw_values) {
-			Value delete_value;
 			if (raw_value.IsNull()) {
-				delete_value = Value(column_definition->type);
-			} else {
-				string error_message;
-				if (!raw_value.DefaultTryCastAs(column_definition->type, delete_value, &error_message, true)) {
-					return false;
-				}
+				predicate.values.push_back(Value(column_definition->type));
+				continue;
 			}
-			predicate.values.push_back(std::move(delete_value));
+			string error_message;
+			auto delete_value = raw_value.DefaultTryCastAs(column_definition->type, &error_message, true);
+			if (!delete_value) {
+				return false;
+			}
+			predicate.values.push_back(std::move(*delete_value));
 		}
 		equality_predicates.push_back(std::move(predicate));
 	}

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -667,7 +667,7 @@ IcebergCopyOptions IcebergInsert::GetCopyOptions(ClientContext &context, const I
 	copy_input.schema.GetColumnNamesAndTypes(names_to_write, types_to_write);
 
 	// Get Parquet Copy function
-	auto &copy_fun = IcebergUtils::GetCopyFunction(context, file_format);
+	auto &copy_fun = IcebergUtils::GetCopyFunction(context, Identifier(file_format));
 	IcebergCopyOptions result(std::move(info), copy_fun.function);
 	GenerateSortOrderExpressions(context, copy_input, result);
 

--- a/src/include/common/iceberg_utils.hpp
+++ b/src/include/common/iceberg_utils.hpp
@@ -43,7 +43,7 @@ public:
 	static optional_ptr<CatalogEntry> GetTableEntry(ClientContext &context, string &input_string);
 	static optional_ptr<SchemaCatalogEntry> GetSchemaEntry(ClientContext &context, string &input_string);
 	static idx_t CountOccurrences(const string &input, const string &to_find);
-	static CopyFunctionCatalogEntry &GetCopyFunction(ClientContext &context, const string &name);
+	static CopyFunctionCatalogEntry &GetCopyFunction(ClientContext &context, const Identifier &name);
 	static idx_t ParseByteSizeOptionallyFormatted(const string &input);
 	static int64_t AddFileSizeChecked(int64_t total, int64_t file_size_in_bytes);
 	static timestamp_ms_t GetTransactionStartTimeMS(ClientContext &context);

--- a/src/include/iceberg_options.hpp
+++ b/src/include/iceberg_options.hpp
@@ -7,23 +7,24 @@
 
 namespace duckdb {
 
-static string VERSION_GUESSING_CONFIG_VARIABLE = "unsafe_enable_version_guessing";
+static constexpr const char *VERSION_GUESSING_CONFIG_VARIABLE = "unsafe_enable_version_guessing";
 
 // The Iceberg format version used when creating a new table without an explicit
 // 'format-version' property. Valid values are 2 and 3. Version 1 is not supported
 // for writing (NotImplementedException); anything outside [2, 3] is rejected
 // (InvalidConfigurationException).
-static string DEFAULT_FORMAT_VERSION_CONFIG_VARIABLE = "iceberg_default_format_version";
+static constexpr const char *DEFAULT_FORMAT_VERSION_CONFIG_VARIABLE = "iceberg_default_format_version";
 static constexpr uint64_t DEFAULT_ICEBERG_FORMAT_VERSION = 2;
 
 // Compatibility escape hatch for deletion-vector files written by DuckDB Iceberg 1.5.3,
 // which contain only the deletion-vector blob rather than a valid Puffin container.
-static string SKIP_PUFFIN_VERIFICATION_CONFIG_VARIABLE = "iceberg_unsafe_skip_puffin_verification";
+static constexpr const char *SKIP_PUFFIN_VERIFICATION_CONFIG_VARIABLE = "iceberg_unsafe_skip_puffin_verification";
 
 // When this is true, a DELETE on a v2 Iceberg table whose WHERE clause is a pure
 // conjunction of equality predicates writes an Iceberg equality-delete file instead
 // of a positional delete. This exists only to exercise the equality-delete read path.
-static string ENABLE_EQUALITY_DELETES_CONFIG_VARIABLE = "unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes";
+static constexpr const char *ENABLE_EQUALITY_DELETES_CONFIG_VARIABLE =
+    "unsafe_and_disabled_for_iceberg_v3_enable_equality_deletes";
 
 static constexpr const char *UNSAFE_STRUCT_NULL_DEFAULT_INTERP_CONFIG_VARIABLE =
     "__iceberg_unsafe_struct_null_default_interp";

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -110,10 +110,6 @@ private:
 	bool TryGetNextBatch(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
 	void FinishScanTasks(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
 	void LoadManifestList(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
-	//! Resolve the table metadata for a path-based scan. The catalog path hands us 'scan_info' up front;
-	//! iceberg_scan('path') does not, and DuckDB can expand the file list (MultiFileList::IsEmpty) before
-	//! Bind() runs, so every entry point that needs the metadata resolves it lazily through here.
-	void EnsureScanInfo() const DUCKDB_REQUIRES(shared_state->lock);
 	void InitializeScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);
 	void StartDataManifestScan(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
 	IcebergScanPlanProvider &GetScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -110,6 +110,10 @@ private:
 	bool TryGetNextBatch(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
 	void FinishScanTasks(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
 	void LoadManifestList(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
+	//! Resolve the table metadata for a path-based scan. The catalog path hands us 'scan_info' up front;
+	//! iceberg_scan('path') does not, and DuckDB can expand the file list (MultiFileList::IsEmpty) before
+	//! Bind() runs, so every entry point that needs the metadata resolves it lazily through here.
+	void EnsureScanInfo() const DUCKDB_REQUIRES(shared_state->lock);
 	void InitializeScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);
 	void StartDataManifestScan(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
 	IcebergScanPlanProvider &GetScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -174,7 +174,21 @@ void IcebergMultiFileList::Bind(vector<LogicalType> &return_types, vector<Identi
 		return_types = this->types;
 		return;
 	}
-	EnsureScanInfo();
+	if (!shared_state->scan_info) {
+		D_ASSERT(!shared_state->path.empty());
+		auto input_string = shared_state->path;
+		auto resolved_metadata = IcebergUtils::ResolveTableMetadata(context, input_string, options);
+
+		auto temp_data = make_uniq<IcebergScanTemporaryData>();
+		temp_data->metadata = std::move(resolved_metadata.metadata);
+		auto &metadata = temp_data->metadata;
+
+		IcebergSnapshotScanInfo snapshot_info;
+		snapshot_info = metadata.GetSnapshot(*options.snapshot_lookup);
+		auto schema = metadata.GetSchemaFromId(snapshot_info.schema_id);
+		shared_state->scan_info = make_shared_ptr<IcebergScanInfo>(resolved_metadata.table_location,
+		                                                           std::move(temp_data), snapshot_info, *schema);
+	}
 
 	auto &schema = GetSchema().columns;
 	for (auto &schema_entry : schema) {
@@ -588,25 +602,6 @@ void IcebergMultiFileList::InitializeView(annotated_lock_guard<annotated_mutex> 
 		view_has_matching_delete_manifests |= matches;
 	}
 	has_matching_delete_manifests.store(view_has_matching_delete_manifests);
-}
-
-void IcebergMultiFileList::EnsureScanInfo() const {
-	if (shared_state->scan_info) {
-		return;
-	}
-	D_ASSERT(!shared_state->path.empty());
-	auto input_string = shared_state->path;
-	auto resolved_metadata = IcebergUtils::ResolveTableMetadata(context, input_string, options);
-
-	auto temp_data = make_uniq<IcebergScanTemporaryData>();
-	temp_data->metadata = std::move(resolved_metadata.metadata);
-	auto &metadata = temp_data->metadata;
-
-	IcebergSnapshotScanInfo snapshot_info;
-	snapshot_info = metadata.GetSnapshot(*options.snapshot_lookup);
-	auto schema = metadata.GetSchemaFromId(snapshot_info.schema_id);
-	shared_state->scan_info = make_shared_ptr<IcebergScanInfo>(resolved_metadata.table_location, std::move(temp_data),
-	                                                           snapshot_info, *schema);
 }
 
 void IcebergMultiFileList::InitializeScanPlanProvider() const {

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -174,21 +174,7 @@ void IcebergMultiFileList::Bind(vector<LogicalType> &return_types, vector<Identi
 		return_types = this->types;
 		return;
 	}
-	if (!shared_state->scan_info) {
-		D_ASSERT(!shared_state->path.empty());
-		auto input_string = shared_state->path;
-		auto resolved_metadata = IcebergUtils::ResolveTableMetadata(context, input_string, options);
-
-		auto temp_data = make_uniq<IcebergScanTemporaryData>();
-		temp_data->metadata = std::move(resolved_metadata.metadata);
-		auto &metadata = temp_data->metadata;
-
-		IcebergSnapshotScanInfo snapshot_info;
-		snapshot_info = metadata.GetSnapshot(*options.snapshot_lookup);
-		auto schema = metadata.GetSchemaFromId(snapshot_info.schema_id);
-		shared_state->scan_info = make_shared_ptr<IcebergScanInfo>(resolved_metadata.table_location,
-		                                                           std::move(temp_data), snapshot_info, *schema);
-	}
+	EnsureScanInfo();
 
 	auto &schema = GetSchema().columns;
 	for (auto &schema_entry : schema) {
@@ -308,9 +294,16 @@ vector<OpenFileInfo> IcebergMultiFileList::GetAllFiles() const {
 }
 
 FileExpandResult IcebergMultiFileList::GetExpandResult() const {
-	// GetFileInternal(1) will ensure files with index 0 and index 1 are expanded if they are available
 	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	GetFileInternal(1, guard);
+	// DuckDB calls MultiFileList::IsEmpty() during MultiFileBindInternal, before the reader's Bind() has
+	// applied the parsed named parameters (SetOptions) or resolved the metadata for a path-based scan.
+	// Expanding here would resolve the table against default options - picking the wrong snapshot for
+	// 'version' / 'snapshot_from_id' - and the result below does not depend on it, so only warm up the
+	// expansion once we are bound.
+	if (have_bound) {
+		// GetFileInternal(1) will ensure files with index 0 and index 1 are expanded if they are available
+		GetFileInternal(1, guard);
+	}
 
 	// always return multiple files, In the case there is only 1 data file,
 	// we only lose performance if it is small
@@ -595,6 +588,25 @@ void IcebergMultiFileList::InitializeView(annotated_lock_guard<annotated_mutex> 
 		view_has_matching_delete_manifests |= matches;
 	}
 	has_matching_delete_manifests.store(view_has_matching_delete_manifests);
+}
+
+void IcebergMultiFileList::EnsureScanInfo() const {
+	if (shared_state->scan_info) {
+		return;
+	}
+	D_ASSERT(!shared_state->path.empty());
+	auto input_string = shared_state->path;
+	auto resolved_metadata = IcebergUtils::ResolveTableMetadata(context, input_string, options);
+
+	auto temp_data = make_uniq<IcebergScanTemporaryData>();
+	temp_data->metadata = std::move(resolved_metadata.metadata);
+	auto &metadata = temp_data->metadata;
+
+	IcebergSnapshotScanInfo snapshot_info;
+	snapshot_info = metadata.GetSnapshot(*options.snapshot_lookup);
+	auto schema = metadata.GetSchemaFromId(snapshot_info.schema_id);
+	shared_state->scan_info = make_shared_ptr<IcebergScanInfo>(resolved_metadata.table_location, std::move(temp_data),
+	                                                           snapshot_info, *schema);
 }
 
 void IcebergMultiFileList::InitializeScanPlanProvider() const {

--- a/src/storage/statistics/iceberg_variant_statistics.cpp
+++ b/src/storage/statistics/iceberg_variant_statistics.cpp
@@ -96,13 +96,13 @@ static string BuildJsonPath(const vector<string> &field_names) {
 //! Serialize a bounds object (a struct keyed by JSON path) to the parquet-variant encoding by casting
 //! it to VARIANT and calling variant_to_parquet_variant, then concatenating the metadata and value blobs.
 static optional<string> SerializeBoundsVariant(ClientContext &context, Value bounds_struct) {
-	Value variant_value;
-	if (!bounds_struct.DefaultTryCastAs(LogicalType::VARIANT(), variant_value, nullptr)) {
+	auto variant_value = bounds_struct.DefaultTryCastAs(LogicalType::VARIANT());
+	if (!variant_value) {
 		return std::nullopt;
 	}
 
 	vector<unique_ptr<Expression>> children;
-	children.push_back(make_uniq<BoundConstantExpression>(std::move(variant_value)));
+	children.push_back(make_uniq<BoundConstantExpression>(std::move(*variant_value)));
 
 	ErrorData error;
 	FunctionBinder binder(context);
@@ -232,15 +232,15 @@ bool IcebergVariantBounds::Finalize(ClientContext &context, optional<string> &lo
 			continue;
 		}
 		if (field.min_value) {
-			Value typed;
-			if (Value(*field.min_value).DefaultTryCastAs(leaf_type, typed, nullptr)) {
-				lower_children.emplace_back(json_path, std::move(typed));
+			auto typed = Value(*field.min_value).DefaultTryCastAs(leaf_type);
+			if (typed) {
+				lower_children.emplace_back(json_path, std::move(*typed));
 			}
 		}
 		if (field.max_value) {
-			Value typed;
-			if (Value(*field.max_value).DefaultTryCastAs(leaf_type, typed, nullptr)) {
-				upper_children.emplace_back(json_path, std::move(typed));
+			auto typed = Value(*field.max_value).DefaultTryCastAs(leaf_type);
+			if (typed) {
+				upper_children.emplace_back(json_path, std::move(*typed));
 			}
 		}
 	}
@@ -381,11 +381,11 @@ bool IcebergVariantBoundsReader::RekeyBoundsVariant(const Value &bounds_variant,
 	}
 
 	Value nested_struct = NodeToValue(root);
-	Value variant_result;
-	if (!nested_struct.DefaultTryCastAs(LogicalType::VARIANT(), variant_result, nullptr)) {
+	auto variant_result = nested_struct.DefaultTryCastAs(LogicalType::VARIANT());
+	if (!variant_result) {
 		return false;
 	}
-	result = std::move(variant_result);
+	result = std::move(*variant_result);
 	return true;
 }
 

--- a/test/sql/local/catalog_custom_setup/fixture/vended_credentials_refresh.test
+++ b/test/sql/local/catalog_custom_setup/fixture/vended_credentials_refresh.test
@@ -501,7 +501,7 @@ statement ok
 SET s3_uploader_max_filesize='50GB'
 
 statement ok
-SET max_threads=1
+SET threads=1
 
 statement ok
 CALL truncate_duckdb_logs()

--- a/test/sql/local/catalog_custom_setup/fixture/vended_credentials_refresh.test
+++ b/test/sql/local/catalog_custom_setup/fixture/vended_credentials_refresh.test
@@ -501,7 +501,7 @@ statement ok
 SET s3_uploader_max_filesize='50GB'
 
 statement ok
-SET s3_uploader_thread_limit=1
+SET max_threads=1
 
 statement ok
 CALL truncate_duckdb_logs()


### PR DESCRIPTION

Settings/catalog lookups now take `Identifier`: config constants 
Value::DefaultTryCastAs` returns `optional<Value>` 
`Value::Reinterpret` has been renamed to `WithType`.
duckdb #24834 made `MultiFileBindInternal` call `IsEmpty()` on every bind, before `Bind()` applies options or resolves metadata expansion warm-up in `GetExpandResult()` only happens if `have_bound` is true