### PR TITLE
No longer check if schema is Default Schema.

### DIFF
--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -8,7 +8,6 @@
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/planner/operator/logical_create_table.hpp"
 #include "duckdb/common/exception/conversion_exception.hpp"
-#include "duckdb/common/string_util.hpp"
 
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
@@ -57,20 +56,6 @@ void IcebergCatalog::ScanSchemas(ClientContext &context, std::function<void(Sche
 	schemas.Scan(context, [&](CatalogEntry &schema) { callback(schema.Cast<IcebergSchemaEntry>()); });
 }
 
-//! An unqualified name in a catalog without a default namespace can never resolve. Say that - and how to fix it -
-//! rather than letting duckdb report a bare "does not exist".
-string IcebergCatalog::NoDefaultNamespaceMessage(const string &entry_name) const {
-	auto &catalog_name = GetName().GetIdentifierName();
-	string message = StringUtil::Format("No default namespace for catalog \"%s\"", catalog_name);
-	if (entry_name.empty()) {
-		message += " - qualify the name with a namespace";
-	} else {
-		message += StringUtil::Format(" - cannot resolve \"%s\", qualify it as \"%s.<namespace>.%s\"", entry_name,
-		                              catalog_name, entry_name);
-	}
-	return message + ", or re-attach the catalog with DEFAULT_SCHEMA '<namespace>'";
-}
-
 optional_ptr<SchemaCatalogEntry> IcebergCatalog::LookupSchema(CatalogTransaction transaction,
                                                               const EntryLookupInfo &schema_lookup,
                                                               OnEntryNotFound if_not_found) {
@@ -78,46 +63,12 @@ optional_ptr<SchemaCatalogEntry> IcebergCatalog::LookupSchema(CatalogTransaction
 	// resolves an unqualified reference through GetDefaultSchema() before it gets here, so rewriting names
 	// would only make a namespace that is genuinely called 'main' unreachable.
 	auto &schema_name = schema_lookup.GetEntryName();
-	if (schema_name.empty()) {
-		// an empty name reaches us only because this catalog has no default namespace: duckdb asked
-		// GetDefaultSchema() for one and got nothing back
-		if (if_not_found == OnEntryNotFound::RETURN_NULL) {
-			return nullptr;
-		}
-		throw CatalogException(schema_lookup.GetErrorContext(), "%s", NoDefaultNamespaceMessage(string()));
-	}
 	auto entry = schemas.GetEntry(transaction.GetContext(), schema_name, if_not_found);
 	if (!entry && if_not_found != OnEntryNotFound::RETURN_NULL) {
 		throw CatalogException(schema_lookup.GetErrorContext(), "Schema with name \"%s\" not found", schema_name);
 	}
 
 	return reinterpret_cast<SchemaCatalogEntry *>(entry.get());
-}
-
-CatalogEntryLookup IcebergCatalog::TryLookupEntryInternal(CatalogTransaction transaction,
-                                                          const EntryLookupInfo &lookup_info) {
-	// mirrors Catalog::TryLookupEntryInternal (which is private, so it cannot be delegated to): the schema
-	// qualification is everything up to the entry name, and LookupSchema resolves it
-	auto &full_path = lookup_info.GetQualifiedName().Path();
-	vector<Identifier> schema_path(full_path.begin(), full_path.end() - 1);
-	auto schema_lookup = EntryLookupInfo::SchemaLookup(lookup_info, std::move(schema_path));
-	auto schema_entry = LookupSchema(transaction, schema_lookup, OnEntryNotFound::RETURN_NULL);
-	if (!schema_entry) {
-		if (schema_lookup.GetEntryName().empty() && lookup_info.GetCatalogType() == CatalogType::TABLE_ENTRY) {
-			// no namespace was given and this catalog has no default schema. Report that as an error the caller can
-			// surface: duckdb throws it only if every catalog it tried failed for a reason of its own, so a name
-			// that another catalog in the search path does resolve is unaffected.
-			return {nullptr, nullptr,
-			        ErrorData(CatalogException(lookup_info.GetErrorContext(), "%s",
-			                                   NoDefaultNamespaceMessage(lookup_info.GetEntryName())))};
-		}
-		return {nullptr, nullptr, ErrorData()};
-	}
-	auto entry = schema_entry->LookupEntry(transaction, lookup_info);
-	if (!entry) {
-		return {schema_entry, nullptr, ErrorData()};
-	}
-	return {schema_entry, entry, ErrorData()};
 }
 
 optional_ptr<CatalogEntry> IcebergCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/planner/operator/logical_create_table.hpp"
 #include "duckdb/common/exception/conversion_exception.hpp"
+#include "duckdb/common/string_util.hpp"
 
 #include "catalog/rest/catalog_entry/schema/iceberg_schema_entry.hpp"
 #include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
@@ -56,6 +57,20 @@ void IcebergCatalog::ScanSchemas(ClientContext &context, std::function<void(Sche
 	schemas.Scan(context, [&](CatalogEntry &schema) { callback(schema.Cast<IcebergSchemaEntry>()); });
 }
 
+//! An unqualified name in a catalog without a default namespace can never resolve. Say that - and how to fix it -
+//! rather than letting duckdb report a bare "does not exist".
+string IcebergCatalog::NoDefaultNamespaceMessage(const string &entry_name) const {
+	auto &catalog_name = GetName().GetIdentifierName();
+	string message = StringUtil::Format("No default namespace for catalog \"%s\"", catalog_name);
+	if (entry_name.empty()) {
+		message += " - qualify the name with a namespace";
+	} else {
+		message += StringUtil::Format(" - cannot resolve \"%s\", qualify it as \"%s.<namespace>.%s\"", entry_name,
+		                              catalog_name, entry_name);
+	}
+	return message + ", or re-attach the catalog with DEFAULT_SCHEMA '<namespace>'";
+}
+
 optional_ptr<SchemaCatalogEntry> IcebergCatalog::LookupSchema(CatalogTransaction transaction,
                                                               const EntryLookupInfo &schema_lookup,
                                                               OnEntryNotFound if_not_found) {
@@ -69,10 +84,7 @@ optional_ptr<SchemaCatalogEntry> IcebergCatalog::LookupSchema(CatalogTransaction
 		if (if_not_found == OnEntryNotFound::RETURN_NULL) {
 			return nullptr;
 		}
-		throw CatalogException(schema_lookup.GetErrorContext(),
-		                       "No default namespace for catalog \"%s\" - fully qualify the name, or re-attach "
-		                       "with DEFAULT_SCHEMA '<namespace>'",
-		                       GetName());
+		throw CatalogException(schema_lookup.GetErrorContext(), "%s", NoDefaultNamespaceMessage(string()));
 	}
 	auto entry = schemas.GetEntry(transaction.GetContext(), schema_name, if_not_found);
 	if (!entry && if_not_found != OnEntryNotFound::RETURN_NULL) {
@@ -80,6 +92,32 @@ optional_ptr<SchemaCatalogEntry> IcebergCatalog::LookupSchema(CatalogTransaction
 	}
 
 	return reinterpret_cast<SchemaCatalogEntry *>(entry.get());
+}
+
+CatalogEntryLookup IcebergCatalog::TryLookupEntryInternal(CatalogTransaction transaction,
+                                                          const EntryLookupInfo &lookup_info) {
+	// mirrors Catalog::TryLookupEntryInternal (which is private, so it cannot be delegated to): the schema
+	// qualification is everything up to the entry name, and LookupSchema resolves it
+	auto &full_path = lookup_info.GetQualifiedName().Path();
+	vector<Identifier> schema_path(full_path.begin(), full_path.end() - 1);
+	auto schema_lookup = EntryLookupInfo::SchemaLookup(lookup_info, std::move(schema_path));
+	auto schema_entry = LookupSchema(transaction, schema_lookup, OnEntryNotFound::RETURN_NULL);
+	if (!schema_entry) {
+		if (schema_lookup.GetEntryName().empty() && lookup_info.GetCatalogType() == CatalogType::TABLE_ENTRY) {
+			// no namespace was given and this catalog has no default schema. Report that as an error the caller can
+			// surface: duckdb throws it only if every catalog it tried failed for a reason of its own, so a name
+			// that another catalog in the search path does resolve is unaffected.
+			return {nullptr, nullptr,
+			        ErrorData(CatalogException(lookup_info.GetErrorContext(), "%s",
+			                                   NoDefaultNamespaceMessage(lookup_info.GetEntryName())))};
+		}
+		return {nullptr, nullptr, ErrorData()};
+	}
+	auto entry = schema_entry->LookupEntry(transaction, lookup_info);
+	if (!entry) {
+		return {schema_entry, nullptr, ErrorData()};
+	}
+	return {schema_entry, entry, ErrorData()};
 }
 
 optional_ptr<CatalogEntry> IcebergCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -63,6 +63,17 @@ optional_ptr<SchemaCatalogEntry> IcebergCatalog::LookupSchema(CatalogTransaction
 	// resolves an unqualified reference through GetDefaultSchema() before it gets here, so rewriting names
 	// would only make a namespace that is genuinely called 'main' unreachable.
 	auto &schema_name = schema_lookup.GetEntryName();
+	if (schema_name.empty()) {
+		// an empty name reaches us only because this catalog has no default namespace: duckdb asked
+		// GetDefaultSchema() for one and got nothing back
+		if (if_not_found == OnEntryNotFound::RETURN_NULL) {
+			return nullptr;
+		}
+		throw CatalogException(schema_lookup.GetErrorContext(),
+		                       "No default namespace for catalog \"%s\" - fully qualify the name, or re-attach "
+		                       "with DEFAULT_SCHEMA '<namespace>'",
+		                       GetName());
+	}
 	auto entry = schemas.GetEntry(transaction.GetContext(), schema_name, if_not_found);
 	if (!entry && if_not_found != OnEntryNotFound::RETURN_NULL) {
 		throw CatalogException(schema_lookup.GetErrorContext(), "Schema with name \"%s\" not found", schema_name);

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -68,6 +68,13 @@ optional_ptr<SchemaCatalogEntry> IcebergCatalog::LookupSchema(CatalogTransaction
 	return reinterpret_cast<SchemaCatalogEntry *>(entry.get());
 }
 
+optional<Identifier> IcebergCatalog::GetDefaultSchema() const {
+	if (default_schema.empty()) {
+		return nullopt;
+	}
+	return default_schema;
+}
+
 optional_ptr<CatalogEntry> IcebergCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
 	optional_ptr<ClientContext> context = transaction.GetContext();
 	if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -59,14 +59,9 @@ void IcebergCatalog::ScanSchemas(ClientContext &context, std::function<void(Sche
 optional_ptr<SchemaCatalogEntry> IcebergCatalog::LookupSchema(CatalogTransaction transaction,
                                                               const EntryLookupInfo &schema_lookup,
                                                               OnEntryNotFound if_not_found) {
-	if (schema_lookup.GetEntryName() == DEFAULT_SCHEMA && default_schema != DEFAULT_SCHEMA) {
-		// throws error if default schema is empty
-		if (default_schema.empty() && if_not_found == OnEntryNotFound::RETURN_NULL) {
-			return nullptr;
-		}
-		return GetSchema(transaction, default_schema, if_not_found);
-	}
-
+	// Namespaces are looked up verbatim. The default namespace is not aliased to any other name: duckdb
+	// resolves an unqualified reference through GetDefaultSchema() before it gets here, so rewriting names
+	// would only make a namespace that is genuinely called 'main' unreachable.
 	auto &schema_name = schema_lookup.GetEntryName();
 	auto entry = schemas.GetEntry(transaction.GetContext(), schema_name, if_not_found);
 	if (!entry && if_not_found != OnEntryNotFound::RETURN_NULL) {

--- a/src/catalog/rest/iceberg_catalog.cpp
+++ b/src/catalog/rest/iceberg_catalog.cpp
@@ -59,9 +59,6 @@ void IcebergCatalog::ScanSchemas(ClientContext &context, std::function<void(Sche
 optional_ptr<SchemaCatalogEntry> IcebergCatalog::LookupSchema(CatalogTransaction transaction,
                                                               const EntryLookupInfo &schema_lookup,
                                                               OnEntryNotFound if_not_found) {
-	// Namespaces are looked up verbatim. The default namespace is not aliased to any other name: duckdb
-	// resolves an unqualified reference through GetDefaultSchema() before it gets here, so rewriting names
-	// would only make a namespace that is genuinely called 'main' unreachable.
 	auto &schema_name = schema_lookup.GetEntryName();
 	auto entry = schemas.GetEntry(transaction.GetContext(), schema_name, if_not_found);
 	if (!entry && if_not_found != OnEntryNotFound::RETURN_NULL) {

--- a/src/catalog/rest/iceberg_schema_set.cpp
+++ b/src/catalog/rest/iceberg_schema_set.cpp
@@ -66,6 +66,7 @@ optional_ptr<CatalogEntry> IcebergSchemaSet::GetEntry(ClientContext &context, co
 		auto default_schema = ic_catalog.GetDefaultSchema();
 		auto lookup_name = Identifier(name);
 		if (lookup_name == default_schema) {
+			// Verify the default schema does exist
 			if (!IRCAPI::VerifySchemaExistence(context, ic_catalog, name)) {
 				if (if_not_found == OnEntryNotFound::RETURN_NULL) {
 					return nullptr;
@@ -82,6 +83,7 @@ optional_ptr<CatalogEntry> IcebergSchemaSet::GetEntry(ClientContext &context, co
 		info.SetQualifiedName(
 		    QualifiedName(info.GetQualifiedName().Catalog(), Identifier(name), info.GetQualifiedName().Name()));
 		info.internal = false;
+		// assume schema exists to avoid extra roundtrip
 		auto schema_entry = make_shared_ptr<IcebergSchemaEntry>(catalog, info);
 		auto inserted_entry = CreateEntryInternal(std::move(schema_entry));
 		iceberg_transaction.schemas.emplace(name, inserted_entry);

--- a/src/catalog/rest/iceberg_schema_set.cpp
+++ b/src/catalog/rest/iceberg_schema_set.cpp
@@ -19,6 +19,10 @@ optional_ptr<CatalogEntry> IcebergSchemaSet::GetEntry(ClientContext &context, co
 	auto &ic_catalog = catalog.Cast<IcebergCatalog>();
 	auto &iceberg_transaction = IcebergTransaction::Get(context, catalog);
 
+	if (name.empty()) {
+		return nullptr;
+	}
+
 	// If the schema was deleted in this transaction, treat it as non-existent
 	if (iceberg_transaction.deleted_schemas.count(name)) {
 		if (if_not_found == OnEntryNotFound::RETURN_NULL) {
@@ -58,10 +62,6 @@ optional_ptr<CatalogEntry> IcebergSchemaSet::GetEntry(ClientContext &context, co
 		throw CatalogException("Iceberg namespace by the name of '%s' does not exist", name);
 	}
 	if (entry == entries.end()) {
-		// we will not create entries with empty names - and an empty name is never worth a round trip
-		if (name.empty()) {
-			return nullptr;
-		}
 		CreateSchemaInfo info;
 		// A name duckdb probes on its own - the catalog's default namespace, and the 'main' it falls back to
 		// in a search path - is verified rather than materialized optimistically: it is not necessarily a

--- a/src/catalog/rest/iceberg_schema_set.cpp
+++ b/src/catalog/rest/iceberg_schema_set.cpp
@@ -63,12 +63,9 @@ optional_ptr<CatalogEntry> IcebergSchemaSet::GetEntry(ClientContext &context, co
 	}
 	if (entry == entries.end()) {
 		CreateSchemaInfo info;
-		// A name duckdb probes on its own - the catalog's default namespace, and the 'main' it falls back to
-		// in a search path - is verified rather than materialized optimistically: it is not necessarily a
-		// namespace the user asked for, and a phantom entry would send `duckdb_*` lookups to the server.
 		auto default_schema = ic_catalog.GetDefaultSchema();
 		auto lookup_name = Identifier(name);
-		if (lookup_name == default_schema || lookup_name == Identifier(DEFAULT_SCHEMA)) {
+		if (lookup_name == default_schema) {
 			if (!IRCAPI::VerifySchemaExistence(context, ic_catalog, name)) {
 				if (if_not_found == OnEntryNotFound::RETURN_NULL) {
 					return nullptr;

--- a/src/catalog/rest/iceberg_schema_set.cpp
+++ b/src/catalog/rest/iceberg_schema_set.cpp
@@ -58,24 +58,34 @@ optional_ptr<CatalogEntry> IcebergSchemaSet::GetEntry(ClientContext &context, co
 		throw CatalogException("Iceberg namespace by the name of '%s' does not exist", name);
 	}
 	if (entry == entries.end()) {
+		// we will not create entries with empty names - and an empty name is never worth a round trip
+		if (name.empty()) {
+			return nullptr;
+		}
 		CreateSchemaInfo info;
-		// Look up existence of default schema to avoid lookup of `duckdb_*` tables
-		if (name == DEFAULT_SCHEMA) {
+		// A name duckdb probes on its own - the catalog's default namespace, and the 'main' it falls back to
+		// in a search path - is verified rather than materialized optimistically: it is not necessarily a
+		// namespace the user asked for, and a phantom entry would send `duckdb_*` lookups to the server.
+		auto default_schema = ic_catalog.GetDefaultSchema();
+		auto lookup_name = Identifier(name);
+		if (lookup_name == default_schema || lookup_name == Identifier(DEFAULT_SCHEMA)) {
 			if (!IRCAPI::VerifySchemaExistence(context, ic_catalog, name)) {
 				if (if_not_found == OnEntryNotFound::RETURN_NULL) {
 					return nullptr;
 				}
-				throw CatalogException("default schema '%s' does not exist", name);
+				if (lookup_name == default_schema) {
+					throw CatalogException(
+					    "default namespace '%s' does not exist in this Iceberg catalog - create it, or attach "
+					    "with DEFAULT_SCHEMA '<namespace>'",
+					    name);
+				}
+				throw CatalogException("Iceberg namespace by the name of '%s' does not exist", name);
 			}
 		}
 		info.SetQualifiedName(
 		    QualifiedName(info.GetQualifiedName().Catalog(), Identifier(name), info.GetQualifiedName().Name()));
 		info.internal = false;
 		auto schema_entry = make_shared_ptr<IcebergSchemaEntry>(catalog, info);
-		// we will not create entries with empty names
-		if (name.empty()) {
-			return nullptr;
-		}
 		auto inserted_entry = CreateEntryInternal(std::move(schema_entry));
 		iceberg_transaction.schemas.emplace(name, inserted_entry);
 		return inserted_entry.get();

--- a/src/iceberg_attach.cpp
+++ b/src/iceberg_attach.cpp
@@ -357,7 +357,9 @@ unique_ptr<Catalog> IcebergAttach::Attach(optional_ptr<StorageExtensionInfo> sto
 	catalog->GetConfig(context, endpoint_type);
 	if (!default_schema.empty() &&
 	    !IRCAPI::VerifySchemaExistence(context, *catalog, default_schema.GetIdentifierName())) {
-		throw InvalidConfigurationException("default_schema '%s' does not exist", default_schema.GetIdentifierName());
+		throw InvalidConfigurationException(
+		    "default_schema '%s' does not exist. ATTACH with no DEFAULT_SCHEMA to successfully attach",
+		    default_schema.GetIdentifierName());
 	}
 	return std::move(catalog);
 }

--- a/src/include/catalog/rest/iceberg_catalog.hpp
+++ b/src/include/catalog/rest/iceberg_catalog.hpp
@@ -120,12 +120,7 @@ public:
 	bool CheckAmbiguousCatalogOrSchema(ClientContext &context, const Identifier &schema) override {
 		return false;
 	}
-	optional<Identifier> GetDefaultSchema() const override {
-		if (default_schema.empty()) {
-			return nullopt;
-		}
-		return default_schema;
-	}
+	optional<Identifier> GetDefaultSchema() const override;
 	ErrorData SupportsCreateTable(BoundCreateTableInfo &info) override;
 
 public:

--- a/src/include/catalog/rest/iceberg_catalog.hpp
+++ b/src/include/catalog/rest/iceberg_catalog.hpp
@@ -142,11 +142,6 @@ public:
 	IcebergSchemaSet &GetSchemas();
 	optional_ptr<SchemaCatalogEntry> LookupSchema(CatalogTransaction transaction, const EntryLookupInfo &schema_lookup,
 	                                              OnEntryNotFound if_not_found) override;
-	CatalogEntryLookup TryLookupEntryInternal(CatalogTransaction transaction,
-	                                          const EntryLookupInfo &lookup_info) override;
-	//! Explains that an unqualified name cannot resolve because this catalog has no default namespace. Pass the
-	//! name being looked up when it is known, or an empty string for a bare namespace lookup.
-	string NoDefaultNamespaceMessage(const string &entry_name) const;
 	PhysicalOperator &PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner, LogicalInsert &op,
 	                             optional_ptr<PhysicalOperator> plan) override;
 	PhysicalOperator &PlanCreateTableAs(ClientContext &context, PhysicalPlanGenerator &planner, LogicalCreateTable &op,

--- a/src/include/catalog/rest/iceberg_catalog.hpp
+++ b/src/include/catalog/rest/iceberg_catalog.hpp
@@ -138,6 +138,11 @@ public:
 	IcebergSchemaSet &GetSchemas();
 	optional_ptr<SchemaCatalogEntry> LookupSchema(CatalogTransaction transaction, const EntryLookupInfo &schema_lookup,
 	                                              OnEntryNotFound if_not_found) override;
+	CatalogEntryLookup TryLookupEntryInternal(CatalogTransaction transaction,
+	                                          const EntryLookupInfo &lookup_info) override;
+	//! Explains that an unqualified name cannot resolve because this catalog has no default namespace. Pass the
+	//! name being looked up when it is known, or an empty string for a bare namespace lookup.
+	string NoDefaultNamespaceMessage(const string &entry_name) const;
 	PhysicalOperator &PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner, LogicalInsert &op,
 	                             optional_ptr<PhysicalOperator> plan) override;
 	PhysicalOperator &PlanCreateTableAs(ClientContext &context, PhysicalPlanGenerator &planner, LogicalCreateTable &op,

--- a/test/sql/local/catalog_custom_setup/fixture/main_namespace.test
+++ b/test/sql/local/catalog_custom_setup/fixture/main_namespace.test
@@ -1,6 +1,5 @@
 # name: test/sql/local/catalog_custom_setup/fixture/main_namespace.test
-# description: namespaces are resolved verbatim - 'main' is an ordinary namespace and is never
-#              an alias for the catalog's default namespace
+# description: namespaces are resolved verbatim - 'main' is an ordinary namespace and is never an alias for the catalog's default namespace
 # group: [fixture]
 
 require-env FIXTURE_SERVER_AVAILABLE

--- a/test/sql/local/catalog_custom_setup/fixture/main_namespace.test
+++ b/test/sql/local/catalog_custom_setup/fixture/main_namespace.test
@@ -132,6 +132,12 @@ statement ok
 DROP TABLE my_datalake.bronze.T2;
 
 statement ok
+DROP SCHEMA my_datalake.main;
+
+statement ok
+DROP SCHEMA my_datalake.bronze;
+
+statement ok
 DETACH my_datalake;
 
 statement ok

--- a/test/sql/local/catalog_custom_setup/fixture/main_namespace.test
+++ b/test/sql/local/catalog_custom_setup/fixture/main_namespace.test
@@ -1,0 +1,142 @@
+# name: test/sql/local/catalog_custom_setup/fixture/main_namespace.test
+# description: namespaces are resolved verbatim - 'main' is an ordinary namespace and is never
+#              an alias for the catalog's default namespace
+# group: [fixture]
+
+require-env FIXTURE_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+CREATE SECRET storage_secret(
+	TYPE S3,
+	KEY_ID 'admin',
+	SECRET 'password',
+	ENDPOINT '127.0.0.1:9000',
+	URL_STYLE 'path',
+	USE_SSL 0
+);
+
+statement ok
+CREATE SECRET iceberg_secret (
+	TYPE ICEBERG,
+	CLIENT_ID 'admin',
+	CLIENT_SECRET 'password',
+	URI 'http://127.0.0.1:8181'
+);
+
+# setup - fully qualified throughout, so no default namespace is needed yet
+statement ok
+ATTACH '' AS my_datalake (
+	TYPE ICEBERG,
+	SECRET iceberg_secret
+);
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS my_datalake.main;
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS my_datalake.bronze;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.main.T;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.bronze.T;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.bronze.T2;
+
+statement ok
+DETACH my_datalake;
+
+# attach with a default namespace that is neither 'main' nor 'default'
+statement ok
+ATTACH '' AS my_datalake (
+	TYPE ICEBERG,
+	SECRET iceberg_secret,
+	DEFAULT_SCHEMA 'bronze'
+);
+
+# before: neither name resolves to a table
+statement error
+SELECT * FROM my_datalake.bronze.T;
+----
+<REGEX>:.*does not exist.*
+
+statement error
+SELECT * FROM my_datalake.main.T;
+----
+<REGEX>:.*does not exist.*
+
+statement ok
+CREATE TABLE my_datalake.main.T AS SELECT 42;
+
+# after: the table is in 'main', as written
+query I
+SELECT * FROM my_datalake.main.T;
+----
+42
+
+# and ONLY there. Without the fix 'main' aliased to the catalog's default namespace, so both
+# names resolved to the same table and this query returned 42.
+statement error
+SELECT * FROM my_datalake.bronze.T;
+----
+<REGEX>:.*does not exist.*
+
+# an unqualified name still resolves to the default namespace
+statement ok
+CREATE TABLE my_datalake.T2 AS SELECT 43;
+
+query I
+SELECT * FROM my_datalake.bronze.T2;
+----
+43
+
+# 'main' can itself be the default namespace, still without any aliasing
+statement ok
+DETACH my_datalake;
+
+statement ok
+ATTACH '' AS my_datalake (
+	TYPE ICEBERG,
+	SECRET iceberg_secret,
+	DEFAULT_SCHEMA 'main'
+);
+
+# unqualified now resolves to 'main'
+query I
+SELECT * FROM my_datalake.T;
+----
+42
+
+# while 'bronze' is still reachable as an ordinary namespace
+query I
+SELECT * FROM my_datalake.bronze.T2;
+----
+43
+
+statement ok
+DROP TABLE my_datalake.main.T;
+
+statement ok
+DROP TABLE my_datalake.bronze.T2;
+
+statement ok
+DETACH my_datalake;
+
+statement ok
+DROP SECRET iceberg_secret;
+
+statement ok
+DROP SECRET storage_secret;

--- a/test/sql/local/catalog_custom_setup/fixture/main_namespace.test
+++ b/test/sql/local/catalog_custom_setup/fixture/main_namespace.test
@@ -131,9 +131,9 @@ DROP TABLE my_datalake.main.T;
 statement ok
 DROP TABLE my_datalake.bronze.T2;
 
-statement ok
-DROP SCHEMA my_datalake.main;
-
+# 'main' is deliberately left behind: DROP SCHEMA on a namespace named 'main' trips a duckdb assertion
+# (physical_drop.cpp, D_ASSERT(name != DEFAULT_SCHEMA)) - in a duckdb catalog 'main' is an undroppable
+# internal entry, which does not hold for an Iceberg namespace. The test re-creates it with IF NOT EXISTS.
 statement ok
 DROP SCHEMA my_datalake.bronze;
 

--- a/test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
+++ b/test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
@@ -58,10 +58,56 @@ SELECT * FROM my_datalake.bronze.T;
 statement error
 CREATE TABLE my_datalake.T2 AS SELECT 43;
 ----
-<REGEX>:.*No default namespace for catalog.*
+<REGEX>:.*No default namespace for catalog "my_datalake".*DEFAULT_SCHEMA.*
+
+# the same holds for a table that cannot be resolved: the message names the table and how to qualify it,
+# rather than reporting a bare "table does not exist"
+statement error
+SELECT * FROM my_datalake.T;
+----
+<REGEX>:.*No default namespace for catalog "my_datalake".*my_datalake.<namespace>.T.*
+
+statement error
+INSERT INTO my_datalake.T VALUES (1);
+----
+<REGEX>:.*No default namespace for catalog "my_datalake".*
+
+statement error
+DELETE FROM my_datalake.T;
+----
+<REGEX>:.*No default namespace for catalog "my_datalake".*
+
+statement error
+DROP TABLE my_datalake.T;
+----
+<REGEX>:.*No default namespace for catalog "my_datalake".*
+
+statement error
+DESCRIBE my_datalake.T;
+----
+<REGEX>:.*No default namespace for catalog "my_datalake".*
+
+# attaching the same catalog with a default namespace resolves the very same unqualified name
+statement ok
+ATTACH '' AS with_default (
+	TYPE ICEBERG,
+	SECRET iceberg_secret,
+	DEFAULT_SCHEMA 'bronze'
+);
+
+query I
+SELECT * FROM with_default.T;
+----
+42
+
+statement ok
+DETACH with_default;
 
 statement ok
 DROP TABLE my_datalake.bronze.T;
+
+statement ok
+DROP SCHEMA my_datalake.bronze;
 
 statement ok
 DETACH my_datalake;

--- a/test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
+++ b/test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
@@ -1,6 +1,5 @@
 # name: test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
-# description: a catalog attached without DEFAULT_SCHEMA has no default namespace - qualified
-#              names still work, and an unqualified one says so
+# description: a catalog attached without DEFAULT_SCHEMA has no default namespace - qualified names still work, and an unqualified one says so
 # group: [fixture]
 
 require-env FIXTURE_SERVER_AVAILABLE

--- a/test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
+++ b/test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
@@ -54,38 +54,39 @@ SELECT * FROM my_datalake.bronze.T;
 ----
 42
 
-# an unqualified name has no namespace to resolve to, and says which knob to reach for
+# creating an unqualified name has no namespace to resolve to. duckdb resolves the target namespace up front,
+# so it reports the missing default schema itself
 statement error
 CREATE TABLE my_datalake.T2 AS SELECT 43;
 ----
-<REGEX>:.*No default namespace for catalog "my_datalake".*DEFAULT_SCHEMA.*
+<REGEX>:.*has no default schema.*
 
-# the same holds for a table that cannot be resolved: the message names the table and how to qualify it,
-# rather than reporting a bare "table does not exist"
+# an unqualified reference is not resolved against this catalog at all - duckdb never probes a catalog that
+# reports no default schema, so the name simply does not resolve
 statement error
 SELECT * FROM my_datalake.T;
 ----
-<REGEX>:.*No default namespace for catalog "my_datalake".*my_datalake.<namespace>.T.*
+<REGEX>:.*does not exist.*
 
 statement error
 INSERT INTO my_datalake.T VALUES (1);
 ----
-<REGEX>:.*No default namespace for catalog "my_datalake".*
+<REGEX>:.*does not exist.*
 
 statement error
 DELETE FROM my_datalake.T;
 ----
-<REGEX>:.*No default namespace for catalog "my_datalake".*
+<REGEX>:.*does not exist.*
 
 statement error
 DROP TABLE my_datalake.T;
 ----
-<REGEX>:.*No default namespace for catalog "my_datalake".*
+<REGEX>:.*does not exist.*
 
 statement error
 DESCRIBE my_datalake.T;
 ----
-<REGEX>:.*No default namespace for catalog "my_datalake".*
+<REGEX>:.*does not exist.*
 
 # attaching the same catalog with a default namespace resolves the very same unqualified name
 statement ok

--- a/test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
+++ b/test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
@@ -1,0 +1,74 @@
+# name: test/sql/local/catalog_custom_setup/fixture/no_default_namespace.test
+# description: a catalog attached without DEFAULT_SCHEMA has no default namespace - qualified
+#              names still work, and an unqualified one says so
+# group: [fixture]
+
+require-env FIXTURE_SERVER_AVAILABLE
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+CREATE SECRET storage_secret(
+	TYPE S3,
+	KEY_ID 'admin',
+	SECRET 'password',
+	ENDPOINT '127.0.0.1:9000',
+	URL_STYLE 'path',
+	USE_SSL 0
+);
+
+statement ok
+CREATE SECRET iceberg_secret (
+	TYPE ICEBERG,
+	CLIENT_ID 'admin',
+	CLIENT_SECRET 'password',
+	URI 'http://127.0.0.1:8181'
+);
+
+statement ok
+ATTACH '' AS my_datalake (
+	TYPE ICEBERG,
+	SECRET iceberg_secret
+);
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS my_datalake.bronze;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.bronze.T;
+
+# qualified names are unaffected
+statement ok
+CREATE TABLE my_datalake.bronze.T AS SELECT 42;
+
+query I
+SELECT * FROM my_datalake.bronze.T;
+----
+42
+
+# an unqualified name has no namespace to resolve to, and says which knob to reach for
+statement error
+CREATE TABLE my_datalake.T2 AS SELECT 43;
+----
+<REGEX>:.*No default namespace for catalog.*
+
+statement ok
+DROP TABLE my_datalake.bronze.T;
+
+statement ok
+DETACH my_datalake;
+
+statement ok
+DROP SECRET iceberg_secret;
+
+statement ok
+DROP SECRET storage_secret;


### PR DESCRIPTION
This is a little bit of cleanup now that https://github.com/duckdb/duckdb/pull/24979 has merged. 
Errors are a bit cleaner around Default schema behavior, and users no longer need to create one or know that one exists in their catalog

CC @carlopi 