### PR TITLE
Fix UTC semantics for Iceberg TIMESTAMPTZ temporal transforms

### DIFF
--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -426,7 +426,18 @@ static unique_ptr<Expression> GetDateDiffFunction(ClientContext &context, const 
 	} else {
 		children.push_back(make_uniq<BoundConstantExpression>(Value::DATE(Date::FromDate(1970, 1, 1))));
 	}
-	children.push_back(CreateSourceColumnReference(context, copy_input, source_id));
+
+	auto source = CreateSourceColumnReference(context, copy_input, source_id);
+	auto source_type = source->GetReturnType().id();
+	auto target_type = source->GetReturnType();
+	if (source_type == LogicalTypeId::TIMESTAMP_TZ) {
+		target_type = LogicalType::TIMESTAMP;
+	}
+	if (source_type == LogicalTypeId::TIMESTAMP_TZ_NS) {
+		target_type = LogicalType::TIMESTAMP_NS;
+	}
+	source = BoundCastExpression::AddDefaultCastToType(std::move(source), target_type);
+	children.push_back(std::move(source));
 	return BindTransformFunction(context, "date_diff", std::move(children));
 }
 

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/temporal/test_timestamptz_utc.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/temporal/test_timestamptz_utc.test
@@ -1,0 +1,78 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/temporal/test_timestamptz_utc.test
+# description: TIMESTAMPTZ temporal partitions are derived from UTC instants, not the session time zone
+# group: [temporal]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+require icu
+
+statement ok
+create schema if not exists my_datalake.default;
+
+statement ok
+drop table if exists my_datalake.default.test_timestamptz_utc;
+
+statement ok
+CREATE TABLE my_datalake.default.test_timestamptz_utc (
+	id INT,
+	year_ts TIMESTAMPTZ,
+	month_ts TIMESTAMPTZ,
+	day_ts TIMESTAMPTZ,
+	hour_ts TIMESTAMPTZ
+)
+PARTITIONED BY (year(year_ts), month(month_ts), day(day_ts), hour(hour_ts));
+
+statement ok
+SET TimeZone = 'America/Los_Angeles';
+
+statement ok
+INSERT INTO my_datalake.default.test_timestamptz_utc
+SELECT id, ts, ts, ts, ts
+FROM (VALUES
+	(1, TIMESTAMPTZ '2024-12-31 23:30:00+00'),
+	(2, TIMESTAMPTZ '2025-01-01 00:30:00+00')
+) source(id, ts);
+
+query III
+SELECT partition_field_transform, lower_bound, upper_bound
+FROM iceberg_partition_stats('my_datalake.default.test_timestamptz_utc')
+ORDER BY partition_field_transform, partition_field_name;
+----
+day	20088	20089
+hour	482135	482136
+month	659	660
+year	54	55
+
+query I
+SELECT id
+FROM my_datalake.default.test_timestamptz_utc
+WHERE year_ts = TIMESTAMPTZ '2024-12-31 23:30:00+00'
+	AND month_ts = TIMESTAMPTZ '2024-12-31 23:30:00+00'
+	AND day_ts = TIMESTAMPTZ '2024-12-31 23:30:00+00'
+	AND hour_ts = TIMESTAMPTZ '2024-12-31 23:30:00+00';
+----
+1
+
+query I
+SELECT id
+FROM my_datalake.default.test_timestamptz_utc
+WHERE year_ts = TIMESTAMPTZ '2025-01-01 00:30:00+00'
+	AND month_ts = TIMESTAMPTZ '2025-01-01 00:30:00+00'
+	AND day_ts = TIMESTAMPTZ '2025-01-01 00:30:00+00'
+	AND hour_ts = TIMESTAMPTZ '2025-01-01 00:30:00+00';
+----
+2
+
+statement ok
+SET TimeZone = 'UTC';
+
+statement ok
+drop table my_datalake.default.test_timestamptz_utc;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/timestamptz_ns/test_partition_timestamptz_ns_temporal.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/timestamptz_ns/test_partition_timestamptz_ns_temporal.test
@@ -39,7 +39,8 @@ statement ok
 INSERT INTO my_datalake.default.test_timestamptz_ns_{transform}_transform VALUES
 	(1, '2020-01-15 09:30:00.123456789+01'::TIMESTAMPTZ_NS),
 	(2, '2021-06-20 16:45:00.987654321+02'::TIMESTAMPTZ_NS),
-	(3, '2022-03-10 23:15:00.000000001+01'::TIMESTAMPTZ_NS);
+	(3, '2022-03-10 23:15:00.000000001+01'::TIMESTAMPTZ_NS),
+	(4, '2024-12-31 23:30:00.123456789+00'::TIMESTAMPTZ_NS);
 
 # transform
 endloop
@@ -52,34 +53,35 @@ ORDER BY id;
 1	2020-01-15 09:30:00.123456789+01
 2	2021-06-20 16:45:00.987654321+02
 3	2022-03-10 23:15:00.000000001+01
+4	2025-01-01 00:30:00.123456789+01
 
 query IIII
 SELECT partition_field_name, partition_field_transform, lower_bound, upper_bound
 FROM iceberg_partition_stats(my_datalake.default.test_timestamptz_ns_year_transform)
 ORDER BY partition_field_name;
 ----
-year_val_2	year	50	52
+year_val_2	year	50	54
 
 query IIII
 SELECT partition_field_name, partition_field_transform, lower_bound, upper_bound
 FROM iceberg_partition_stats(my_datalake.default.test_timestamptz_ns_month_transform)
 ORDER BY partition_field_name;
 ----
-month_val_2	month	600	626
+month_val_2	month	600	659
 
 query IIII
 SELECT partition_field_name, partition_field_transform, lower_bound, upper_bound
 FROM iceberg_partition_stats(my_datalake.default.test_timestamptz_ns_day_transform)
 ORDER BY partition_field_name;
 ----
-day_val_2	day	18276	19061
+day_val_2	day	18276	20088
 
 query IIII
 SELECT partition_field_name, partition_field_transform, lower_bound, upper_bound
 FROM iceberg_partition_stats(my_datalake.default.test_timestamptz_ns_hour_transform)
 ORDER BY partition_field_name;
 ----
-hour_val_2	hour	438632	457486
+hour_val_2	hour	438632	482135
 
 foreach transform year month day hour
 
@@ -89,6 +91,13 @@ FROM my_datalake.default.test_timestamptz_ns_{transform}_transform
 WHERE val = '2021-06-20 16:45:00.987654321+02'::TIMESTAMPTZ_NS;
 ----
 2	2021-06-20 16:45:00.987654321+02
+
+query II
+SELECT id, val
+FROM my_datalake.default.test_timestamptz_ns_{transform}_transform
+WHERE val = '2024-12-31 23:30:00.123456789+00'::TIMESTAMPTZ_NS;
+----
+4	2025-01-01 00:30:00.123456789+01
 
 statement ok
 DROP TABLE my_datalake.default.test_timestamptz_ns_{transform}_transform;


### PR DESCRIPTION
Fix Iceberg temporal transforms for `TIMESTAMPTZ` and `TIMESTAMPTZ_NS` to use the encoded UTC instant during writes.

Previously, `date_diff` used ICU and the session time zone, while partition pruning used UTC epoch semantics. Reinterpreting zoned timestamps as their timezone-free physical equivalents keeps write and pruning values consistent.