### PR TITLE
Remove iceberg_via_aws_sdk_for_catalog_interactions option, and remove aws-sdk-cpp dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,21 +23,10 @@ endif()
 # Resolve dependencies before descending into src/ so that every per-directory OBJECT library
 # inherits the include directories it needs (these commands set directory-scoped properties that
 # are inherited by subdirectories added afterwards).
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-    find_package(CURL REQUIRED)
-    find_package(AWSSDK REQUIRED COMPONENTS core sso sts)
-    include_directories(${CURL_INCLUDE_DIRS})
-    include_directories(${AWSSDK_INCLUDE_DIRS})
-endif()
-
 # Roaring is installed via vcpkg and used here
 find_package(roaring CONFIG REQUIRED)
 # Propagate roaring's usage requirements (its headers) to every OBJECT library under src/.
 link_libraries(roaring::roaring roaring::roaring-headers roaring::roaring-headers-cpp)
-
-# Reset the TARGET_NAME, the AWS find_package build could bleed into our build -
-# overriding `TARGET_NAME`
-set(TARGET_NAME iceberg)
 
 # Each directory under src/ contributes its sources as an OBJECT library and appends them to
 # ALL_OBJECT_FILES (see the per-directory CMakeLists.txt files).
@@ -48,26 +37,11 @@ add_library(${EXTENSION_NAME} STATIC ${ALL_OBJECT_FILES})
 set(PARAMETERS "-warnings")
 
 if(EMSCRIPTEN)
-  set (DUCKDB_EXTENSION_ICEBERG_LINKED_LIBS "../../vcpkg_installed/wasm32-emscripten/lib/libaws-c-mqtt.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-cpp-sdk-kinesis.a;../../vcpkg_installed/wasm32-emscripten/lib/liblzma.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-c-auth.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-c-s3.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-cpp-sdk-s3.a;../../vcpkg_installed/wasm32-emscripten/lib/libroaring.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-c-cal.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-c-sdkutils.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-cpp-sdk-sso.a;../../vcpkg_installed/wasm32-emscripten/lib/libs2n.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-c-common.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-checksums.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-cpp-sdk-sts.a;../../vcpkg_installed/wasm32-emscripten/lib/libsnappy.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-c-compression.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-cpp-sdk-cognito-identity.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-crt-cpp.a;../../vcpkg_installed/wasm32-emscripten/lib/libssl.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-c-event-stream.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-cpp-sdk-core.a;../../vcpkg_installed/wasm32-emscripten/lib/libcrypto.a;../../vcpkg_installed/wasm32-emscripten/lib/libz.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-c-http.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-cpp-sdk-dynamodb.a;../../vcpkg_installed/wasm32-emscripten/lib/libcurl.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-c-io.a;../../vcpkg_installed/wasm32-emscripten/lib/libaws-cpp-sdk-identity-management.a;../../vcpkg_installed/wasm32-emscripten/lib/libjansson.a;../../third_party/mbedtls/libduckdb_mbedtls.a")
+  set (DUCKDB_EXTENSION_ICEBERG_LINKED_LIBS "../../vcpkg_installed/wasm32-emscripten/lib/liblzma.a;../../vcpkg_installed/wasm32-emscripten/lib/libroaring.a;../../vcpkg_installed/wasm32-emscripten/lib/libsnappy.a;../../vcpkg_installed/wasm32-emscripten/lib/libz.a;../../vcpkg_installed/wasm32-emscripten/lib/libjansson.a;../../third_party/mbedtls/libduckdb_mbedtls.a")
 endif()
 
 
 build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${ALL_OBJECT_FILES})
-
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-    # AWS SDK FROM vcpkg
-    target_include_directories(${EXTENSION_NAME}
-                            PUBLIC $<BUILD_INTERFACE:${AWSSDK_INCLUDE_DIRS}>)
-    target_link_libraries(${EXTENSION_NAME} PUBLIC ${AWSSDK_LINK_LIBRARIES})
-    target_include_directories(${TARGET_NAME}_loadable_extension
-                            PRIVATE $<BUILD_INTERFACE:${AWSSDK_INCLUDE_DIRS}>)
-    target_link_libraries(${TARGET_NAME}_loadable_extension
-                        ${AWSSDK_LINK_LIBRARIES})
-
-    # Link dependencies into extension
-    target_link_libraries(${EXTENSION_NAME} PUBLIC ${CURL_LIBRARIES})
-    target_link_libraries(${TARGET_NAME}_loadable_extension ${CURL_LIBRARIES})
-endif()
 
 # Link Roaring library
 target_link_libraries(${EXTENSION_NAME} PUBLIC roaring::roaring roaring::roaring-headers roaring::roaring-headers-cpp)

