### PR TITLE
Update vcpkg 2026 06 24

### DIFF
--- a/.github/workflows/BuildIceberg.yml
+++ b/.github/workflows/BuildIceberg.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           build-type: relassert
           build: python3 duckdb/scripts/ci/retry.py -- make relassert
-          vcpkg-commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+          vcpkg-commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
           bundle: bash duckdb/scripts/prepare_build_artifact.sh relassert
           upload-name: duckdb-iceberg
           upload-path: build/relassert-artifact.tar.gz
@@ -110,7 +110,7 @@ jobs:
         with:
           build-type: release
           build: python3 duckdb/scripts/ci/retry.py -- make release
-          vcpkg-commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+          vcpkg-commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
           bundle: bash duckdb/scripts/prepare_build_artifact.sh release
           upload-name: duckdb-iceberg-equality-delete-support
 

--- a/.github/workflows/CloudTesting.yml
+++ b/.github/workflows/CloudTesting.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11.1
         with:
-          vcpkgGitCommitId: 84bab45d415d22042bd0b9081aea57f362da3f35
+          vcpkgGitCommitId: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
 
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,6 +19,7 @@ jobs:
       extension_name: iceberg
       duckdb_version: 169987abf3fcf2d4726af3784968e96c0cc84182
       ci_tools_version: main
+      # Temporary override; remove when extension-ci-tools updates its default.
       vcpkg_commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
       exclude_archs: 'windows_amd64_mingw'
       extra_toolchains: 'python3'

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,6 +19,7 @@ jobs:
       extension_name: iceberg
       duckdb_version: 169987abf3fcf2d4726af3784968e96c0cc84182
       ci_tools_version: main
+      vcpkg_commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
       exclude_archs: 'windows_amd64_mingw'
       extra_toolchains: 'python3'
 

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           build-type: release
           build: python3 duckdb/scripts/ci/retry.py -- make release
-          vcpkg-commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+          vcpkg-commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
 
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1
@@ -146,7 +146,7 @@ jobs:
         with:
           build-type: release
           build: python3 duckdb/scripts/ci/retry.py -- make -C base release
-          vcpkg-commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+          vcpkg-commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
 
       - name: Regression Test TPCH
         run: |

--- a/.github/workflows/test-s3tables-catalog.yml
+++ b/.github/workflows/test-s3tables-catalog.yml
@@ -116,7 +116,7 @@ jobs:
         with:
           build-type: release
           build: python3 duckdb/scripts/ci/retry.py -- make release
-          vcpkg-commit: 84bab45d415d22042bd0b9081aea57f362da3f35
+          vcpkg-commit: cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3 # Release 2026.06.24
 
       - name: Create S3 Tables table bucket
         run: |

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -35,7 +35,7 @@
 			}
 		]
 	},
-	"builtin-baseline": "84bab45d415d22042bd0b9081aea57f362da3f35",
+	"builtin-baseline": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3",
 	"overrides": [
 		{
 			"name": "openssl",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -40,10 +40,6 @@
 		{
 			"name": "openssl",
 			"version": "3.6.0"
-		},
-		{
-			"name": "aws-c-http",
-			"version": "0.10.2"
 		}
 	]
 }

--- a/vcpkg_ports/aws-c-io/no_op_implementation.patch
+++ b/vcpkg_ports/aws-c-io/no_op_implementation.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c306a19..882f110 100644
+index faa76c3..c722a3b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -166,9 +166,12 @@ aws_add_sanitizers(${PROJECT_NAME})
+@@ -178,9 +178,12 @@ aws_add_sanitizers(${PROJECT_NAME})
  # We are not ABI stable yet
  set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 1.0.0)
  
@@ -16,14 +16,13 @@ index c306a19..882f110 100644
      target_compile_definitions(${PROJECT_NAME} PUBLIC "-DAWS_ENABLE_${EVENT_LOOP_DEFINE}")
  endforeach()
 diff --git a/source/event_loop.c b/source/event_loop.c
-index 0ec298d..6dea0f7 100644
+index dfb919d..0a0393f 100644
 --- a/source/event_loop.c
 +++ b/source/event_loop.c
-@@ -17,6 +17,18 @@
- 
+@@ -23,6 +23,17 @@ static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_L
  static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_LOOP_PLATFORM_DEFAULT;
+ #endif
  
