### PR TITLE
Enable TopN late materialization for Iceberg scans

### DIFF
--- a/src/function/scan/iceberg_scan.cpp
+++ b/src/function/scan/iceberg_scan.cpp
@@ -78,6 +78,13 @@ static void IcebergSetScanOrder(unique_ptr<RowGroupOrderOptions> order_options, 
 	file_list.SetScanOrder(std::move(order_options));
 }
 
+static vector<column_t> IcebergGetRowIdColumns(ClientContext &, optional_ptr<FunctionData>) {
+	vector<column_t> result;
+	result.push_back(MultiFileReader::COLUMN_IDENTIFIER_FILENAME);
+	result.push_back(MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER);
+	return result;
+}
+
 //! FIXME: needs v1.5.1, causes a crash on v1.5.0
 // static bool IcebergScanSupportsPushdownType(const FunctionData &bind_data_p, idx_t column_id) {
 //	// Don't push down filters on the _row_id virtual column
@@ -100,6 +107,7 @@ TableFunctionSet IcebergFunctions::GetIcebergScanFunction(ExtensionLoader &loade
 		// Register the MultiFileReader as the driver for reads
 		function.get_multi_file_reader = IcebergMultiFileReader::CreateInstance;
 		function.late_materialization = false;
+		function.get_row_id_columns = IcebergGetRowIdColumns;
 
 		// Unset all of these: they are either broken, very inefficient.
 		// TODO: implement/fix these

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -68,9 +68,11 @@ public:
 	void GetStatistics(vector<PartitionStatistics> &result) const;
 	const IcebergTableMetadata &GetMetadata() const;
 	const IcebergTableSchema &GetSchema() const;
+	bool SupportsLateMaterialization() const;
 	BoundIcebergManifestEntry GetManifestEntry(idx_t file_id) const;
 	IcebergManifestFile GetManifestFileForDataFile(idx_t file_id) const;
 	IcebergDeletePlan ProcessDeletes(const BoundIcebergManifestEntry &data_manifest_entry) const;
+	unique_ptr<MultiFileList> Copy() const override;
 
 private:
 	const string &GetPath() const;

--- a/src/include/planning/iceberg_multi_file_reader.hpp
+++ b/src/include/planning/iceberg_multi_file_reader.hpp
@@ -114,6 +114,7 @@ public:
 	                   ExpressionExecutor &executor, optional_ptr<MultiFileReaderGlobalState> global_state) override;
 	bool ParseOption(const Identifier &key, const Value &val, MultiFileOptions &options,
 	                 ClientContext &context) override;