--- a/src/catalog/rest/api/api_utils.cpp
+++ b/src/catalog/rest/api/api_utils.cpp
@@ -10,24 +10,7 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
-#include <sys/stat.h>
-
 namespace duckdb {
-//! Grab the first path that exists, from a list of well-known locations
-static string SelectCURLCertPath() {
-	for (string &caFile : certFileLocations) {
-		struct stat buf;
-		if (stat(caFile.c_str(), &buf) == 0) {
-			return caFile;
-		}
-	}
-	return string();
-}
-
-const string &APIUtils::GetCURLCertPath() {
-	static string cert_path = SelectCURLCertPath();
-	return cert_path;
-}
 
 unique_ptr<HTTPResponse> APIUtils::Request(RequestType request_type, optional_ptr<AttachedDatabase> attached_db,
                                            ClientContext &context, const IRCEndpointBuilder &endpoint_builder,

--- a/src/catalog/rest/storage/authorization/sigv4.cpp
+++ b/src/catalog/rest/storage/authorization/sigv4.cpp
@@ -17,12 +17,8 @@ namespace duckdb {
 namespace {
 
 //! Detect the scheme from a host string, defaulting to HTTPS
-Aws::Http::Scheme DetectScheme(const string &host) {
-	auto lower = StringUtil::Lower(host);
-	if (StringUtil::StartsWith(lower, "http://")) {
-		return Aws::Http::Scheme::HTTP;
-	}
-	return Aws::Http::Scheme::HTTPS;
+bool DetectHttps(const string &host) {
+	return !StringUtil::StartsWith(StringUtil::Lower(host), "http://");
 }
 
 } // namespace
@@ -64,21 +60,9 @@ unique_ptr<IcebergAuthorization> SIGV4Authorization::FromAttachOptions(AttachedD
 
 AWSInput SIGV4Authorization::CreateAWSInput(ClientContext &context, const IRCEndpointBuilder &endpoint_builder) {
 	AWSInput aws_input(db);
-	aws_input.cert_path = APIUtils::GetCURLCertPath();
-
-	// Set the user Agent
-	auto &config = DBConfig::GetConfig(context);
-	aws_input.user_agent = config.UserAgent();
-	Value val;
-	auto lookup_result = context.TryGetCurrentSetting("http_timeout", val);
-	if (lookup_result.GetScope() != SettingScope::INVALID) {
-		aws_input.use_httpfs_timeout = true;
-		// http timeout is in seconds, multiply by 1000 to get ms
-		aws_input.request_timeout_in_ms = val.GetValue<idx_t>() * 1000;
-	}
 
 	auto host = endpoint_builder.GetHost();
-	aws_input.scheme = DetectScheme(host);
+	aws_input.use_https = DetectHttps(host);
 	auto stripped_host = StripScheme(host);
 
 	// AWS service and region: use explicit overrides if provided, otherwise parse from host

--- a/src/catalog/rest/storage/aws.cpp
+++ b/src/catalog/rest/storage/aws.cpp
@@ -12,9 +12,6 @@
 #include "iceberg_logging.hpp"
 #include "catalog/rest/storage/iceberg_authorization.hpp"
 
-#include <aws/core/auth/AWSCredentialsProviderChain.h>
-#include <aws/core/http/HttpClient.h>
-
 namespace duckdb {
 
 namespace {
@@ -44,108 +41,73 @@ void hex256(hash_bytes &in, hash_str &out) {
 	}
 }
 
-class DuckDBSecretCredentialProvider : public Aws::Auth::AWSCredentialsProviderChain {
-public:
-	DuckDBSecretCredentialProvider(const string &key_id, const string &secret, const string &sesh_token) {
-		credentials.SetAWSAccessKeyId(key_id);
-		credentials.SetAWSSecretKey(secret);
-		credentials.SetSessionToken(sesh_token);
-	}
-
-	~DuckDBSecretCredentialProvider() = default;
-
-	Aws::Auth::AWSCredentials GetAWSCredentials() override {
-		return credentials;
-	};
-
-protected:
-	Aws::Auth::AWSCredentials credentials;
-};
-
-} // namespace
-
-static void InitAWSAPI() {
-	static bool loaded = false;
-	if (!loaded) {
-		Aws::SDKOptions options;
-
-		Aws::InitAPI(options); // Should only be called once.
-		loaded = true;
-	}
-}
-
-static void LogAWSHTTPRequest(ClientContext &context, std::shared_ptr<Aws::Http::HttpRequest> &req,
-                              HTTPResponse &response, Aws::Http::HttpMethod &method) {
-	D_ASSERT(context.db);
-	auto &http_util = HTTPUtil::Get(*context.db);
-	auto aws_headers = req->GetHeaders();
-	auto http_headers = HTTPHeaders();
-	for (auto &header : aws_headers) {
-		http_headers.Insert(header.first, header.second);
-	}
-	auto params = HTTPParams(http_util);
-	auto scheme_str = req->GetUri().GetScheme() == Aws::Http::Scheme::HTTPS ? "https://" : "http://";
-	auto url = string(scheme_str) + req->GetUri().GetAuthority() + req->GetUri().GetPath();
-	const auto query_str = req->GetUri().GetQueryString();
-	if (!query_str.empty()) {
-		url += "?" + query_str;
-	}
-	RequestType type;
-	switch (method) {
-	case Aws::Http::HttpMethod::HTTP_GET:
-		type = RequestType::GET_REQUEST;
-		break;
-	case Aws::Http::HttpMethod::HTTP_HEAD:
-		type = RequestType::HEAD_REQUEST;
-		break;
-	case Aws::Http::HttpMethod::HTTP_DELETE:
-		type = RequestType::DELETE_REQUEST;
-		break;
-	case Aws::Http::HttpMethod::HTTP_POST:
-		type = RequestType::POST_REQUEST;
-		break;
-	case Aws::Http::HttpMethod::HTTP_PUT:
-		type = RequestType::PUT_REQUEST;
-		break;
+//! The verb as it appears on the first line of the SigV4 canonical request.
+const char *MethodName(RequestType request_type) {
+	switch (request_type) {
+	case RequestType::GET_REQUEST:
+		return "GET";
+	case RequestType::PUT_REQUEST:
+		return "PUT";
+	case RequestType::HEAD_REQUEST:
+		return "HEAD";
+	case RequestType::DELETE_REQUEST:
+		return "DELETE";
+	case RequestType::POST_REQUEST:
+		return "POST";
 	default:
-		throw InvalidConfigurationException("Aws client cannot create request of type %s",
-		                                    Aws::Http::HttpMethodMapper::GetNameForHttpMethod(method));
+		throw NotImplementedException("Cannot sign a request of type %s", EnumUtil::ToString(request_type));
 	}
-	auto request = BaseRequest(type, url, std::move(http_headers), params);
-	request.params.logger = context.logger;
-	http_util.LogRequest(request, response);
 }
 
-Aws::Client::ClientConfiguration AWSInput::BuildClientConfig() {
-	auto config = Aws::Client::ClientConfiguration();
-	if (!cert_path.empty()) {
-		config.caFile = cert_path;
+//! Aws::Http::URI::AddPathSegment stripped leading and trailing slashes from every segment it
+//! was given, and kept interior ones (which is why the canonical path needs the %2F rewrite
+//! below). Segments are stored raw here, so do it on the way out.
+string NormalizeSegment(const string &segment) {
+	auto begin = segment.find_first_not_of('/');
+	if (begin == string::npos) {
+		return "";
 	}
-	if (use_httpfs_timeout) {
-		// requestTimeoutMS is for Windows
-		config.requestTimeoutMs = request_timeout_in_ms;
-		// httpRequestTimoutMS is for all other OS's
-		// see
-		// https://github.com/aws/aws-sdk-cpp/blob/199c0a80b29a30db35b8d23c043aacf7ccb28957/src/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h#L190
-		config.httpRequestTimeoutMs = request_timeout_in_ms;
-	}
-	return config;
+	auto end = segment.find_last_not_of('/');
+	return segment.substr(begin, end - begin + 1);
 }
 
-Aws::Http::URI AWSInput::BuildURI() {
-	Aws::Http::URI uri;
-	uri.SetScheme(scheme);
-	uri.SetAuthority(authority);
-	for (auto &segment : path_segments) {
-		uri.AddPathSegment(segment);
+//! The SDK's non-RFC path encoder (urlEncodeSegment with s_compliantRfc3986Encoding false).
+//! Unreserved characters plus the reserved set AWS chose to leave alone for compatibility.
+string WireEncodeSegment(const string &segment) {
+	static const char *HEX_DIGIT = "0123456789ABCDEF";
+	string result;
+	for (auto character : segment) {
+		auto ch = static_cast<unsigned char>(character);
+		if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')) {
+			result += character;
+			continue;
+		}
+		switch (ch) {
+		// RFC 3986 unreserved
+		case '-':
+		case '_':
+		case '.':
+		case '~':
+		// Reserved, but deliberately not escaped by the SDK, to match services that never
+		// escaped them either.
+		case '$':
+		case '&':
+		case ',':
+		case ':':
+		case '=':
+		case '@':
+			result += character;
+			break;
+		default:
+			result += '%';
+			result += HEX_DIGIT[ch >> 4];
+			result += HEX_DIGIT[ch & 15];
+		}
 	}
-	for (auto &param : query_string_parameters) {
-		uri.AddQueryStringParameter(param.first.c_str(), param.second.c_str());
-	}
-	return uri;
+	return result;
 }
 
-static string GetPayloadHash(const char *buffer, idx_t buffer_len) {
+string GetPayloadHash(const char *buffer, idx_t buffer_len) {
 	if (buffer_len > 0) {
 		hash_bytes payload_hash_bytes;
 		hash_str payload_hash_str;
@@ -157,106 +119,54 @@ static string GetPayloadHash(const char *buffer, idx_t buffer_len) {
 	}
 }
 
-std::shared_ptr<Aws::Http::HttpRequest> AWSInput::CreateSignedRequest(Aws::Http::HttpMethod method,
-                                                                      const Aws::Http::URI &uri, HTTPHeaders &headers,
-                                                                      const string &body) {
-#ifndef EMSCRIPTEN
-	auto request = Aws::Http::CreateHttpRequest(uri, method, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
-	request->SetUserAgent(user_agent);
+} // namespace
 
-	if (!body.empty()) {
-		auto bodyStream = Aws::MakeShared<Aws::StringStream>("");
-		*bodyStream << body;
-		request->AddContentBody(bodyStream);
-		request->SetContentLength(std::to_string(body.size()));
-		if (headers.HasHeader("Content-Type")) {
-			request->SetHeaderValue("Content-Type", headers.GetHeaderValue("Content-Type"));
-		}
+string AWSInput::CanonicalPath() const {
+	if (path_segments.empty()) {
+		return "/";
 	}
-
-	std::shared_ptr<Aws::Auth::AWSCredentialsProviderChain> provider;
-	provider = std::make_shared<DuckDBSecretCredentialProvider>(key_id, secret, session_token);
-	auto signer = make_uniq<Aws::Client::AWSAuthV4Signer>(provider, service.c_str(), region.c_str());
-	if (!signer->SignRequest(*request)) {
-		throw HTTPException("Failed to sign request");
-	}
-
-	return request;
-#else
-	return nullptr;
-#endif
-}
-
-unique_ptr<HTTPResponse> AWSInput::ExecuteRequestLegacy(ClientContext &context, Aws::Http::HttpMethod method,
-                                                        HTTPHeaders &headers, const string &body) {
-#ifndef EMSCRIPTEN
-	InitAWSAPI();
-	auto clientConfig = BuildClientConfig();
-	auto uri = BuildURI();
-	auto request = CreateSignedRequest(method, uri, headers, body);
-
-	auto httpClient = Aws::Http::CreateHttpClient(clientConfig);
-	auto response = httpClient->MakeRequest(request);
-	auto resCode = response->GetResponseCode();
-
-	auto result = make_uniq<HTTPResponse>(resCode == Aws::Http::HttpResponseCode::REQUEST_NOT_MADE
-	                                          ? HTTPStatusCode::INVALID
-	                                          : HTTPStatusCode(static_cast<idx_t>(resCode)));
-
-	bool throw_exception = false;
-	result->url = uri.GetURIString();
-	if (resCode == Aws::Http::HttpResponseCode::REQUEST_NOT_MADE) {
-		D_ASSERT(response->HasClientError());
-		result->reason = response->GetClientErrorMessage();
-		throw_exception = true;
-	}
-	for (auto &header : response->GetHeaders()) {
-		result->headers[header.first] = header.second;
-	}
-	Aws::StringStream resBody;
-	resBody << response->GetResponseBody().rdbuf();
-	result->body = resBody.str();
-	if (static_cast<uint16_t>(result->status) > 400) {
-		result->success = false;
-	}
-	LogAWSHTTPRequest(context, request, *result, method);
-	if (throw_exception) {
-		throw HTTPException(*result, result->reason);
+	string result;
+	for (auto &segment : path_segments) {
+		result += "/" + StringUtil::URLEncode(NormalizeSegment(segment));
 	}
 	return result;
-#else
-	throw NotImplementedException("ExecuteRequestLegacy is not implemented in duckdb-wasm");
-#endif
 }
 
-unique_ptr<HTTPResponse> AWSInput::ExecuteRequest(ClientContext &context, Aws::Http::HttpMethod method,
-                                                  HTTPHeaders &headers, const string &body) {
-	bool use_httputils = true;
-	{
-		Value result;
-		(void)context.TryGetCurrentSetting("iceberg_via_aws_sdk_for_catalog_interactions", result);
-		if (!result.IsNull() && result.GetValue<bool>()) {
-			use_httputils = false;
-		}
+string AWSInput::WirePath() const {
+	// GetURIString appended no path at all when the segment list was empty, rather than "/".
+	string result;
+	for (auto &segment : path_segments) {
+		result += "/" + WireEncodeSegment(NormalizeSegment(segment));
 	}
-	if (!use_httputils) {
-		// Query Iceberg REST catalog via AWS's SDK
-		return ExecuteRequestLegacy(context, method, headers, body);
-	}
+	return result;
+}
 
-	auto uri = BuildURI();
+string AWSInput::QueryString() const {
+	string result;
+	for (auto &param : query_string_parameters) {
+		result += result.empty() ? "?" : "&";
+		result += StringUtil::URLEncode(param.first) + "=" + StringUtil::URLEncode(param.second);
+	}
+	return result;
+}
+
+string AWSInput::URL() const {
+	return string(use_https ? "https://" : "http://") + authority + WirePath() + QueryString();
+}
+
+unique_ptr<HTTPResponse> AWSInput::Request(RequestType request_type, ClientContext &context, HTTPHeaders &headers,
+                                           const string &data) {
 	auto &db = DatabaseInstance::GetDatabase(context);
 
 	HTTPHeaders res(db);
 
-	const string host = uri.GetAuthority();
-	res["host"] = host;
+	res["host"] = authority;
 	// If access key is not set, we don't set the headers at all to allow accessing public files through s3 urls
 
 	string payload_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"; // Empty payload hash
 
-	if (!body.empty()) {
-		payload_hash = GetPayloadHash(body.c_str(), body.size());
+	if (!data.empty()) {
+		payload_hash = GetPayloadHash(data.c_str(), data.size());
 	}
 
 	// key_id, secret, session_token
@@ -290,7 +200,7 @@ unique_ptr<HTTPResponse> AWSInput::ExecuteRequest(ClientContext &context, Aws::H
 		signed_headers += ";x-amz-security-token";
 	}
 
-	string url_encoded_path = uri.GetURLEncodedPath();
+	string url_encoded_path = CanonicalPath();
 
 	{
 		// it's unclear to be why we need to transform %2F into %252F, see
@@ -298,16 +208,18 @@ unique_ptr<HTTPResponse> AWSInput::ExecuteRequest(ClientContext &context, Aws::H
 		url_encoded_path = StringUtil::Replace(url_encoded_path, "%2F", "%252F");
 	}
 
-	auto canonical_request =
-	    string(Aws::Http::HttpMethodMapper::GetNameForHttpMethod(method)) + "\n" + url_encoded_path + "\n";
-	if (uri.GetQueryString().size()) {
-		canonical_request += uri.GetQueryString().substr(1);
+	auto query_string = QueryString();
+
+	auto canonical_request = string(MethodName(request_type)) + "\n" + url_encoded_path + "\n";
+	if (query_string.size()) {
+		canonical_request += query_string.substr(1);
 	}
 
 	if (content_type.length() > 0) {
 		canonical_request += "\ncontent-type:" + content_type;
 	}
-	canonical_request += "\nhost:" + host + "\nx-amz-content-sha256:" + payload_hash + "\nx-amz-date:" + datetime_now;
+	canonical_request +=
+	    "\nhost:" + authority + "\nx-amz-content-sha256:" + payload_hash + "\nx-amz-date:" + datetime_now;
 	if (session_token.length() > 0) {
 		canonical_request += "\nx-amz-security-token:" + session_token;
 	}
@@ -338,7 +250,7 @@ unique_ptr<HTTPResponse> AWSInput::ExecuteRequest(ClientContext &context, Aws::H
 	auto &http_util = HTTPUtil::Get(db);
 	unique_ptr<HTTPParams> params;
 
-	string request_url = uri.GetURIString();
+	string request_url = URL();
 
 	params = http_util.InitializeParameters(context, request_url);
 
@@ -348,44 +260,28 @@ unique_ptr<HTTPResponse> AWSInput::ExecuteRequest(ClientContext &context, Aws::H
 		client->Initialize(*params);
 	}
 
-	switch (method) {
-	case Aws::Http::HttpMethod::HTTP_HEAD: {
+	switch (request_type) {
+	case RequestType::HEAD_REQUEST: {
 		HeadRequestInfo head_request(request_url, res, *params);
 		return http_util.Request(head_request, client);
 	}
-	case Aws::Http::HttpMethod::HTTP_DELETE: {
+	case RequestType::DELETE_REQUEST: {
 		DeleteRequestInfo delete_request(request_url, res, *params);
 		return http_util.Request(delete_request, client);
 	}
-	case Aws::Http::HttpMethod::HTTP_GET: {
+	case RequestType::GET_REQUEST: {
 		GetRequestInfo get_request(request_url, res, *params, nullptr, nullptr);
 		return http_util.Request(get_request, client);
 	}
-	case Aws::Http::HttpMethod::HTTP_POST: {
-		PostRequestInfo post_request(request_url, res, *params, reinterpret_cast<const_data_ptr_t>(body.c_str()),
-		                             body.size());
+	case RequestType::POST_REQUEST: {
+		PostRequestInfo post_request(request_url, res, *params, reinterpret_cast<const_data_ptr_t>(data.c_str()),
+		                             data.size());
 		auto x = http_util.Request(post_request, client);
 		if (x) {
 			x->body = post_request.buffer_out;
 		}
 		return x;
 	}
-	default:
-		throw NotImplementedException("Unexpected HTTP Method requested");
-	}
-}
-
-unique_ptr<HTTPResponse> AWSInput::Request(RequestType request_type, ClientContext &context, HTTPHeaders &headers,
-                                           const string &data) {
-	switch (request_type) {
-	case RequestType::GET_REQUEST:
-		return ExecuteRequest(context, Aws::Http::HttpMethod::HTTP_GET, headers);
-	case RequestType::POST_REQUEST:
-		return ExecuteRequest(context, Aws::Http::HttpMethod::HTTP_POST, headers, data);
-	case RequestType::DELETE_REQUEST:
-		return ExecuteRequest(context, Aws::Http::HttpMethod::HTTP_DELETE, headers);
-	case RequestType::HEAD_REQUEST:
-		return ExecuteRequest(context, Aws::Http::HttpMethod::HTTP_HEAD, headers);
 	default:
 		throw NotImplementedException("Cannot make request of type %s", EnumUtil::ToString(request_type));
 	}

--- a/src/iceberg_extension.cpp
+++ b/src/iceberg_extension.cpp
@@ -94,9 +94,6 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    "Skip structural Puffin verification for deletion-vector files. This unsafe compatibility option permits "
 	    "reading invalid bare-blob files written by DuckDB Iceberg 1.5.3.",
 	    LogicalType::BOOLEAN, Value::BOOLEAN(false), nullptr, SetScope::GLOBAL);
-	config.AddExtensionOption("iceberg_via_aws_sdk_for_catalog_interactions",
-	                          "Use legacy code to interact with AWS-based catalogs, via AWS's SDK",
-	                          LogicalType::BOOLEAN, Value::BOOLEAN(false));
 	config.AddExtensionOption("iceberg_test_force_token_expiry",
 	                          "DEBUG SETTING: force OAuth2 token expiry for testing automatic refresh",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(false));

--- a/src/include/catalog/rest/api/api_utils.hpp
+++ b/src/include/catalog/rest/api/api_utils.hpp
@@ -18,29 +18,11 @@
 
 namespace duckdb {
 
-// we statically compile in libcurl, which means the cert file location of the build machine is the
-// place curl will look. But not every distro has this file in the same location, so we search a
-// number of common locations and use the first one we find.
-static string certFileLocations[] = {
-    // Arch, Debian-based, Gentoo
-    "/etc/ssl/certs/ca-certificates.crt",
-    // RedHat 7 based
-    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
-    // Redhat 6 based
-    "/etc/pki/tls/certs/ca-bundle.crt",
-    // OpenSUSE
-    "/etc/ssl/ca-bundle.pem",
-    // Alpine
-    "/etc/ssl/cert.pem"};
-
 class APIUtils {
 public:
 	static unique_ptr<HTTPResponse> Request(RequestType request_type, optional_ptr<AttachedDatabase> db,
 	                                        ClientContext &context, const IRCEndpointBuilder &endpoint_builder,
 	                                        HTTPHeaders &headers, const string &data);
-
-	//! We use a singleton here to store the path, set by SelectCurlCertPath
-	static const string &GetCURLCertPath();
 };
 
 } // namespace duckdb

--- a/src/include/catalog/rest/storage/aws.hpp
+++ b/src/include/catalog/rest/storage/aws.hpp
@@ -5,13 +5,11 @@
 #include "duckdb/main/client_context.hpp"
 #include "catalog/rest/storage/iceberg_authorization.hpp"
 
-#include <aws/core/Aws.h>
-#include <aws/core/auth/AWSCredentials.h>
-#include <aws/core/auth/AWSCredentialsProvider.h>
-#include <aws/core/http/HttpRequest.h>
-
 namespace duckdb {
 
+//! A SigV4-signed request to an AWS-hosted Iceberg REST catalog. Signing is done here with
+//! duckdb_mbedtls and the request goes out over duckdb's HTTPUtil, so this needs nothing from
+//! aws-sdk-cpp.
 class AWSInput {
 public:
 	AWSInput(AttachedDatabase &db) : attached_db(db) {
@@ -21,26 +19,32 @@ public:
 	unique_ptr<HTTPResponse> Request(RequestType request_type, ClientContext &context, HTTPHeaders &headers,
 	                                 const string &data);
 
-	unique_ptr<HTTPResponse> ExecuteRequestLegacy(ClientContext &context, Aws::Http::HttpMethod method,
-	                                              HTTPHeaders &headers, const string &body = "");
-	unique_ptr<HTTPResponse> ExecuteRequest(ClientContext &context, Aws::Http::HttpMethod method, HTTPHeaders &headers,
-	                                        const string &body = "");
-	std::shared_ptr<Aws::Http::HttpRequest> CreateSignedRequest(Aws::Http::HttpMethod method, const Aws::Http::URI &uri,
-	                                                            HTTPHeaders &headers, const string &body = "");
-	Aws::Http::URI BuildURI();
-	Aws::Client::ClientConfiguration BuildClientConfig();
+	//! The path that goes into the SigV4 canonical request. Mirrors
+	//! Aws::Http::URI::GetURLEncodedPath: every byte outside A-Za-z0-9-_.~ is percent-encoded,
+	//! and no segments at all yields "/".
+	string CanonicalPath() const;
+	//! The path that goes on the wire. Mirrors Aws::Http::URI::GetURLEncodedPathRFC3986 in the
+	//! non-RFC mode the SDK defaults to, which additionally leaves $ & , : = @ unescaped -- and
+	//! mirrors GetURIString in emitting nothing at all when there are no segments.
+	//!
+	//! That this differs from CanonicalPath() is the SDK's behaviour, not an oversight here:
+	//! iceberg has always signed one encoding and sent the other. Changing it is a separate
+	//! decision from removing the SDK, so it is preserved verbatim.
+	string WirePath() const;
+	//! "" when there are no parameters, otherwise "?k=v&k2=v2" in insertion order. Callers must
+	//! add parameters in the order SigV4 signs them; nothing sorts them here. Both the wire URL
+	//! and the canonical request use this same string, as they did with the SDK.
+	string QueryString() const;
+	//! The URL to send to: scheme, authority, wire path, query string.
+	string URL() const;
 
 public:
 	AttachedDatabase &attached_db;
-	//! The scheme to use for this request (HTTP or HTTPS), defaults to HTTPS
-	Aws::Http::Scheme scheme = Aws::Http::Scheme::HTTPS;
+	//! The scheme to use for this request, defaults to HTTPS
+	bool use_https = true;
 	string authority;
 	vector<string> path_segments;
 	vector<std::pair<string, string>> query_string_parameters;
-	string user_agent;
-	string cert_path;
-	bool use_httpfs_timeout = false;
-	idx_t request_timeout_in_ms;
 
 	//! Provider credentials
 	string key_id;

--- a/test/sql/cloud/s3tables/test_create_table_s3tables.test
+++ b/test/sql/cloud/s3tables/test_create_table_s3tables.test
@@ -24,11 +24,6 @@ CREATE SECRET (
     PROVIDER credential_chain
 );
 
-foreach aws_sdk_val true false
-
-statement ok
-SET iceberg_via_aws_sdk_for_catalog_interactions={aws_sdk_val};
-
 statement ok
 attach or replace 'arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing' as s3_catalog (
     TYPE ICEBERG,
@@ -104,4 +99,3 @@ use main;
 statement ok
 drop schema s3_catalog.test_create_schema;
 
-endloop

--- a/test/sql/cloud/s3tables/test_direct_keys_s3tables.test
+++ b/test/sql/cloud/s3tables/test_direct_keys_s3tables.test
@@ -18,8 +18,6 @@ require httpfs
 
 require aws
 
-foreach aws_sdk_val true false
-
 # test using keys directory
 statement ok
 CREATE SECRET s1 (
@@ -28,9 +26,6 @@ CREATE SECRET s1 (
       SECRET '{AWS_SECRET_ACCESS_KEY}',
       REGION 'us-east-2'
 );
-
-statement ok
-SET iceberg_via_aws_sdk_for_catalog_interactions={aws_sdk_val};
 
 statement ok
 attach or replace 'arn:aws:s3tables:us-east-2:840140254803:bucket/iceberg-testing' as my_datalake (
@@ -100,4 +95,3 @@ query T nosort tables_1
 show all tables;
 ----
 
-endloop

--- a/test/sql/cloud/s3tables/test_direct_keys_s3tables_no_endpoint_type.test
+++ b/test/sql/cloud/s3tables/test_direct_keys_s3tables_no_endpoint_type.test
@@ -18,11 +18,6 @@ require httpfs
 
 require aws
 
-foreach aws_sdk_val true false
-
-statement ok
-SET iceberg_via_aws_sdk_for_catalog_interactions={aws_sdk_val};
-
 # test using keys directly
 statement ok
 CREATE OR REPLACE SECRET s1 (
@@ -102,4 +97,3 @@ query T nosort tables_1
 show all tables;
 ----
 
-endloop

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,26 +1,49 @@
 {
-  "dependencies": [
-    "vcpkg-cmake",
-    "jansson",
-    "liblzma",
-    "snappy",
-    "zlib",
-    "roaring"
-  ],
-  "vcpkg-configuration": {
-    "overlay-ports": [
-      "./vcpkg_ports"
-    ],
-    "registries": [
-      {
-        "kind": "git",
-        "repository": "https://github.com/duckdb/vcpkg-duckdb-ports",
-        "baseline": "f13de79b66345fe31d3f9c119517613023d194a8",
-        "packages": [
-          "vcpkg-cmake"
-        ]
-      }
-    ]
-  },
-  "builtin-baseline": "84bab45d415d22042bd0b9081aea57f362da3f35"
+	"dependencies": [
+		"vcpkg-cmake",
+		"jansson",
+		"liblzma",
+		"snappy",
+		"zlib",
+		"curl",
+		"openssl",
+		"roaring",
+		{
+			"name": "aws-sdk-cpp",
+			"features": [
+				"sso",
+				"sts",
+				"identity-management",
+				"redshift",
+				"rds",
+				"cloudformation"
+			]
+		}
+	],
+	"vcpkg-configuration": {
+		"overlay-ports": [
+			"./vcpkg_ports"
+		],
+		"registries": [
+			{
+				"kind": "git",
+				"repository": "https://github.com/duckdb/vcpkg-duckdb-ports",
+				"baseline": "f13de79b66345fe31d3f9c119517613023d194a8",
+				"packages": [
+					"vcpkg-cmake"
+				]
+			}
+		]
+	},
+	"builtin-baseline": "84bab45d415d22042bd0b9081aea57f362da3f35",
+	"overrides": [
+		{
+			"name": "openssl",
+			"version": "3.6.0"
+		},
+		{
+			"name": "aws-c-http",
+			"version": "0.10.2"
+		}
+	]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,49 +1,26 @@
 {
-	"dependencies": [
-		"vcpkg-cmake",
-		"jansson",
-		"liblzma",
-		"snappy",
-		"zlib",
-		"curl",
-		"openssl",
-		"roaring",
-		{
-			"name": "aws-sdk-cpp",
-			"features": [
-				"sso",
-				"sts",
-				"identity-management",
-				"redshift",
-				"rds",
-				"cloudformation"
-			]
-		}
-	],
-	"vcpkg-configuration": {
-		"overlay-ports": [
-			"./vcpkg_ports"
-		],
-		"registries": [
-			{
-				"kind": "git",
-				"repository": "https://github.com/duckdb/vcpkg-duckdb-ports",
-				"baseline": "f13de79b66345fe31d3f9c119517613023d194a8",
-				"packages": [
-					"vcpkg-cmake"
-				]
-			}
-		]
-	},
-	"builtin-baseline": "84bab45d415d22042bd0b9081aea57f362da3f35",
-	"overrides": [
-		{
-			"name": "openssl",
-			"version": "3.6.0"
-		},
-		{
-			"name": "aws-c-http",
-			"version": "0.10.2"
-		}
-	]
+  "dependencies": [
+    "vcpkg-cmake",
+    "jansson",
+    "liblzma",
+    "snappy",
+    "zlib",
+    "roaring"
+  ],
+  "vcpkg-configuration": {
+    "overlay-ports": [
+      "./vcpkg_ports"
+    ],
+    "registries": [
+      {
+        "kind": "git",
+        "repository": "https://github.com/duckdb/vcpkg-duckdb-ports",
+        "baseline": "f13de79b66345fe31d3f9c119517613023d194a8",
+        "packages": [
+          "vcpkg-cmake"
+        ]
+      }
+    ]
+  },
+  "builtin-baseline": "84bab45d415d22042bd0b9081aea57f362da3f35"
 }


### PR DESCRIPTION
Proper responsibility split: credentials to be managed by duckdb-aws extension, catalog interactions via iceberg

`iceberg_via_aws_sdk_for_catalog_interactions` has been a legacy codepath for a while now, now properly removed.