### PR TITLE
fix(credentials): Load vended credentials manually when LoadTable omits them

### DIFF
--- a/scripts/data_generators/tests/default/vended_credentials_refresh_tables/__init__.py
+++ b/scripts/data_generators/tests/default/vended_credentials_refresh_tables/__init__.py
@@ -54,6 +54,23 @@ class Test(IcebergTest):
             """
         )
 
+        con.con.sql(
+            """
+            CREATE OR REPLACE TABLE default.vended_rewrite_table (
+                id integer,
+                payload string
+            )
+            USING iceberg
+            """
+        )
+        for i in range(1, 7):
+            con.con.sql(
+                f"""
+                INSERT INTO default.vended_rewrite_table
+                VALUES ({i}, 'p{i}')
+                """
+            )
+
         for table in REFRESH_METADATA_TABLES:
             con.con.sql(
                 f"""

--- a/scripts/vended_credentials_refresh_proxy.py
+++ b/scripts/vended_credentials_refresh_proxy.py
@@ -46,6 +46,7 @@ MIXED_REFRESH_A_TABLE = "vended_mixed_delete_refresh_a"
 MIXED_REFRESH_B_TABLE = "vended_mixed_delete_refresh_b"
 SAME_BAD_TABLE = "vended_same_bad_refresh"
 RANGE_FAIL_TABLE = "vended_range_fail_refresh"
+REWRITE_TABLE = "vended_rewrite_table"
 
 OLD_SCAN_KEY = "OLD_SCAN_KEY"
 NEW_SCAN_KEY = "NEW_SCAN_KEY"
@@ -78,6 +79,7 @@ NEW_MIXED_REFRESH_B_KEY = "NEW_MIXED_REFRESH_B_KEY"
 OLD_SAME_BAD_KEY = "OLD_SAME_BAD_KEY"
 OLD_RANGE_FAIL_KEY = "OLD_RANGE_FAIL_KEY"
 NEW_RANGE_FAIL_KEY = "NEW_RANGE_FAIL_KEY"
+REWRITE_TABLE_KEY = "REWRITE_TABLE_KEY"
 
 UPSTREAM_S3_KEY = "admin"
 UPSTREAM_S3_SECRET = "password"
@@ -120,6 +122,7 @@ class VendedCredentialRefreshAddon:
             MIXED_REFRESH_B_TABLE: False,
             SAME_BAD_TABLE: False,
             RANGE_FAIL_TABLE: False,
+            REWRITE_TABLE: False,
         }
         self.table_scan_refresh_path = None
         # Force a rollback if this branch reaches the catalog commit after writing the
@@ -134,11 +137,42 @@ class VendedCredentialRefreshAddon:
             self._handle_s3_request(flow)
 
     def response(self, flow: http.HTTPFlow):
+        if not flow.response or flow.response.status_code >= 300:
+            return
+
+        if self._is_catalog_request(flow):
+            path = urllib.parse.urlparse(flow.request.path).path
+            if path == "/v1/config" or path.startswith("/v1/config"):
+                payload = json.loads(flow.response.content.decode())
+                endpoints = payload.setdefault("endpoints", [])
+                credentials_endpoint = (
+                    "GET /v1/{prefix}/namespaces/{namespace}/tables/{table}/credentials"
+                )
+                if credentials_endpoint not in endpoints:
+                    endpoints.append(credentials_endpoint)
+                flow.response.text = json.dumps(payload)
+                return
+
         table = flow.metadata.get("vended_table")
-        if not table or not flow.response or flow.response.status_code >= 300:
+        if not table:
             return
 
         response = json.loads(flow.response.content.decode())
+        if table == REWRITE_TABLE:
+            # Model R2-style catalogs: LoadTable omits usable storage credentials;
+            # the client must fetch GET .../credentials before touching object storage.
+            response.pop("storage-credentials", None)
+            config = response.get("config")
+            if isinstance(config, dict):
+                for key in list(config):
+                    lowered = key.lower()
+                    if lowered.startswith("s3.access-key") or lowered.startswith("s3.secret") or lowered.startswith(
+                        "s3.session-token"
+                    ):
+                        del config[key]
+            flow.response.text = json.dumps(response)
+            return
+
         response["storage-credentials"] = [self._credentials_for_table(table)]
         flow.response.text = json.dumps(response)
 
@@ -314,6 +348,7 @@ class VendedCredentialRefreshAddon:
             NEW_MIXED_REFRESH_A_KEY,
             NEW_MIXED_REFRESH_B_KEY,
             OLD_RANGE_FAIL_KEY,
+            REWRITE_TABLE_KEY,
         }:
             self._forbidden(flow, "unknown test credentials")
             return