-+
 +#ifdef EMSCRIPTEN
 +int aws_default_dns_resolve(
 +    struct aws_allocator *allocator,
@@ -38,7 +37,7 @@ index 0ec298d..6dea0f7 100644
  struct aws_event_loop *aws_event_loop_new_default(struct aws_allocator *alloc, aws_io_clock_fn *clock) {
      struct aws_event_loop_options options = {
          .thread_options = NULL,
-@@ -84,6 +96,9 @@ struct aws_event_loop *aws_event_loop_new_with_epoll(
+@@ -90,6 +101,9 @@ struct aws_event_loop *aws_event_loop_new_with_epoll(
   * If `aws_event_loop_override_default_type` has been called, return the override default type.
   */
  enum aws_event_loop_type aws_event_loop_get_default_type(void) {
@@ -48,7 +47,7 @@ index 0ec298d..6dea0f7 100644
      if (s_default_event_loop_type_override != AWS_EVENT_LOOP_PLATFORM_DEFAULT) {
          return s_default_event_loop_type_override;
      }
-@@ -103,6 +118,7 @@ enum aws_event_loop_type aws_event_loop_get_default_type(void) {
+@@ -109,6 +123,7 @@ enum aws_event_loop_type aws_event_loop_get_default_type(void) {
  #    error                                                                                                             \
          "Default event loop type required. Failed to get default event loop type. The library is not built correctly on the platform. "
  #endif
@@ -56,25 +55,6 @@ index 0ec298d..6dea0f7 100644
  }
  
  static int aws_event_loop_type_validate_platform(enum aws_event_loop_type type) {
-diff --git a/source/io.c b/source/io.c
-index e8a5216..18f5274 100644
---- a/source/io.c
-+++ b/source/io.c
-@@ -396,8 +396,14 @@ static struct aws_log_subject_info_list s_io_log_subject_list = {
- 
- static bool s_io_library_initialized = false;
- 
-+
-+#ifdef EMSCRIPTEN
-+void aws_tls_init_static_state(struct aws_allocator *alloc) {}
-+void aws_tls_clean_up_static_state(void) {}
-+#else
- void aws_tls_init_static_state(struct aws_allocator *alloc);
- void aws_tls_clean_up_static_state(void);
-+#endif
- 
- void aws_io_library_init(struct aws_allocator *allocator) {
-     if (!s_io_library_initialized) {
 diff --git a/source/posix/socket.c b/source/posix/socket.c
 index 22cd1fc..f19579c 100644
 --- a/source/posix/socket.c
@@ -117,22 +97,51 @@ index 22cd1fc..f19579c 100644
  
  static void s_handle_socket_timeout(struct aws_task *task, void *args, aws_task_status status) {
 diff --git a/source/tls_channel_handler.c b/source/tls_channel_handler.c
-index 353877b..8101337 100644
+index de516be..a2a6930 100644
 --- a/source/tls_channel_handler.c
 +++ b/source/tls_channel_handler.c
-@@ -21,6 +21,15 @@
- 
- #include <aws/common/string.h>
- 
-+#ifdef EMSCRIPTEN
-+struct aws_tls_ctx *aws_tls_client_ctx_new(
-+    struct aws_allocator *alloc,
-+    const struct aws_tls_ctx_options *options) {
-+   printf("aws_tls_client_ctx_new\n");
-+       return 0;
-+}
+@@ -805,6 +805,7 @@ void secure_channel_init_tls_vtable(struct aws_tls_vtable *vtable);
+ void aws_tls_init_vtable(struct aws_allocator *allocator) {
+     (void)allocator;
+
++#ifndef EMSCRIPTEN
+     /* Allow the vtable to be set up only once on library initialization. */
+     static bool s_vtable_initialized = false;
+     if (s_vtable_initialized) {
+@@ -836,16 +837,23 @@ void aws_tls_init_vtable(struct aws_allocator *allocator) {
+ #    else
+     AWS_FATAL_ASSERT(false && "No TLS implementation available.");
+ #    endif
 +#endif
-+
- void aws_tls_ctx_options_init_default_client(struct aws_tls_ctx_options *options, struct aws_allocator *allocator) {
-     AWS_ZERO_STRUCT(*options);
-     options->allocator = allocator;
+ }
+
+ void aws_tls_init_static_state(struct aws_allocator *allocator) {
++#ifdef EMSCRIPTEN
++    (void)allocator;
++#else
+     AWS_PRECONDITION(s_tls_channel_handler_vtable.init_static_state);
+     s_tls_channel_handler_vtable.init_static_state(allocator);
++#endif
+ }
+
+ void aws_tls_clean_up_static_state(void) {
++#ifndef EMSCRIPTEN
+     AWS_PRECONDITION(s_tls_channel_handler_vtable.clean_up_static_state);
+     s_tls_channel_handler_vtable.clean_up_static_state();
++#endif
+ }
+
+ struct aws_tls_ctx *aws_tls_server_ctx_new(struct aws_allocator *alloc, const struct aws_tls_ctx_options *options) {
+@@ -854,8 +862,12 @@ struct aws_tls_ctx *aws_tls_server_ctx_new(struct aws_allocator *alloc, const st
+ }
+
+ struct aws_tls_ctx *aws_tls_client_ctx_new(struct aws_allocator *alloc, const struct aws_tls_ctx_options *options) {
++#ifdef EMSCRIPTEN
++    return NULL;
++#else
+     AWS_PRECONDITION(s_tls_channel_handler_vtable.client_ctx_new);
+     return s_tls_channel_handler_vtable.client_ctx_new(alloc, options);
++#endif
+ }
+
+ struct aws_channel_handler *aws_tls_client_handler_new(

--- a/vcpkg_ports/aws-c-io/portfile.cmake
+++ b/vcpkg_ports/aws-c-io/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-c-io
     REF "v${VERSION}"
-    SHA512 ba809c397ca824b9b56d3c73b9e1b18b955bc68f737700695b7d4242707ab570f1d80a1d74267b06b46e2c8b3fc307756883eff40959e6ddd34e2e7683a9ab2f
+    SHA512 dd897e063a8cd3fb1f6ea2ab356789a6368ee239cb8f03e26c02a21232b020150c9ec2938fda34e7c7e81f5e6910afabc422ef07d5350b186dbef5e5effa417c
     HEAD_REF master
     PATCHES no_op_implementation.patch
 )

--- a/vcpkg_ports/aws-c-io/vcpkg.json
+++ b/vcpkg_ports/aws-c-io/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-c-io",
-  "version": "0.24.0",
+  "version": "0.27.2",
   "description": "Handles all IO and TLS work for application protocols.",
   "homepage": "https://github.com/awslabs/aws-c-io",
   "license": "Apache-2.0",


### PR DESCRIPTION
This pr updates the vcpkg version to 2026.06.24.

This is part of updating all of duckdb, therefore merging should be done in coordination with stakeholders.

References:
https://github.com/duckdb/duckdb/pull/25094
https://github.com/duckdblabs/duckdb-internal/issues/10429