### PR TITLE
Support incremental reads between iceberg snapshots for append-only tables

### DIFF
--- a/src/core/metadata/manifest/iceberg_manifest.cpp
+++ b/src/core/metadata/manifest/iceberg_manifest.cpp
@@ -466,6 +466,18 @@ int64_t IcebergManifestEntry::GetSnapshotId() const {
 	return *snapshot_id;
 }
 
+int64_t IcebergManifestEntry::GetSnapshotId(const IcebergManifestFile &manifest_file) const {
+	if (!snapshot_id) {
+		if (!manifest_file.added_snapshot_id) {
+			throw InvalidConfigurationException(
+			    "'manifest_entry.snapshot_id' is NULL and 'manifest_file.added_snapshot_id' is not set, so the "
+			    "snapshot id can not be inherited");
+		}
+		return *manifest_file.added_snapshot_id;
+	}
+	return *snapshot_id;
+}
+
 static Value CreateFieldID(int32_t field_id, bool nullable) {
 	child_list_t<Value> fields;
 	fields.emplace_back("__duckdb_field_id", Value::INTEGER(field_id));

--- a/src/core/metadata/snapshot/iceberg_snapshot.cpp
+++ b/src/core/metadata/snapshot/iceberg_snapshot.cpp
@@ -20,7 +20,7 @@ int64_t IcebergSnapshot::NewSnapshotId() {
 	return random_number;
 }
 
-static string OperationTypeToString(IcebergSnapshotOperationType type) {
+string IcebergSnapshotOperationTypeToString(IcebergSnapshotOperationType type) {
 	switch (type) {
 	case IcebergSnapshotOperationType::APPEND:
 		return "append";
@@ -48,7 +48,7 @@ rest_api_objects::Snapshot IcebergSnapshot::ToRESTObject(const IcebergTableMetad
 	}
 	res.manifest_list = manifest_list;
 
-	res.summary.operation = OperationTypeToString(operation);
+	res.summary.operation = IcebergSnapshotOperationTypeToString(operation);
 	res.summary.additional_properties = metrics.ToString();
 
 	if (parent_snapshot_id) {

--- a/src/function/metadata/iceberg_snapshots.cpp
+++ b/src/function/metadata/iceberg_snapshots.cpp
@@ -13,21 +13,6 @@
 
 namespace duckdb {
 
-static string SnapshotOperationToString(IcebergSnapshotOperationType type) {
-	switch (type) {
-	case IcebergSnapshotOperationType::APPEND:
-		return "append";
-	case IcebergSnapshotOperationType::REPLACE:
-		return "replace";
-	case IcebergSnapshotOperationType::OVERWRITE:
-		return "overwrite";
-	case IcebergSnapshotOperationType::DELETE:
-		return "delete";
-	default:
-		return "unknown";
-	}
-}
-
 struct IcebergSnaphotsBindData : public TableFunctionData {
 	IcebergSnaphotsBindData() {};
 	IcebergTableMetadata metadata;
@@ -120,7 +105,7 @@ static void IcebergSnapshotsFunction(ClientContext &context, TableFunctionInput 
 			string_t manifest_string_t = StringVector::AddString(output.data[3], string_t(snapshot.manifest_list));
 			FlatVector::GetDataMutable<string_t>(output.data[3])[i] = manifest_string_t;
 		}
-		auto operation_str = SnapshotOperationToString(snapshot.operation);
+		auto operation_str = IcebergSnapshotOperationTypeToString(snapshot.operation);
 		FlatVector::GetDataMutable<string_t>(output.data[4])[i] =
 		    StringVector::AddString(output.data[4], operation_str);
 		i++;

--- a/src/function/scan/iceberg_scan.cpp
+++ b/src/function/scan/iceberg_scan.cpp
@@ -45,6 +45,8 @@ static void AddNamedParameters(TableFunction &fun) {
 	fun.named_parameters["version_name_format"] = LogicalType::VARCHAR;
 	fun.named_parameters["snapshot_from_timestamp"] = LogicalType::TIMESTAMP_MS;
 	fun.named_parameters["snapshot_from_id"] = LogicalType::UBIGINT;
+	fun.named_parameters["start_snapshot_id"] = LogicalType::BIGINT;
+	fun.named_parameters["end_snapshot_id"] = LogicalType::BIGINT;
 }
 
 virtual_column_map_t IcebergVirtualColumns(ClientContext &context, optional_ptr<FunctionData> bind_data_p) {

--- a/src/iceberg_options.cpp
+++ b/src/iceberg_options.cpp
@@ -57,6 +57,7 @@ IcebergOptions &IcebergOptions::operator=(const IcebergOptions &other) {
 	infer_schema = other.infer_schema;
 	table_version = other.table_version;
 	version_name_format = other.version_name_format;
+	incremental_range = other.incremental_range;
 	snapshot_lookup.reset();
 	if (other.snapshot_lookup) {
 		snapshot_lookup.emplace(*other.snapshot_lookup);

--- a/src/include/core/metadata/manifest/iceberg_manifest.hpp
+++ b/src/include/core/metadata/manifest/iceberg_manifest.hpp
@@ -132,6 +132,9 @@ public:
 	void SetSnapshotId(optional<int64_t> snapshot_id);
 	bool HasSnapshotId() const;
 	int64_t GetSnapshotId() const;
+	//! Inherits from the manifest file's 'added_snapshot_id' when the field is NULL. Writers may omit
+	//! it precisely so it can be inherited, so read paths must use this overload.
+	int64_t GetSnapshotId(const IcebergManifestFile &manifest_file) const;
 	void SetSequenceNumber(optional<sequence_number_t> value);
 	void SetFileSequenceNumber(optional<sequence_number_t> value);
 	sequence_number_t GetSequenceNumber(const IcebergManifestFile &manifest_file) const;

--- a/src/include/core/metadata/snapshot/iceberg_snapshot.hpp
+++ b/src/include/core/metadata/snapshot/iceberg_snapshot.hpp
@@ -11,6 +11,8 @@ struct IcebergTable;
 
 enum class IcebergSnapshotOperationType : uint8_t { APPEND, REPLACE, OVERWRITE, DELETE };
 
+string IcebergSnapshotOperationTypeToString(IcebergSnapshotOperationType type);
+
 //! An Iceberg snapshot https://iceberg.apache.org/spec/#snapshots
 class IcebergSnapshot {
 public:

--- a/src/include/iceberg_options.hpp
+++ b/src/include/iceberg_options.hpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/optional.hpp"
 #include "duckdb/common/named_parameter_map.hpp"
+#include "planning/snapshot/iceberg_incremental_scan.hpp"
 #include "planning/snapshot/iceberg_snapshot_lookup.hpp"
 
 namespace duckdb {
@@ -60,6 +61,9 @@ public:
 	string version_name_format = DEFAULT_TABLE_VERSION_FORMAT;
 
 	optional<IcebergSnapshotLookup> snapshot_lookup;
+
+	//! Mutually exclusive with 'snapshot_lookup' being anything other than 'latest'.
+	IcebergIncrementalScanRange incremental_range;
 };
 
 } // namespace duckdb

--- a/src/include/planning/scan_plan/iceberg_scan_plan_provider.hpp
+++ b/src/include/planning/scan_plan/iceberg_scan_plan_provider.hpp
@@ -47,6 +47,10 @@ public:
 	virtual bool TryGetNextBatch(IcebergDataViewCursor &cursor) = 0;
 	virtual void FinishScanTasks() = 0;
 	virtual bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const = 0;
+	//! Only an incremental client-side scan narrows this, a server-side plan is already the file set.
+	virtual bool ManifestIsVisible(const IcebergManifestFile &manifest_file) const = 0;
+	//! Whether a manifest entry can contribute a file to this scan.
+	virtual bool EntryIsVisible(const IcebergManifestEntry &entry, const IcebergManifestFile &manifest_file) const = 0;
 	virtual vector<IcebergManifestListEntry> &DataManifests() = 0;
 	virtual vector<IcebergManifestListEntry> &DeleteManifests() = 0;
 	virtual shared_ptr<IcebergDeleteFileLoadState> &GetDeleteFileLoad(IcebergDeleteFileReference delete_file) = 0;
@@ -66,6 +70,8 @@ public:
 	bool TryGetNextBatch(IcebergDataViewCursor &cursor) override DUCKDB_REQUIRES(shared_state.lock);
 	void FinishScanTasks() override DUCKDB_REQUIRES(shared_state.lock);
 	bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const override;
+	bool ManifestIsVisible(const IcebergManifestFile &manifest_file) const override;
+	bool EntryIsVisible(const IcebergManifestEntry &entry, const IcebergManifestFile &manifest_file) const override;
 	vector<IcebergManifestListEntry> &DataManifests() override DUCKDB_REQUIRES(shared_state.lock);
 	vector<IcebergManifestListEntry> &DeleteManifests() override DUCKDB_REQUIRES(shared_state.lock);
 	shared_ptr<IcebergDeleteFileLoadState> &GetDeleteFileLoad(IcebergDeleteFileReference delete_file) override
@@ -88,6 +94,8 @@ public:
 	bool TryGetNextBatch(IcebergDataViewCursor &cursor) override;
 	void FinishScanTasks() override;
 	bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const override;
+	bool ManifestIsVisible(const IcebergManifestFile &manifest_file) const override;
+	bool EntryIsVisible(const IcebergManifestEntry &entry, const IcebergManifestFile &manifest_file) const override;
 	vector<IcebergManifestListEntry> &DataManifests() override;
 	vector<IcebergManifestListEntry> &DeleteManifests() override;
 	shared_ptr<IcebergDeleteFileLoadState> &GetDeleteFileLoad(IcebergDeleteFileReference delete_file) override;

--- a/src/include/planning/scan_plan/iceberg_scan_plan_state.hpp
+++ b/src/include/planning/scan_plan/iceberg_scan_plan_state.hpp
@@ -8,6 +8,7 @@
 #include "planning/iceberg_manifest_read_state.hpp"
 #include "planning/metadata_io/avro/avro_scan.hpp"
 #include "planning/metadata_io/manifest/bound_iceberg_manifest_entry.hpp"
+#include "planning/snapshot/iceberg_incremental_scan.hpp"
 #include "planning/snapshot/iceberg_scan_info.hpp"
 
 #include <condition_variable>
@@ -58,6 +59,8 @@ struct IcebergScanPlanState {
 	string path;
 	optional_ptr<IcebergTableSchemaVersion> table;
 	IcebergOptions options;
+	//! The resolved range of an incremental scan, unset otherwise. Written in Bind, read-only after.
+	optional<IcebergIncrementalSnapshots> incremental;
 
 	mutable annotated_mutex lock;
 	mutable annotated_mutex delete_lock DUCKDB_ACQUIRED_AFTER(lock);

--- a/src/include/planning/snapshot/iceberg_incremental_scan.hpp
+++ b/src/include/planning/snapshot/iceberg_incremental_scan.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "duckdb/common/optional.hpp"
+#include "duckdb/common/typedefs.hpp"
+#include "duckdb/common/unordered_set.hpp"
+
+namespace duckdb {
+
+struct IcebergManifestEntry;
+struct IcebergManifestFile;
+struct IcebergTableMetadata;
+
+//! The unresolved 'start_snapshot_id' / 'end_snapshot_id' options of 'iceberg_scan'.
+struct IcebergIncrementalScanRange {
+public:
+	//! Exclusive lower bound. Its presence is what makes a scan incremental.
+	optional<int64_t> start_snapshot_id;
+	//! Inclusive upper bound. When unset the table's current snapshot is used.
+	optional<int64_t> end_snapshot_id;
+
+public:
+	bool IsIncremental() const {
+		return start_snapshot_id.has_value();
+	}
+	//! Whether either bound was supplied, used to reject combining a range with a point-in-time read.
+	bool IsSet() const {
+		return start_snapshot_id.has_value() || end_snapshot_id.has_value();
+	}
+};
+
+//! The resolved ancestor chain between the two bounds. Resolved during bind from already parsed
+//! metadata, so it reads no files.
+struct IcebergIncrementalSnapshots {
+public:
+	//! Throws when a bound does not exist, when start is not an ancestor of end, or when a snapshot
+	//! in the range is not an append.
+	static IcebergIncrementalSnapshots Resolve(const IcebergTableMetadata &metadata,
+	                                           const IcebergIncrementalScanRange &range);
+
+public:
+	//! An unattributable manifest (no 'added_snapshot_id') returns true, the entry check decides.
+	bool ManifestInRange(const IcebergManifestFile &manifest_file) const;
+	//! Whether a manifest entry was added by a snapshot in the range.
+	bool EntryInRange(const IcebergManifestEntry &entry, const IcebergManifestFile &manifest_file) const;
+
+public:
+	//! Ancestors of the end snapshot down to, but excluding, the start snapshot.
+	unordered_set<int64_t> snapshot_ids;
+	//! The resolved inclusive upper bound, whose manifest list and schema the scan reads.
+	int64_t end_snapshot_id = 0;
+};
+
+} // namespace duckdb

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -16,6 +16,7 @@
 #include "planning/iceberg_multi_file_reader.hpp"
 #include "planning/pruning/iceberg_file_pruner.hpp"
 #include "planning/scan_plan/iceberg_scan_plan_provider.hpp"
+#include "planning/snapshot/iceberg_incremental_scan.hpp"
 
 namespace duckdb {
 
@@ -174,6 +175,11 @@ void IcebergMultiFileList::Bind(vector<LogicalType> &return_types, vector<Identi
 		return_types = this->types;
 		return;
 	}
+	auto &incremental_range = options.incremental_range;
+	if (incremental_range.end_snapshot_id && !incremental_range.start_snapshot_id) {
+		throw InvalidInputException("'end_snapshot_id' can only be used together with 'start_snapshot_id'");
+	}
+
 	if (!shared_state->scan_info) {
 		D_ASSERT(!shared_state->path.empty());
 		auto input_string = shared_state->path;
@@ -184,10 +190,23 @@ void IcebergMultiFileList::Bind(vector<LogicalType> &return_types, vector<Identi
 		auto &metadata = temp_data->metadata;
 
 		IcebergSnapshotScanInfo snapshot_info;
-		snapshot_info = metadata.GetSnapshot(*options.snapshot_lookup);
+		if (incremental_range.IsIncremental()) {
+			//! Validates the bounds before any manifest is read. The scan then reads the end snapshot
+			//! like a normal time travel read, and the range narrows which of its files are visible.
+			shared_state->incremental = IcebergIncrementalSnapshots::Resolve(metadata, incremental_range);
+			snapshot_info =
+			    metadata.GetSnapshot(IcebergSnapshotLookup::FromSnapshotId(shared_state->incremental->end_snapshot_id));
+		} else {
+			snapshot_info = metadata.GetSnapshot(*options.snapshot_lookup);
+		}
 		auto schema = metadata.GetSchemaFromId(snapshot_info.schema_id);
 		shared_state->scan_info = make_shared_ptr<IcebergScanInfo>(resolved_metadata.table_location,
 		                                                           std::move(temp_data), snapshot_info, *schema);
+	} else if (incremental_range.IsIncremental()) {
+		//! A table reference already chose the snapshot and can not carry named parameters, so this is
+		//! unreachable through SQL. Fail loudly rather than ignoring the range.
+		throw InvalidInputException("'start_snapshot_id' is only supported when scanning through "
+		                            "'iceberg_scan', not through a table reference");
 	}
 
 	auto &schema = GetSchema().columns;
@@ -474,6 +493,10 @@ IcebergMultiFileList::GetDataFile(idx_t file_id, annotated_lock_guard<annotated_
 			if (manifest_entry.status == IcebergManifestEntryStatusType::DELETED) {
 				continue;
 			}
+			if (!GetScanPlanProvider().EntryIsVisible(manifest_entry, manifest_file)) {
+				//! Not added by a snapshot in the requested incremental range
+				continue;
+			}
 
 			// Check whether current data file is filtered out.
 			if (table_filters.HasFilters() && !IcebergFilePruner(context, GetMetadata(), GetSchema(), table_filters)
@@ -568,13 +591,16 @@ void IcebergMultiFileList::InitializeView(annotated_lock_guard<annotated_mutex> 
 	IcebergFilePruner pruner(context, GetMetadata(), GetSchema(), table_filters);
 	data_manifests.reserve(committed_data_manifests.size() + transaction_data_manifests.size());
 	data_manifest_matches.reserve(committed_data_manifests.size() + transaction_data_manifests.size());
+	auto &provider = GetScanPlanProvider();
 	for (auto &manifest : committed_data_manifests) {
 		data_manifests.emplace_back(data_manifests.size(), manifest);
-		data_manifest_matches.push_back(pruner.ManifestMatchesFilter(manifest.file));
+		data_manifest_matches.push_back(pruner.ManifestMatchesFilter(manifest.file) &&
+		                                provider.ManifestIsVisible(manifest.file));
 	}
 	for (auto &manifest : transaction_data_manifests) {
 		data_manifests.emplace_back(data_manifests.size(), manifest);
-		data_manifest_matches.push_back(pruner.ManifestMatchesFilter(manifest.get().file));
+		data_manifest_matches.push_back(pruner.ManifestMatchesFilter(manifest.get().file) &&
+		                                provider.ManifestIsVisible(manifest.get().file));
 	}
 
 	auto &committed_delete_manifests = GetScanPlanProvider().DeleteManifests();

--- a/src/planning/iceberg_multi_file_reader.cpp
+++ b/src/planning/iceberg_multi_file_reader.cpp
@@ -554,6 +554,12 @@ void IcebergMultiFileReader::FinalizeChunk(ClientContext &context, const MultiFi
 	}
 }
 
+static void RejectIncrementalRangeCombination(const IcebergOptions &options, const char *key) {
+	if (options.incremental_range.IsSet()) {
+		throw InvalidInputException("Can't use '%s' in combination with 'start_snapshot_id' or 'end_snapshot_id'", key);
+	}
+}
+
 bool IcebergMultiFileReader::ParseOption(const Identifier &key, const Value &val, MultiFileOptions &options,
                                          ClientContext &context) {
 	auto &snapshot_lookup = this->options.snapshot_lookup;
@@ -584,6 +590,7 @@ bool IcebergMultiFileReader::ParseOption(const Identifier &key, const Value &val
 		if (snapshot_lookup->GetSource() != SnapshotSource::LATEST) {
 			throw InvalidInputException("Can't use 'snapshot_from_id' in combination with 'snapshot_from_timestamp'");
 		}
+		RejectIncrementalRangeCombination(this->options, "snapshot_from_id");
 		snapshot_lookup.emplace(IcebergSnapshotLookup::FromSnapshotId(val.GetValue<uint64_t>()));
 		return true;
 	}
@@ -591,8 +598,24 @@ bool IcebergMultiFileReader::ParseOption(const Identifier &key, const Value &val
 		if (snapshot_lookup->GetSource() != SnapshotSource::LATEST) {
 			throw InvalidInputException("Can't use 'snapshot_from_id' in combination with 'snapshot_from_timestamp'");
 		}
+		RejectIncrementalRangeCombination(this->options, "snapshot_from_timestamp");
 		snapshot_lookup.emplace(IcebergSnapshotLookup::FromTimestamp(
 		    val.DefaultCastAs(LogicalType::TIMESTAMP_MS).GetValue<timestamp_ms_t>()));
+		return true;
+	}
+	if (key == "start_snapshot_id" || key == "end_snapshot_id") {
+		//! 'named_parameter_map_t' has no defined iteration order, so both directions are checked.
+		if (snapshot_lookup->GetSource() != SnapshotSource::LATEST) {
+			throw InvalidInputException("Can't use '%s' in combination with 'snapshot_from_id' or "
+			                            "'snapshot_from_timestamp'",
+			                            key.GetIdentifierName());
+		}
+		auto snapshot_id = val.DefaultCastAs(LogicalType::BIGINT).GetValue<int64_t>();
+		if (key == "start_snapshot_id") {
+			this->options.incremental_range.start_snapshot_id = snapshot_id;
+		} else {
+			this->options.incremental_range.end_snapshot_id = snapshot_id;
+		}
 		return true;
 	}
 	return MultiFileReader::ParseOption(key, val, options, context);

--- a/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
+++ b/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
@@ -451,6 +451,21 @@ bool ClientSideScanPlanProvider::DeleteFileAppliesToDataFile(const string &data_
 	return true;
 }
 
+bool ClientSideScanPlanProvider::ManifestIsVisible(const IcebergManifestFile &manifest_file) const {
+	if (!shared_state.incremental) {
+		return true;
+	}
+	return shared_state.incremental->ManifestInRange(manifest_file);
+}
+
+bool ClientSideScanPlanProvider::EntryIsVisible(const IcebergManifestEntry &entry,
+                                                const IcebergManifestFile &manifest_file) const {
+	if (!shared_state.incremental) {
+		return true;
+	}
+	return shared_state.incremental->EntryInRange(entry, manifest_file);
+}
+
 vector<IcebergManifestListEntry> &ClientSideScanPlanProvider::DataManifests() {
 	return shared_state.committed_data_manifests;
 }

--- a/src/planning/scan_plan/iceberg_server_scan_plan_provider.cpp
+++ b/src/planning/scan_plan/iceberg_server_scan_plan_provider.cpp
@@ -53,6 +53,16 @@ bool ServerSideScanPlanProvider::DeleteFileAppliesToDataFile(const string &data_
 	return refs != plan.delete_files_by_data_file.end() && refs->second.count(delete_file_path);
 }
 
+bool ServerSideScanPlanProvider::ManifestIsVisible(const IcebergManifestFile &manifest_file) const {
+	//! The plan returned by the server is already exactly the set of files to read
+	return true;
+}
+
+bool ServerSideScanPlanProvider::EntryIsVisible(const IcebergManifestEntry &entry,
+                                                const IcebergManifestFile &manifest_file) const {
+	return true;
+}
+
 vector<IcebergManifestListEntry> &ServerSideScanPlanProvider::DataManifests() {
 	return plan.data_manifests;
 }

--- a/src/planning/snapshot/CMakeLists.txt
+++ b/src/planning/snapshot/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(iceberg_planning_snapshot OBJECT iceberg_snapshot_lookup.cpp)
+add_library(iceberg_planning_snapshot OBJECT iceberg_incremental_scan.cpp
+                                             iceberg_snapshot_lookup.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_planning_snapshot>
     PARENT_SCOPE)

--- a/src/planning/snapshot/iceberg_incremental_scan.cpp
+++ b/src/planning/snapshot/iceberg_incremental_scan.cpp
@@ -1,0 +1,97 @@
+#include "planning/snapshot/iceberg_incremental_scan.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/vector.hpp"
+
+#include "core/metadata/iceberg_table_metadata.hpp"
+#include "core/metadata/manifest/iceberg_manifest.hpp"
+#include "core/metadata/manifest/iceberg_manifest_list.hpp"
+#include "core/metadata/snapshot/iceberg_snapshot.hpp"
+
+namespace duckdb {
+
+IcebergIncrementalSnapshots IcebergIncrementalSnapshots::Resolve(const IcebergTableMetadata &metadata,
+                                                                 const IcebergIncrementalScanRange &range) {
+	D_ASSERT(range.IsIncremental());
+	auto start_snapshot_id = *range.start_snapshot_id;
+
+	int64_t end_snapshot_id;
+	if (range.end_snapshot_id) {
+		end_snapshot_id = *range.end_snapshot_id;
+	} else if (metadata.current_snapshot_id) {
+		end_snapshot_id = *metadata.current_snapshot_id;
+	} else {
+		throw InvalidInputException("'end_snapshot_id' is not set and the table has no current snapshot");
+	}
+
+	//! Both throw when the snapshot does not exist
+	metadata.GetSnapshotById(start_snapshot_id);
+	auto end_snapshot = metadata.GetSnapshotById(end_snapshot_id);
+
+	IcebergIncrementalSnapshots result;
+	result.end_snapshot_id = end_snapshot_id;
+	if (start_snapshot_id == end_snapshot_id) {
+		//! An empty range, the scan produces no files
+		return result;
+	}
+
+	//! 'start_snapshot_id' is exclusive, so it is never collected.
+	vector<reference<const IcebergSnapshot>> collected;
+	optional_ptr<const IcebergSnapshot> cursor = end_snapshot;
+	bool found_start = false;
+	//! The bound stops a cycle in corrupt metadata
+	for (idx_t step = 0; cursor && step <= metadata.snapshots.size(); step++) {
+		collected.push_back(*cursor);
+		if (!cursor->parent_snapshot_id) {
+			//! Reached the root of the chain without passing the start snapshot
+			break;
+		}
+		auto parent_snapshot_id = *cursor->parent_snapshot_id;
+		if (parent_snapshot_id == start_snapshot_id) {
+			found_start = true;
+			break;
+		}
+		cursor = metadata.FindSnapshotByIdInternal(parent_snapshot_id);
+	}
+	if (!found_start) {
+		throw InvalidInputException(
+		    "'start_snapshot_id' %lld is not an ancestor of 'end_snapshot_id' %lld, so the range of "
+		    "appended data between them is not defined",
+		    start_snapshot_id, end_snapshot_id);
+	}
+
+	for (auto &snapshot_ref : collected) {
+		auto &snapshot = snapshot_ref.get();
+		if (!snapshot.snapshot_id) {
+			throw InvalidConfigurationException("Snapshot in the requested range has no 'snapshot-id'");
+		}
+		if (snapshot.operation != IcebergSnapshotOperationType::APPEND) {
+			throw InvalidInputException(
+			    "Snapshot %lld in the requested range has operation '%s', incremental reads only support "
+			    "'append' snapshots. Reading between these snapshots would silently skip the data it changed",
+			    *snapshot.snapshot_id, IcebergSnapshotOperationTypeToString(snapshot.operation));
+		}
+		result.snapshot_ids.insert(*snapshot.snapshot_id);
+	}
+	return result;
+}
+
+bool IcebergIncrementalSnapshots::ManifestInRange(const IcebergManifestFile &manifest_file) const {
+	if (!manifest_file.added_snapshot_id) {
+		//! Not attributable, leave the decision to the entry check
+		return true;
+	}
+	return snapshot_ids.count(*manifest_file.added_snapshot_id) != 0;
+}
+
+bool IcebergIncrementalSnapshots::EntryInRange(const IcebergManifestEntry &entry,
+                                               const IcebergManifestFile &manifest_file) const {
+	if (entry.status != IcebergManifestEntryStatusType::ADDED) {
+		//! An EXISTING entry was carried forward from an earlier snapshot, it is not new data
+		return false;
+	}
+	return snapshot_ids.count(entry.GetSnapshotId(manifest_file)) != 0;
+}
+
+} // namespace duckdb

--- a/test/sql/local/iceberg_scans/iceberg_scan_incremental.test
+++ b/test/sql/local/iceberg_scans/iceberg_scan_incremental.test
@@ -1,0 +1,150 @@
+# name: test/sql/local/iceberg_scans/iceberg_scan_incremental.test
+# description: incremental reads between two snapshots of an append only table
+# group: [iceberg_scans]
+
+require avro
+
+require parquet
+
+require iceberg
+
+# 'data/persistent/is_null_is_not_null' has a linear chain of three append snapshots:
+#   6009550004485738065 adds id 1, 2, 3
+#   2353095958979530531 adds id 4, 5, 6
+#   1222714758486840798 adds id 7, 8   (the current snapshot)
+
+# 'start_snapshot_id' is exclusive, so the first snapshot's own rows are not returned
+query II
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=6009550004485738065, end_snapshot_id=2353095958979530531) ORDER BY id;
+----
+4	foo
+5	bar
+6	baz
+
+# spanning two snapshots returns the union of what both appended
+query II
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=6009550004485738065, end_snapshot_id=1222714758486840798) ORDER BY id;
+----
+4	foo
+5	bar
+6	baz
+7	NULL
+8	blah
+
+# 'end_snapshot_id' is optional and defaults to the current snapshot
+query II
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=6009550004485738065) ORDER BY id;
+----
+4	foo
+5	bar
+6	baz
+7	NULL
+8	blah
+
+# the last increment only
+query II
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=2353095958979530531, end_snapshot_id=1222714758486840798) ORDER BY id;
+----
+7	NULL
+8	blah
+
+# an empty range: the bounds are the same snapshot
+query I
+SELECT count(*) FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=6009550004485738065, end_snapshot_id=6009550004485738065);
+----
+0
+
+# starting from the current snapshot means there is nothing new to read
+query I
+SELECT count(*) FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=1222714758486840798);
+----
+0
+
+# consecutive increments plus the base snapshot reconstruct the table exactly, with no duplicates
+query II
+SELECT * FROM (
+	SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', snapshot_from_id=6009550004485738065)
+	UNION ALL
+	SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=6009550004485738065, end_snapshot_id=2353095958979530531)
+	UNION ALL
+	SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=2353095958979530531, end_snapshot_id=1222714758486840798)
+) ORDER BY id;
+----
+1	NULL
+2	NULL
+3	NULL
+4	foo
+5	bar
+6	baz
+7	NULL
+8	blah
+
+# a filter still applies on top of the range
+query II
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=6009550004485738065) WHERE value IS NOT NULL ORDER BY id;
+----
+4	foo
+5	bar
+6	baz
+8	blah
+
+# the start snapshot has to be an ancestor of the end snapshot, here the two are swapped
+statement error
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=1222714758486840798, end_snapshot_id=2353095958979530531);
+----
+is not an ancestor of
+
+# 'data/persistent/name_mapping/warehouse_1/mydb/t1' is append then replace. A range covering the
+# replace is rejected rather than silently returning only the part of it that was appended.
+statement error
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/name_mapping/warehouse_1/mydb/t1', start_snapshot_id=6597550917742534971, end_snapshot_id=2651609110244230974);
+----
+incremental reads only support 'append' snapshots
+
+# 'data/persistent/iceberg/lineitem_iceberg' is append then overwrite, same rejection
+statement error
+SELECT count(*) FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/iceberg/lineitem_iceberg', start_snapshot_id=7817332053627255703, end_snapshot_id=2354745328521181395);
+----
+incremental reads only support 'append' snapshots
+
+# an unknown bound is reported, not silently ignored
+statement error
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=1);
+----
+Could not find snapshot with id 1
+
+statement error
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=6009550004485738065, end_snapshot_id=2);
+----
+Could not find snapshot with id 2
+
+# Manifest level pruning: the range is applied to the same 'data_manifest_matches' vector that
+# partition pruning fills, so manifests outside the range are never read. Without this the entry
+# level check alone would still return the right rows, but every manifest would be opened.
+statement ok
+set threads=1;
+
+statement ok
+set enable_logging=true;
+
+statement ok
+call enable_logging('Iceberg');
+
+statement ok
+select id, value from ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null');
+
+query I
+select message from duckdb_logs() where type = 'Iceberg' and message like '%data_manifest_scan_started%';
+----
+Iceberg metadata phase=data_manifest_scan_started selected_data_manifests=3 total_data_manifests=3 filters=0
+
+statement ok
+call truncate_duckdb_logs();
+
+statement ok
+select id, value from ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=2353095958979530531, end_snapshot_id=1222714758486840798);
+
+query I
+select message from duckdb_logs() where type = 'Iceberg' and message like '%data_manifest_scan_started%';
+----
+Iceberg metadata phase=data_manifest_scan_started selected_data_manifests=1 total_data_manifests=3 filters=0

--- a/test/sql/local/iceberg_scans/iceberg_scan_incremental_errors.test
+++ b/test/sql/local/iceberg_scans/iceberg_scan_incremental_errors.test
@@ -1,0 +1,52 @@
+# name: test/sql/local/iceberg_scans/iceberg_scan_incremental_errors.test
+# description: option validation for the incremental read parameters of iceberg_scan
+# group: [iceberg_scans]
+
+require avro
+
+require parquet
+
+require iceberg
+
+# 'start_snapshot_id' is what activates an incremental scan, so an end bound alone is meaningless
+statement error
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', end_snapshot_id=2353095958979530531);
+----
+'end_snapshot_id' can only be used together with 'start_snapshot_id'
+
+# a range and a point in time read are mutually exclusive, in either parameter order
+statement error
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', snapshot_from_id=6009550004485738065, start_snapshot_id=6009550004485738065);
+----
+in combination with
+
+statement error
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=6009550004485738065, snapshot_from_id=6009550004485738065);
+----
+in combination with
+
+statement error
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', snapshot_from_timestamp='2023-01-01 00:00:00', start_snapshot_id=6009550004485738065);
+----
+in combination with
+
+statement error
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=6009550004485738065, snapshot_from_timestamp='2023-01-01 00:00:00');
+----
+in combination with
+
+statement error
+SELECT * FROM ICEBERG_SCAN('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', end_snapshot_id=2353095958979530531, snapshot_from_id=6009550004485738065);
+----
+in combination with
+
+# the metadata functions do not accept the range parameters
+statement error
+SELECT * FROM ICEBERG_METADATA('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=6009550004485738065);
+----
+start_snapshot_id
+
+statement error
+SELECT * FROM ICEBERG_SNAPSHOTS('{WORKING_DIRECTORY}/data/persistent/is_null_is_not_null', start_snapshot_id=6009550004485738065);
+----
+start_snapshot_id

--- a/test/sql/local/iceberg_scans/iceberg_scan_incremental_generated.test
+++ b/test/sql/local/iceberg_scans/iceberg_scan_incremental_generated.test
@@ -1,0 +1,80 @@
+# name: test/sql/local/iceberg_scans/iceberg_scan_incremental_generated.test
+# description: incremental reads over a table with five append snapshots
+# group: [iceberg_scans]
+
+require-env DUCKDB_ICEBERG_HAVE_GENERATED_DATA
+
+require avro
+
+require parquet
+
+require iceberg
+
+# 'filtering_on_bounds' is five append snapshots of 1000 rows each, where snapshot i appends
+# col1 values [1000 * i, 1000 * i + 1000). The snapshot ids are not stable across regeneration,
+# so they are resolved by position.
+
+loop i 0 5
+
+statement ok
+set variable s{i} = (
+	select snapshot_id from iceberg_snapshots('{WORKING_DIRECTORY}/data/generated/iceberg/spark-local/default/filtering_on_bounds')
+	order by sequence_number offset {i} limit 1
+);
+
+endloop
+
+query I
+select count(*) from iceberg_scan('{WORKING_DIRECTORY}/data/generated/iceberg/spark-local/default/filtering_on_bounds');
+----
+5000
+
+# one increment is exactly the 1000 rows that snapshot appended
+query III
+select count(*), min(col1), max(col1) from iceberg_scan('{WORKING_DIRECTORY}/data/generated/iceberg/spark-local/default/filtering_on_bounds', start_snapshot_id=getvariable('s0'), end_snapshot_id=getvariable('s1'));
+----
+1000	1000	1999
+
+query III
+select count(*), min(col1), max(col1) from iceberg_scan('{WORKING_DIRECTORY}/data/generated/iceberg/spark-local/default/filtering_on_bounds', start_snapshot_id=getvariable('s3'), end_snapshot_id=getvariable('s4'));
+----
+1000	4000	4999
+
+# spanning the whole chain returns everything except the first snapshot's rows
+query III
+select count(*), min(col1), max(col1) from iceberg_scan('{WORKING_DIRECTORY}/data/generated/iceberg/spark-local/default/filtering_on_bounds', start_snapshot_id=getvariable('s0'), end_snapshot_id=getvariable('s4'));
+----
+4000	1000	4999
+
+# 'end_snapshot_id' defaults to the current snapshot, which is s4
+query III
+select count(*), min(col1), max(col1) from iceberg_scan('{WORKING_DIRECTORY}/data/generated/iceberg/spark-local/default/filtering_on_bounds', start_snapshot_id=getvariable('s0'));
+----
+4000	1000	4999
+
+query I
+select count(*) from iceberg_scan('{WORKING_DIRECTORY}/data/generated/iceberg/spark-local/default/filtering_on_bounds', start_snapshot_id=getvariable('s4'));
+----
+0
+
+# the base snapshot plus every increment reconstructs the table with no duplicates
+query III
+select count(*), count(distinct col1), sum(col1) from (
+	select * from iceberg_scan('{WORKING_DIRECTORY}/data/generated/iceberg/spark-local/default/filtering_on_bounds', snapshot_from_id=getvariable('s0'))
+	union all
+	select * from iceberg_scan('{WORKING_DIRECTORY}/data/generated/iceberg/spark-local/default/filtering_on_bounds', start_snapshot_id=getvariable('s0'), end_snapshot_id=getvariable('s1'))
+	union all
+	select * from iceberg_scan('{WORKING_DIRECTORY}/data/generated/iceberg/spark-local/default/filtering_on_bounds', start_snapshot_id=getvariable('s1'), end_snapshot_id=getvariable('s2'))
+	union all
+	select * from iceberg_scan('{WORKING_DIRECTORY}/data/generated/iceberg/spark-local/default/filtering_on_bounds', start_snapshot_id=getvariable('s2'), end_snapshot_id=getvariable('s3'))
+	union all
+	select * from iceberg_scan('{WORKING_DIRECTORY}/data/generated/iceberg/spark-local/default/filtering_on_bounds', start_snapshot_id=getvariable('s3'), end_snapshot_id=getvariable('s4'))
+);
+----
+5000	5000	12497500
+
+# a filter on top of the range still prunes
+query III
+select count(*), min(col1), max(col1) from iceberg_scan('{WORKING_DIRECTORY}/data/generated/iceberg/spark-local/default/filtering_on_bounds', start_snapshot_id=getvariable('s0')) where col1 >= 2500 and col1 < 3500;
+----
+1000	2500	3499


### PR DESCRIPTION
closes #1355 

This PR adds support for incremental reads in `iceberg_scan()`.

You can now specify a starting and ending snapshot:

```sql
SELECT *
FROM iceberg_scan(
    'ice.sales.events',
    start_snapshot_id = 111,
    end_snapshot_id = 222
);
```

This returns only the data files that were added between the two snapshots. The start snapshot is exclusive, while the end snapshot is inclusive. If no end snapshot is provided, the current snapshot is used.

### How it works

Iceberg keeps a history of snapshots. We walk that history from the end snapshot back to the start snapshot to find which snapshots are part of the requested range.

We then do two levels of filtering:

1. **Manifest filtering:** Skip manifests that cannot contain data from the requested snapshot range, so we don't need to read them.
2. **Data-file filtering:** For the manifests we do read, only keep data-file entries that were added by a snapshot in the requested range.

This allows the scan to avoid reading unrelated manifests and data files.

The implementation uses metadata that DuckDB already has available, so it does not require additional metadata parsing or catalog requests.

The feature also works with attached catalogs such as `catalog.schema.table`.

One important correctness detail is that snapshot IDs can be inherited from the manifest when an individual manifest entry does not have its own snapshot ID. This PR fixes that inheritance as well.

The scan also rejects ranges containing non-append operations such as deletes or compaction, rather than silently returning an incomplete result.
