### PR TITLE
Accept bare scheme names as vended credential prefixes

### DIFF
--- a/src/catalog/rest/catalog_entry/table/iceberg_table.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table.cpp
@@ -241,14 +241,18 @@ IcebergTable::GetVendedCredentials(ClientContext &context,
 		create_secret_input.on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
 		create_secret_input.persist_type = SecretPersistType::TRANSACTION;
 
+		//! A bare scheme name would score below any secret scoped to the full "scheme://" prefix, so
+		//! widen it to that prefix: it stays the least specific credential, as in Java's S3FileIO
+		const string scope_prefix =
+		    StringUtil::Contains(credential.prefix, "://") ? credential.prefix : credential.prefix + "://";
 		if (ignore_credential_prefix) {
 			create_secret_input.scope.push_back(table_location);
 		} else {
-			create_secret_input.scope.push_back(credential.prefix);
+			create_secret_input.scope.push_back(scope_prefix);
 			//! Also match paths whose scheme differs from the credential prefix
 			//! (e.g. oss:// files with s3 credentials), equivalent to Java S3FileIO's
 			//! ROOT_PREFIX fallback in clientForStoragePath()
-			if (!StringUtil::StartsWith(table_location, credential.prefix)) {
+			if (!StringUtil::StartsWith(table_location, scope_prefix)) {
 				create_secret_input.scope.push_back(table_location);
 			}
 		}

--- a/src/include/catalog/rest/storage/authorization/sigv4_utils.hpp
+++ b/src/include/catalog/rest/storage/authorization/sigv4_utils.hpp
@@ -77,21 +77,27 @@ inline string DetectStorageType(const string &location) {
 	return "s3";
 }
 
+//! The scheme a credential prefix refers to. A prefix is a plain string matched against file paths,
+//! so catalogs write it either as a url ("s3://bucket/path") or as a bare scheme ("s3").
+inline string CredentialPrefixScheme(const string &credential_prefix) {
+	auto scheme_end = credential_prefix.find("://");
+	if (scheme_end == string::npos) {
+		return StringUtil::Lower(credential_prefix);
+	}
+	return StringUtil::Lower(credential_prefix.substr(0, scheme_end));
+}
+
 //! Check whether a credential prefix belongs to the given storage type.
 //! This handles the mismatch between friendly storage type names (e.g. "azure", "gcs")
 //! and actual URI scheme prefixes used in vended credentials (e.g. "abfs://", "gs://").
 inline bool CredentialMatchesStorageType(const string &credential_prefix, const string &storage_type) {
+	auto scheme = CredentialPrefixScheme(credential_prefix);
 	if (storage_type == "s3") {
-		return StringUtil::StartsWith(credential_prefix, "s3://") ||
-		       StringUtil::StartsWith(credential_prefix, "s3a://") ||
-		       StringUtil::StartsWith(credential_prefix, "s3n://");
+		return scheme == "s3" || scheme == "s3a" || scheme == "s3n";
 	} else if (storage_type == "gcs") {
-		return StringUtil::StartsWith(credential_prefix, "gs://") ||
-		       StringUtil::StartsWith(credential_prefix, "gcs://");
+		return scheme == "gs" || scheme == "gcs";
 	} else if (storage_type == "azure") {
-		return StringUtil::StartsWith(credential_prefix, "abfs://") ||
-		       StringUtil::StartsWith(credential_prefix, "abfss://") ||
-		       StringUtil::StartsWith(credential_prefix, "az://");
+		return scheme == "abfs" || scheme == "abfss" || scheme == "az";
 	}
 	// Unknown storage type — accept the credential to be safe
 	return StringUtil::StartsWith(credential_prefix, storage_type);


### PR DESCRIPTION
  ### Problem

  A storage credential's `prefix` is a plain string matched against file paths — the Java `S3FileIO` filters with `c.prefix().startsWith(ROOT_PREFIX)` — so catalogs write it either as a url (`s3://bucket/path`) or as a bare scheme name (`s3`). Both are legal, but the bare form breaks twice:

  1. `CredentialMatchesStorageType` only accepts the url form, so every credential from such a catalog is filtered out and reads fall back to long-term credentials. Against buckets that only accept the vended session credentials that fails with `403 AccessDenied`, after a successful `ATTACH` and table listing.
  2. Even if it survives the filter, the bare name is used as the secret scope, and `BaseSecret::MatchScore` scores by matched prefix length — scope `s3` (2) loses to any secret scoped `s3://` (5). The fallback that appends the table location does not fire, because `s3://bucket/path` does start with `s3`.

  This only bites when a catalog vends more than one credential; with exactly one, `ignore_credential_prefix` skips the filter.

  ### Fix

  Normalize a prefix to its scheme before comparing (url-form behaviour unchanged), and scope such credentials to the table location, as already happens for a single vended credential — a bare scheme says which storage the credential is for, not which paths it covers.