@@ -445,6 +480,8 @@ class VendedCredentialRefreshAddon:
             return OLD_SAME_BAD_KEY
         if table == RANGE_FAIL_TABLE:
             return NEW_RANGE_FAIL_KEY if self.refresh_unlocked[table] else OLD_RANGE_FAIL_KEY
+        if table == REWRITE_TABLE:
+            return REWRITE_TABLE_KEY
         raise ValueError(f"unexpected table: {table}")
 
     @staticmethod
@@ -479,6 +516,8 @@ class VendedCredentialRefreshAddon:
             return "s3://warehouse/vended_credentials_refresh/same_bad"
         if table == RANGE_FAIL_TABLE:
             return "s3://warehouse/vended_credentials_refresh/range_fail"
+        if table == REWRITE_TABLE:
+            return "s3://warehouse/"
         raise ValueError(f"unexpected table: {table}")
 
     @staticmethod

--- a/src/catalog/rest/catalog_entry/table/iceberg_table.cpp
+++ b/src/catalog/rest/catalog_entry/table/iceberg_table.cpp
@@ -1,6 +1,7 @@
 #include "catalog/rest/catalog_entry/table/iceberg_table.hpp"
 
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/exception/http_exception.hpp"
@@ -512,12 +513,43 @@ static void AddHTTPSecretsToOptions(SecretEntry &http_secret_entry, case_insensi
 	                            : http_kv_secret.TryGetValue("verify_ssl").DefaultCastAs(LogicalType::BOOLEAN);
 }
 
