### PR TITLE
Add default_table_location_from_namespace attach option

### DIFF
--- a/src/catalog/rest/iceberg_table_set.cpp
+++ b/src/catalog/rest/iceberg_table_set.cpp
@@ -262,6 +262,15 @@ IcebergTable &IcebergTableSet::CreateNewEntry(ClientContext &context, IcebergCat
 		location = ParseTableProperty(property_binder, context, *location_it->second, "location", LogicalType::VARCHAR)
 		               .GetValue<string>();
 	}
+	if (location.empty() && catalog.attach_options.default_table_location_from_namespace) {
+		schema.LoadProperties(context);
+		auto ns_location_it = schema.schema_info.properties.find("location");
+		if (ns_location_it != schema.schema_info.properties.end() && !ns_location_it->second.empty()) {
+			location = ns_location_it->second;
+			StringUtil::RTrim(location, "/");
+			location += "/" + info.GetTableName().GetIdentifierName();
+		}
+	}
 
 	IcebergTableMetadata bootstrap_metadata;
 	bootstrap_metadata.iceberg_version = iceberg_version.GetIndex();

--- a/src/iceberg_attach.cpp
+++ b/src/iceberg_attach.cpp
@@ -246,6 +246,10 @@ unique_ptr<Catalog> IcebergAttach::Attach(optional_ptr<StorageExtensionInfo> sto
 		} else if (lower_name == "purge_requested") {
 			attach_options.purge_requested = entry.second.DefaultCastAs(LogicalType::BOOLEAN).GetValue<bool>();
 			set_by_attach_options.insert("purge_requested");
+		} else if (lower_name == "default_table_location_from_namespace") {
+			attach_options.default_table_location_from_namespace =
+			    entry.second.DefaultCastAs(LogicalType::BOOLEAN).GetValue<bool>();
+			set_by_attach_options.insert("default_table_location_from_namespace");
 		} else if (lower_name == "default_schema") {
 			default_schema = Identifier(entry.second.ToString());
 		} else if (lower_name == "encode_entire_prefix") {

--- a/src/include/iceberg_attach.hpp
+++ b/src/include/iceberg_attach.hpp
@@ -32,6 +32,9 @@ struct IcebergAttachOptions {
 	bool encode_entire_prefix = false;
 	// in rest api spec, purge requested defaults to false.
 	bool purge_requested = false;
+	// some catalogs (e.g. AWS Glue) do not assign a table location server-side; derive one from the namespace's
+	// 'location' property
+	bool default_table_location_from_namespace = false;
 	IRCAccessDelegationMode access_mode = IRCAccessDelegationMode::VENDED_CREDENTIALS;
 	IcebergAuthorizationType authorization_type = IcebergAuthorizationType::INVALID;
 	unordered_map<string, Value> options;

--- a/test/sql/local/catalog_test_config_setup/catalog_specifc/fixture/create/create_table_default_location_from_namespace.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_specifc/fixture/create/create_table_default_location_from_namespace.test
@@ -1,0 +1,96 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_specifc/fixture/create/create_table_default_location_from_namespace.test
+# description: derive a default table location from the namespace's 'location' property (issue #1299)
+# group: [create]
+
+require-env CATALOG_TEST_CONFIG_SETUP fixture
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# attach a second catalog with the option enabled; my_datalake (attached without it) keeps the default behavior
+statement ok
+ATTACH '' AS loc_datalake (
+    TYPE ICEBERG,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    URI 'http://127.0.0.1:8181',
+    default_table_location_from_namespace true
+);
+
+statement ok
+DROP TABLE IF EXISTS loc_datalake.loc_ns.tbl_derived;
+
+statement ok
+DROP TABLE IF EXISTS loc_datalake.loc_ns.tbl_explicit;
+
+statement ok
+DROP TABLE IF EXISTS loc_datalake.loc_ns.tbl_server_assigned;
+
+statement ok
+DROP SCHEMA IF EXISTS loc_datalake.loc_ns;
+
+statement ok
+CREATE SCHEMA loc_datalake.loc_ns;
+
+# point the namespace at a custom location (trailing slash on purpose: it must be trimmed before appending)
+statement ok
+CALL set_iceberg_schema_properties(loc_datalake.loc_ns, {'location': 's3://warehouse/custom_ns_location/'});
+
+query II
+FROM iceberg_schema_properties(loc_datalake.loc_ns) WHERE key = 'location';
+----
+location	s3://warehouse/custom_ns_location/
+
+# no explicit 'location': it must be derived as '<namespace location>/<table name>'
+statement ok
+CREATE TABLE loc_datalake.loc_ns.tbl_derived (a INTEGER);
+
+query I
+SELECT metadata."location" FROM iceberg_load_table_response(loc_datalake.loc_ns.tbl_derived);
+----
+s3://warehouse/custom_ns_location/tbl_derived
+
+# the derived location is usable for reads and writes
+statement ok
+INSERT INTO loc_datalake.loc_ns.tbl_derived VALUES (42);
+
+query I
+SELECT a FROM loc_datalake.loc_ns.tbl_derived;
+----
+42
+
+# an explicit 'location' still wins over the derived one
+statement ok
+CREATE TABLE loc_datalake.loc_ns.tbl_explicit (a INTEGER)
+WITH ('location' = 's3://warehouse/explicit_location/tbl_explicit');
+
+query I
+SELECT metadata."location" FROM iceberg_load_table_response(loc_datalake.loc_ns.tbl_explicit);
+----
+s3://warehouse/explicit_location/tbl_explicit
+
+# without the attach option the server keeps assigning the location, even when the namespace has a custom one
+statement ok
+CREATE TABLE my_datalake.loc_ns.tbl_server_assigned (a INTEGER);
+
+query I
+SELECT metadata."location" NOT LIKE 's3://warehouse/custom_ns_location/%' FROM iceberg_load_table_response(my_datalake.loc_ns.tbl_server_assigned);
+----
+true
+
+statement ok
+DROP TABLE loc_datalake.loc_ns.tbl_server_assigned;
+
+statement ok
+DROP TABLE loc_datalake.loc_ns.tbl_explicit;
+
+statement ok
+DROP TABLE loc_datalake.loc_ns.tbl_derived;
+
+statement ok
+DROP SCHEMA loc_datalake.loc_ns;


### PR DESCRIPTION
Fixes #1299

### Problem

AWS Glue's Iceberg REST endpoint does not assign a table location server-side. `CREATE TABLE` without an explicit `WITH ('location' = ...)` fails:

```
400 InvalidInputException: "Location information cannot be null while creating an iceberg table"
```

The `WITH ('location')` workaround (from #1128) is per-table, which tools like dbt-duckdb cannot inject.

### Solution

A new boolean attach option, `default_table_location_from_namespace` (default `false`). When enabled and `CREATE TABLE` has no explicit location, the client derives `<namespace location>/<table name>` from the namespace's `location` property (fetched via the existing `IcebergSchemaEntry::LoadProperties`, which caches the `GET /namespaces/{ns}` response). Trailing slashes are trimmed. If the namespace has no `location` property, behavior is unchanged.

The derivation rule matches the default behavior of Java's [`GlueCatalog.defaultWarehouseLocation`](https://github.com/apache/iceberg/blob/7f879b11366e17a676a03f15247a821751415529/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java#L287) (`dbLocationUri + "/" + tableName`). Java additionally supports a `unique-table-location` catalog property that appends a UUID suffix to the table name; it is off by default and is not implemented here.

Because this is a per-connection attach option rather than a per-table clause, tools that cannot emit `WITH ('location')` should be able to set it once when configuring the attachment (dbt-duckdb, for example, passes arbitrary attach options through to `ATTACH`), which should resolve the dbt use case from the issue.

### Why opt-in (not defaulted on for `ENDPOINT_TYPE 'glue'`)

Verified against a real Glue account (ap-northeast-1):

- Native Glue namespace **with** `locationUri`: `GET /namespaces/{ns}` returns a `location` property. Before: 400. After (option enabled): create succeeds at `<locationUri>/<table>`, and the table is readable/writable.
- Native Glue namespace **without** `locationUri`: no `location` property, so derivation is skipped and behavior is unchanged.
- **Glue-federated S3 Tables** (`<account>:s3tablescatalog/<bucket>`, the setup used by this repo's Glue cloud tests): `GET /namespaces/{ns}` returns only `ownerAccountId`/`createdBy` and no `location` property, so derivation is a no-op there and server-side assignment keeps working as today.

Other Glue federated catalog types (e.g. Redshift/RMS) are unverified, so the option is opt-in everywhere for now. Defaulting it on for `ENDPOINT_TYPE 'glue'` could be a follow-up once those are verified.

### Testing

New fixture test (placed under `catalog_specifc/fixture/` following the existing pattern of tests that need their own `ATTACH` with non-default options, like `test_polaris.test`): covers derivation including trailing-slash trimming, reads/writes through the derived location, explicit `WITH ('location')` still taking precedence, and no behavior change without the option. The fixture is discriminative here because the server side (JdbcCatalog) assigns locations from the warehouse root and ignores the namespace's `location` property.
