### PR TITLE
Fixes around `DEFAULT_SCHEMA`

### DIFF
--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -63,6 +63,17 @@ optional_ptr<SchemaCatalogEntry> IcebergCatalog::LookupSchema(CatalogTransaction
 	// resolves an unqualified reference through GetDefaultSchema() before it gets here, so rewriting names
 	// would only make a namespace that is genuinely called 'main' unreachable.
 	auto &schema_name = schema_lookup.GetEntryName();
+	if (schema_name.empty()) {
+		// an empty name reaches us only because this catalog has no default namespace: duckdb asked
+		// GetDefaultSchema() for one and got nothing back
+		if (if_not_found == OnEntryNotFound::RETURN_NULL) {
+			return nullptr;
+		}
+		throw CatalogException(schema_lookup.GetErrorContext(),
+		                       "No default namespace for catalog \"%s\" - fully qualify the name, or re-attach "
+		                       "with DEFAULT_SCHEMA '<namespace>'",
+		                       GetName());
+	}
 	auto entry = schemas.GetEntry(transaction.GetContext(), schema_name, if_not_found);
 	if (!entry && if_not_found != OnEntryNotFound::RETURN_NULL) {
 		throw CatalogException(schema_lookup.GetErrorContext(), "Schema with name \"%s\" not found", schema_name);

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -59,14 +59,9 @@ void IcebergCatalog::ScanSchemas(ClientContext &context, std::function<void(Sche
 optional_ptr<SchemaCatalogEntry> IcebergCatalog::LookupSchema(CatalogTransaction transaction,
                                                               const EntryLookupInfo &schema_lookup,
                                                               OnEntryNotFound if_not_found) {
-	if (schema_lookup.GetEntryName() == DEFAULT_SCHEMA && default_schema != DEFAULT_SCHEMA) {
-		// throws error if default schema is empty
-		if (default_schema.empty() && if_not_found == OnEntryNotFound::RETURN_NULL) {
-			return nullptr;
-		}
-		return GetSchema(transaction, default_schema, if_not_found);
-	}
-
+	// Namespaces are looked up verbatim. The default namespace is not aliased to any other name: duckdb
+	// resolves an unqualified reference through GetDefaultSchema() before it gets here, so rewriting names
+	// would only make a namespace that is genuinely called 'main' unreachable.
 	auto &schema_name = schema_lookup.GetEntryName();
 	auto entry = schemas.GetEntry(transaction.GetContext(), schema_name, if_not_found);
 	if (!entry && if_not_found != OnEntryNotFound::RETURN_NULL) {

--- a/src/catalog/rest/iceberg_schema_set.cpp
+++ b/src/catalog/rest/iceberg_schema_set.cpp
@@ -58,24 +58,34 @@ optional_ptr<CatalogEntry> IcebergSchemaSet::GetEntry(ClientContext &context, co
 		throw CatalogException("Iceberg namespace by the name of '%s' does not exist", name);
 	}
 	if (entry == entries.end()) {
+		// we will not create entries with empty names - and an empty name is never worth a round trip
+		if (name.empty()) {
+			return nullptr;
+		}
 		CreateSchemaInfo info;
-		// Look up existence of default schema to avoid lookup of `duckdb_*` tables
-		if (name == DEFAULT_SCHEMA) {
+		// A name duckdb probes on its own - the catalog's default namespace, and the 'main' it falls back to
+		// in a search path - is verified rather than materialized optimistically: it is not necessarily a
+		// namespace the user asked for, and a phantom entry would send `duckdb_*` lookups to the server.
+		auto default_schema = ic_catalog.GetDefaultSchema();
+		auto lookup_name = Identifier(name);
+		if (lookup_name == default_schema || lookup_name == Identifier(DEFAULT_SCHEMA)) {
 			if (!IRCAPI::VerifySchemaExistence(context, ic_catalog, name)) {
 				if (if_not_found == OnEntryNotFound::RETURN_NULL) {
 					return nullptr;
 				}
-				throw CatalogException("default schema '%s' does not exist", name);
+				if (lookup_name == default_schema) {
+					throw CatalogException(
+					    "default namespace '%s' does not exist in this Iceberg catalog - create it, or attach "
+					    "with DEFAULT_SCHEMA '<namespace>'",
+					    name);
+				}
+				throw CatalogException("Iceberg namespace by the name of '%s' does not exist", name);
 			}
 		}
 		info.SetQualifiedName(
 		    QualifiedName(info.GetQualifiedName().Catalog(), Identifier(name), info.GetQualifiedName().Name()));
 		info.internal = false;
 		auto schema_entry = make_shared_ptr<IcebergSchemaEntry>(catalog, info);
-		// we will not create entries with empty names
-		if (name.empty()) {
-			return nullptr;
-		}
 		auto inserted_entry = CreateEntryInternal(std::move(schema_entry));
 		iceberg_transaction.schemas.emplace(name, inserted_entry);
 		return inserted_entry.get();

--- a/test/sql/local/catalog_custom_setup/fixture/main_namespace.test
+++ b/test/sql/local/catalog_custom_setup/fixture/main_namespace.test
@@ -1,6 +1,5 @@
 # name: test/sql/local/catalog_custom_setup/fixture/main_namespace.test
-# description: namespaces are resolved verbatim - 'main' is an ordinary namespace and is never
-#              an alias for the catalog's default namespace
+# description: namespaces are resolved verbatim - 'main' is an ordinary namespace and is never an alias for the catalog's default namespace
 # group: [fixture]
 
 require-env FIXTURE_SERVER_AVAILABLE

--- a/test/sql/local/catalog_custom_setup/fixture/main_namespace.test
+++ b/test/sql/local/catalog_custom_setup/fixture/main_namespace.test
@@ -1,0 +1,142 @@
+# name: test/sql/local/catalog_custom_setup/fixture/main_namespace.test
+# description: namespaces are resolved verbatim - 'main' is an ordinary namespace and is never
+#              an alias for the catalog's default namespace
+# group: [fixture]
+
+require-env FIXTURE_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+CREATE SECRET storage_secret(
+	TYPE S3,
+	KEY_ID 'admin',
+	SECRET 'password',
+	ENDPOINT '127.0.0.1:9000',
+	URL_STYLE 'path',
+	USE_SSL 0
+);
+
+statement ok
+CREATE SECRET iceberg_secret (
+	TYPE ICEBERG,
+	CLIENT_ID 'admin',
+	CLIENT_SECRET 'password',
+	URI 'http://127.0.0.1:8181'
+);
+
+# setup - fully qualified throughout, so no default namespace is needed yet
+statement ok
+ATTACH '' AS my_datalake (
+	TYPE ICEBERG,
+	SECRET iceberg_secret
+);
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS my_datalake.main;
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS my_datalake.bronze;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.main.T;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.bronze.T;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.bronze.T2;
+
+statement ok
+DETACH my_datalake;
+
+# attach with a default namespace that is neither 'main' nor 'default'
+statement ok
+ATTACH '' AS my_datalake (
+	TYPE ICEBERG,
+	SECRET iceberg_secret,
+	DEFAULT_SCHEMA 'bronze'
+);
+
+# before: neither name resolves to a table
+statement error
+SELECT * FROM my_datalake.bronze.T;
+----
+<REGEX>:.*does not exist.*
+
+statement error
+SELECT * FROM my_datalake.main.T;
+----
+<REGEX>:.*does not exist.*
+
+statement ok
+CREATE TABLE my_datalake.main.T AS SELECT 42;
+
+# after: the table is in 'main', as written
+query I
+SELECT * FROM my_datalake.main.T;
+----
+42
+
+# and ONLY there. Without the fix 'main' aliased to the catalog's default namespace, so both
+# names resolved to the same table and this query returned 42.
+statement error
+SELECT * FROM my_datalake.bronze.T;
+----
+<REGEX>:.*does not exist.*
+
+# an unqualified name still resolves to the default namespace
+statement ok
+CREATE TABLE my_datalake.T2 AS SELECT 43;
+
+query I
+SELECT * FROM my_datalake.bronze.T2;
+----
+43
+
+# 'main' can itself be the default namespace, still without any aliasing
+statement ok
+DETACH my_datalake;
+
+statement ok
+ATTACH '' AS my_datalake (
+	TYPE ICEBERG,
+	SECRET iceberg_secret,
+	DEFAULT_SCHEMA 'main'
+);
+
+# unqualified now resolves to 'main'
+query I
+SELECT * FROM my_datalake.T;
+----
+42
+
+# while 'bronze' is still reachable as an ordinary namespace
+query I
+SELECT * FROM my_datalake.bronze.T2;
+----
+43
+
+statement ok
+DROP TABLE my_datalake.main.T;
+
+statement ok
+DROP TABLE my_datalake.bronze.T2;
+
+statement ok
+DETACH my_datalake;
+
+statement ok
+DROP SECRET iceberg_secret;
+
+statement ok
+DROP SECRET storage_secret;

--- a/test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
+++ b/test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
@@ -1,6 +1,5 @@
 # name: test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
-# description: a catalog attached without DEFAULT_SCHEMA has no default namespace - qualified
-#              names still work, and an unqualified one says so
+# description: a catalog attached without DEFAULT_SCHEMA has no default namespace - qualified names still work, and an unqualified one says so
 # group: [fixture]
 
 require-env FIXTURE_SERVER_AVAILABLE

--- a/test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
+++ b/test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
@@ -1,0 +1,74 @@
+# name: test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
+# description: a catalog attached without DEFAULT_SCHEMA has no default namespace - qualified
+#              names still work, and an unqualified one says so
+# group: [fixture]
+
+require-env FIXTURE_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+CREATE SECRET storage_secret(
+	TYPE S3,
+	KEY_ID 'admin',
+	SECRET 'password',
+	ENDPOINT '127.0.0.1:9000',
+	URL_STYLE 'path',
+	USE_SSL 0
+);
+
+statement ok
+CREATE SECRET iceberg_secret (
+	TYPE ICEBERG,
+	CLIENT_ID 'admin',
+	CLIENT_SECRET 'password',
+	URI 'http://127.0.0.1:8181'
+);
+
+statement ok
+ATTACH '' AS my_datalake (
+	TYPE ICEBERG,
+	SECRET iceberg_secret
+);
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS my_datalake.bronze;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.bronze.T;
+
+# qualified names are unaffected
+statement ok
+CREATE TABLE my_datalake.bronze.T AS SELECT 42;
+
+query I
+SELECT * FROM my_datalake.bronze.T;
+----
+42
+
+# an unqualified name has no namespace to resolve to, and says which knob to reach for
+statement error
+CREATE TABLE my_datalake.T2 AS SELECT 43;
+----
+<REGEX>:.*No default namespace for catalog.*
+
+statement ok
+DROP TABLE my_datalake.bronze.T;
+
+statement ok
+DETACH my_datalake;
+
+statement ok
+DROP SECRET iceberg_secret;
+
+statement ok
+DROP SECRET storage_secret;


### PR DESCRIPTION
Fixes around `DEFAULT_SCHEMA`.

1. A bug around:
```sql
ATTACH '' AS db (TYPE ICEBERG, SECRET s, DEFAULT_SCHEMA 'bronze');
CREATE SCHEMA db.main;
CREATE TABLE db.main.T AS SELECT 42;
```
would currently land table T in schema `bronze` (like, in the actual catalog, not only in our views, making basically schema named `main` not at the same level of functionality.

2. Make:
```
ATTACH '' AS db (TYPE ICEBERG, SECRET s, DEFAULT_SCHEMA '');
```
viable, with `''` basically meaning "disable default schema behaviour, and don't validate it"

3. And improve error message around:
```sql
ATTACH '' AS db (TYPE ICEBERG, SECRET s);
CREATE TABLE db.T AS SELECT 42;
```
```
--- before
Catalog Error: Schema with name "" not found

--- after
Catalog Error: No default namespace for catalog "db" - fully qualify the name, or re-attach with DEFAULT_SCHEMA '<namespace>'
```