+static bool CreateSecretInputHasStorageAuth(const CreateSecretInput &info) {
+	auto has_option = [&](const char *key) {
+		return info.options.find(key) != info.options.end();
+	};
+	return has_option("key_id") || has_option("secret") || has_option("token") || has_option("account_name") ||
+	       has_option("connection_string") || has_option("bearer_token");
+}
+
+static bool HasUsableStorageAuthentication(const IRCAPITableCredentials &table_credentials) {
+	//! LoadTable storage-credentials take precedence even when individual entries lack keys.
+	if (!table_credentials.storage_credentials.empty()) {
+		return true;
+	}
+	if (table_credentials.config) {
+		return CreateSecretInputHasStorageAuth(*table_credentials.config);
+	}
+	return false;
+}
+
 void IcebergTable::LoadCredentials(ClientContext &context) const {
 	if (catalog.attach_options.access_mode != IRCAccessDelegationMode::VENDED_CREDENTIALS) {
 		// assume secret already exists
 		return;
 	}
-	LoadCredentials(context, GetVendedCredentials(context));
+	auto table_credentials = GetVendedCredentials(context);
+	if (!HasUsableStorageAuthentication(table_credentials) &&
+	    catalog.supported_urls.count(IRCAPI::CREDENTIALS_ENDPOINT)) {
+		auto api_result = IRCAPI::GetTableCredentials(context, catalog, schema, name);
+		if (api_result.error_) {
+			throw HTTPException(StringUtil::Format(
+			    "Could not load Iceberg vended credentials for table '%s': GetTableCredentials returned "
+			    "response code %s with message \"%s\"",
+			    name, EnumUtil::ToString(api_result.status_), api_result.error_->_error.message));
+		}
+		table_credentials = GetVendedCredentials(context, api_result.result_->storage_credentials);
+	}
+	LoadCredentials(context, std::move(table_credentials));
 }
 
 void IcebergTable::LoadCredentials(ClientContext &context, IRCAPITableCredentials table_credentials) const {

--- a/src/include/catalog/rest/api/catalog_api.hpp
+++ b/src/include/catalog/rest/api/catalog_api.hpp
@@ -66,6 +66,8 @@ public:
 class IRCAPI {
 public:
 	static const string API_VERSION_1;
+	static constexpr const char *CREDENTIALS_ENDPOINT =
+	    "GET /v1/{prefix}/namespaces/{namespace}/tables/{table}/credentials";
 	//! Returns 'nullopt' if the catalog refused the listing, which must not be read as "the schema is empty".
 	static optional<vector<rest_api_objects::TableIdentifier>>
 	GetTables(ClientContext &context, IcebergCatalog &catalog, const IcebergSchemaEntry &schema);

--- a/src/include/catalog/rest/api/iceberg_scan_planning.hpp
+++ b/src/include/catalog/rest/api/iceberg_scan_planning.hpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/unordered_map.hpp"
 
+#include "catalog/rest/api/catalog_api.hpp"
 #include "core/metadata/manifest/iceberg_manifest_list.hpp"
 #include "rest_catalog/objects/plan_table_scan_request.hpp"
 #include "rest_catalog/objects/storage_credential.hpp"
@@ -30,8 +31,7 @@ public:
 	static constexpr const char *CANCEL_ENDPOINT =
 	    "DELETE /v1/{prefix}/namespaces/{namespace}/tables/{table}/plan/{plan-id}";
 	static constexpr const char *TASKS_ENDPOINT = "POST /v1/{prefix}/namespaces/{namespace}/tables/{table}/tasks";
-	static constexpr const char *CREDENTIALS_ENDPOINT =
-	    "GET /v1/{prefix}/namespaces/{namespace}/tables/{table}/credentials";
+	static constexpr const char *CREDENTIALS_ENDPOINT = IRCAPI::CREDENTIALS_ENDPOINT;
 
 	//! Returns false only when the server explicitly declines planning with HTTP 406.
 	static bool Plan(ClientContext &context, IcebergTable &table_info, rest_api_objects::PlanTableScanRequest request,

--- a/test/sql/local/catalog_custom_setup/fixture/vended_credentials_refresh.test
+++ b/test/sql/local/catalog_custom_setup/fixture/vended_credentials_refresh.test
@@ -1,5 +1,5 @@
 # name: test/sql/local/catalog_custom_setup/fixture/vended_credentials_refresh.test
-# description: vended Iceberg storage credentials refresh on S3 auth failures, including ranged reads
+# description: vended Iceberg storage credentials refresh on S3 auth failures, including ranged reads and rewrite compaction without a priming scan
 # group: [fixture]
 
 require-env FIXTURE_SERVER_AVAILABLE
@@ -1036,6 +1036,38 @@ WHERE starts_with(request.url, 'http://127.0.0.1:9000/')
   AND request.headers['Authorization'] LIKE '%NEW_RANGE_FAIL_KEY%'
   AND request.headers['Range'] IS NOT NULL
   AND response.status IS NULL
+----
+1
+
+# Rewrite must load storage credentials from GET .../credentials when LoadTable
+# omits them. Do not scan or call iceberg_metadata on this table first.
+statement ok
+CALL truncate_duckdb_logs()
+
+query III
+CALL iceberg_rewrite_data_files('vended_refresh.default.vended_rewrite_table')
+----
+6	1	<REGEX>:[1-9][0-9]*
+
+query I
+SELECT count(*) FROM vended_refresh.default.vended_rewrite_table
+----
+6
+
+query I
+SELECT count(*) >= 1
+FROM duckdb_logs_parsed('HTTP')
+WHERE request.url = 'http://127.0.0.1:8181/v1/namespaces/default/tables/vended_rewrite_table/credentials'
+  AND response.status = 'OK_200'
+----
+1
+
+query I
+SELECT count(*) > 0
+FROM duckdb_logs_parsed('HTTP')
+WHERE starts_with(request.url, 'http://127.0.0.1:9000/')
+  AND request.headers['Authorization'] LIKE '%REWRITE_TABLE_KEY%'
+  AND response.status IN ('OK_200', 'PartialContent_206')
 ----
 1
 

--- a/test/sql/local/catalog_custom_setup/nessie/test_nessie.test
+++ b/test/sql/local/catalog_custom_setup/nessie/test_nessie.test
@@ -122,23 +122,17 @@ attach '' as my_datalake (
 );
 
 statement ok
-call enable_logging();
-
-statement ok
 create schema if not exists my_datalake.new_schema;
 
 statement ok
 drop table if exists my_datalake.new_schema.table_1;
 
+# Nessie LoadTable omits usable storage keys, so credentials are fetched from
+# GET .../tables/{table}/credentials. The table does not exist yet during CREATE.
 statement error
 create table my_datalake.new_schema.table_1 as select range a from range(100);
 ----
-<REGEX>:.*HTTP Error:.*uploading to.*403 Forbidden.*
-
-query I
-select message from duckdb_logs() where message like '%Failed%';
-----
-Failed to create valid secret from Vended Credentials for table 'table_1'
+<REGEX>:.*HTTP Error:.*Could not load Iceberg vended credentials for table 'table_1': GetTableCredentials returned response code NotFound_404 with message "Table does not exist: new_schema.table_1".*
 
 statement ok
 SET httpfs_enable_credential_refresh=true;


### PR DESCRIPTION
## Summary
- Fixes `iceberg_rewrite_data_files` failing in a catalog-only session when LoadTable does not include usable storage credentials. This matches the [Cloudflare R2 report](https://github.com/duckdb/duckdb-iceberg/issues/1349#issuecomment-5423023604): compaction returned HTTP 403 / "No credentials are provided" until a prior `iceberg_metadata` read primed the session.
- `IcebergTable::LoadCredentials` now falls back to the advertised `GET /v1/{prefix}/namespaces/{namespace}/tables/{table}/credentials` endpoint when LoadTable `storage-credentials` / `config` do not contain usable storage authentication. LoadTable credentials still take precedence.
- Not sure if there is a cleaner solution
- Feedback requested

Fixes #1349

