### PR TITLE
fix: handle pre-epoch Iceberg month and day transforms

### DIFF
--- a/src/core/expression/iceberg_transform.cpp
+++ b/src/core/expression/iceberg_transform.cpp
@@ -245,12 +245,12 @@ string IcebergTransform::PartitionValueToString(const Value &partition_value) co
 	case IcebergTransformType::MONTH: {
 		int32_t m = partition_value.GetValue<int32_t>();
 		// Floor-divide to correctly handle months before 1970
-		int32_t year = 1970 + (m >= 0 ? m : m - 11) / 12;
+		int32_t year = Date::EPOCH_YEAR + (m >= 0 ? m : m - 11) / 12;
 		int32_t month = ((m % 12) + 12) % 12 + 1;
 		return StringUtil::Format("%04d-%02d", year, month);
 	}
 	case IcebergTransformType::YEAR: {
-		return std::to_string(1970 + partition_value.GetValue<int32_t>());
+		return std::to_string(Date::EPOCH_YEAR + partition_value.GetValue<int32_t>());
 	}
 	case IcebergTransformType::HOUR: {
 		int64_t hours = partition_value.GetValue<int32_t>();

--- a/src/execution/operator/iceberg_insert.cpp
+++ b/src/execution/operator/iceberg_insert.cpp
@@ -424,7 +424,7 @@ static unique_ptr<Expression> GetDateDiffFunction(ClientContext &context, const 
 	if (date_part == "hour") {
 		children.push_back(make_uniq<BoundConstantExpression>(Value::TIMESTAMP(Timestamp::FromEpochSeconds(0))));
 	} else {
-		children.push_back(make_uniq<BoundConstantExpression>(Value::DATE(Date::FromDate(1970, 1, 1))));
+		children.push_back(make_uniq<BoundConstantExpression>(Value::DATE(Date::FromDate(Date::EPOCH_YEAR, 1, 1))));
 	}
 	children.push_back(CreateSourceColumnReference(context, copy_input, source_id));
 	return BindTransformFunction(context, "date_diff", std::move(children));

--- a/src/include/core/expression/iceberg_transform.hpp
+++ b/src/include/core/expression/iceberg_transform.hpp
@@ -2,6 +2,7 @@
 
 #include "common/iceberg_math.hpp"
 #include "core/expression/iceberg_predicate_stats.hpp"
+#include "duckdb/common/types/date.hpp"
 #include "duckdb/common/types/interval.hpp"
 
 namespace duckdb {
@@ -107,31 +108,31 @@ struct YearTransform {
 		case LogicalTypeId::TIMESTAMP: {
 			auto val = constant.GetValue<timestamp_t>();
 			auto components = Timestamp::GetComponents(val);
-			return Value::INTEGER(components.year - 1970);
+			return Value::INTEGER(components.year - Date::EPOCH_YEAR);
 		}
 		case LogicalTypeId::TIMESTAMP_TZ: {
 			timestamp_t val(constant.GetValue<timestamp_tz_t>());
 			auto components = Timestamp::GetComponents(val);
-			return Value::INTEGER(components.year - 1970);
+			return Value::INTEGER(components.year - Date::EPOCH_YEAR);
 		}
 		case LogicalTypeId::TIMESTAMP_NS: {
 			auto val = constant.GetValue<timestamp_ns_t>();
 			auto micros = IcebergNanosToMicrosFloor(val.value);
 			auto components = Timestamp::GetComponents(timestamp_t(micros));
-			return Value::INTEGER(components.year - 1970);
+			return Value::INTEGER(components.year - Date::EPOCH_YEAR);
 		}
 		case LogicalTypeId::TIMESTAMP_TZ_NS: {
 			auto val = constant.GetValue<timestamp_tz_ns_t>();
 			auto micros = IcebergNanosToMicrosFloor(val.value);
 			auto components = Timestamp::GetComponents(timestamp_t(micros));
-			return Value::INTEGER(components.year - 1970);
+			return Value::INTEGER(components.year - Date::EPOCH_YEAR);
 		}
 		case LogicalTypeId::DATE: {
 			int32_t year;
 			int32_t month;
 			int32_t day;
 			Date::Convert(constant.GetValue<date_t>(), year, month, day);
-			return Value::INTEGER(year - 1970);
+			return Value::INTEGER(year - Date::EPOCH_YEAR);
 		}
 		default:
 			throw NotImplementedException("'year' transform for type %s", constant.type().ToString());
@@ -161,29 +162,29 @@ struct MonthTransform {
 		case LogicalTypeId::TIMESTAMP: {
 			auto val = constant.GetValue<timestamp_t>();
 			auto components = Timestamp::GetComponents(val);
-			return Value::INTEGER((components.year - 1970) * 12 + (components.month - 1));
+			return Value::INTEGER((components.year - Date::EPOCH_YEAR) * 12 + (components.month - 1));
 		}
 		case LogicalTypeId::TIMESTAMP_TZ: {
 			timestamp_t val(constant.GetValue<timestamp_tz_t>());
 			auto components = Timestamp::GetComponents(val);
-			return Value::INTEGER((components.year - 1970) * 12 + (components.month - 1));
+			return Value::INTEGER((components.year - Date::EPOCH_YEAR) * 12 + (components.month - 1));
 		}
 		case LogicalTypeId::TIMESTAMP_NS: {
 			auto val = constant.GetValue<timestamp_ns_t>();
 			auto micros = IcebergNanosToMicrosFloor(val.value);
 			auto components = Timestamp::GetComponents(timestamp_t(micros));
-			return Value::INTEGER((components.year - 1970) * 12 + (components.month - 1));
+			return Value::INTEGER((components.year - Date::EPOCH_YEAR) * 12 + (components.month - 1));
 		}
 		case LogicalTypeId::TIMESTAMP_TZ_NS: {
 			auto val = constant.GetValue<timestamp_tz_ns_t>();
 			auto micros = IcebergNanosToMicrosFloor(val.value);
 			auto components = Timestamp::GetComponents(timestamp_t(micros));
-			return Value::INTEGER((components.year - 1970) * 12 + (components.month - 1));
+			return Value::INTEGER((components.year - Date::EPOCH_YEAR) * 12 + (components.month - 1));
 		}
 		case LogicalTypeId::DATE: {
 			int32_t year, month, day;
 			Date::Convert(constant.GetValue<date_t>(), year, month, day);
-			return Value::INTEGER((year - 1970) * 12 + (month - 1));
+			return Value::INTEGER((year - Date::EPOCH_YEAR) * 12 + (month - 1));
 		}
 		default:
 			throw NotImplementedException("'month' transform for type %s", constant.type().ToString());

--- a/src/include/core/expression/iceberg_transform.hpp
+++ b/src/include/core/expression/iceberg_transform.hpp
@@ -160,25 +160,25 @@ struct MonthTransform {
 		switch (constant.type().id()) {
 		case LogicalTypeId::TIMESTAMP: {
 			auto val = constant.GetValue<timestamp_t>();
-			auto diff = Interval::GetAge(val, timestamp_t::epoch());
-			return Value::INTEGER(diff.months);
+			auto components = Timestamp::GetComponents(val);
+			return Value::INTEGER((components.year - 1970) * 12 + (components.month - 1));
 		}
 		case LogicalTypeId::TIMESTAMP_TZ: {
 			timestamp_t val(constant.GetValue<timestamp_tz_t>());
-			auto diff = Interval::GetAge(val, timestamp_t::epoch());
-			return Value::INTEGER(diff.months);
+			auto components = Timestamp::GetComponents(val);
+			return Value::INTEGER((components.year - 1970) * 12 + (components.month - 1));
 		}
 		case LogicalTypeId::TIMESTAMP_NS: {
 			auto val = constant.GetValue<timestamp_ns_t>();
-			auto ts = timestamp_t(IcebergNanosToMicrosFloor(val.value));
-			auto diff = Interval::GetAge(ts, timestamp_t::epoch());
-			return Value::INTEGER(diff.months);
+			auto micros = IcebergNanosToMicrosFloor(val.value);
+			auto components = Timestamp::GetComponents(timestamp_t(micros));
+			return Value::INTEGER((components.year - 1970) * 12 + (components.month - 1));
 		}
 		case LogicalTypeId::TIMESTAMP_TZ_NS: {
 			auto val = constant.GetValue<timestamp_tz_ns_t>();
-			auto ts = timestamp_t(IcebergNanosToMicrosFloor(val.value));
-			auto diff = Interval::GetAge(ts, timestamp_t::epoch());
-			return Value::INTEGER(diff.months);
+			auto micros = IcebergNanosToMicrosFloor(val.value);
+			auto components = Timestamp::GetComponents(timestamp_t(micros));
+			return Value::INTEGER((components.year - 1970) * 12 + (components.month - 1));
 		}
 		case LogicalTypeId::DATE: {
 			int32_t year, month, day;
@@ -212,25 +212,19 @@ struct DayTransform {
 		switch (constant.type().id()) {
 		case LogicalTypeId::TIMESTAMP: {
 			auto val = constant.GetValue<timestamp_t>();
-			auto diff = Interval::GetDifference(val, timestamp_t::epoch());
-			return Value::INTEGER(diff.days);
+			return Value::INTEGER(static_cast<int32_t>(IcebergFloorDiv(val.value, Interval::MICROS_PER_DAY)));
 		}
 		case LogicalTypeId::TIMESTAMP_TZ: {
-			timestamp_t val(constant.GetValue<timestamp_tz_t>());
-			auto diff = Interval::GetDifference(val, timestamp_t::epoch());
-			return Value::INTEGER(diff.days);
+			auto val = constant.GetValue<timestamp_tz_t>();
+			return Value::INTEGER(static_cast<int32_t>(IcebergFloorDiv(val.value, Interval::MICROS_PER_DAY)));
 		}
 		case LogicalTypeId::TIMESTAMP_NS: {
 			auto val = constant.GetValue<timestamp_ns_t>();
-			auto ts = timestamp_t(IcebergNanosToMicrosFloor(val.value));
-			auto diff = Interval::GetDifference(ts, timestamp_t::epoch());
-			return Value::INTEGER(diff.days);
+			return Value::INTEGER(static_cast<int32_t>(IcebergFloorDiv(val.value, Interval::NANOS_PER_DAY)));
 		}
 		case LogicalTypeId::TIMESTAMP_TZ_NS: {
 			auto val = constant.GetValue<timestamp_tz_ns_t>();
-			auto ts = timestamp_t(IcebergNanosToMicrosFloor(val.value));
-			auto diff = Interval::GetDifference(ts, timestamp_t::epoch());
-			return Value::INTEGER(diff.days);
+			return Value::INTEGER(static_cast<int32_t>(IcebergFloorDiv(val.value, Interval::NANOS_PER_DAY)));
 		}
 		case LogicalTypeId::DATE: {
 			auto val = constant.GetValue<date_t>();

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/temporal/test_timestamp_pre_epoch.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/temporal/test_timestamp_pre_epoch.test
@@ -1,0 +1,50 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/insert/partitions/temporal/test_timestamp_pre_epoch.test
+# description: Month and day pruning use floor semantics for timestamps before the Unix epoch
+# group: [temporal]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+statement ok
+create schema if not exists my_datalake.default;
+
+statement ok
+drop table if exists my_datalake.default.test_timestamp_pre_epoch;
+
+statement ok
+CREATE TABLE my_datalake.default.test_timestamp_pre_epoch (id INT, month_ts TIMESTAMP, day_ts TIMESTAMP)
+PARTITIONED BY (month(month_ts), day(day_ts));
+
+statement ok
+INSERT INTO my_datalake.default.test_timestamp_pre_epoch
+SELECT id, ts, ts
+FROM (VALUES
+	(1, TIMESTAMP '1969-12-31 23:59:59.999999'),
+	(2, TIMESTAMP '1970-01-01 00:00:00')
+) source(id, ts);
+
+query III
+SELECT partition_field_transform, lower_bound, upper_bound
+FROM iceberg_partition_stats('my_datalake.default.test_timestamp_pre_epoch')
+ORDER BY partition_field_transform;
+----
+day	-1	0
+month	-1	0
+
+query I
+SELECT id
+FROM my_datalake.default.test_timestamp_pre_epoch
+WHERE month_ts = TIMESTAMP '1969-12-31 23:59:59.999999'
+	AND day_ts = TIMESTAMP '1969-12-31 23:59:59.999999';
+----
+1
+
+statement ok
+drop table my_datalake.default.test_timestamp_pre_epoch;


### PR DESCRIPTION
Fix Iceberg month and day transforms for timestamps before the Unix epoch.

Month now follows the existing year transform by using calendar components, while day follows the existing hour transform by using floor division. This ensures correct partition pruning for negative timestamps.