+	unique_ptr<MultiFileReader> Copy() const override;
 
 	MultiFileReaderVirtualColumnBinding
 	GetVirtualColumnExpression(ClientContext &context, MultiFileReaderData &reader_data,

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -90,6 +90,29 @@ IcebergMultiFileList::IcebergMultiFileList(shared_ptr<IcebergScanPlanState> shar
 IcebergMultiFileList::~IcebergMultiFileList() {
 }
 
+unique_ptr<MultiFileList> IcebergMultiFileList::Copy() const {
+	auto result = make_uniq<IcebergMultiFileList>(context, shared_state->scan_info, GetPath(), options);
+	if (GetTable()) {
+		result->SetTable(*GetTable());
+	}
+	result->have_bound = have_bound;
+	result->names = names;
+	result->types = types;
+	for (auto &entry : table_filters) {
+		result->table_filters.PushFilter(entry.first, entry.second->Copy());
+	}
+	{
+		annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+		result->shared_state->server_side_planning_enabled = shared_state->server_side_planning_enabled;
+		auto order_options = scan_order.CopyOptions();
+		if (order_options) {
+			result->scan_order.Set(std::move(order_options));
+		}
+	}
+	// Per-view providers, cursors, manifest selections, and delete state start uninitialized.
+	return std::move(result);
+}
+
 const string &IcebergMultiFileList::GetPath() const {
 	return shared_state->path;
 }
@@ -113,6 +136,11 @@ const IcebergSnapshotScanInfo &IcebergMultiFileList::GetSnapshot() const {
 
 const IcebergTableSchema &IcebergMultiFileList::GetSchema() const {
 	return shared_state->scan_info->schema;
+}
+
+bool IcebergMultiFileList::SupportsLateMaterialization() const {
+	// Both scans share the bound snapshot, schema, and transaction state.
+	return GetMetadata().iceberg_version == 2;
 }
 
 IcebergScanPlanProvider &IcebergMultiFileList::GetScanPlanProvider() const {

--- a/src/planning/iceberg_multi_file_reader.cpp
+++ b/src/planning/iceberg_multi_file_reader.cpp
@@ -86,6 +86,13 @@ unique_ptr<MultiFileReader> IcebergMultiFileReader::CreateInstance(const TableFu
 	return make_uniq<IcebergMultiFileReader>(table.function_info);
 }
 
+unique_ptr<MultiFileReader> IcebergMultiFileReader::Copy() const {
+	auto result = make_uniq<IcebergMultiFileReader>(function_info);
+	result->function_name = function_name;
+	result->options = options;
+	return std::move(result);
+}
+
 shared_ptr<MultiFileList> IcebergMultiFileReader::CreateFileList(ClientContext &context, const vector<string> &paths,
                                                                  const FileGlobInput &glob_input) {
 	if (paths.size() != 1) {

--- a/src/planning/iceberg_optimizer.cpp
+++ b/src/planning/iceberg_optimizer.cpp
@@ -14,6 +14,9 @@
 #include "planning/iceberg_multi_file_reader.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/optimizer/topn_optimizer.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 
 namespace duckdb {
 
@@ -66,12 +69,83 @@ void IcebergOptimizerRoutine::VisitOperator(unique_ptr<LogicalOperator> &op, boo
 	}
 }
 
+static optional_ptr<LogicalGet> TryGetTopNTableScan(ClientContext &context, LogicalOperator &op) {
+	if (!TopN::CanOptimize(op, &context)) {
+		return nullptr;
+	}
+	auto current = op.children[0].get();
+	while (current->type == LogicalOperatorType::LOGICAL_PROJECTION) {
+		current = current->children[0].get();
+	}
+	D_ASSERT(current->type == LogicalOperatorType::LOGICAL_ORDER_BY);
+	current = current->children[0].get();
+	while (current->type == LogicalOperatorType::LOGICAL_PROJECTION ||
+	       current->type == LogicalOperatorType::LOGICAL_FILTER) {
+		current = current->children[0].get();
+	}
+	if (current->type != LogicalOperatorType::LOGICAL_GET) {
+		return nullptr;
+	}
+	return current->Cast<LogicalGet>();
+}
+
+static optional_ptr<IcebergMultiFileList> TryGetIcebergFileList(LogicalGet &get) {
+	if (get.function.get_multi_file_reader != IcebergMultiFileReader::CreateInstance) {
+		return nullptr;
+	}
+	D_ASSERT(get.bind_data);
+	auto &multi_file_data = get.bind_data->Cast<MultiFileBindData>();
+	D_ASSERT(multi_file_data.file_list);
+	return multi_file_data.file_list->Cast<IcebergMultiFileList>();
+}
+
+static void IcebergLateMaterializationFilterPushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data,
+                                                     vector<unique_ptr<Expression>> &filters) {
+	auto &data = bind_data->Cast<MultiFileBindData>();
+	MultiFilePushdownInfo info(get);
+	auto new_list =
+	    data.multi_file_reader->ComplexFilterPushdown(context, *data.file_list, data.file_options, info, filters);
+	if (new_list) {
+		data.file_list = std::move(new_list);
+		MultiFileReader::PruneReaders(data, *data.file_list);
+	}
+
+	// Filters have been pushed through projections, so aliases now refer to the scan's columns. The core's
+	// CreateLHSGet cannot copy a table filter on a virtual column; projection/order-only references are safe.
+	for (auto &filter : filters) {
+		ExpressionIterator::VisitExpression<BoundColumnRefExpression>(
+		    *filter, [&](const BoundColumnRefExpression &ref) {
+			    auto &binding = ref.Binding();
+			    if (binding.table_index == get.table_index &&
+			        get.GetColumnIds()[binding.column_index].IsVirtualColumn()) {
+				    get.function.late_materialization = false;
+			    }
+		    });
+	}
+}
+
+static void EnableIcebergTopNLateMaterialization(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
+	auto get = TryGetTopNTableScan(input.context, *plan);
+	if (get) {
+		auto file_list = TryGetIcebergFileList(*get);
+		if (file_list && file_list->SupportsLateMaterialization()) {
+			get->function.late_materialization = true;
+			get->function.pushdown_complex_filter = IcebergLateMaterializationFilterPushdown;
+		}
+	}
+	for (auto &child : plan->children) {
+		EnableIcebergTopNLateMaterialization(input, child);
+	}
+}
+
 void IcebergOptimizer::PreOptimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
 	IcebergOptimizerRoutine iceberg_optimizer_routine(input.context);
 	if (plan->children.size() == 0) {
 		return;
 	}
 	iceberg_optimizer_routine.VisitOperator(plan);
+	// Keep local-planning restrictions ahead of TopN cardinality estimation, which may initialize scan planning.
+	EnableIcebergTopNLateMaterialization(input, plan);
 }
 
 OptimizerExtension IcebergOptimizer::Create() {

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/late_materialization_mixed_transactions.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/late_materialization_mixed_transactions.test
@@ -1,0 +1,387 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/late_materialization_mixed_transactions.test
+# description: TopN results and admission across mixed metadata and data changes
+# group: [filtering]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+foreach threads 1 4
+
+foreach finish COMMIT ROLLBACK
+
+foreach ddl schema property format
+
+statement ok
+SET threads = 1;
+
+statement ok
+SET late_materialization_max_rows = 5;
+
+statement ok
+SET explain_output = 'optimized_only';
+
+statement ok
+SET disabled_optimizers = '';
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.late_materialization_mixed_transactions;
+
+# Native reference tables are built before BEGIN, independently of Iceberg reads.
+statement ok
+CREATE OR REPLACE TEMP TABLE e0 AS
+SELECT i::INTEGER AS id,
+	CASE WHEN i % 9 = 0 THEN NULL ELSE (i % 7)::INTEGER END AS k,
+	CASE WHEN i = 5 THEN NULL ELSE concat(repeat('x', 256), '_', i) END AS p,
+	(i % 3)::INTEGER AS g
+FROM range(32) r(i);
+
+statement ok
+CREATE OR REPLACE TEMP TABLE e1 AS
+SELECT id,
+	CASE WHEN id=2 THEN 100 ELSE k END AS k,
+	CASE WHEN id=2 THEN 'u2' ELSE p END AS p, g
+FROM e0 WHERE id < 28
+UNION ALL SELECT 100, 110, 'i100', 1;
+
+statement ok
+CREATE OR REPLACE TEMP TABLE e2 AS
+SELECT id,
+	CASE WHEN id=3 THEN 120 ELSE k END AS k,
+	CASE WHEN id=3 THEN 'u3' ELSE p END AS p, g
+FROM e1 WHERE id <> 100
+UNION ALL SELECT 101, 130, 'i101', 1;
+
+statement ok
+CREATE TABLE my_datalake.default.late_materialization_mixed_transactions (id INTEGER,k INTEGER,p VARCHAR,g INTEGER) WITH ('format-version' = 2);
+
+statement ok
+INSERT INTO my_datalake.default.late_materialization_mixed_transactions SELECT * FROM e0 WHERE id%2=0;
+
+statement ok
+INSERT INTO my_datalake.default.late_materialization_mixed_transactions SELECT * FROM e0 WHERE id%2=1;
+
+statement ok
+SET threads = {threads};
+
+statement ok
+BEGIN;
+
+statement ok
+DELETE FROM my_datalake.default.late_materialization_mixed_transactions WHERE id >= 28;
+
+statement ok
+UPDATE my_datalake.default.late_materialization_mixed_transactions SET k = 100, p = 'u2' WHERE id = 2;
+
+statement ok
+INSERT INTO my_datalake.default.late_materialization_mixed_transactions (id,k,p,g) VALUES (100,110,'i100',1);
+
+# mixed_{ddl}_dml: independent reference, optimized result, and plan.
+query I
+WITH actual AS (
+	SELECT id, k, p, g
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5
+), expected AS (
+	SELECT id, k, p, g
+FROM e1
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5
+)
+SELECT count(*) FROM (
+	(FROM actual EXCEPT ALL FROM expected)
+	UNION ALL
+	(FROM expected EXCEPT ALL FROM actual)
+);
+----
+0
+
+query I
+WITH actual AS (
+	SELECT id,k,p,g FROM my_datalake.default.late_materialization_mixed_transactions
+), expected AS (
+	SELECT id,k,p,g FROM e1
+)
+SELECT count(*) FROM (
+	(FROM actual EXCEPT ALL FROM expected)
+	UNION ALL
+	(FROM expected EXCEPT ALL FROM actual)
+);
+----
+0
+
+statement ok
+SET disabled_optimizers = 'late_materialization';
+
+query IITI nosort mixed_{ddl}_dml_{threads}_{finish}
+SELECT id, k, p, g
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5;
+
+statement ok
+SET disabled_optimizers = '';
+
+query IITI nosort mixed_{ddl}_dml_{threads}_{finish}
+SELECT id, k, p, g
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5;
+
+query II
+EXPLAIN (FORMAT JSON) SELECT id, k, p, g
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*
+
+# Pending schema/property/format updates keep V2 late materialization enabled.
+onlyif ddl==schema
+statement ok
+ALTER TABLE my_datalake.default.late_materialization_mixed_transactions ADD COLUMN extra VARCHAR;
+
+onlyif ddl==property
+statement ok
+ALTER TABLE my_datalake.default.late_materialization_mixed_transactions SET ('lm-mixed' = 'pending');
+
+onlyif ddl==format
+statement ok
+ALTER TABLE my_datalake.default.late_materialization_mixed_transactions SET ('format-version' = 2);
+
+# The newly added payload is absent from all existing files and must read as NULL.
+onlyif ddl==schema
+query IT
+SELECT id, extra
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC LIMIT 2;
+----
+100	NULL
+2	NULL
+
+# mixed_{ddl}_metadata: independent reference, optimized result, and plan.
+query I
+WITH actual AS (
+	SELECT id, k, p, g
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5
+), expected AS (
+	SELECT id, k, p, g
+FROM e1
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5
+)
+SELECT count(*) FROM (
+	(FROM actual EXCEPT ALL FROM expected)
+	UNION ALL
+	(FROM expected EXCEPT ALL FROM actual)
+);
+----
+0
+
+query I
+WITH actual AS (
+	SELECT id,k,p,g FROM my_datalake.default.late_materialization_mixed_transactions
+), expected AS (
+	SELECT id,k,p,g FROM e1
+)
+SELECT count(*) FROM (
+	(FROM actual EXCEPT ALL FROM expected)
+	UNION ALL
+	(FROM expected EXCEPT ALL FROM actual)
+);
+----
+0
+
+statement ok
+SET disabled_optimizers = 'late_materialization';
+
+query IITI nosort mixed_{ddl}_metadata_{threads}_{finish}
+SELECT id, k, p, g
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5;
+
+statement ok
+SET disabled_optimizers = '';
+
+query IITI nosort mixed_{ddl}_metadata_{threads}_{finish}
+SELECT id, k, p, g
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5;
+
+query II
+EXPLAIN (FORMAT JSON) SELECT id, k, p, g
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*
+
+statement ok
+DELETE FROM my_datalake.default.late_materialization_mixed_transactions WHERE id = 100;
+
+statement ok
+UPDATE my_datalake.default.late_materialization_mixed_transactions SET k = 120, p = 'u3' WHERE id = 3;
+
+statement ok
+INSERT INTO my_datalake.default.late_materialization_mixed_transactions (id,k,p,g) VALUES (101,130,'i101',1);
+
+# mixed_{ddl}_second_dml: independent reference, optimized result, and plan.
+query I
+WITH actual AS (
+	SELECT id, k, p, g
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5
+), expected AS (
+	SELECT id, k, p, g
+FROM e2
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5
+)
+SELECT count(*) FROM (
+	(FROM actual EXCEPT ALL FROM expected)
+	UNION ALL
+	(FROM expected EXCEPT ALL FROM actual)
+);
+----
+0
+
+query I
+WITH actual AS (
+	SELECT id,k,p,g FROM my_datalake.default.late_materialization_mixed_transactions
+), expected AS (
+	SELECT id,k,p,g FROM e2
+)
+SELECT count(*) FROM (
+	(FROM actual EXCEPT ALL FROM expected)
+	UNION ALL
+	(FROM expected EXCEPT ALL FROM actual)
+);
+----
+0
+
+statement ok
+SET disabled_optimizers = 'late_materialization';
+
+query IITI nosort mixed_{ddl}_second_dml_{threads}_{finish}
+SELECT id, k, p, g
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5;
+
+statement ok
+SET disabled_optimizers = '';
+
+query IITI nosort mixed_{ddl}_second_dml_{threads}_{finish}
+SELECT id, k, p, g
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5;
+
+query II
+EXPLAIN (FORMAT JSON) SELECT id, k, p, g
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*
+
+# A new value in the added payload must also be visible to the delayed scan.
+onlyif ddl==schema
+statement ok
+UPDATE my_datalake.default.late_materialization_mixed_transactions
+SET extra = 'transaction_payload' WHERE id = 101;
+
+onlyif ddl==schema
+query II
+EXPLAIN (FORMAT JSON) SELECT id, extra
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*
+
+onlyif ddl==schema
+query IT
+SELECT id, extra
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC LIMIT 2;
+----
+101	transaction_payload
+3	NULL
+
+# A later metadata update must preserve LM after the intervening DML.
+statement ok
+ALTER TABLE my_datalake.default.late_materialization_mixed_transactions SET ('lm-mixed-last' = 'pending');
+
+query II
+EXPLAIN (FORMAT JSON) SELECT id, k, p, g
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*
+
+statement ok
+{finish};
+
+query I
+WITH actual AS (
+	SELECT id,k,p,g FROM my_datalake.default.late_materialization_mixed_transactions
+), expected AS (
+	SELECT * FROM e2 WHERE '{finish}'='COMMIT' UNION ALL SELECT * FROM e0 WHERE '{finish}'='ROLLBACK'
+)
+SELECT count(*) FROM (
+	(FROM actual EXCEPT ALL FROM expected)
+	UNION ALL
+	(FROM expected EXCEPT ALL FROM actual)
+);
+----
+0
+
+query II
+EXPLAIN (FORMAT JSON) SELECT id, k, p, g
+FROM my_datalake.default.late_materialization_mixed_transactions
+ORDER BY k DESC NULLS LAST, id DESC
+LIMIT 5;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*
+
+statement ok
+DROP TABLE my_datalake.default.late_materialization_mixed_transactions;
+
+statement ok
+DROP TABLE e0;
+
+statement ok
+DROP TABLE e1;
+
+statement ok
+DROP TABLE e2;
+
+endloop
+
+endloop
+
+endloop
+
+statement ok
+RESET threads;
+
+statement ok
+RESET explain_output;
+
+statement ok
+RESET late_materialization_max_rows;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/late_materialization_prepared_transactions.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/late_materialization_prepared_transactions.test
@@ -1,0 +1,217 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/late_materialization_prepared_transactions.test
+# description: Rebind prepared TopN scans across metadata updates and transaction boundaries
+# group: [filtering]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+foreach threads 1 4
+
+foreach finish COMMIT ROLLBACK
+
+foreach mode on off
+
+statement ok
+SET threads = 1;
+
+statement ok
+SET late_materialization_max_rows = 3;
+
+statement ok
+SET explain_output = 'optimized_only';
+
+onlyif mode==on
+statement ok
+SET disabled_optimizers = '';
+
+onlyif mode==off
+statement ok
+SET disabled_optimizers = 'late_materialization';
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.lm_prepared_transactions;
+
+statement ok
+CREATE TABLE my_datalake.default.lm_prepared_transactions (id INTEGER, k INTEGER, p VARCHAR, spare VARCHAR) WITH ('format-version' = 2);
+
+statement ok
+INSERT INTO my_datalake.default.lm_prepared_transactions SELECT i, i, concat('p', i), repeat('x', 256) FROM range(32) r(i);
+
+statement ok
+INSERT INTO my_datalake.default.lm_prepared_transactions SELECT i, i, concat('p', i), repeat('x', 256) FROM range(32, 64) r(i);
+
+statement ok
+SET threads = {threads};
+
+statement ok
+SET VARIABLE prepared_snapshot = (SELECT snapshot_id FROM iceberg_snapshots(my_datalake.default.lm_prepared_transactions) ORDER BY sequence_number DESC LIMIT 1);
+
+# Bind once before BEGIN. Re-execution must observe the correct local changes.
+statement ok
+PREPARE live_topn AS SELECT id, p FROM my_datalake.default.lm_prepared_transactions WHERE id >= $1 ORDER BY k DESC, id DESC LIMIT 3;
+
+statement ok
+PREPARE historical_topn AS SELECT id, p FROM my_datalake.default.lm_prepared_transactions AT (VERSION => getvariable('prepared_snapshot')) ORDER BY k DESC, id DESC LIMIT 3;
+
+query IT
+EXECUTE live_topn(0);
+----
+63	p63
+62	p62
+61	p61
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE my_datalake.default.lm_prepared_transactions ADD COLUMN extra VARCHAR;
+
+statement ok
+DELETE FROM my_datalake.default.lm_prepared_transactions WHERE id = 63;
+
+statement ok
+UPDATE my_datalake.default.lm_prepared_transactions SET k = 100, p = 'updated', extra = 'u' WHERE id = 60;
+
+statement ok
+INSERT INTO my_datalake.default.lm_prepared_transactions (id, k, p, extra) VALUES (100, 200, 'inserted', 'new');
+
+query IT
+EXECUTE live_topn(0);
+----
+100	inserted
+60	updated
+62	p62
+
+onlyif mode==on
+query II
+EXPLAIN (FORMAT JSON) EXECUTE live_topn(0);
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*
+
+onlyif mode==off
+query II
+EXPLAIN (FORMAT JSON) EXECUTE live_topn(0);
+----
+logical_opt	<!REGEX>:(?s).*COMPARISON_JOIN.*
+
+statement ok
+PREPARE pending_topn AS SELECT id, p, extra FROM my_datalake.default.lm_prepared_transactions ORDER BY k DESC, id DESC LIMIT 3;
+
+# The new payload column is present only in the newly written files.
+query ITT
+EXECUTE pending_topn;
+----
+100	inserted	new
+60	updated	u
+62	p62	NULL
+
+onlyif mode==on
+query II
+EXPLAIN (FORMAT JSON) EXECUTE pending_topn;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*
+
+onlyif mode==off
+query II
+EXPLAIN (FORMAT JSON) EXECUTE pending_topn;
+----
+logical_opt	<!REGEX>:(?s).*COMPARISON_JOIN.*
+
+# Explicit time travel must exclude uncommitted data and metadata changes.
+query IT
+EXECUTE historical_topn;
+----
+63	p63
+62	p62
+61	p61
+
+onlyif mode==on
+query II
+EXPLAIN (FORMAT JSON) EXECUTE historical_topn;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*
+
+onlyif mode==off
+query II
+EXPLAIN (FORMAT JSON) EXECUTE historical_topn;
+----
+logical_opt	<!REGEX>:(?s).*COMPARISON_JOIN.*
+
+statement ok
+{finish};
+
+onlyif finish==COMMIT
+query IT
+EXECUTE live_topn(0);
+----
+100	inserted
+60	updated
+62	p62
+
+onlyif finish==COMMIT
+query ITT
+EXECUTE pending_topn;
+----
+100	inserted	new
+60	updated	u
+62	p62	NULL
+
+onlyif finish==ROLLBACK
+query IT
+EXECUTE live_topn(0);
+----
+63	p63
+62	p62
+61	p61
+
+onlyif finish==ROLLBACK
+statement error
+EXECUTE pending_topn;
+----
+extra
+
+query IT
+EXECUTE historical_topn;
+----
+63	p63
+62	p62
+61	p61
+
+statement ok
+DEALLOCATE live_topn;
+
+statement ok
+DEALLOCATE pending_topn;
+
+statement ok
+DEALLOCATE historical_topn;
+
+statement ok
+DROP TABLE my_datalake.default.lm_prepared_transactions;
+
+endloop
+
+endloop
+
+endloop
+
+statement ok
+RESET disabled_optimizers;
+
+statement ok
+RESET late_materialization_max_rows;
+
+statement ok
+RESET explain_output;
+
+statement ok
+RESET threads;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/late_materialization_topn_v2.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/late_materialization_topn_v2.test
@@ -1,0 +1,660 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/late_materialization_topn_v2.test
+# description: Iceberg V2 TopN late materialization
+# group: [filtering]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Do not ignore 'HTTP' error messages!
+set ignore_error_messages
+
+statement ok
+CREATE SCHEMA IF NOT EXISTS my_datalake.default;
+
+statement ok
+DROP VIEW IF EXISTS late_materialization_topn;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.late_materialization_topn_v2;
+
+statement ok
+SET threads = 1;
+
+statement ok
+CREATE TABLE my_datalake.default.late_materialization_topn_v2 (
+	record_id BIGINT,
+	sort_key BIGINT,
+	filter_key VARCHAR,
+	payload_a VARCHAR,
+	payload_b VARCHAR,
+	payload_c VARCHAR
+) WITH ('format-version' = 2);
+
+# Each INSERT creates one data file, so equal offsets have overlapping
+# file_row_number values. Position 6 is filtered out, and the fifth TopN row
+# comes from only one file at position 7. Joining on file_row_number alone
+# would therefore return an extra row.
+statement ok
+INSERT INTO my_datalake.default.late_materialization_topn_v2
+SELECT
+	2 * i AS record_id,
+	CASE WHEN i < 2 THEN 100 - i ELSE NULL END AS sort_key,
+	CASE WHEN i = 6 THEN 'excluded' ELSE 'selected' END AS filter_key,
+	concat(repeat('a', 256), '_', CAST(2 * i AS VARCHAR)) AS payload_a,
+	concat(repeat('b', 256), '_', CAST(2 * i AS VARCHAR)) AS payload_b,
+	concat(repeat('c', 256), '_', CAST(2 * i AS VARCHAR)) AS payload_c
+FROM range(8) t(i);
+
+statement ok
+INSERT INTO my_datalake.default.late_materialization_topn_v2
+SELECT
+	2 * i + 1 AS record_id,
+	CASE WHEN i < 2 THEN 100 - i ELSE NULL END AS sort_key,
+	CASE WHEN i = 6 THEN 'excluded' ELSE 'selected' END AS filter_key,
+	concat(repeat('a', 256), '_', CAST(2 * i + 1 AS VARCHAR)) AS payload_a,
+	concat(repeat('b', 256), '_', CAST(2 * i + 1 AS VARCHAR)) AS payload_b,
+	concat(repeat('c', 256), '_', CAST(2 * i + 1 AS VARCHAR)) AS payload_c
+FROM range(8) t(i);
+
+query I
+SELECT count(*)
+FROM iceberg_metadata(my_datalake.default.late_materialization_topn_v2)
+WHERE manifest_content = 'DATA';
+----
+2
+
+statement ok
+SET threads = 4;
+
+statement ok
+CREATE VIEW late_materialization_topn AS
+SELECT
+	record_id,
+	sort_key,
+	payload_a,
+	payload_b,
+	payload_c
+FROM my_datalake.default.late_materialization_topn_v2
+WHERE filter_key = 'selected'
+ORDER BY sort_key DESC NULLS LAST, record_id DESC
+LIMIT 5;
+
+statement ok
+SET late_materialization_max_rows = 5;
+
+# The optimized scan must return the same ordered rows and payload as the
+# original plan.
+statement ok
+SET disabled_optimizers = 'late_materialization';
+
+query IITTT nosort late_materialization_result
+SELECT * FROM late_materialization_topn;
+
+statement ok
+SET disabled_optimizers = '';
+
+query IITTT nosort late_materialization_result
+SELECT * FROM late_materialization_topn;
+
+statement ok
+SET explain_output = 'optimized_only';
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM late_materialization_topn;
+----
+logical_opt	<REGEX>:(?s).*ORDER_BY.*COMPARISON_JOIN.*ICEBERG_SCAN.*TOP_N.*ICEBERG_SCAN.*filename.*file_row_number.*
+
+# Iceberg only opts in when DuckDB can lower the ORDER BY ... LIMIT shape to
+# its TopN path; LIMIT without ORDER BY, SAMPLE, and window paths remain
+# unchanged.
+query II
+EXPLAIN (FORMAT JSON) SELECT payload_a
+FROM my_datalake.default.late_materialization_topn_v2
+LIMIT 5 OFFSET 1;
+----
+logical_opt	<!REGEX>:(?s).*COMPARISON_JOIN.*
+
+query II
+EXPLAIN (FORMAT JSON) SELECT payload_a
+FROM my_datalake.default.late_materialization_topn_v2
+USING SAMPLE 5 ROWS;
+----
+logical_opt	<!REGEX>:(?s).*COMPARISON_JOIN.*
+
+query II
+EXPLAIN (FORMAT JSON) SELECT
+	record_id,
+	payload_a,
+	row_number() OVER (ORDER BY record_id DESC) AS row_number
+FROM my_datalake.default.late_materialization_topn_v2
+QUALIFY row_number <= 5;
+----
+logical_opt	<!REGEX>:(?s).*COMPARISON_JOIN.*
+
+query II
+EXPLAIN (FORMAT JSON) SELECT record_id, payload_a
+FROM my_datalake.default.late_materialization_topn_v2
+ORDER BY sort_key DESC NULLS LAST, record_id DESC
+LIMIT 6;
+----
+logical_opt	<!REGEX>:(?s).*COMPARISON_JOIN.*
+
+# Create position-delete files for the same physical position in both data
+# files. Late materialization remains enabled, and both scans must apply both
+# delete files.
+statement ok
+DELETE FROM my_datalake.default.late_materialization_topn_v2
+WHERE record_id = 15;
+
+statement ok
+DELETE FROM my_datalake.default.late_materialization_topn_v2
+WHERE record_id = 14;
+
+query I
+SELECT count(*)
+FROM iceberg_metadata(my_datalake.default.late_materialization_topn_v2)
+WHERE manifest_content = 'DELETE';
+----
+2
+
+statement ok
+SET disabled_optimizers = 'late_materialization';
+
+query IITTT nosort late_materialization_delete_result
+SELECT * FROM late_materialization_topn;
+
+statement ok
+SET disabled_optimizers = '';
+
+query IITTT nosort late_materialization_delete_result
+SELECT * FROM late_materialization_topn;
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM late_materialization_topn;
+----
+logical_opt	<REGEX>:(?s).*ORDER_BY.*COMPARISON_JOIN.*ICEBERG_SCAN.*TOP_N.*ICEBERG_SCAN.*filename.*file_row_number.*
+
+# Data-only write plans can use TopN late materialization in their source scans.
+statement ok
+CREATE TEMP TABLE late_materialization_insert_target (
+	record_id BIGINT,
+	sort_key BIGINT,
+	filter_key VARCHAR,
+	payload_a VARCHAR,
+	payload_b VARCHAR,
+	payload_c VARCHAR
+);
+
+query II
+EXPLAIN (FORMAT JSON)
+INSERT INTO late_materialization_insert_target
+SELECT record_id, sort_key, filter_key, payload_a, payload_b, payload_c
+FROM my_datalake.default.late_materialization_topn_v2
+WHERE filter_key = 'selected'
+ORDER BY sort_key DESC NULLS LAST, record_id DESC
+LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+statement ok
+SET disabled_optimizers = 'late_materialization';
+
+query IITTTT nosort late_materialization_insert_result
+INSERT INTO late_materialization_insert_target
+SELECT * FROM my_datalake.default.late_materialization_topn_v2
+WHERE filter_key = 'selected'
+ORDER BY sort_key DESC NULLS LAST, record_id DESC LIMIT 2
+RETURNING *;
+
+statement ok
+DELETE FROM late_materialization_insert_target;
+
+statement ok
+SET disabled_optimizers = '';
+
+query IITTTT nosort late_materialization_insert_result
+INSERT INTO late_materialization_insert_target
+SELECT * FROM my_datalake.default.late_materialization_topn_v2
+WHERE filter_key = 'selected'
+ORDER BY sort_key DESC NULLS LAST, record_id DESC LIMIT 2
+RETURNING *;
+
+statement ok
+DROP TABLE late_materialization_insert_target;
+
+# Materialized CTE producers feeding INSERT use the same admission policy.
+statement ok
+CREATE TEMP TABLE late_materialization_cte_insert_target (
+	record_id BIGINT,
+	sort_key BIGINT,
+	filter_key VARCHAR,
+	payload_a VARCHAR,
+	payload_b VARCHAR,
+	payload_c VARCHAR
+);
+
+query II
+EXPLAIN (FORMAT JSON)
+WITH source AS MATERIALIZED (
+	SELECT record_id, sort_key, filter_key, payload_a, payload_b, payload_c
+	FROM my_datalake.default.late_materialization_topn_v2
+	WHERE filter_key = 'selected'
+	ORDER BY sort_key DESC NULLS LAST, record_id DESC
+	LIMIT 2
+)
+INSERT INTO late_materialization_cte_insert_target
+SELECT * FROM source;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+query IITTTT nosort late_materialization_insert_result
+WITH source AS MATERIALIZED (
+    SELECT * FROM my_datalake.default.late_materialization_topn_v2
+    WHERE filter_key = 'selected'
+    ORDER BY sort_key DESC NULLS LAST, record_id DESC LIMIT 2
+)
+INSERT INTO late_materialization_cte_insert_target SELECT * FROM source
+RETURNING *;
+
+statement ok
+DROP TABLE late_materialization_cte_insert_target;
+
+# A prepared Iceberg query must be rebound when transaction-local metadata changes.
+statement ok
+PREPARE late_materialization_rebind AS
+SELECT record_id, payload_a
+FROM my_datalake.default.late_materialization_topn_v2
+WHERE filter_key = 'selected'
+ORDER BY sort_key DESC NULLS LAST, record_id DESC
+LIMIT 5;
+
+query II
+EXPLAIN (FORMAT JSON) EXECUTE late_materialization_rebind;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE my_datalake.default.late_materialization_topn_v2 ADD COLUMN prepared_rebind_column VARCHAR;
+
+query II
+EXPLAIN (FORMAT JSON) EXECUTE late_materialization_rebind;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+statement ok
+ROLLBACK;
+
+query II
+EXPLAIN (FORMAT JSON) EXECUTE late_materialization_rebind;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+statement ok
+DEALLOCATE late_materialization_rebind;
+
+# A plan bound before a data change must also be rebound. This covers the case
+# where transaction_data is created after the original late-materialization
+# decision, without relying on a schema change to invalidate the statement.
+statement ok
+PREPARE late_materialization_data_rebind AS
+SELECT record_id, sort_key, length(payload_a) AS payload_length
+FROM my_datalake.default.late_materialization_topn_v2
+WHERE filter_key = 'selected'
+ORDER BY sort_key DESC NULLS LAST, record_id DESC
+LIMIT 1;
+
+query II
+EXPLAIN (FORMAT JSON) EXECUTE late_materialization_data_rebind;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO my_datalake.default.late_materialization_topn_v2
+VALUES (100, 101, 'selected', 'prepared_insert_a', 'prepared_insert_b', 'prepared_insert_c');
+
+query II
+EXPLAIN (FORMAT JSON) EXECUTE late_materialization_data_rebind;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+query III
+EXECUTE late_materialization_data_rebind;
+----
+100	101	17
+
+statement ok
+ROLLBACK;
+
+query II
+EXPLAIN (FORMAT JSON) EXECUTE late_materialization_data_rebind;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+statement ok
+DEALLOCATE late_materialization_data_rebind;
+
+# A read-only transaction has a fixed snapshot and remains eligible.
+statement ok
+BEGIN;
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM late_materialization_topn;
+----
+logical_opt	<REGEX>:(?s).*ORDER_BY.*COMPARISON_JOIN.*ICEBERG_SCAN.*TOP_N.*ICEBERG_SCAN.*
+
+statement ok
+ROLLBACK;
+
+# Both independent scans include the transaction-local delete manifests.
+statement ok
+BEGIN;
+
+statement ok
+DELETE FROM my_datalake.default.late_materialization_topn_v2
+WHERE record_id = 11;
+
+statement ok
+SET disabled_optimizers = 'late_materialization';
+
+query IITTT nosort late_materialization_transaction_delete_result
+SELECT * FROM late_materialization_topn;
+
+statement ok
+SET disabled_optimizers = '';
+
+query IITTT nosort late_materialization_transaction_delete_result
+SELECT * FROM late_materialization_topn;
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM late_materialization_topn;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+statement ok
+ROLLBACK;
+
+# Both independent scans include transaction-local data manifests from appends.
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO my_datalake.default.late_materialization_topn_v2
+VALUES (100, 101, 'selected', 'insert_a', 'insert_b', 'insert_c');
+
+statement ok
+SET disabled_optimizers = 'late_materialization';
+
+query IITTT nosort late_materialization_transaction_insert_result
+SELECT * FROM late_materialization_topn;
+
+statement ok
+SET disabled_optimizers = '';
+
+query IITTT nosort late_materialization_transaction_insert_result
+SELECT * FROM late_materialization_topn;
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM late_materialization_topn;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+statement ok
+ROLLBACK;
+
+# UPDATE contributes both data and delete manifests to the two scans.
+statement ok
+BEGIN;
+
+statement ok
+UPDATE my_datalake.default.late_materialization_topn_v2
+SET sort_key = 102, payload_a = 'update_a'
+WHERE record_id = 10;
+
+statement ok
+SET disabled_optimizers = 'late_materialization';
+
+query IITTT nosort late_materialization_transaction_update_result
+SELECT * FROM late_materialization_topn;
+
+statement ok
+SET disabled_optimizers = '';
+
+query IITTT nosort late_materialization_transaction_update_result
+SELECT * FROM late_materialization_topn;
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM late_materialization_topn;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+statement ok
+ROLLBACK;
+
+# Repeated reads must initialize fresh manifest state as the transaction grows.
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO my_datalake.default.late_materialization_topn_v2
+VALUES (100, 101, 'selected', 'append', 'b', 'c');
+
+query IIT
+SELECT record_id, sort_key, payload_a
+FROM my_datalake.default.late_materialization_topn_v2
+ORDER BY sort_key DESC NULLS LAST, record_id DESC LIMIT 1;
+----
+100	101	append
+
+statement ok
+DELETE FROM my_datalake.default.late_materialization_topn_v2 WHERE record_id = 1;
+
+statement ok
+UPDATE my_datalake.default.late_materialization_topn_v2
+SET sort_key = 102, payload_a = 'mixed' WHERE record_id = 0;
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM late_materialization_topn;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+query IIT nosort late_materialization_mixed_result
+SELECT record_id, sort_key, payload_a
+FROM my_datalake.default.late_materialization_topn_v2
+ORDER BY sort_key DESC NULLS LAST, record_id DESC LIMIT 2;
+----
+0	102	mixed
+100	101	append
+
+statement ok
+SET disabled_optimizers = 'late_materialization';
+
+query IIT nosort late_materialization_mixed_result
+SELECT record_id, sort_key, payload_a
+FROM my_datalake.default.late_materialization_topn_v2
+ORDER BY sort_key DESC NULLS LAST, record_id DESC LIMIT 2;
+
+statement ok
+SET disabled_optimizers = '';
+
+statement ok
+ROLLBACK;
+
+statement ok
+SET VARIABLE late_materialization_snapshot = (
+	SELECT snapshot_id FROM iceberg_snapshots(my_datalake.default.late_materialization_topn_v2)
+	ORDER BY sequence_number DESC LIMIT 1
+);
+
+# Explicit time travel shares the bound snapshot, with independent scan state.
+query II
+EXPLAIN (FORMAT JSON) SELECT record_id, payload_a
+FROM my_datalake.default.late_materialization_topn_v2
+AT (VERSION => getvariable('late_materialization_snapshot'))
+ORDER BY sort_key DESC NULLS LAST, record_id DESC LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+# Both scans use transaction-visible metadata after DDL. Each rollback restores V2 state.
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE my_datalake.default.late_materialization_topn_v2 ADD COLUMN pending_schema_column VARCHAR;
+
+query IITTT nosort late_materialization_delete_result
+SELECT * FROM late_materialization_topn;
+
+# Time travel omits pending manifests, but still uses the transaction-local table object.
+query II
+EXPLAIN (FORMAT JSON) SELECT record_id, payload_a
+FROM my_datalake.default.late_materialization_topn_v2
+AT (VERSION => getvariable('late_materialization_snapshot'))
+ORDER BY sort_key DESC NULLS LAST, record_id DESC LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+query II
+EXPLAIN (FORMAT JSON) SELECT record_id, pending_schema_column, payload_a
+FROM my_datalake.default.late_materialization_topn_v2
+ORDER BY sort_key DESC NULLS LAST, record_id DESC
+LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+statement ok
+ROLLBACK;
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE my_datalake.default.late_materialization_topn_v2 SET PARTITIONED BY (filter_key);
+
+query IITTT nosort late_materialization_delete_result
+SELECT * FROM late_materialization_topn;
+
+query II
+EXPLAIN (FORMAT JSON) SELECT record_id, payload_a
+FROM my_datalake.default.late_materialization_topn_v2
+WHERE filter_key = 'selected'
+ORDER BY sort_key DESC NULLS LAST, record_id DESC
+LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+statement ok
+ROLLBACK;
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE my_datalake.default.late_materialization_topn_v2 SET ('late-materialization-test' = 'pending');
+
+query IITTT nosort late_materialization_delete_result
+SELECT * FROM late_materialization_topn;
+
+query II
+EXPLAIN (FORMAT JSON) SELECT record_id, payload_a
+FROM my_datalake.default.late_materialization_topn_v2
+ORDER BY sort_key DESC NULLS LAST, record_id DESC
+LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+statement ok
+ROLLBACK;
+
+statement ok
+BEGIN;
+
+# A format update that stays at V2 keeps late materialization enabled.
+statement ok
+ALTER TABLE my_datalake.default.late_materialization_topn_v2 SET ('format-version' = 2);
+
+query IITTT nosort late_materialization_delete_result
+SELECT * FROM late_materialization_topn;
+
+query II
+EXPLAIN (FORMAT JSON) SELECT record_id, payload_a
+FROM my_datalake.default.late_materialization_topn_v2
+ORDER BY sort_key DESC NULLS LAST, record_id DESC
+LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+statement ok
+ROLLBACK;
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM late_materialization_topn;
+----
+logical_opt	<REGEX>:(?s).*ORDER_BY.*COMPARISON_JOIN.*ICEBERG_SCAN.*TOP_N.*ICEBERG_SCAN.*filename.*file_row_number.*
+
+# Unlike the RDS binder error, the current partition resolver throws an
+# InvalidInputException and aborts the transaction. This is independent of LM.
+foreach mode on off
+
+onlyif mode==off
+statement ok
+SET disabled_optimizers = 'late_materialization';
+
+statement ok
+BEGIN;
+
+statement error
+ALTER TABLE my_datalake.default.late_materialization_topn_v2 SET PARTITIONED BY (missing_partition_column);
+----
+No column by the name 'missing_partition_column' exists in the current schema
+
+statement error
+SELECT * FROM late_materialization_topn;
+----
+Current transaction is aborted
+
+statement ok
+ROLLBACK;
+
+endloop
+
+statement ok
+SET disabled_optimizers = '';
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM late_materialization_topn;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+query IITTT nosort late_materialization_delete_result
+SELECT * FROM late_materialization_topn;
+
+statement ok
+RESET explain_output;
+
+statement ok
+RESET late_materialization_max_rows;
+
+statement ok
+SET disabled_optimizers = '';
+
+statement ok
+RESET threads;
+
+statement ok
+DROP VIEW late_materialization_topn;
+
+statement ok
+DROP TABLE my_datalake.default.late_materialization_topn_v2;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/late_materialization_topn_v2_concurrent.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/late_materialization_topn_v2_concurrent.test
@@ -1,0 +1,135 @@
+# name: test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/filtering/late_materialization_topn_v2_concurrent.test
+# description: Deterministic multi-connection snapshot isolation for V2 TopN late materialization
+# group: [filtering]
+
+require-env CATALOG_TEST_CONFIG_SETUP
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+set ignore_error_messages
+
+statement ok
+SET threads = 1;
+
+statement ok
+DROP TABLE IF EXISTS my_datalake.default.late_materialization_topn_v2_concurrent;
+
+statement ok
+CREATE TABLE my_datalake.default.late_materialization_topn_v2_concurrent (
+	id BIGINT,
+	sort_key BIGINT,
+	payload VARCHAR
+) WITH ('format-version' = 2);
+
+# Two committed files give the candidate and payload scans independent file-row
+# positions to join. The named connections below are deliberately sequenced by
+# transaction boundaries, so the snapshot transition is deterministic.
+statement ok
+INSERT INTO my_datalake.default.late_materialization_topn_v2_concurrent VALUES
+	(1, 10, 'base_1'),
+	(2, 9, 'base_2'),
+	(3, 8, 'base_3');
+
+statement ok
+INSERT INTO my_datalake.default.late_materialization_topn_v2_concurrent VALUES
+	(4, 7, 'base_4'),
+	(5, 6, 'base_5');
+
+# con1 binds and executes the optimized read before the concurrent writer
+# commits. Its transaction must retain this fixed snapshot.
+statement ok con1
+BEGIN;
+
+statement ok con1
+SET late_materialization_max_rows = 2;
+
+statement ok con1
+SET explain_output = 'optimized_only';
+
+query II con1 lm_concurrent_plan
+EXPLAIN (FORMAT JSON)
+SELECT id, sort_key, payload
+FROM my_datalake.default.late_materialization_topn_v2_concurrent
+ORDER BY sort_key DESC, id DESC
+LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+query IIT con1 lm_concurrent_before
+SELECT id, sort_key, payload
+FROM my_datalake.default.late_materialization_topn_v2_concurrent
+ORDER BY sort_key DESC, id DESC
+LIMIT 2;
+----
+1	10	base_1
+2	9	base_2
+
+# con2 commits a newer snapshot while con1 remains open.
+statement ok con2
+INSERT INTO my_datalake.default.late_materialization_topn_v2_concurrent VALUES (99, 100, 'external');
+
+query IIT con2 lm_concurrent_writer
+SELECT id, sort_key, payload
+FROM my_datalake.default.late_materialization_topn_v2_concurrent
+ORDER BY sort_key DESC, id DESC
+LIMIT 1;
+----
+99	100	external
+
+# Repeating the same TopN in con1 must not observe con2's committed row or mix
+# the two snapshots between the candidate and payload scans.
+query IIT con1 lm_concurrent_during
+SELECT id, sort_key, payload
+FROM my_datalake.default.late_materialization_topn_v2_concurrent
+ORDER BY sort_key DESC, id DESC
+LIMIT 2;
+----
+1	10	base_1
+2	9	base_2
+
+statement ok con1
+ROLLBACK;
+
+# Once con1 leaves its transaction, the newer snapshot is visible normally.
+query IIT lm_concurrent_after
+SELECT id, sort_key, payload
+FROM my_datalake.default.late_materialization_topn_v2_concurrent
+ORDER BY sort_key DESC, id DESC
+LIMIT 2;
+----
+99	100	external
+1	10	base_1
+
+# A prepared statement bound on con1 must be rebound after con2 commits a
+# schema change. The execution still returns the current rows and must not
+# retain a stale late-materialization plan or column binding.
+statement ok con1
+PREPARE lm_concurrent_rebind AS
+SELECT *
+FROM my_datalake.default.late_materialization_topn_v2_concurrent
+ORDER BY sort_key DESC, id DESC
+LIMIT 2;
+
+statement ok con2
+ALTER TABLE my_datalake.default.late_materialization_topn_v2_concurrent ADD COLUMN rebound_column VARCHAR;
+
+query IITT con1 lm_concurrent_rebound
+EXECUTE lm_concurrent_rebind;
+----
+99	100	external	NULL
+1	10	base_1	NULL
+
+statement ok con1
+DEALLOCATE lm_concurrent_rebind;
+
+statement ok con1
+RESET explain_output;
+
+statement ok
+DROP TABLE my_datalake.default.late_materialization_topn_v2_concurrent;

--- a/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/partitioned_reads_v3/test_partitioned_reads_v3.test
+++ b/test/sql/local/catalog_test_config_setup/catalog_agnostic/reads/partitioned_reads_v3/test_partitioned_reads_v3.test
@@ -56,6 +56,28 @@ select count(*) from my_datalake.default.test_v3_partitioned_reads where categor
 ----
 1000
 
+# Iceberg V3 late materialization is not enabled or validated yet. The selected
+# category is a delayable payload while id is only needed by TopN.
+statement ok
+SET late_materialization_max_rows = 100;
+
+statement ok
+SET explain_output = 'optimized_only';
+
+query II
+EXPLAIN (FORMAT JSON) SELECT category
+FROM my_datalake.default.test_v3_partitioned_reads
+ORDER BY id
+LIMIT 10;
+----
+logical_opt	<!REGEX>:(?s).*COMPARISON_JOIN.*
+
+statement ok
+RESET explain_output;
+
+statement ok
+RESET late_materialization_max_rows;
+
 statement ok
 CALL enable_logging();
 

--- a/test/sql/local/column_mapping_delete.test
+++ b/test/sql/local/column_mapping_delete.test
@@ -50,3 +50,25 @@ query I
 SELECT count(*) FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/name_mapping/warehouse_1/mydb/t1', version=7, snapshot_from_id=2651609110244230974) where b is null;
 ----
 10000
+
+# Iceberg V1 late materialization is not enabled or validated yet. Column b is
+# a delayable payload, so this specifically exercises the format-version gate.
+statement ok
+SET late_materialization_max_rows = 100;
+
+statement ok
+SET explain_output = 'optimized_only';
+
+query II
+EXPLAIN (FORMAT JSON) SELECT *
+FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/name_mapping/warehouse_1/mydb/t1', version=3, snapshot_from_id=6597550917742534971)
+ORDER BY a
+LIMIT 10;
+----
+logical_opt	<!REGEX>:(?s).*COMPARISON_JOIN.*
+
+statement ok
+RESET explain_output;
+
+statement ok
+RESET late_materialization_max_rows;

--- a/test/sql/local/equality_deletes.test
+++ b/test/sql/local/equality_deletes.test
@@ -85,6 +85,37 @@ SELECT count(*) FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/equality_
 ----
 2
 
+# Both scans must apply equality deletes before late materialization joins them.
+statement ok
+SET late_materialization_max_rows = 1;
+
+statement ok
+SET explain_output = 'optimized_only';
+
+query II
+EXPLAIN (FORMAT JSON) SELECT bir
+FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/equality_deletes/warehouse/mydb/mytable')
+ORDER BY id
+LIMIT 1;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*ICEBERG_SCAN.*TOP_N.*ICEBERG_SCAN.*filename.*file_row_number.*
+
+# Deleted ids 1, 2, and 3 must not consume the TopN slot even though the
+# equality-delete columns are not projected in the final result.
+query I
+SELECT bir
+FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/equality_deletes/warehouse/mydb/mytable')
+ORDER BY id
+LIMIT 1;
+----
+2025-01-04
+
+statement ok
+RESET explain_output;
+
+statement ok
+RESET late_materialization_max_rows;
+
 # Equality deletes are a scan correctness requirement and must not depend on an optimizer extension.
 statement ok
 PRAGMA disable_optimizer;

--- a/test/sql/local/late_materialization_equality_snapshots.test
+++ b/test/sql/local/late_materialization_equality_snapshots.test
@@ -1,0 +1,112 @@
+# name: test/sql/local/late_materialization_equality_snapshots.test
+# description: Prepared TopN scans preserve equality deletes across historical snapshots
+# group: [local]
+
+require avro
+
+require parquet
+
+require iceberg
+
+require httpfs
+
+# Independent visible-row oracle for the existing equality-delete fixture.
+statement ok
+CREATE TABLE expected_ids(snapshot BIGINT, id INTEGER);
+
+statement ok
+INSERT INTO expected_ids VALUES
+	(853766660775201079, 1), (853766660775201079, 2), (853766660775201079, 3), (853766660775201079, 4),
+	(1584331123492059582, 3), (1584331123492059582, 4),
+	(842401149381792626, 4),
+	(3340507003387467420, 4), (3340507003387467420, 5), (3340507003387467420, 6),
+	(1916084761853986166, 4), (1916084761853986166, 5);
+
+statement ok
+SET late_materialization_max_rows = 2;
+
+statement ok
+SET explain_output = 'optimized_only';
+
+foreach threads 1 4
+
+statement ok
+SET threads = {threads};
+
+foreach mode on off
+
+onlyif mode==on
+statement ok
+SET disabled_optimizers = '';
+
+onlyif mode==off
+statement ok
+SET disabled_optimizers = 'late_materialization';
+
+foreach direction ASC DESC
+
+# Snapshot 2 names a manifest list absent from this fixture.
+foreach snapshot 853766660775201079 1584331123492059582 842401149381792626 3340507003387467420 1916084761853986166
+
+# Covers single and compound equality keys, deleted TopN candidates, a result
+# smaller than LIMIT, and newly appended files after the equality deletes.
+statement ok
+PREPARE equality_history AS
+SELECT bir
+FROM iceberg_scan('{WORKING_DIRECTORY}/data/persistent/equality_deletes/warehouse/mydb/mytable', snapshot_from_id = {snapshot})
+ORDER BY id {direction}
+LIMIT 2;
+
+query I nosort eq_snapshot
+SELECT DATE '2025-01-01' + id - 1 AS bir
+FROM expected_ids
+WHERE snapshot = {snapshot}
+ORDER BY id {direction}
+LIMIT 2;
+
+query I nosort eq_snapshot
+EXECUTE equality_history;
+
+# Re-execution exercises independent runtime scan state with the same binding.
+query I nosort eq_snapshot
+EXECUTE equality_history;
+
+onlyif mode==on
+query II
+EXPLAIN (FORMAT JSON) EXECUTE equality_history;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*
+
+onlyif mode==off
+query II
+EXPLAIN (FORMAT JSON) EXECUTE equality_history;
+----
+logical_opt	<!REGEX>:(?s).*COMPARISON_JOIN.*
+
+statement ok
+DEALLOCATE equality_history;
+
+reset label eq_snapshot
+
+endloop
+
+endloop
+
+endloop
+
+endloop
+
+statement ok
+DROP TABLE expected_ids;
+
+statement ok
+RESET disabled_optimizers;
+
+statement ok
+RESET late_materialization_max_rows;
+
+statement ok
+RESET explain_output;
+
+statement ok
+RESET threads;

--- a/test/sql/local/late_materialization_filters.test
+++ b/test/sql/local/late_materialization_filters.test
@@ -1,0 +1,249 @@
+# name: test/sql/local/late_materialization_filters.test
+# description: TopN virtual projections remain eligible while virtual filters fall back
+# group: [local]
+
+require avro
+
+require parquet
+
+require iceberg
+
+statement ok
+CREATE VIEW lm_filter_input AS
+SELECT *
+FROM iceberg_scan('{WORKING_DIRECTORY}/data/persistent/null_stats/default/test_nulls',
+                  version='00003-9d6a621e-8a72-4190-a880-f6ca02e32b86');
+
+statement ok
+CREATE VIEW lm_virtual_filter_input AS
+SELECT *, filename, file_row_number
+FROM iceberg_scan('{WORKING_DIRECTORY}/data/persistent/null_stats/default/test_nulls',
+                  version='00003-9d6a621e-8a72-4190-a880-f6ca02e32b86');
+
+statement ok
+SET late_materialization_max_rows = 10;
+
+statement ok
+SET explain_output = 'optimized_only';
+
+foreach threads 1 4
+
+statement ok
+SET threads = {threads};
+
+foreach mode off on
+
+onlyif mode==off
+statement ok
+SET disabled_optimizers = 'late_materialization';
+
+onlyif mode==on
+statement ok
+SET disabled_optimizers = '';
+
+onlyif mode==on
+query II
+EXPLAIN (FORMAT JSON)
+SELECT name FROM lm_filter_input
+WHERE id + CASE WHEN flag THEN 1 ELSE 0 END > 5
+ORDER BY id DESC LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*FILTER.*
+
+# The filter needs two columns, one of which can be discarded above it.
+query T
+SELECT name FROM lm_filter_input
+WHERE id + CASE WHEN flag THEN 1 ELSE 0 END > 5
+ORDER BY id DESC LIMIT 2;
+----
+i
+h
+
+query T
+SELECT name FROM lm_virtual_filter_input
+WHERE file_row_number = 0
+ORDER BY id DESC LIMIT 2;
+----
+g
+d
+
+query T
+SELECT name FROM lm_virtual_filter_input
+WHERE filename LIKE '%null_stats%'
+ORDER BY id DESC LIMIT 2;
+----
+i
+h
+
+# Virtual-column filters must not reach the core late-materialization rewrite.
+query II
+EXPLAIN (FORMAT JSON)
+SELECT name FROM lm_virtual_filter_input
+WHERE file_row_number = 0
+ORDER BY id DESC LIMIT 2;
+----
+logical_opt	<!REGEX>:(?s).*COMPARISON_JOIN.*
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT name FROM lm_virtual_filter_input
+WHERE filename LIKE '%null_stats%'
+ORDER BY id DESC LIMIT 2;
+----
+logical_opt	<!REGEX>:(?s).*COMPARISON_JOIN.*
+
+# A physical-column filter remains eligible even when both virtual keys are projected.
+onlyif mode==on
+query II
+EXPLAIN (FORMAT JSON)
+SELECT file_row_number, name, filename FROM lm_virtual_filter_input
+WHERE id > 5 ORDER BY id DESC LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+query ITI
+SELECT file_row_number, name, CAST(filename IS NOT NULL AS INTEGER) FROM lm_virtual_filter_input
+WHERE id > 5 ORDER BY id DESC LIMIT 2;
+----
+2	i	1
+1	h	1
+
+# Compare the complete virtual values against the LM-disabled execution.
+query ITT nosort lm_virtual_keys
+SELECT file_row_number, name, filename FROM lm_virtual_filter_input
+WHERE id > 5 ORDER BY id DESC LIMIT 2;
+
+# Reuse an existing filename binding while the rewrite adds file_row_number.
+onlyif mode==on
+query II
+EXPLAIN (FORMAT JSON)
+SELECT filename, name FROM lm_virtual_filter_input WHERE id > 5 ORDER BY id DESC LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+query TT nosort lm_filename
+SELECT filename, name FROM lm_virtual_filter_input WHERE id > 5 ORDER BY id DESC LIMIT 2;
+
+# An unused virtual column in a view must not block the rewrite either.
+onlyif mode==on
+query II
+EXPLAIN (FORMAT JSON)
+SELECT name FROM lm_virtual_filter_input WHERE id > 5 ORDER BY id DESC LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+# Ordering on a virtual column does not create the unsafe static table filter.
+onlyif mode==on
+query II
+EXPLAIN (FORMAT JSON)
+SELECT file_row_number, name FROM lm_virtual_filter_input
+ORDER BY file_row_number DESC, id DESC LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*
+
+query IT
+SELECT file_row_number, name FROM lm_virtual_filter_input
+ORDER BY file_row_number DESC, id DESC LIMIT 2;
+----
+2	i
+2	f
+
+# This virtual filter stays above LIMIT, so it does not affect the scan's eligibility.
+onlyif mode==on
+query II
+EXPLAIN (FORMAT JSON)
+SELECT name FROM (
+    SELECT id, name, file_row_number FROM lm_virtual_filter_input ORDER BY id DESC LIMIT 3
+) limited WHERE file_row_number = 0;
+----
+logical_opt	<REGEX>:(?s).*FILTER.*COMPARISON_JOIN.*TOP_N.*
+
+query T
+SELECT name FROM (
+    SELECT id, name, file_row_number FROM lm_virtual_filter_input ORDER BY id DESC LIMIT 3
+) limited WHERE file_row_number = 0;
+----
+g
+
+# A virtual filter pushed through an alias must still disable the rewrite.
+query II
+EXPLAIN (FORMAT JSON)
+SELECT name FROM (
+    SELECT id, name, file_row_number AS pos FROM lm_virtual_filter_input
+) aliased WHERE pos + 1 = 1 ORDER BY id DESC LIMIT 2;
+----
+logical_opt	<!REGEX>:(?s).*COMPARISON_JOIN.*
+
+query T
+SELECT name FROM (
+    SELECT id, name, file_row_number AS pos FROM lm_virtual_filter_input
+) aliased WHERE pos + 1 = 1 ORDER BY id DESC LIMIT 2;
+----
+g
+d
+
+statement ok
+PREPARE lm_position_filter AS
+SELECT name FROM lm_virtual_filter_input WHERE file_row_number = $1 ORDER BY id DESC LIMIT 2;
+
+query T
+EXECUTE lm_position_filter(0);
+----
+g
+d
+
+query T
+EXECUTE lm_position_filter(2);
+----
+i
+f
+
+query II
+EXPLAIN (FORMAT JSON) EXECUTE lm_position_filter(2);
+----
+logical_opt	<!REGEX>:(?s).*COMPARISON_JOIN.*
+
+statement ok
+DEALLOCATE lm_position_filter;
+
+endloop
+
+reset label lm_virtual_keys
+
+reset label lm_filename
+
+endloop
+
+# Without table-filter pushdown, even a virtual predicate is a safe residual filter.
+statement ok
+SET disabled_optimizers = 'filter_pushdown';
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT name FROM lm_virtual_filter_input WHERE file_row_number = 0 ORDER BY id DESC LIMIT 2;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*TOP_N.*FILTER.*
+
+query T
+SELECT name FROM lm_virtual_filter_input WHERE file_row_number = 0 ORDER BY id DESC LIMIT 2;
+----
+g
+d
+
+statement ok
+RESET disabled_optimizers;
+
+statement ok
+RESET late_materialization_max_rows;
+
+statement ok
+RESET explain_output;
+
+statement ok
+RESET threads;
+
+statement ok
+DROP VIEW lm_filter_input;
+
+statement ok
+DROP VIEW lm_virtual_filter_input;

--- a/test/sql/local/null_stats.test
+++ b/test/sql/local/null_stats.test
@@ -43,3 +43,37 @@ select * from iceberg_scan('{WORKING_DIRECTORY}/data/persistent/null_stats/defau
 2	b	2024-03-02 17:20:00+00	false
 3	c	2024-03-03 21:06:40+00	true
 6	f	2024-03-07 08:26:40+00	true
+
+# Both late-materialized scans must retain the finalized version and snapshot.
+# The selected snapshot contains ids 1-3, while the latest contains ids 1-9.
+statement ok
+SET late_materialization_max_rows = 100;
+
+statement ok
+SET explain_output = 'optimized_only';
+
+query II
+EXPLAIN (FORMAT JSON) SELECT *
+FROM iceberg_scan('{WORKING_DIRECTORY}/data/persistent/null_stats/default/test_nulls',
+                  version='00003-9d6a621e-8a72-4190-a880-f6ca02e32b86',
+                  snapshot_from_id=250057325269371674)
+ORDER BY id DESC
+LIMIT 1;
+----
+logical_opt	<REGEX>:(?s).*COMPARISON_JOIN.*ICEBERG_SCAN.*TOP_N.*ICEBERG_SCAN.*filename.*file_row_number.*
+
+query IIII
+SELECT *
+FROM iceberg_scan('{WORKING_DIRECTORY}/data/persistent/null_stats/default/test_nulls',
+                  version='00003-9d6a621e-8a72-4190-a880-f6ca02e32b86',
+                  snapshot_from_id=250057325269371674)
+ORDER BY id DESC
+LIMIT 1;
+----
+3	c	2024-03-03 21:06:40+00	true
+
+statement ok
+RESET explain_output;
+
+statement ok
+RESET late_materialization_max_rows;


### PR DESCRIPTION
## Summary

Enable DuckDB's TopN late materialization for eligible Iceberg V2
`ORDER BY ... LIMIT` queries. A narrow candidate scan selects rows, and a
payload scan joins them using `(filename, file_row_number)`.

- Preserve the bound snapshot, schema, options, and transaction view, with
  independent scan state.
- Support equality/position deletes and transaction-local changes.
- Keep `IcebergOptimizerRoutine` unchanged and detect LM candidates after it.
- Fall back for scan predicates referencing virtual columns. Virtual-column
  projections and ordering remain eligible.

No DuckDB core changes are required.

## Performance

Measured on a 500,000-row Iceberg V2 table stored in 10 Parquet files (about 145 MB). The table has two numeric columns and eight 64-character payload columns. Each configuration used four threads, one warmup, and three interleaved measured runs.

```sql
SELECT *
FROM iceberg_scan('topn_wide')
ORDER BY abs(sort_key) DESC, id DESC
LIMIT 100;
```

| | Time (median of 3 runs) | Bytes read |
|---|---:|---:|
| Before (disabled) | 147.27 ms | 144.67 MB |
| After (enabled) | 80.09 ms | 17.52 MB |

This reduces median latency by 45.6% (1.84x speedup) and bytes read by 87.9%.
