### PR TITLE
[Dev] Separating the `IcebergMultiFileList` state and methods into "scan planner" and "delete file reading"

### DIFF
--- a/src/execution/operator/iceberg_delete.cpp
+++ b/src/execution/operator/iceberg_delete.cpp
@@ -349,7 +349,7 @@ void IcebergDelete::FlushDeletes(IcebergTransaction &transaction, ClientContext 
 
 		IcebergDeleteFileInfo delete_file;
 		delete_file.data_file_path = filename;
-		delete_file.partition_info = multi_file_list->GetPartitionForDataFile(filename);
+		delete_file.partition_info = multi_file_list->GetScanPlanner().GetPartitionForDataFile(filename);
 
 		auto &fs = FileSystem::GetFileSystem(context);
 

--- a/src/function/scan/iceberg_scan.cpp
+++ b/src/function/scan/iceberg_scan.cpp
@@ -75,7 +75,7 @@ BindInfo IcebergBindInfo(const optional_ptr<FunctionData> bind_data) {
 static void IcebergSetScanOrder(unique_ptr<RowGroupOrderOptions> order_options, optional_ptr<FunctionData> bind_data) {
 	auto &multi_file_data = bind_data->Cast<MultiFileBindData>();
 	auto &file_list = multi_file_data.file_list->Cast<IcebergMultiFileList>();
-	file_list.SetScanOrder(std::move(order_options));
+	file_list.GetScanPlanner().SetScanOrder(std::move(order_options));
 }
 
 //! FIXME: needs v1.5.1, causes a crash on v1.5.0

--- a/src/include/planning/deletes/iceberg_delete_file_scanner.hpp
+++ b/src/include/planning/deletes/iceberg_delete_file_scanner.hpp
@@ -2,9 +2,32 @@
 
 #include "planning/deletes/iceberg_delete_planner.hpp"
 
+#include <condition_variable>
+
 namespace duckdb {
 
-struct IcebergDeleteFileLoadState;
+class IcebergScanPlanner;
+struct IcebergDeleteFileReference;
+struct IcebergScanTask;
+
+//! Only execution dependencies: no manifest discovery, filtering, or scan-plan provider.
+struct IcebergDeleteExecutionContext {
+	ClientContext &context;
+	FileSystem &fs;
+	const string &table_path;
+	const IcebergOptions &options;
+	const IcebergTableMetadata &metadata;
+};
+
+//! Execution state for one delete file. This deliberately lives outside scan
+//! planning: it caches the result of reading the selected delete descriptor.
+struct IcebergDeleteFileLoadState {
+	mutex lock;
+	std::condition_variable cv;
+	bool complete = false;
+	ErrorData error;
+	shared_ptr<IcebergEqualityDeleteFile> equality_delete;
+};
 
 //! Input to ScanFiles, so it can run without holding the (delete_)lock
 struct IcebergDeleteScanEntry {
@@ -38,8 +61,25 @@ struct IcebergDeleteScanResult {
 };
 
 struct IcebergDeleteFileScanner {
-	static IcebergDeleteScanResult ScanFiles(const IcebergDeletePlanningContext &context,
+	static IcebergDeleteScanResult ScanFiles(const IcebergDeleteExecutionContext &context,
 	                                         const vector<IcebergDeleteScanEntry> &entries);
+};
+
+//! Materialized delete contents and synchronization for executing planned tasks.
+//! The scan planner only selects descriptors; this state reads and caches them.
+class IcebergDeleteExecutionState {
+public:
+	IcebergDeletePlan ProcessDeletes(const IcebergScanPlanner &planner, const IcebergScanTask &task);
+	shared_ptr<IcebergDeleteData> GetExistingPositionalDeleteData(const string &file_path) const;
+
+private:
+	shared_ptr<IcebergDeleteFileLoadState> &GetDeleteFileLoad(const IcebergScanPlanner &planner,
+	                                                          IcebergDeleteFileReference delete_file);
+
+private:
+	mutable mutex lock;
+	vector<unordered_map<idx_t, shared_ptr<IcebergDeleteFileLoadState>>> delete_file_loads;
+	position_delete_map_t positional_delete_data;
 };
 
 } // namespace duckdb

--- a/src/include/planning/deletes/iceberg_delete_planner.hpp
+++ b/src/include/planning/deletes/iceberg_delete_planner.hpp
@@ -45,8 +45,6 @@ struct IcebergDeletePlanner {
 	                                         const IcebergManifestEntry &delete_manifest_entry,
 	                                         const BoundIcebergManifestEntry &data_manifest_entry,
 	                                         const partition_value_map_t &data_partition_values);
-	static shared_ptr<IcebergDeleteData> GetExistingPositionalDeleteData(const IcebergDeletePlanningContext &context,
-	                                                                     const string &file_path);
 };
 
 } // namespace duckdb

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -35,13 +35,7 @@ public:
 	void SetTable(IcebergTableSchemaVersion &table);
 	optional_ptr<IcebergTableSchemaVersion> GetTable() const;
 	void SetOptions(const IcebergOptions &options);
-	void SetScanOrder(unique_ptr<RowGroupOrderOptions> options);
-	void DisableServerSidePlanning();
 	void Bind(vector<LogicalType> &return_types, vector<Identifier> &names);
-	void GetStatistics(vector<PartitionStatistics> &result) const;
-	const IcebergTableMetadata &GetMetadata() const;
-	const IcebergTableSchema &GetSchema() const;
-	IcebergPartition GetPartitionForDataFile(const string &file_path) const;
 	shared_ptr<IcebergDeleteData> GetExistingPositionalDeleteData(const string &file_path) const;
 	IcebergDeletePlan ProcessDeletes(const IcebergScanTask &task) const;
 	IcebergScanPlanner &GetScanPlanner();

--- a/src/include/planning/iceberg_multi_file_list.hpp
+++ b/src/include/planning/iceberg_multi_file_list.hpp
@@ -3,47 +3,25 @@
 //
 // planning/iceberg_multi_file_list.hpp
 //
-//
 //===----------------------------------------------------------------------===//
 
 #pragma once
 
 #include "duckdb/common/multi_file/multi_file_list.hpp"
-#include "duckdb/common/types/batched_data_collection.hpp"
 #include "duckdb/common/multi_file/multi_file_data.hpp"
-#include "duckdb/common/list.hpp"
-#include "duckdb/common/unordered_map.hpp"
-#include "duckdb/planner/filter/expression_filter.hpp"
-#include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
-#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 
-#include "common/iceberg_utils.hpp"
-#include "planning/metadata_io/manifest/iceberg_manifest_reader.hpp"
-#include "core/metadata/schema/iceberg_column_definition.hpp"
-#include "planning/metadata_io/manifest/bound_iceberg_manifest_entry.hpp"
-#include "planning/deletes/iceberg_delete_planner.hpp"
-#include "planning/pruning/iceberg_table_filter.hpp"
-#include "planning/scan_order/iceberg_scan_order.hpp"
-#include "planning/scan_plan/iceberg_scan_plan_state.hpp"
+#include "planning/deletes/iceberg_delete_file_scanner.hpp"
+#include "planning/scan_plan/iceberg_scan_planner.hpp"
 
 namespace duckdb {
-
-class IcebergTableSchemaVersion;
-class IcebergScanPlanProvider;
-struct IcebergScanPlanContext;
-struct IcebergMultiFileList;
-struct IcebergMultiFileReader;
-struct IcebergDeleteFileReference;
 
 struct IcebergMultiFileList : public MultiFileList {
 public:
 	IcebergMultiFileList(ClientContext &context, shared_ptr<IcebergScanInfo> scan_info, const string &path,
 	                     const IcebergOptions &options);
-	virtual ~IcebergMultiFileList() override;
+	~IcebergMultiFileList() override;
 
-public:
-	//! MultiFileList API
 	unique_ptr<MultiFileList> DynamicFilterPushdown(MultiFileDynamicPushdownInfo &pushdown_info) const override;
 	unique_ptr<MultiFileList> ComplexFilterPushdown(ClientContext &context, const MultiFileOptions &options,
 	                                                MultiFilePushdownInfo &info,
@@ -54,98 +32,35 @@ public:
 	unique_ptr<NodeStatistics> GetCardinality(ClientContext &context) const override;
 	OpenFileInfo GetFile(idx_t i) const override;
 
-public:
 	void SetTable(IcebergTableSchemaVersion &table);
-	shared_ptr<IcebergDeleteData> GetExistingPositionalDeleteData(const string &file_path) const;
-	IcebergPartition GetPartitionForDataFile(const string &file_path) const;
-	void SetScanOrder(unique_ptr<RowGroupOrderOptions> options);
 	optional_ptr<IcebergTableSchemaVersion> GetTable() const;
-	void DisableServerSidePlanning();
-
-	//! Narrow integration surface used by IcebergMultiFileReader.
 	void SetOptions(const IcebergOptions &options);
+	void SetScanOrder(unique_ptr<RowGroupOrderOptions> options);
+	void DisableServerSidePlanning();
 	void Bind(vector<LogicalType> &return_types, vector<Identifier> &names);
 	void GetStatistics(vector<PartitionStatistics> &result) const;
 	const IcebergTableMetadata &GetMetadata() const;
 	const IcebergTableSchema &GetSchema() const;
-	BoundIcebergManifestEntry GetManifestEntry(idx_t file_id) const;
-	IcebergManifestFile GetManifestFileForDataFile(idx_t file_id) const;
-	IcebergDeletePlan ProcessDeletes(const BoundIcebergManifestEntry &data_manifest_entry) const;
+	IcebergPartition GetPartitionForDataFile(const string &file_path) const;
+	shared_ptr<IcebergDeleteData> GetExistingPositionalDeleteData(const string &file_path) const;
+	IcebergDeletePlan ProcessDeletes(const IcebergScanTask &task) const;
+	IcebergScanPlanner &GetScanPlanner();
+	const IcebergScanPlanner &GetScanPlanner() const;
 
 private:
-	const string &GetPath() const;
-	const IcebergTransactionData &GetTransactionData() const;
-	const IcebergSnapshotScanInfo &GetSnapshot() const;
-
-	unique_ptr<IcebergMultiFileList> PushdownInternal(ClientContext &context, TableFilterSet &new_filters,
+	IcebergMultiFileList(unique_ptr<IcebergScanPlanner> planner,
+	                     shared_ptr<IcebergDeleteExecutionState> delete_execution);
+	unique_ptr<IcebergMultiFileList> PushdownInternal(TableFilterSet &new_filters,
 	                                                  const vector<ColumnIndex> &column_indexes) const;
-	IcebergMultiFileList(shared_ptr<IcebergScanPlanState> shared_state);
-
-	void InitializeView(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
-
-	//! The delete-manifest entries that apply to a data file, after manifest pruning and the per-entry
-	//! filter and data-file checks. Must be called without holding the shared lock - reading the delete
-	//! manifests takes it.
-	vector<IcebergDeleteFileReference>
-	ResolveApplicableDeleteFiles(const BoundIcebergManifestEntry &data_manifest_entry) const;
-
-	bool HasTransactionData() const;
-	//! Reorder (and prune, when a LIMIT is present) the materialized data files by the
-	//! ORDER BY column's per-file min/max bounds, mirroring the native RowGroupReorderer.
-	void EnsureScanOrderApplied(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
-	OpenFileInfo GetFileInternal(idx_t i, annotated_lock_guard<annotated_mutex> &guard) const
-	    DUCKDB_REQUIRES(shared_state->lock);
-	const IcebergManifestFile &GetManifestFileForEntry(const BoundIcebergManifestEntry &entry,
-	                                                   IcebergManifestContentType type) const
-	    DUCKDB_REQUIRES(shared_state->lock);
-
-	//! Whether a delete file's manifest entry can apply to any file selected by the current scan filter.
-	//! Delete files are pruned on partition only: one whose partition is excluded by the filter cannot
-	//! delete a row from any surviving data file, so it does not need to be read.
-	//! NOTE: this requires the lock because it modifies the 'data_files' vector, potentially invalidating references
-	optional_ptr<const BoundIcebergManifestEntry> GetDataFile(idx_t file_id,
-	                                                          annotated_lock_guard<annotated_mutex> &guard) const
-	    DUCKDB_REQUIRES(shared_state->lock);
-
-	bool TryGetNextBatch(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
-	void FinishScanTasks(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
-	void LoadManifestList(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
-	void InitializeScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);
-	void StartDataManifestScan(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
-	IcebergScanPlanProvider &GetScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);
-	IcebergScanPlanContext GetScanPlanContext() const DUCKDB_REQUIRES(shared_state->lock);
-	IcebergDeletePlanningContext GetDeletePlanningContext() const DUCKDB_REQUIRES(shared_state->lock);
+	OpenFileInfo GetFileInternal(idx_t file_id) const;
 
 private:
-	shared_ptr<IcebergScanPlanState> shared_state;
-	ClientContext &context;
-	FileSystem &fs;
-	const IcebergOptions &options;
-	//! ComplexFilterPushdown results
+	unique_ptr<IcebergScanPlanner> planner;
 	bool have_bound = false;
 	vector<string> names;
 	vector<LogicalType> types;
-	IcebergTableFilters table_filters;
-
-	//! The provider is per-view. The server-side implementation owns its filter-derived plan, while the client-side
-	//! implementation delegates to the shared manifest state above.
-	mutable unique_ptr<IcebergScanPlanProvider> scan_plan_provider DUCKDB_GUARDED_BY(shared_state->lock);
-
-	//! Combination of committed + transaction delete manifests
-	mutable vector<BoundIcebergManifestListEntry> delete_manifests DUCKDB_GUARDED_BY(shared_state->lock);
-	mutable vector<bool> delete_manifest_matches DUCKDB_GUARDED_BY(shared_state->lock);
-	//! Conservative until InitializeView determines whether this filtered view has any matching delete manifests.
-	mutable atomic<bool> has_matching_delete_manifests {true};
-
-	mutable IcebergDataViewCursor data_view_cursor DUCKDB_GUARDED_BY(shared_state->lock);
-	//! References to items inside the 'manifest_entries' of the list entries in the 'data_manifests'
-	mutable vector<BoundIcebergManifestEntry> data_manifest_entries DUCKDB_GUARDED_BY(shared_state->lock);
-	//! Combination of committed + transaction data manifests
-	mutable vector<BoundIcebergManifestListEntry> data_manifests DUCKDB_GUARDED_BY(shared_state->lock);
-	mutable vector<bool> data_manifest_matches DUCKDB_GUARDED_BY(shared_state->lock);
-
-	//! Set by the table function's set_scan_order callback when an ORDER BY ... LIMIT can drive scan order.
-	mutable IcebergScanOrder scan_order DUCKDB_GUARDED_BY(shared_state->lock);
+	//! Filtered MultiFileList views share execution caches just as they share metadata planning state.
+	shared_ptr<IcebergDeleteExecutionState> delete_execution;
 };
 
 } // namespace duckdb

--- a/src/include/planning/scan_plan/iceberg_scan_plan_provider.hpp
+++ b/src/include/planning/scan_plan/iceberg_scan_plan_provider.hpp
@@ -49,8 +49,6 @@ public:
 	virtual bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const = 0;
 	virtual vector<IcebergManifestListEntry> &DataManifests() = 0;
 	virtual vector<IcebergManifestListEntry> &DeleteManifests() = 0;
-	virtual shared_ptr<IcebergDeleteFileLoadState> &GetDeleteFileLoad(IcebergDeleteFileReference delete_file) = 0;
-	virtual position_delete_map_t &PositionalDeleteData() = 0;
 };
 
 class ClientSideScanPlanProvider final : public IcebergScanPlanProvider {
@@ -62,15 +60,12 @@ public:
 	    DUCKDB_REQUIRES(shared_state.lock);
 	void ReadDeleteManifests(const vector<idx_t> &manifest_indexes, idx_t filter_count) override;
 	vector<IcebergDeleteFileReference> GetDeleteFiles(const vector<idx_t> &manifest_indexes) override
-	    DUCKDB_REQUIRES(shared_state.lock, shared_state.delete_lock);
+	    DUCKDB_REQUIRES(shared_state.lock);
 	bool TryGetNextBatch(IcebergDataViewCursor &cursor) override DUCKDB_REQUIRES(shared_state.lock);
 	void FinishScanTasks() override DUCKDB_REQUIRES(shared_state.lock);
 	bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const override;
 	vector<IcebergManifestListEntry> &DataManifests() override DUCKDB_REQUIRES(shared_state.lock);
 	vector<IcebergManifestListEntry> &DeleteManifests() override DUCKDB_REQUIRES(shared_state.lock);
-	shared_ptr<IcebergDeleteFileLoadState> &GetDeleteFileLoad(IcebergDeleteFileReference delete_file) override
-	    DUCKDB_REQUIRES(shared_state.lock, shared_state.delete_lock);
-	position_delete_map_t &PositionalDeleteData() override DUCKDB_REQUIRES(shared_state.delete_lock);
 
 private:
 	IcebergScanPlanState &shared_state;
@@ -90,16 +85,12 @@ public:
 	bool DeleteFileAppliesToDataFile(const string &data_file_path, const string &delete_file_path) const override;
 	vector<IcebergManifestListEntry> &DataManifests() override;
 	vector<IcebergManifestListEntry> &DeleteManifests() override;
-	shared_ptr<IcebergDeleteFileLoadState> &GetDeleteFileLoad(IcebergDeleteFileReference delete_file) override;
-	position_delete_map_t &PositionalDeleteData() override;
 
 private:
 	//! Declared before parsed delete data so its manifest-entry references are destroyed first.
 	IcebergServerSideScanPlan plan;
 	ManifestEntryReadState read_state;
 	bool data_manifest_scan_started = false;
-	vector<unordered_map<idx_t, shared_ptr<IcebergDeleteFileLoadState>>> delete_file_loads;
-	position_delete_map_t positional_delete_data;
 };
 
 } // namespace duckdb

--- a/src/include/planning/scan_plan/iceberg_scan_plan_state.hpp
+++ b/src/include/planning/scan_plan/iceberg_scan_plan_state.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include "core/deletes/iceberg_delete_data.hpp"
-#include "core/deletes/iceberg_equality_delete.hpp"
-#include "core/deletes/iceberg_positional_delete.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/parallel/task_executor.hpp"
 #include "planning/iceberg_manifest_read_state.hpp"
@@ -10,20 +7,10 @@
 #include "planning/metadata_io/manifest/bound_iceberg_manifest_entry.hpp"
 #include "planning/snapshot/iceberg_scan_info.hpp"
 
-#include <condition_variable>
-
 namespace duckdb {
 
 class IcebergTableSchemaVersion;
 struct IcebergDeleteManifestLoadState;
-
-struct IcebergDeleteFileLoadState {
-	mutex lock;
-	std::condition_variable cv;
-	bool complete = false;
-	ErrorData error;
-	shared_ptr<IcebergEqualityDeleteFile> equality_delete;
-};
 
 struct IcebergManifestScanningState {
 	IcebergManifestScanningState(ClientContext &context, unique_ptr<AvroScan> scan,
@@ -45,8 +32,9 @@ struct IcebergDataViewCursor {
 	idx_t current_batch_offset = 0;
 };
 
-//! State shared by filtered views of one Iceberg scan. Providers own the algorithms
-//! that mutate this state; the multi-file list only coordinates lock transitions.
+//! Metadata-planning state shared by filtered views of one Iceberg scan.
+//! Delete-file contents and filters created while executing a task are intentionally
+//! kept outside this state.
 struct IcebergScanPlanState {
 	IcebergScanPlanState(ClientContext &context, shared_ptr<IcebergScanInfo> scan_info, string path,
 	                     const IcebergOptions &options);
@@ -60,7 +48,7 @@ struct IcebergScanPlanState {
 	IcebergOptions options;
 
 	mutable annotated_mutex lock;
-	mutable annotated_mutex delete_lock DUCKDB_ACQUIRED_AFTER(lock);
+	mutable annotated_mutex delete_manifest_lock DUCKDB_ACQUIRED_AFTER(lock);
 	mutable ManifestEntryReadState read_state;
 
 	mutable bool server_side_planning_enabled DUCKDB_GUARDED_BY(lock) = true;
@@ -69,9 +57,8 @@ struct IcebergScanPlanState {
 
 	mutable vector<IcebergManifestListEntry> committed_delete_manifests DUCKDB_GUARDED_BY(lock);
 	mutable vector<reference<const IcebergManifestListEntry>> transaction_delete_manifests DUCKDB_GUARDED_BY(lock);
-	mutable vector<shared_ptr<IcebergDeleteManifestLoadState>> delete_manifest_loads DUCKDB_GUARDED_BY(delete_lock);
-	mutable vector<unordered_map<idx_t, shared_ptr<IcebergDeleteFileLoadState>>>
-	    delete_file_loads DUCKDB_GUARDED_BY(delete_lock);
+	mutable vector<shared_ptr<IcebergDeleteManifestLoadState>>
+	    delete_manifest_loads DUCKDB_GUARDED_BY(delete_manifest_lock);
 
 	mutable vector<IcebergManifestListEntry> committed_data_manifests DUCKDB_GUARDED_BY(lock);
 	//! Keep track of which manifests we had to eagerly load, so we can emit batches for them once the data scan is
@@ -79,10 +66,7 @@ struct IcebergScanPlanState {
 	mutable vector<bool> eagerly_loaded_data_manifests DUCKDB_GUARDED_BY(lock);
 	mutable vector<reference<const IcebergManifestListEntry>> transaction_data_manifests DUCKDB_GUARDED_BY(lock);
 	mutable unique_ptr<IcebergManifestScanningState> data_manifest_read_state DUCKDB_GUARDED_BY(lock);
-
-	//! Declared after manifest owners so references in parsed positional-delete data are destroyed first.
-	mutable unordered_map<string, shared_ptr<IcebergDeleteData>> positional_delete_data DUCKDB_GUARDED_BY(delete_lock);
-
+	//! FIXME: these are only used by deletes, we should find a better way to do this
 	mutable unordered_map<string, IcebergPartition> data_file_partitions DUCKDB_GUARDED_BY(lock);
 };
 

--- a/src/include/planning/scan_plan/iceberg_scan_planner.hpp
+++ b/src/include/planning/scan_plan/iceberg_scan_planner.hpp
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// planning/scan_plan/iceberg_scan_planner.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/types/batched_data_collection.hpp"
+#include "duckdb/function/partition_stats.hpp"
+
+#include "planning/deletes/iceberg_delete_planner.hpp"
+#include "planning/pruning/iceberg_table_filter.hpp"
+#include "planning/scan_order/iceberg_scan_order.hpp"
+#include "planning/scan_plan/iceberg_scan_plan_provider.hpp"
+#include "planning/scan_plan/iceberg_scan_plan_state.hpp"
+
+namespace duckdb {
+
+class IcebergTableSchemaVersion;
+struct IcebergScanPlanContext;
+
+//! A query-lifetime view of all metadata needed to initialize one data-file scan.
+//! The manifest entries referenced by this object are owned by the planner.
+struct IcebergScanTask {
+	BoundIcebergManifestEntry data_file;
+	IcebergManifestFile manifest_file;
+	string file_path;
+	vector<IcebergDeleteFileReference> delete_files;
+};
+
+//! Plans Iceberg data-file scans independently of DuckDB's MultiFileReader API.
+//! A planner represents one filtered view; filtered views share the underlying
+//! manifest read state but own their provider, pruning, ordering, and cursors.
+class IcebergScanPlanner {
+public:
+	IcebergScanPlanner(ClientContext &context, shared_ptr<IcebergScanInfo> scan_info, const string &path,
+	                   const IcebergOptions &options);
+	~IcebergScanPlanner();
+
+	unique_ptr<IcebergScanPlanner> CreateView(IcebergTableFilters filters) const;
+
+	void SetTable(IcebergTableSchemaVersion &table);
+	optional_ptr<IcebergTableSchemaVersion> GetTable() const;
+	void SetScanInfo(shared_ptr<IcebergScanInfo> scan_info);
+	void SetOptions(const IcebergOptions &options);
+	void SetScanOrder(unique_ptr<RowGroupOrderOptions> options);
+	void DisableServerSidePlanning();
+
+	const IcebergTableFilters &Filters() const;
+
+	const IcebergTableMetadata &GetMetadata() const;
+	const IcebergTableSchema &GetSchema() const;
+	ClientContext &GetContext() const;
+	const string &GetPath() const;
+	const IcebergOptions &GetOptions() const;
+	bool HasScanInfo() const;
+
+	optional<IcebergScanTask> GetScanTask(idx_t file_id) const;
+	optional<IcebergScanTask> GetDataFileTask(idx_t file_id) const;
+	optional_ptr<const BoundIcebergManifestEntry> GetDataFile(idx_t file_id) const;
+	idx_t GetTotalFileCount() const;
+	unique_ptr<NodeStatistics> GetCardinality() const;
+	void GetStatistics(vector<PartitionStatistics> &result) const;
+	IcebergPartition GetPartitionForDataFile(const string &file_path) const;
+	const IcebergManifestListEntry &GetDeleteManifest(IcebergDeleteFileReference delete_file) const;
+	unique_ptr<IcebergDeletePlanningContext> CreateDeletePlanningContext() const;
+
+private:
+	explicit IcebergScanPlanner(shared_ptr<IcebergScanPlanState> shared_state);
+
+	bool HasTransactionData() const;
+	const IcebergTransactionData &GetTransactionData() const;
+	const IcebergSnapshotScanInfo &GetSnapshot() const;
+	IcebergScanPlanProvider &GetScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);
+	IcebergScanPlanContext GetScanPlanContext() const DUCKDB_REQUIRES(shared_state->lock);
+	IcebergDeletePlanningContext GetDeletePlanningContext() const DUCKDB_REQUIRES(shared_state->lock);
+
+	void InitializeView(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
+	void EnsureScanOrderApplied(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
+	optional_ptr<const BoundIcebergManifestEntry> GetDataFile(idx_t file_id,
+	                                                          annotated_lock_guard<annotated_mutex> &guard) const
+	    DUCKDB_REQUIRES(shared_state->lock);
+	const IcebergManifestFile &GetManifestFileForEntry(const BoundIcebergManifestEntry &entry,
+	                                                   IcebergManifestContentType type) const
+	    DUCKDB_REQUIRES(shared_state->lock);
+	bool TryGetNextBatch(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
+	void FinishScanTasks(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
+	void LoadManifestList(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
+	void InitializeScanPlanProvider() const DUCKDB_REQUIRES(shared_state->lock);
+	void StartDataManifestScan(annotated_lock_guard<annotated_mutex> &guard) const DUCKDB_REQUIRES(shared_state->lock);
+	vector<IcebergDeleteFileReference>
+	ResolveApplicableDeleteFiles(const BoundIcebergManifestEntry &data_manifest_entry) const;
+
+private:
+	shared_ptr<IcebergScanPlanState> shared_state;
+	ClientContext &context;
+	FileSystem &fs;
+	const IcebergOptions &options;
+	IcebergTableFilters table_filters;
+
+	mutable unique_ptr<IcebergScanPlanProvider> scan_plan_provider DUCKDB_GUARDED_BY(shared_state->lock);
+	mutable vector<BoundIcebergManifestListEntry> delete_manifests DUCKDB_GUARDED_BY(shared_state->lock);
+	mutable vector<bool> delete_manifest_matches DUCKDB_GUARDED_BY(shared_state->lock);
+	mutable atomic<bool> has_matching_delete_manifests {true};
+	mutable IcebergDataViewCursor data_view_cursor DUCKDB_GUARDED_BY(shared_state->lock);
+	mutable vector<BoundIcebergManifestEntry> data_manifest_entries DUCKDB_GUARDED_BY(shared_state->lock);
+	mutable vector<BoundIcebergManifestListEntry> data_manifests DUCKDB_GUARDED_BY(shared_state->lock);
+	mutable vector<bool> data_manifest_matches DUCKDB_GUARDED_BY(shared_state->lock);
+	mutable IcebergScanOrder scan_order DUCKDB_GUARDED_BY(shared_state->lock);
+};
+
+} // namespace duckdb

--- a/src/planning/deletes/iceberg_delete_file_scanner.cpp
+++ b/src/planning/deletes/iceberg_delete_file_scanner.cpp
@@ -16,6 +16,7 @@
 #include "iceberg_logging.hpp"
 #include "iceberg_options.hpp"
 #include "planning/scan_plan/iceberg_scan_plan_provider.hpp"
+#include "planning/scan_plan/iceberg_scan_planner.hpp"
 #include "planning/metadata_io/deletes/iceberg_deletes_file_reader.hpp"
 
 #include <variant>
@@ -63,7 +64,7 @@ static PuffinDeletionVectorVerificationResult VerifyPuffinDeletionVector(FileSys
 	return std::monostate {};
 }
 
-static void ScanPuffinFile(const IcebergDeletePlanningContext &context, const IcebergDeleteScanEntry &scan_entry,
+static void ScanPuffinFile(const IcebergDeleteExecutionContext &context, const IcebergDeleteScanEntry &scan_entry,
                            IcebergDeleteScanResult &scan_result) {
 	auto bound_entry = scan_entry.BindEntry();
 	auto &data_file = bound_entry.entry.data_file;
@@ -127,7 +128,7 @@ static optional_ptr<IcebergPositionalDeleteData> TryGetOrCreatePositionDeletes(p
 	return reinterpret_cast<IcebergPositionalDeleteData &>(*it->second);
 }
 
-static void ScanPositionalDeleteFile(const IcebergDeletePlanningContext &context,
+static void ScanPositionalDeleteFile(const IcebergDeleteExecutionContext &context,
                                      const IcebergDeleteScanEntry &scan_entry, DataChunk &result,
                                      IcebergDeleteScanResult &scan_result) {
 	auto bound_entry = scan_entry.BindEntry();
@@ -192,7 +193,7 @@ static void ColumnsReferencedByEqualityIds(DataChunk &source, DataChunk &result,
 	result.ReferenceColumns(source, column_ids);
 }
 
-static void ScanEqualityDeleteFile(const IcebergDeletePlanningContext &context,
+static void ScanEqualityDeleteFile(const IcebergDeleteExecutionContext &context,
                                    const IcebergDeleteScanEntry &scan_entry, IcebergEqualityDeleteFile &delete_file,
                                    DataChunk &source, const vector<MultiFileColumnDefinition> &global_columns) {
 	auto &manifest_entry = scan_entry.GetEntry();
@@ -270,7 +271,7 @@ static vector<MultiFileColumnDefinition> BuildPositionalDeleteSchema() {
 	return schema;
 }
 
-static void ScanParquetDeleteFiles(const IcebergDeletePlanningContext &context,
+static void ScanParquetDeleteFiles(const IcebergDeleteExecutionContext &context,
                                    const vector<reference<const IcebergDeleteScanEntry>> &scan_entries,
                                    IcebergManifestEntryContentType content, IcebergDeleteScanResult &scan_result) {
 	if (scan_entries.empty()) {
@@ -371,7 +372,7 @@ static void ScanParquetDeleteFiles(const IcebergDeletePlanningContext &context,
 
 } // namespace
 
-IcebergDeleteScanResult IcebergDeleteFileScanner::ScanFiles(const IcebergDeletePlanningContext &context,
+IcebergDeleteScanResult IcebergDeleteFileScanner::ScanFiles(const IcebergDeleteExecutionContext &context,
                                                             const vector<IcebergDeleteScanEntry> &entries) {
 	IcebergDeleteScanResult result;
 	vector<reference<const IcebergDeleteScanEntry>> positional_delete_entries;
@@ -402,6 +403,146 @@ IcebergDeleteScanResult IcebergDeleteFileScanner::ScanFiles(const IcebergDeleteP
 	                       result);
 	ScanParquetDeleteFiles(context, equality_delete_entries, IcebergManifestEntryContentType::EQUALITY_DELETES, result);
 	return result;
+}
+
+namespace {
+
+static void MergeDeleteScanResult(position_delete_map_t &positional_delete_data,
+                                  IcebergDeleteScanResult &&scan_result) {
+	for (auto &entry : scan_result.positional_delete_data) {
+		auto existing = positional_delete_data.find(entry.first);
+		if (existing == positional_delete_data.end()) {
+			positional_delete_data.emplace(entry.first, std::move(entry.second));
+			continue;
+		}
+
+		auto &target = existing->second;
+		auto &source = entry.second;
+		if (target->type == IcebergDeleteType::DELETION_VECTOR) {
+			if (source->type == IcebergDeleteType::DELETION_VECTOR) {
+				throw InvalidConfigurationException(
+				    "Table is corrupt, two or more deletion vectors exist for the same referenced_data_file");
+			}
+			continue;
+		}
+		if (source->type == IcebergDeleteType::DELETION_VECTOR) {
+			target = std::move(source);
+			continue;
+		}
+
+		auto &target_positions = static_cast<IcebergPositionalDeleteData &>(*target);
+		auto &source_positions = static_cast<IcebergPositionalDeleteData &>(*source);
+		for (auto &source_entry : source_positions.entries) {
+			target_positions.entries.push_back(source_entry);
+		}
+		target_positions.invalid_rows.insert(source_positions.invalid_rows.begin(),
+		                                     source_positions.invalid_rows.end());
+	}
+
+	for (auto &entry : scan_result.equality_delete_data) {
+		if (entry.delete_file->equality_values.size() == 0) {
+			continue;
+		}
+		lock_guard<mutex> guard(entry.load->lock);
+		entry.load->equality_delete = std::move(entry.delete_file);
+	}
+}
+
+static void CompleteDeleteFileLoads(const vector<shared_ptr<IcebergDeleteFileLoadState>> &loads,
+                                    const ErrorData &error) {
+	for (auto &load : loads) {
+		{
+			lock_guard<mutex> guard(load->lock);
+			load->error = error;
+			load->complete = true;
+		}
+		load->cv.notify_all();
+	}
+}
+
+} // namespace
+
+shared_ptr<IcebergDeleteFileLoadState> &
+IcebergDeleteExecutionState::GetDeleteFileLoad(const IcebergScanPlanner &planner,
+                                               IcebergDeleteFileReference delete_file) {
+	planner.GetDeleteManifest(delete_file);
+	if (delete_file.manifest_idx >= delete_file_loads.size()) {
+		delete_file_loads.resize(delete_file.manifest_idx + 1);
+	}
+	return delete_file_loads[delete_file.manifest_idx][delete_file.entry_idx];
+}
+
+IcebergDeletePlan IcebergDeleteExecutionState::ProcessDeletes(const IcebergScanPlanner &planner,
+                                                              const IcebergScanTask &task) {
+	IcebergDeletePlan result;
+	if (task.delete_files.empty()) {
+		return result;
+	}
+
+	auto delete_context = planner.CreateDeletePlanningContext();
+	vector<IcebergDeleteScanEntry> scan_entries;
+	vector<shared_ptr<IcebergDeleteFileLoadState>> required_loads;
+	vector<shared_ptr<IcebergDeleteFileLoadState>> new_loads;
+	{
+		lock_guard<mutex> guard(lock);
+		unordered_set<IcebergDeleteFileLoadState *> seen_loads;
+		for (auto delete_file : task.delete_files) {
+			auto &delete_manifest = planner.GetDeleteManifest(delete_file);
+			auto &load = GetDeleteFileLoad(planner, delete_file);
+			if (!load) {
+				load = make_shared_ptr<IcebergDeleteFileLoadState>();
+				new_loads.push_back(load);
+				scan_entries.emplace_back(delete_file.manifest_idx, delete_file.entry_idx, delete_manifest, load);
+			}
+			if (seen_loads.insert(load.get()).second) {
+				required_loads.push_back(load);
+			}
+		}
+	}
+
+	if (!scan_entries.empty()) {
+		ErrorData scan_error;
+		try {
+			auto scan_result = IcebergDeleteFileScanner::ScanFiles({delete_context->context, delete_context->fs,
+			                                                        delete_context->table_path, delete_context->options,
+			                                                        delete_context->metadata},
+			                                                       scan_entries);
+			lock_guard<mutex> guard(lock);
+			MergeDeleteScanResult(positional_delete_data, std::move(scan_result));
+		} catch (std::exception &ex) {
+			scan_error = ErrorData(ex);
+		} catch (...) { // LCOV_EXCL_START
+			scan_error = ErrorData("Unknown exception while reading Iceberg delete files");
+		} // LCOV_EXCL_STOP
+		CompleteDeleteFileLoads(new_loads, scan_error);
+	}
+
+	for (auto &load : required_loads) {
+		unique_lock<mutex> guard(load->lock);
+		load->cv.wait(guard, [&load] { return load->complete; });
+		if (load->error.HasError()) {
+			load->error.Throw();
+		}
+		if (load->equality_delete) {
+			result.equality_deletes.emplace_back(*load->equality_delete);
+		}
+	}
+
+	{
+		lock_guard<mutex> guard(lock);
+		auto entry = positional_delete_data.find(task.data_file.entry.data_file.file_path);
+		if (entry != positional_delete_data.end()) {
+			result.positional_deletes = entry->second->ToFilter();
+		}
+	}
+	return result;
+}
+
+shared_ptr<IcebergDeleteData>
+IcebergDeleteExecutionState::GetExistingPositionalDeleteData(const string &file_path) const {
+	lock_guard<mutex> guard(lock);
+	auto entry = positional_delete_data.find(file_path);
+	return entry == positional_delete_data.end() ? nullptr : entry->second;
 }
 
 } // namespace duckdb

--- a/src/planning/deletes/iceberg_delete_planner.cpp
+++ b/src/planning/deletes/iceberg_delete_planner.cpp
@@ -56,12 +56,4 @@ bool IcebergDeletePlanner::DeleteEntryAppliesToDataFile(const IcebergDeletePlann
 	                               data_partition_values);
 }
 
-shared_ptr<IcebergDeleteData>
-IcebergDeletePlanner::GetExistingPositionalDeleteData(const IcebergDeletePlanningContext &context,
-                                                      const string &file_path) {
-	auto &positional_delete_data = context.provider.PositionalDeleteData();
-	auto it = positional_delete_data.find(file_path);
-	return it == positional_delete_data.end() ? nullptr : it->second;
-}
-
 } // namespace duckdb

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -1,224 +1,117 @@
 #include "planning/iceberg_multi_file_list.hpp"
 
-#include "core/metadata/manifest/iceberg_manifest_list.hpp"
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/file_system.hpp"
-#include "duckdb/function/partition_stats.hpp"
+#include "duckdb/common/multi_file/multi_file_reader.hpp"
 #include "duckdb/optimizer/filter_combiner.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/planner/table_filter_set.hpp"
 #include "duckdb/storage/table/row_group_reorderer.hpp"
 
-#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
-#include "catalog/rest/transaction/iceberg_transaction.hpp"
 #include "common/iceberg_utils.hpp"
 #include "core/metadata/iceberg_table_metadata.hpp"
-#include "planning/deletes/iceberg_delete_file_scanner.hpp"
-#include "planning/iceberg_multi_file_reader.hpp"
-#include "planning/pruning/iceberg_file_pruner.hpp"
-#include "planning/scan_plan/iceberg_scan_plan_provider.hpp"
 
 namespace duckdb {
 
-namespace {
-
-static void MergeDeleteScanResult(IcebergScanPlanProvider &provider, IcebergDeleteScanResult &&scan_result) {
-	auto &positional_delete_data = provider.PositionalDeleteData();
-	for (auto &entry : scan_result.positional_delete_data) {
-		auto existing = positional_delete_data.find(entry.first);
-		if (existing == positional_delete_data.end()) {
-			positional_delete_data.emplace(entry.first, std::move(entry.second));
-			continue;
-		}
-
-		auto &target = existing->second;
-		auto &source = entry.second;
-		if (target->type == IcebergDeleteType::DELETION_VECTOR) {
-			if (source->type == IcebergDeleteType::DELETION_VECTOR) {
-				throw InvalidConfigurationException(
-				    "Table is corrupt, two or more deletion vectors exist for the same referenced_data_file");
-			}
-			continue;
-		}
-		if (source->type == IcebergDeleteType::DELETION_VECTOR) {
-			target = std::move(source);
-			continue;
-		}
-
-		auto &target_positions = static_cast<IcebergPositionalDeleteData &>(*target);
-		auto &source_positions = static_cast<IcebergPositionalDeleteData &>(*source);
-		for (auto &source_entry : source_positions.entries) {
-			target_positions.entries.push_back(source_entry);
-		}
-		target_positions.invalid_rows.insert(source_positions.invalid_rows.begin(),
-		                                     source_positions.invalid_rows.end());
-	}
-
-	for (auto &entry : scan_result.equality_delete_data) {
-		if (entry.delete_file->equality_values.size() == 0) {
-			continue;
-		}
-		lock_guard<mutex> guard(entry.load->lock);
-		entry.load->equality_delete = std::move(entry.delete_file);
-	}
-}
-
-static void CompleteDeleteFileLoads(const vector<shared_ptr<IcebergDeleteFileLoadState>> &loads,
-                                    const ErrorData &error) {
-	for (auto &load : loads) {
-		{
-			lock_guard<mutex> guard(load->lock);
-			load->error = error;
-			load->complete = true;
-		}
-		load->cv.notify_all();
-	}
-}
-
-} // namespace
-
-IcebergMultiFileList::IcebergMultiFileList(ClientContext &context_p, shared_ptr<IcebergScanInfo> scan_info,
+IcebergMultiFileList::IcebergMultiFileList(ClientContext &context, shared_ptr<IcebergScanInfo> scan_info,
                                            const string &path, const IcebergOptions &options)
-    : shared_state(make_shared_ptr<IcebergScanPlanState>(context_p, std::move(scan_info), path, options)),
-      context(shared_state->context), fs(shared_state->fs), options(shared_state->options) {
+    : planner(make_uniq<IcebergScanPlanner>(context, std::move(scan_info), path, options)),
+      delete_execution(make_shared_ptr<IcebergDeleteExecutionState>()) {
 }
 
-IcebergMultiFileList::IcebergMultiFileList(shared_ptr<IcebergScanPlanState> shared_state_p)
-    : shared_state(std::move(shared_state_p)), context(shared_state->context), fs(shared_state->fs),
-      options(shared_state->options) {
+IcebergMultiFileList::IcebergMultiFileList(unique_ptr<IcebergScanPlanner> planner_p,
+                                           shared_ptr<IcebergDeleteExecutionState> delete_execution_p)
+    : planner(std::move(planner_p)), delete_execution(std::move(delete_execution_p)) {
 }
 
 IcebergMultiFileList::~IcebergMultiFileList() {
 }
 
-const string &IcebergMultiFileList::GetPath() const {
-	return shared_state->path;
+IcebergScanPlanner &IcebergMultiFileList::GetScanPlanner() {
+	return *planner;
 }
 
-const IcebergTableMetadata &IcebergMultiFileList::GetMetadata() const {
-	return shared_state->scan_info->metadata;
-}
-
-bool IcebergMultiFileList::HasTransactionData() const {
-	return shared_state->scan_info->transaction_data;
-}
-
-const IcebergTransactionData &IcebergMultiFileList::GetTransactionData() const {
-	D_ASSERT(HasTransactionData());
-	return *shared_state->scan_info->transaction_data;
-}
-
-const IcebergSnapshotScanInfo &IcebergMultiFileList::GetSnapshot() const {
-	return shared_state->scan_info->snapshot_info;
-}
-
-const IcebergTableSchema &IcebergMultiFileList::GetSchema() const {
-	return shared_state->scan_info->schema;
-}
-
-IcebergScanPlanProvider &IcebergMultiFileList::GetScanPlanProvider() const {
-	D_ASSERT(scan_plan_provider);
-	return *scan_plan_provider;
-}
-
-IcebergScanPlanContext IcebergMultiFileList::GetScanPlanContext() const {
-	optional_ptr<const IcebergTransactionData> transaction_data;
-	if (HasTransactionData()) {
-		transaction_data = &GetTransactionData();
-	}
-	return {context, fs, GetPath(), options, GetSnapshot(), GetMetadata(), GetSchema(), transaction_data};
-}
-
-IcebergDeletePlanningContext IcebergMultiFileList::GetDeletePlanningContext() const {
-	return {context,
-	        fs,
-	        GetPath(),
-	        options,
-	        GetMetadata(),
-	        GetSchema(),
-	        table_filters,
-	        data_manifests,
-	        delete_manifests,
-	        delete_manifest_matches,
-	        GetScanPlanProvider()};
-}
-
-optional_ptr<IcebergTableSchemaVersion> IcebergMultiFileList::GetTable() const {
-	return shared_state->table;
+const IcebergScanPlanner &IcebergMultiFileList::GetScanPlanner() const {
+	return *planner;
 }
 
 void IcebergMultiFileList::SetTable(IcebergTableSchemaVersion &table) {
-	shared_state->table = table;
+	planner->SetTable(table);
+}
+
+optional_ptr<IcebergTableSchemaVersion> IcebergMultiFileList::GetTable() const {
+	return planner->GetTable();
 }
 
 void IcebergMultiFileList::SetOptions(const IcebergOptions &options) {
-	shared_state->options = options;
+	planner->SetOptions(options);
 }
 
 void IcebergMultiFileList::SetScanOrder(unique_ptr<RowGroupOrderOptions> options) {
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	scan_order.Set(std::move(options));
+	planner->SetScanOrder(std::move(options));
 }
 
 void IcebergMultiFileList::DisableServerSidePlanning() {
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	if (!shared_state->manifest_list_loaded) {
-		shared_state->server_side_planning_enabled = false;
-	}
+	planner->DisableServerSidePlanning();
 }
 
 void IcebergMultiFileList::Bind(vector<LogicalType> &return_types, vector<Identifier> &names) {
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-
 	if (have_bound) {
 		names = StringsToIdentifiers(this->names);
-		return_types = this->types;
+		return_types = types;
 		return;
 	}
-	if (!shared_state->scan_info) {
-		D_ASSERT(!shared_state->path.empty());
-		auto input_string = shared_state->path;
-		auto resolved_metadata = IcebergUtils::ResolveTableMetadata(context, input_string, options);
-
+	if (!planner->HasScanInfo()) {
+		D_ASSERT(!planner->GetPath().empty());
+		auto resolved_metadata =
+		    IcebergUtils::ResolveTableMetadata(planner->GetContext(), planner->GetPath(), planner->GetOptions());
 		auto temp_data = make_uniq<IcebergScanTemporaryData>();
 		temp_data->metadata = std::move(resolved_metadata.metadata);
 		auto &metadata = temp_data->metadata;
-
-		IcebergSnapshotScanInfo snapshot_info;
-		snapshot_info = metadata.GetSnapshot(*options.snapshot_lookup);
+		auto snapshot_info = metadata.GetSnapshot(*planner->GetOptions().snapshot_lookup);
 		auto schema = metadata.GetSchemaFromId(snapshot_info.schema_id);
-		shared_state->scan_info = make_shared_ptr<IcebergScanInfo>(resolved_metadata.table_location,
-		                                                           std::move(temp_data), snapshot_info, *schema);
+		planner->SetScanInfo(make_shared_ptr<IcebergScanInfo>(resolved_metadata.table_location, std::move(temp_data),
+		                                                      snapshot_info, *schema));
 	}
-
-	auto &schema = GetSchema().columns;
-	for (auto &schema_entry : schema) {
+	for (auto &schema_entry : planner->GetSchema().columns) {
 		names.push_back(Identifier(schema_entry->name));
 		return_types.push_back(schema_entry->type);
 	}
-
 	QueryResult::DeduplicateColumns(names);
 	for (idx_t i = 0; i < names.size(); i++) {
-		schema[i]->name = names[i].GetIdentifierName();
+		planner->GetSchema().columns[i]->name = names[i].GetIdentifierName();
 	}
-
 	have_bound = true;
 	this->names = IdentifiersToStrings(names);
-	this->types = return_types;
+	types = return_types;
+}
+
+const IcebergTableMetadata &IcebergMultiFileList::GetMetadata() const {
+	return planner->GetMetadata();
+}
+
+const IcebergTableSchema &IcebergMultiFileList::GetSchema() const {
+	return planner->GetSchema();
+}
+
+IcebergPartition IcebergMultiFileList::GetPartitionForDataFile(const string &file_path) const {
+	return planner->GetPartitionForDataFile(file_path);
+}
+
+shared_ptr<IcebergDeleteData> IcebergMultiFileList::GetExistingPositionalDeleteData(const string &file_path) const {
+	return delete_execution->GetExistingPositionalDeleteData(file_path);
+}
+
+IcebergDeletePlan IcebergMultiFileList::ProcessDeletes(const IcebergScanTask &task) const {
+	return delete_execution->ProcessDeletes(*planner, task);
+}
+
+void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) const {
+	planner->GetStatistics(result);
 }
 
 unique_ptr<IcebergMultiFileList>
-IcebergMultiFileList::PushdownInternal(ClientContext &context, TableFilterSet &new_filters,
-                                       const vector<ColumnIndex> &column_indexes) const {
-	unique_ptr<RowGroupOrderOptions> filtered_scan_order;
-	{
-		annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-		filtered_scan_order = scan_order.CopyOptions();
-	}
-	auto filtered_list = unique_ptr<IcebergMultiFileList>(new IcebergMultiFileList(shared_state));
-
+IcebergMultiFileList::PushdownInternal(TableFilterSet &new_filters, const vector<ColumnIndex> &column_indexes) const {
 	IcebergTableFilters result_filter_set;
-
-	// The supplied filter set is the complete set of filters for the new view.
 	for (auto &entry : new_filters) {
 		auto projection_index = ProjectionIndex(entry.GetIndex().GetIndex());
 		auto &column_index = column_indexes[projection_index];
@@ -229,47 +122,35 @@ IcebergMultiFileList::PushdownInternal(ClientContext &context, TableFilterSet &n
 		auto &filter = ExpressionFilter::GetExpressionFilter(entry.Filter(), "IcebergMultiFileList::PushdownInternal");
 		result_filter_set.PushFilter(column_index, filter.Copy());
 	}
-
-	filtered_list->table_filters = std::move(result_filter_set);
-	filtered_list->names = names;
-	filtered_list->types = types;
-	filtered_list->have_bound = true;
-	if (filtered_scan_order) {
-		filtered_list->SetScanOrder(std::move(filtered_scan_order));
-	}
-	return filtered_list;
+	auto result = unique_ptr<IcebergMultiFileList>(
+	    new IcebergMultiFileList(planner->CreateView(std::move(result_filter_set)), delete_execution));
+	result->have_bound = true;
+	result->names = names;
+	result->types = types;
+	return result;
 }
 
 unique_ptr<MultiFileList>
 IcebergMultiFileList::DynamicFilterPushdown(MultiFileDynamicPushdownInfo &pushdown_info) const {
 	auto &column_indexes = pushdown_info.column_indexes;
-	auto &context = pushdown_info.context;
 	auto &filters = pushdown_info.filters;
-
 	if (!filters.HasFilters()) {
 		return nullptr;
 	}
 
 	auto filters_copy = filters.Copy();
-	D_ASSERT(filters_copy->FilterCount() >= table_filters.FilterCount());
+	D_ASSERT(filters_copy->FilterCount() >= planner->Filters().FilterCount());
 	bool filters_changed = false;
 	for (auto &entry : filters) {
 		auto &filter =
 		    ExpressionFilter::GetExpressionFilter(entry.Filter(), "IcebergMultiFileList::DynamicFilterPushdown");
 		auto column_id = column_indexes[entry.GetIndex().GetIndex()];
-		auto previously_pushed_down_filter = table_filters.TryGetFilterByColumnIndex(column_id);
-		if (!previously_pushed_down_filter || !filter.Equals(*previously_pushed_down_filter)) {
+		auto previous = planner->Filters().TryGetFilterByColumnIndex(column_id);
+		if (!previous || !filter.Equals(*previous)) {
 			filters_changed = true;
 		}
 	}
-
-	if (filters_changed) {
-		// Dynamic filter pushdown supplies the complete effective filter for every column. This includes filters
-		// already pushed down by ComplexFilterPushdown, potentially combined with a new runtime filter.
-		auto new_snap = PushdownInternal(context, *filters_copy, column_indexes);
-		return std::move(new_snap);
-	}
-	return nullptr;
+	return filters_changed ? PushdownInternal(*filters_copy, column_indexes) : nullptr;
 }
 
 unique_ptr<MultiFileList> IcebergMultiFileList::ComplexFilterPushdown(ClientContext &context, const MultiFileOptions &,
@@ -278,477 +159,72 @@ unique_ptr<MultiFileList> IcebergMultiFileList::ComplexFilterPushdown(ClientCont
 	if (filters.empty()) {
 		return nullptr;
 	}
-
 	FilterCombiner combiner(context);
 	for (const auto &filter : filters) {
 		combiner.AddFilter(filter->Copy());
 	}
-
 	vector<FilterPushdownResult> unused;
 	auto filter_set = combiner.GenerateTableScanFilters(info.column_indexes, unused);
 	if (!filter_set.HasFilters()) {
 		return nullptr;
 	}
-
-	return PushdownInternal(context, filter_set, info.column_indexes);
+	return PushdownInternal(filter_set, info.column_indexes);
 }
 
-vector<OpenFileInfo> IcebergMultiFileList::GetAllFiles() const {
-	vector<OpenFileInfo> file_list;
-	//! Lock is required because it reads the 'manifest_entries' vector
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	for (idx_t i = 0;; i++) {
-		auto file = GetFileInternal(i, guard);
-		if (file.path.empty()) {
-			break;
-		}
-		file_list.push_back(std::move(file));
-	}
-	return file_list;
-}
-
-FileExpandResult IcebergMultiFileList::GetExpandResult() const {
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	// DuckDB calls MultiFileList::IsEmpty() during MultiFileBindInternal, before the reader's Bind() has
-	// applied named parameters (SetOptions) or resolved metadata for a path-based scan.
-	// do not call GetFileInternal before binding, otherwise we loose arguemnts from ICEBERG_SCAN like 'version' or
-	// 'snapshot_from_id'
-	if (have_bound) {
-		// GetFileInternal(1) will ensure files with index 0 and index 1 are expanded if they are available
-		GetFileInternal(1, guard);
-	}
-
-	// always return multiple files, In the case there is only 1 data file,
-	// we only lose performance if it is small
-	return FileExpandResult::MULTIPLE_FILES;
-}
-
-idx_t IcebergMultiFileList::GetTotalFileCount() const {
-	// FIXME: the 'added_files_count' + the 'existing_files_count'
-	// in the Manifest List should give us this information without scanning the manifest file(s)
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-
-	idx_t i = data_manifest_entries.size();
-	while (!GetFileInternal(i, guard).path.empty()) {
-		i++;
-	}
-	return data_manifest_entries.size();
-}
-
-unique_ptr<NodeStatistics> IcebergMultiFileList::GetCardinality(ClientContext &context) const {
-	if (GetMetadata().iceberg_version == 1) {
-		//! We collect no cardinality information from manifests for V1 tables.
-		return nullptr;
-	}
-
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	InitializeView(guard);
-
-	idx_t cardinality = 0;
-	for (idx_t i = 0; i < data_manifests.size(); i++) {
-		auto &manifest = data_manifests[i].entry.file;
-		if (!data_manifest_matches[i]) {
-			continue;
-		}
-		if (!manifest.counts || !manifest.counts->added_rows_count || !manifest.counts->existing_rows_count) {
-			return nullptr;
-		}
-		cardinality += *manifest.counts->added_rows_count;
-		cardinality += *manifest.counts->existing_rows_count;
-	}
-	for (idx_t i = 0; i < delete_manifests.size(); i++) {
-		auto &manifest = delete_manifests[i].entry.file;
-		if (!delete_manifest_matches[i]) {
-			continue;
-		}
-		if (!manifest.counts || !manifest.counts->added_rows_count) {
-			return nullptr;
-		}
-		cardinality -= *manifest.counts->added_rows_count;
-	}
-	return make_uniq<NodeStatistics>(cardinality, cardinality);
-}
-
-BoundIcebergManifestEntry IcebergMultiFileList::GetManifestEntry(idx_t file_id) const {
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	return data_manifest_entries[file_id];
-}
-
-IcebergManifestFile IcebergMultiFileList::GetManifestFileForDataFile(idx_t file_id) const {
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	auto manifest_file_idx = data_manifest_entries[file_id].manifest_file_idx;
-	return data_manifests[manifest_file_idx].entry.file;
-}
-
-IcebergPartition IcebergMultiFileList::GetPartitionForDataFile(const string &file_path) const {
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	auto entry = shared_state->data_file_partitions.find(file_path);
-	if (entry != shared_state->data_file_partitions.end()) {
-		return entry->second;
-	}
-	throw InvalidConfigurationException("Could not find data file '%s' in manifest entries", file_path);
-}
-
-const IcebergManifestFile &IcebergMultiFileList::GetManifestFileForEntry(const BoundIcebergManifestEntry &entry,
-                                                                         IcebergManifestContentType type) const {
-	if (type == IcebergManifestContentType::DATA) {
-		return data_manifests[entry.manifest_file_idx].entry.file;
-	} else {
-		return delete_manifests[entry.manifest_file_idx].entry.file;
-	}
-}
-
-void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) const {
-	if (GetMetadata().iceberg_version == 1) {
-		//! We collect no statistics information from manifests for V1 tables.
-		return;
-	}
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	InitializeView(guard);
-
-	for (idx_t i = 0; i < delete_manifests.size(); i++) {
-		if (delete_manifest_matches[i]) {
-			//! if a matching delete manifest exists, return;
-			return;
-		}
-	}
-
-	idx_t count = 0;
-	for (idx_t i = 0; i < data_manifests.size(); i++) {
-		auto &manifest = data_manifests[i].entry.file;
-		if (!data_manifest_matches[i]) {
-			continue;
-		}
-		if (!manifest.counts || !manifest.counts->added_rows_count || !manifest.counts->existing_rows_count) {
-			return;
-		}
-		count += *manifest.counts->existing_rows_count;
-		count += *manifest.counts->added_rows_count;
-	}
-
-	PartitionStatistics partition_stats;
-	partition_stats.count = count;
-	partition_stats.count_type = CountType::COUNT_EXACT;
-	result.push_back(partition_stats);
-}
-
-bool IcebergMultiFileList::TryGetNextBatch(annotated_lock_guard<annotated_mutex> &guard) const {
-	return GetScanPlanProvider().TryGetNextBatch(data_view_cursor);
-}
-
-void IcebergMultiFileList::FinishScanTasks(annotated_lock_guard<annotated_mutex> &guard) const {
-	GetScanPlanProvider().FinishScanTasks();
-};
-
-optional_ptr<const BoundIcebergManifestEntry>
-IcebergMultiFileList::GetDataFile(idx_t file_id, annotated_lock_guard<annotated_mutex> &guard) const {
-	D_ASSERT(scan_plan_provider);
-	if (file_id < data_manifest_entries.size()) {
-		//! Have we already scanned this data file and returned it? If so, return it
-		return data_manifest_entries[file_id];
-	}
-
-	while (file_id >= data_manifest_entries.size()) {
-		if (!TryGetNextBatch(guard)) {
-			FinishScanTasks(guard);
-			return nullptr;
-		}
-
-		auto &view_cursor = data_view_cursor;
-		auto &current_batch = view_cursor.current_batch;
-		auto &bound_manifest_list_entry = data_manifests[current_batch.manifest_list_entry_idx];
-		auto &manifest_list_entry = bound_manifest_list_entry.entry;
-		auto &manifest_entries = manifest_list_entry.GetManifestEntries();
-		auto &manifest_file = manifest_list_entry.file;
-		if (!data_manifest_matches[current_batch.manifest_list_entry_idx]) {
-			view_cursor.current_batch_offset = current_batch.end_index;
-		}
-		for (; view_cursor.current_batch_offset < current_batch.end_index && file_id >= data_manifest_entries.size();
-		     view_cursor.current_batch_offset++) {
-			auto &manifest_entry = manifest_entries[view_cursor.current_batch_offset];
-			auto &data_file = manifest_entry.data_file;
-			auto entry_path = data_file.file_path;
-			if (options.allow_moved_paths) {
-				entry_path = IcebergUtils::GetFullPath(GetPath(), entry_path, fs);
-			}
-			IcebergPartition partition {manifest_file.partition_spec_id, data_file.partition_info};
-			shared_state->data_file_partitions[entry_path] = partition;
-			shared_state->data_file_partitions[data_file.file_path] = std::move(partition);
-
-			//! Bind the entry in order for the manifest list entry to record its row count
-			auto bound_entry = bound_manifest_list_entry.BindEntry(manifest_entry);
-			if (manifest_entry.status == IcebergManifestEntryStatusType::DELETED) {
-				continue;
-			}
-
-			// Check whether current data file is filtered out.
-			if (table_filters.HasFilters() && !IcebergFilePruner(context, GetMetadata(), GetSchema(), table_filters)
-			                                       .FileMatchesFilter(manifest_file, manifest_entry)) {
-				// Note: FileMatches filter will log a message if the file is pruned
-				//! Skip this file
-				continue;
-			}
-
-			// Check whether current data file belongs to an unknown puffin file, skip if so.
-			if (StringUtil::CIEquals(data_file.file_format, "puffin")) {
-				//! Skip this file
-				continue;
-			}
-			data_manifest_entries.push_back(bound_entry);
-		}
-		if (view_cursor.current_batch_offset >= current_batch.end_index) {
-			view_cursor.has_current_batch = false;
-		}
-	}
-	return data_manifest_entries[file_id];
-}
-
-void IcebergMultiFileList::EnsureScanOrderApplied(annotated_lock_guard<annotated_mutex> &guard) const {
-	if (!scan_order.IsPending()) {
-		return;
-	}
-
-	idx_t materialized = 0;
-	while (GetDataFile(materialized, guard)) {
-		materialized++;
-	}
-	scan_order.Apply(context, GetSchema(), has_matching_delete_manifests.load(), data_manifest_entries);
-}
-
-OpenFileInfo IcebergMultiFileList::GetFileInternal(idx_t file_id, annotated_lock_guard<annotated_mutex> &guard) const {
-	InitializeView(guard);
-	StartDataManifestScan(guard);
-	EnsureScanOrderApplied(guard);
-
-	auto found_manifest_entry = GetDataFile(file_id, guard);
-	if (!found_manifest_entry) {
+OpenFileInfo IcebergMultiFileList::GetFileInternal(idx_t file_id) const {
+	auto task = planner->GetDataFileTask(file_id);
+	if (!task) {
 		return OpenFileInfo();
 	}
-
-	const auto &bound_manifest_entry = *found_manifest_entry;
-	auto &manifest_file = GetManifestFileForEntry(bound_manifest_entry, IcebergManifestContentType::DATA);
-	auto &manifest_entry = bound_manifest_entry.entry;
-	auto &data_file = manifest_entry.data_file;
-	const auto &path = data_file.file_path;
-
+	auto &data_file = task->data_file.entry.data_file;
 	if (!StringUtil::CIEquals(data_file.file_format, "parquet")) {
 		throw NotImplementedException("File format '%s' not supported, only supports 'parquet' currently",
 		                              data_file.file_format);
 	}
-
-	string file_path = path;
-	if (options.allow_moved_paths) {
-		auto iceberg_path = GetPath();
-		auto &fs = FileSystem::GetFileSystem(context);
-		file_path = IcebergUtils::GetFullPath(iceberg_path, path, fs);
-	}
-	OpenFileInfo res(file_path);
+	OpenFileInfo result(task->file_path);
 	auto extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
 	extended_info->options["file_size"] = Value::UBIGINT(data_file.file_size_in_bytes);
-	// files managed by Iceberg are never modified - we can keep them cached
 	extended_info->options["validate_external_file_cache"] = Value::BOOLEAN(false);
-	// etag / last modified time can be set to dummy values
 	extended_info->options["etag"] = Value("");
 	extended_info->options["last_modified"] = Value::TIMESTAMP(timestamp_t(0));
-	if (bound_manifest_entry.HasFirstRowId()) {
-		extended_info->options["first_row_id"] = Value::BIGINT(bound_manifest_entry.GetFirstRowId());
+	if (task->data_file.HasFirstRowId()) {
+		extended_info->options["first_row_id"] = Value::BIGINT(task->data_file.GetFirstRowId());
 	}
-	extended_info->options["sequence_number"] = Value::BIGINT(manifest_entry.GetSequenceNumber(manifest_file));
-	res.extended_info = extended_info;
-	return res;
+	extended_info->options["sequence_number"] =
+	    Value::BIGINT(task->data_file.entry.GetSequenceNumber(task->manifest_file));
+	result.extended_info = std::move(extended_info);
+	return result;
+}
+
+vector<OpenFileInfo> IcebergMultiFileList::GetAllFiles() const {
+	vector<OpenFileInfo> result;
+	for (idx_t i = 0;; i++) {
+		auto file = GetFileInternal(i);
+		if (file.path.empty()) {
+			break;
+		}
+		result.push_back(std::move(file));
+	}
+	return result;
+}
+
+FileExpandResult IcebergMultiFileList::GetExpandResult() const {
+	if (have_bound) {
+		GetFileInternal(1);
+	}
+	return FileExpandResult::MULTIPLE_FILES;
+}
+
+idx_t IcebergMultiFileList::GetTotalFileCount() const {
+	return planner->GetTotalFileCount();
+}
+
+unique_ptr<NodeStatistics> IcebergMultiFileList::GetCardinality(ClientContext &) const {
+	return planner->GetCardinality();
 }
 
 OpenFileInfo IcebergMultiFileList::GetFile(idx_t file_id) const {
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	return GetFileInternal(file_id, guard);
-}
-
-void IcebergMultiFileList::InitializeView(annotated_lock_guard<annotated_mutex> &guard) const {
-	if (scan_plan_provider) {
-		return;
-	}
-	LoadManifestList(guard);
-
-	auto &committed_data_manifests = GetScanPlanProvider().DataManifests();
-	auto &transaction_data_manifests = shared_state->transaction_data_manifests;
-	IcebergFilePruner pruner(context, GetMetadata(), GetSchema(), table_filters);
-	data_manifests.reserve(committed_data_manifests.size() + transaction_data_manifests.size());
-	data_manifest_matches.reserve(committed_data_manifests.size() + transaction_data_manifests.size());
-	for (auto &manifest : committed_data_manifests) {
-		data_manifests.emplace_back(data_manifests.size(), manifest);
-		data_manifest_matches.push_back(pruner.ManifestMatchesFilter(manifest.file));
-	}
-	for (auto &manifest : transaction_data_manifests) {
-		data_manifests.emplace_back(data_manifests.size(), manifest);
-		data_manifest_matches.push_back(pruner.ManifestMatchesFilter(manifest.get().file));
-	}
-
-	auto &committed_delete_manifests = GetScanPlanProvider().DeleteManifests();
-	auto &transaction_delete_manifests = shared_state->transaction_delete_manifests;
-	delete_manifests.reserve(committed_delete_manifests.size() + transaction_delete_manifests.size());
-	delete_manifest_matches.reserve(committed_delete_manifests.size() + transaction_delete_manifests.size());
-	bool view_has_matching_delete_manifests = false;
-	for (auto &manifest : committed_delete_manifests) {
-		delete_manifests.emplace_back(delete_manifests.size(), manifest);
-		auto matches = pruner.ManifestMatchesFilter(manifest.file);
-		delete_manifest_matches.push_back(matches);
-		view_has_matching_delete_manifests |= matches;
-	}
-	for (auto &manifest : transaction_delete_manifests) {
-		delete_manifests.emplace_back(delete_manifests.size(), manifest);
-		auto matches = pruner.ManifestMatchesFilter(manifest.get().file);
-		delete_manifest_matches.push_back(matches);
-		view_has_matching_delete_manifests |= matches;
-	}
-	has_matching_delete_manifests.store(view_has_matching_delete_manifests);
-}
-
-void IcebergMultiFileList::InitializeScanPlanProvider() const {
-	if (scan_plan_provider) {
-		return;
-	}
-	scan_plan_provider = IcebergScanPlanProvider::Create(*shared_state, GetScanPlanContext(), GetTable(), table_filters,
-	                                                     scan_order, shared_state->server_side_planning_enabled);
-}
-
-void IcebergMultiFileList::LoadManifestList(annotated_lock_guard<annotated_mutex> &guard) const {
-	InitializeScanPlanProvider();
-	GetScanPlanProvider().LoadManifestList();
-}
-
-void IcebergMultiFileList::StartDataManifestScan(annotated_lock_guard<annotated_mutex> &guard) const {
-	D_ASSERT(scan_plan_provider);
-	GetScanPlanProvider().StartDataManifestScan(data_manifest_matches, table_filters.FilterCount());
-}
-
-vector<IcebergDeleteFileReference>
-IcebergMultiFileList::ResolveApplicableDeleteFiles(const BoundIcebergManifestEntry &data_manifest_entry) const {
-	vector<IcebergDeleteFileReference> result;
-	if (!has_matching_delete_manifests.load()) {
-		return result;
-	}
-
-	vector<idx_t> manifest_indexes;
-	optional_ptr<IcebergScanPlanProvider> provider;
-	{
-		annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-		InitializeView(guard);
-		manifest_indexes =
-		    IcebergDeletePlanner::GetDeleteManifestsForDataFile(GetDeletePlanningContext(), data_manifest_entry);
-		provider = scan_plan_provider.get();
-	}
-	if (manifest_indexes.empty()) {
-		return result;
-	}
-
-	D_ASSERT(provider);
-	provider->ReadDeleteManifests(manifest_indexes, table_filters.FilterCount());
-
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
-	auto delete_context = GetDeletePlanningContext();
-	auto data_partition_values = IcebergFilePruner::PartitionValueMap(data_manifest_entry.entry.data_file);
-	for (auto delete_file : provider->GetDeleteFiles(manifest_indexes)) {
-		if (delete_file.manifest_idx >= delete_manifests.size()) {
-			throw InternalException("Delete manifest index %llu is out of bounds for %llu manifests",
-			                        delete_file.manifest_idx, delete_manifests.size());
-		}
-		auto &manifest_entries = delete_manifests[delete_file.manifest_idx].entry.GetManifestEntries();
-		if (delete_file.entry_idx >= manifest_entries.size()) {
-			throw InternalException("Delete manifest entry index %llu is out of bounds for manifest %llu",
-			                        delete_file.entry_idx, delete_file.manifest_idx);
-		}
-		auto &delete_entry = manifest_entries[delete_file.entry_idx];
-		if (!IcebergDeletePlanner::DeleteEntryMatchesFilters(delete_context, delete_file.manifest_idx, delete_entry)) {
-			continue;
-		}
-		if (!IcebergDeletePlanner::DeleteEntryAppliesToDataFile(delete_context, delete_file.manifest_idx, delete_entry,
-		                                                        data_manifest_entry, data_partition_values)) {
-			continue;
-		}
-		result.push_back(delete_file);
-	}
-	return result;
-}
-
-IcebergDeletePlan IcebergMultiFileList::ProcessDeletes(const BoundIcebergManifestEntry &data_manifest_entry) const {
-	IcebergDeletePlan result;
-	if (!has_matching_delete_manifests.load()) {
-		return result;
-	}
-
-	auto applicable_delete_files = ResolveApplicableDeleteFiles(data_manifest_entry);
-
-	optional_ptr<IcebergScanPlanProvider> provider;
-	vector<IcebergDeleteScanEntry> scan_entries;
-	vector<shared_ptr<IcebergDeleteFileLoadState>> required_loads;
-	vector<shared_ptr<IcebergDeleteFileLoadState>> new_loads;
-	unique_ptr<IcebergDeletePlanningContext> delete_context;
-	{
-		annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-		annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
-		provider = scan_plan_provider.get();
-		if (!provider) {
-			//! ResolveApplicableDeleteFiles ran InitializeView, which creates the provider, so it is always
-			//! set here - a null is a broken invariant, not a "nothing to do".
-			throw InternalException("scan_plan_provider is not initialized in ProcessDeletes");
-		}
-		delete_context = make_uniq<IcebergDeletePlanningContext>(GetDeletePlanningContext());
-		unordered_set<IcebergDeleteFileLoadState *> seen_loads;
-		for (auto delete_file : applicable_delete_files) {
-			auto &delete_manifest = delete_manifests[delete_file.manifest_idx].entry;
-			auto &load = provider->GetDeleteFileLoad(delete_file);
-			if (!load) {
-				load = make_shared_ptr<IcebergDeleteFileLoadState>();
-				new_loads.push_back(load);
-				scan_entries.emplace_back(delete_file.manifest_idx, delete_file.entry_idx, delete_manifest, load);
-			}
-			if (seen_loads.insert(load.get()).second) {
-				required_loads.push_back(load);
-			}
-		}
-	}
-
-	if (!scan_entries.empty()) {
-		ErrorData scan_error;
-		try {
-			auto scan_result = IcebergDeleteFileScanner::ScanFiles(*delete_context, scan_entries);
-			annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
-			MergeDeleteScanResult(*provider, std::move(scan_result));
-		} catch (std::exception &ex) {
-			scan_error = ErrorData(ex);
-		} catch (...) { // LCOV_EXCL_START
-			scan_error = ErrorData("Unknown exception while reading Iceberg delete files");
-		} // LCOV_EXCL_STOP
-		CompleteDeleteFileLoads(new_loads, scan_error);
-	}
-
-	for (auto &load : required_loads) {
-		unique_lock<mutex> guard(load->lock);
-		load->cv.wait(guard, [&load] { return load->complete; });
-		if (load->error.HasError()) {
-			load->error.Throw();
-		}
-		if (load->equality_delete) {
-			result.equality_deletes.emplace_back(*load->equality_delete);
-		}
-	}
-
-	{
-		annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
-		auto &positional_delete_data = provider->PositionalDeleteData();
-		auto entry = positional_delete_data.find(data_manifest_entry.entry.data_file.file_path);
-		if (entry != positional_delete_data.end()) {
-			result.positional_deletes = entry->second->ToFilter();
-		}
-	}
-	return result;
-}
-
-shared_ptr<IcebergDeleteData> IcebergMultiFileList::GetExistingPositionalDeleteData(const string &file_path) const {
-	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
-	annotated_lock_guard<annotated_mutex> delete_guard(shared_state->delete_lock);
-	return IcebergDeletePlanner::GetExistingPositionalDeleteData(GetDeletePlanningContext(), file_path);
+	return GetFileInternal(file_id);
 }
 
 } // namespace duckdb

--- a/src/planning/iceberg_multi_file_list.cpp
+++ b/src/planning/iceberg_multi_file_list.cpp
@@ -46,14 +46,6 @@ void IcebergMultiFileList::SetOptions(const IcebergOptions &options) {
 	planner->SetOptions(options);
 }
 
-void IcebergMultiFileList::SetScanOrder(unique_ptr<RowGroupOrderOptions> options) {
-	planner->SetScanOrder(std::move(options));
-}
-
-void IcebergMultiFileList::DisableServerSidePlanning() {
-	planner->DisableServerSidePlanning();
-}
-
 void IcebergMultiFileList::Bind(vector<LogicalType> &return_types, vector<Identifier> &names) {
 	if (have_bound) {
 		names = StringsToIdentifiers(this->names);
@@ -85,28 +77,12 @@ void IcebergMultiFileList::Bind(vector<LogicalType> &return_types, vector<Identi
 	types = return_types;
 }
 
-const IcebergTableMetadata &IcebergMultiFileList::GetMetadata() const {
-	return planner->GetMetadata();
-}
-
-const IcebergTableSchema &IcebergMultiFileList::GetSchema() const {
-	return planner->GetSchema();
-}
-
-IcebergPartition IcebergMultiFileList::GetPartitionForDataFile(const string &file_path) const {
-	return planner->GetPartitionForDataFile(file_path);
-}
-
 shared_ptr<IcebergDeleteData> IcebergMultiFileList::GetExistingPositionalDeleteData(const string &file_path) const {
 	return delete_execution->GetExistingPositionalDeleteData(file_path);
 }
 
 IcebergDeletePlan IcebergMultiFileList::ProcessDeletes(const IcebergScanTask &task) const {
 	return delete_execution->ProcessDeletes(*planner, task);
-}
-
-void IcebergMultiFileList::GetStatistics(vector<PartitionStatistics> &result) const {
-	planner->GetStatistics(result);
 }
 
 unique_ptr<IcebergMultiFileList>

--- a/src/planning/iceberg_multi_file_reader.cpp
+++ b/src/planning/iceberg_multi_file_reader.cpp
@@ -395,11 +395,14 @@ ReaderInitializeType IcebergMultiFileReader::InitializeReader(MultiFileReaderDat
                                                               ClientContext &context, MultiFileGlobalState &gstate) {
 	auto &iceberg_state = gstate.multi_file_reader_state->Cast<IcebergMultiFileReaderGlobalState>();
 	const auto &multi_file_list = dynamic_cast<const IcebergMultiFileList &>(*iceberg_state.file_list);
-	auto &metadata = multi_file_list.GetMetadata();
+	auto &planner = multi_file_list.GetScanPlanner();
+	auto &metadata = planner.GetMetadata();
 	auto file_id = reader_data.reader->file_list_idx.GetIndex();
-	auto bound_manifest_entry = multi_file_list.GetManifestEntry(file_id);
-	auto manifest_file = multi_file_list.GetManifestFileForDataFile(file_id);
-	auto delete_plan = multi_file_list.ProcessDeletes(bound_manifest_entry);
+	auto task = planner.GetScanTask(file_id);
+	if (!task) {
+		throw InternalException("Unable to find Iceberg scan task for file index %llu", file_id);
+	}
+	auto delete_plan = multi_file_list.ProcessDeletes(*task);
 
 	//! Make a copy of the global columns+column_ids, if we have equality deletes we will add columns to this
 	//! This is done so CreateMapping treats these columns as required for the current file,
@@ -424,7 +427,7 @@ ReaderInitializeType IcebergMultiFileReader::InitializeReader(MultiFileReaderDat
 			ApplyFieldMapping(local_column, mappings, root.field_mapping_indexes, context);
 		}
 	}
-	ApplyPartitionConstants(manifest_file, bound_manifest_entry, metadata, reader_data, scan_columns, scan_column_ids,
+	ApplyPartitionConstants(task->manifest_file, task->data_file, metadata, reader_data, scan_columns, scan_column_ids,
 	                        context);
 
 	vector<bool> accelerated_files;

--- a/src/planning/iceberg_multi_file_reader.cpp
+++ b/src/planning/iceberg_multi_file_reader.cpp
@@ -114,7 +114,7 @@ bool IcebergMultiFileReader::Bind(MultiFileOptions &options, MultiFileList &file
 	iceberg_multi_file_list.SetOptions(this->options);
 	iceberg_multi_file_list.Bind(return_types, names);
 	// FIXME: apply final transformation for 'file_row_number' ???
-	auto &schema = iceberg_multi_file_list.GetSchema().columns;
+	auto &schema = iceberg_multi_file_list.GetScanPlanner().GetSchema().columns;
 	auto &columns = bind_data.schema;
 	for (auto &item : schema) {
 		columns.push_back(item->GetMultiFileColumnDefinition());
@@ -762,7 +762,8 @@ vector<PartitionStatistics> IcebergMultiFileReader::IcebergGetPartitionStats(Cli
 	auto &bind_data = input.bind_data->Cast<MultiFileBindData>();
 	vector<PartitionStatistics> result;
 	auto &multi_file_list = bind_data.file_list->Cast<IcebergMultiFileList>();
-	multi_file_list.GetStatistics(result);
+	auto &scan_planner = multi_file_list.GetScanPlanner();
+	scan_planner.GetStatistics(result);
 	return result;
 }
 

--- a/src/planning/iceberg_optimizer.cpp
+++ b/src/planning/iceberg_optimizer.cpp
@@ -61,7 +61,7 @@ void IcebergOptimizerRoutine::VisitOperator(unique_ptr<LogicalOperator> &op, boo
 			}
 		}
 		if (requires_local_planning) {
-			iceberg_list.DisableServerSidePlanning();
+			iceberg_list.GetScanPlanner().DisableServerSidePlanning();
 		}
 	}
 }

--- a/src/planning/scan_plan/CMakeLists.txt
+++ b/src/planning/scan_plan/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(
   iceberg_planning_scan_plan OBJECT
   iceberg_client_scan_plan_provider.cpp iceberg_scan_plan_provider.cpp
-  iceberg_scan_plan_state.cpp iceberg_server_scan_plan_provider.cpp)
+  iceberg_scan_plan_state.cpp iceberg_scan_planner.cpp
+  iceberg_server_scan_plan_provider.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:iceberg_planning_scan_plan>
     PARENT_SCOPE)

--- a/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
+++ b/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
@@ -191,10 +191,8 @@ void ClientSideScanPlanProvider::LoadManifestList() {
 	}
 
 	{
-		annotated_lock_guard<annotated_mutex> delete_guard(shared_state.delete_lock);
+		annotated_lock_guard<annotated_mutex> delete_guard(shared_state.delete_manifest_lock);
 		shared_state.delete_manifest_loads.resize(DeleteManifests().size());
-		shared_state.delete_file_loads.resize(DeleteManifests().size() +
-		                                      shared_state.transaction_delete_manifests.size());
 	}
 
 	shared_state.manifest_list_loaded = true;
@@ -267,7 +265,7 @@ void ClientSideScanPlanProvider::ReadDeleteManifests(const vector<idx_t> &manife
 	idx_t committed_manifest_count;
 	{
 		annotated_lock_guard<annotated_mutex> guard(shared_state.lock);
-		annotated_lock_guard<annotated_mutex> delete_guard(shared_state.delete_lock);
+		annotated_lock_guard<annotated_mutex> delete_guard(shared_state.delete_manifest_lock);
 		committed_manifest_count = shared_state.committed_delete_manifests.size();
 		auto total_manifest_count = committed_manifest_count + shared_state.transaction_delete_manifests.size();
 		for (auto manifest_idx : manifest_indexes) {
@@ -457,30 +455,6 @@ vector<IcebergManifestListEntry> &ClientSideScanPlanProvider::DataManifests() {
 
 vector<IcebergManifestListEntry> &ClientSideScanPlanProvider::DeleteManifests() {
 	return shared_state.committed_delete_manifests;
-}
-
-shared_ptr<IcebergDeleteFileLoadState> &
-ClientSideScanPlanProvider::GetDeleteFileLoad(IcebergDeleteFileReference delete_file) {
-	auto committed_manifest_count = DeleteManifests().size();
-	auto total_manifest_count = committed_manifest_count + shared_state.transaction_delete_manifests.size();
-	if (delete_file.manifest_idx >= total_manifest_count) {
-		throw InternalException("Delete manifest index %llu is out of bounds", delete_file.manifest_idx);
-	}
-	auto &manifest =
-	    delete_file.manifest_idx < committed_manifest_count
-	        ? DeleteManifests()[delete_file.manifest_idx]
-	        : shared_state.transaction_delete_manifests[delete_file.manifest_idx - committed_manifest_count].get();
-	auto &manifest_entries = manifest.GetManifestEntries();
-	if (delete_file.entry_idx >= manifest_entries.size()) {
-		throw InternalException("Delete manifest entry index %llu is out of bounds for manifest %llu",
-		                        delete_file.entry_idx, delete_file.manifest_idx);
-	}
-	auto &loads = shared_state.delete_file_loads[delete_file.manifest_idx];
-	return loads[delete_file.entry_idx];
-}
-
-position_delete_map_t &ClientSideScanPlanProvider::PositionalDeleteData() {
-	return shared_state.positional_delete_data;
 }
 
 } // namespace duckdb

--- a/src/planning/scan_plan/iceberg_scan_planner.cpp
+++ b/src/planning/scan_plan/iceberg_scan_planner.cpp
@@ -1,0 +1,433 @@
+#include "planning/scan_plan/iceberg_scan_planner.hpp"
+
+#include "catalog/rest/catalog_entry/table/iceberg_table_schema_version.hpp"
+#include "common/iceberg_utils.hpp"
+#include "core/metadata/iceberg_table_metadata.hpp"
+#include "planning/pruning/iceberg_file_pruner.hpp"
+#include "planning/scan_plan/iceberg_scan_plan_provider.hpp"
+#include "duckdb/storage/table/row_group_reorderer.hpp"
+
+namespace duckdb {
+
+IcebergScanPlanner::IcebergScanPlanner(ClientContext &context_p, shared_ptr<IcebergScanInfo> scan_info,
+                                       const string &path, const IcebergOptions &options_p)
+    : shared_state(make_shared_ptr<IcebergScanPlanState>(context_p, std::move(scan_info), path, options_p)),
+      context(shared_state->context), fs(shared_state->fs), options(shared_state->options) {
+}
+
+IcebergScanPlanner::IcebergScanPlanner(shared_ptr<IcebergScanPlanState> shared_state_p)
+    : shared_state(std::move(shared_state_p)), context(shared_state->context), fs(shared_state->fs),
+      options(shared_state->options) {
+}
+
+IcebergScanPlanner::~IcebergScanPlanner() {
+}
+
+unique_ptr<IcebergScanPlanner> IcebergScanPlanner::CreateView(IcebergTableFilters filters) const {
+	unique_ptr<RowGroupOrderOptions> filtered_scan_order;
+	{
+		annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+		filtered_scan_order = scan_order.CopyOptions();
+	}
+	auto result = unique_ptr<IcebergScanPlanner>(new IcebergScanPlanner(shared_state));
+	result->table_filters = std::move(filters);
+	if (filtered_scan_order) {
+		result->SetScanOrder(std::move(filtered_scan_order));
+	}
+	return result;
+}
+
+const string &IcebergScanPlanner::GetPath() const {
+	return shared_state->path;
+}
+
+const IcebergOptions &IcebergScanPlanner::GetOptions() const {
+	return options;
+}
+
+const IcebergTableMetadata &IcebergScanPlanner::GetMetadata() const {
+	return shared_state->scan_info->metadata;
+}
+
+const IcebergTableSchema &IcebergScanPlanner::GetSchema() const {
+	return shared_state->scan_info->schema;
+}
+
+ClientContext &IcebergScanPlanner::GetContext() const {
+	return context;
+}
+
+bool IcebergScanPlanner::HasScanInfo() const {
+	return shared_state->scan_info != nullptr;
+}
+
+bool IcebergScanPlanner::HasTransactionData() const {
+	return shared_state->scan_info->transaction_data;
+}
+
+const IcebergTransactionData &IcebergScanPlanner::GetTransactionData() const {
+	D_ASSERT(HasTransactionData());
+	return *shared_state->scan_info->transaction_data;
+}
+
+const IcebergSnapshotScanInfo &IcebergScanPlanner::GetSnapshot() const {
+	return shared_state->scan_info->snapshot_info;
+}
+
+optional_ptr<IcebergTableSchemaVersion> IcebergScanPlanner::GetTable() const {
+	return shared_state->table;
+}
+
+void IcebergScanPlanner::SetTable(IcebergTableSchemaVersion &table) {
+	shared_state->table = table;
+}
+
+void IcebergScanPlanner::SetScanInfo(shared_ptr<IcebergScanInfo> scan_info) {
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	if (scan_plan_provider) {
+		throw InternalException("Cannot replace Iceberg scan info after scan planning has started");
+	}
+	shared_state->scan_info = std::move(scan_info);
+}
+
+void IcebergScanPlanner::SetOptions(const IcebergOptions &new_options) {
+	shared_state->options = new_options;
+}
+
+void IcebergScanPlanner::SetScanOrder(unique_ptr<RowGroupOrderOptions> order_options) {
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	scan_order.Set(std::move(order_options));
+}
+
+void IcebergScanPlanner::DisableServerSidePlanning() {
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	if (!shared_state->manifest_list_loaded) {
+		shared_state->server_side_planning_enabled = false;
+	}
+}
+
+const IcebergTableFilters &IcebergScanPlanner::Filters() const {
+	return table_filters;
+}
+
+IcebergScanPlanProvider &IcebergScanPlanner::GetScanPlanProvider() const {
+	D_ASSERT(scan_plan_provider);
+	return *scan_plan_provider;
+}
+
+IcebergScanPlanContext IcebergScanPlanner::GetScanPlanContext() const {
+	optional_ptr<const IcebergTransactionData> transaction_data;
+	if (HasTransactionData()) {
+		transaction_data = &GetTransactionData();
+	}
+	return {context, fs, GetPath(), options, GetSnapshot(), GetMetadata(), GetSchema(), transaction_data};
+}
+
+IcebergDeletePlanningContext IcebergScanPlanner::GetDeletePlanningContext() const {
+	return {context,
+	        fs,
+	        GetPath(),
+	        options,
+	        GetMetadata(),
+	        GetSchema(),
+	        table_filters,
+	        data_manifests,
+	        delete_manifests,
+	        delete_manifest_matches,
+	        GetScanPlanProvider()};
+}
+
+void IcebergScanPlanner::InitializeScanPlanProvider() const {
+	if (!scan_plan_provider) {
+		scan_plan_provider =
+		    IcebergScanPlanProvider::Create(*shared_state, GetScanPlanContext(), GetTable(), table_filters, scan_order,
+		                                    shared_state->server_side_planning_enabled);
+	}
+}
+
+void IcebergScanPlanner::LoadManifestList(annotated_lock_guard<annotated_mutex> &) const {
+	InitializeScanPlanProvider();
+	GetScanPlanProvider().LoadManifestList();
+}
+
+void IcebergScanPlanner::InitializeView(annotated_lock_guard<annotated_mutex> &guard) const {
+	if (scan_plan_provider) {
+		return;
+	}
+	LoadManifestList(guard);
+	IcebergFilePruner pruner(context, GetMetadata(), GetSchema(), table_filters);
+	auto &committed_data = GetScanPlanProvider().DataManifests();
+	for (auto &manifest : committed_data) {
+		data_manifests.emplace_back(data_manifests.size(), manifest);
+		data_manifest_matches.push_back(pruner.ManifestMatchesFilter(manifest.file));
+	}
+	for (auto &manifest : shared_state->transaction_data_manifests) {
+		data_manifests.emplace_back(data_manifests.size(), manifest);
+		data_manifest_matches.push_back(pruner.ManifestMatchesFilter(manifest.get().file));
+	}
+	auto &committed_deletes = GetScanPlanProvider().DeleteManifests();
+	bool has_matching_deletes = false;
+	for (auto &manifest : committed_deletes) {
+		delete_manifests.emplace_back(delete_manifests.size(), manifest);
+		auto matches = pruner.ManifestMatchesFilter(manifest.file);
+		delete_manifest_matches.push_back(matches);
+		has_matching_deletes |= matches;
+	}
+	for (auto &manifest : shared_state->transaction_delete_manifests) {
+		delete_manifests.emplace_back(delete_manifests.size(), manifest);
+		auto matches = pruner.ManifestMatchesFilter(manifest.get().file);
+		delete_manifest_matches.push_back(matches);
+		has_matching_deletes |= matches;
+	}
+	has_matching_delete_manifests.store(has_matching_deletes);
+}
+
+void IcebergScanPlanner::StartDataManifestScan(annotated_lock_guard<annotated_mutex> &) const {
+	D_ASSERT(scan_plan_provider);
+	GetScanPlanProvider().StartDataManifestScan(data_manifest_matches, table_filters.FilterCount());
+}
+
+bool IcebergScanPlanner::TryGetNextBatch(annotated_lock_guard<annotated_mutex> &) const {
+	return GetScanPlanProvider().TryGetNextBatch(data_view_cursor);
+}
+
+void IcebergScanPlanner::FinishScanTasks(annotated_lock_guard<annotated_mutex> &) const {
+	GetScanPlanProvider().FinishScanTasks();
+}
+
+optional_ptr<const BoundIcebergManifestEntry>
+IcebergScanPlanner::GetDataFile(idx_t file_id, annotated_lock_guard<annotated_mutex> &guard) const {
+	InitializeView(guard);
+	StartDataManifestScan(guard);
+	if (file_id < data_manifest_entries.size()) {
+		return data_manifest_entries[file_id];
+	}
+	while (file_id >= data_manifest_entries.size()) {
+		if (!TryGetNextBatch(guard)) {
+			FinishScanTasks(guard);
+			return nullptr;
+		}
+		auto &batch = data_view_cursor.current_batch;
+		auto &bound_manifest = data_manifests[batch.manifest_list_entry_idx];
+		auto &manifest_entries = bound_manifest.entry.GetManifestEntries();
+		auto &manifest_file = bound_manifest.entry.file;
+		if (!data_manifest_matches[batch.manifest_list_entry_idx]) {
+			data_view_cursor.current_batch_offset = batch.end_index;
+		}
+		for (; data_view_cursor.current_batch_offset < batch.end_index && file_id >= data_manifest_entries.size();
+		     data_view_cursor.current_batch_offset++) {
+			auto &manifest_entry = manifest_entries[data_view_cursor.current_batch_offset];
+			auto &data_file = manifest_entry.data_file;
+			auto entry_path = data_file.file_path;
+			if (options.allow_moved_paths) {
+				entry_path = IcebergUtils::GetFullPath(GetPath(), entry_path, fs);
+			}
+			IcebergPartition partition {manifest_file.partition_spec_id, data_file.partition_info};
+			shared_state->data_file_partitions[entry_path] = partition;
+			shared_state->data_file_partitions[data_file.file_path] = std::move(partition);
+			auto bound_entry = bound_manifest.BindEntry(manifest_entry);
+			if (manifest_entry.status == IcebergManifestEntryStatusType::DELETED) {
+				continue;
+			}
+			if (table_filters.HasFilters() && !IcebergFilePruner(context, GetMetadata(), GetSchema(), table_filters)
+			                                       .FileMatchesFilter(manifest_file, manifest_entry)) {
+				continue;
+			}
+			if (StringUtil::CIEquals(data_file.file_format, "puffin")) {
+				continue;
+			}
+			data_manifest_entries.push_back(bound_entry);
+		}
+		if (data_view_cursor.current_batch_offset >= batch.end_index) {
+			data_view_cursor.has_current_batch = false;
+		}
+	}
+	return data_manifest_entries[file_id];
+}
+
+void IcebergScanPlanner::EnsureScanOrderApplied(annotated_lock_guard<annotated_mutex> &guard) const {
+	if (!scan_order.IsPending()) {
+		return;
+	}
+	idx_t materialized = 0;
+	while (GetDataFile(materialized, guard)) {
+		materialized++;
+	}
+	scan_order.Apply(context, GetSchema(), has_matching_delete_manifests.load(), data_manifest_entries);
+}
+
+optional_ptr<const BoundIcebergManifestEntry> IcebergScanPlanner::GetDataFile(idx_t file_id) const {
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	GetDataFile(file_id, guard);
+	EnsureScanOrderApplied(guard);
+	return file_id < data_manifest_entries.size()
+	           ? optional_ptr<const BoundIcebergManifestEntry>(data_manifest_entries[file_id])
+	           : nullptr;
+}
+
+const IcebergManifestFile &IcebergScanPlanner::GetManifestFileForEntry(const BoundIcebergManifestEntry &entry,
+                                                                       IcebergManifestContentType type) const {
+	return type == IcebergManifestContentType::DATA ? data_manifests[entry.manifest_file_idx].entry.file
+	                                                : delete_manifests[entry.manifest_file_idx].entry.file;
+}
+
+optional<IcebergScanTask> IcebergScanPlanner::GetDataFileTask(idx_t file_id) const {
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	GetDataFile(file_id, guard);
+	EnsureScanOrderApplied(guard);
+	if (file_id >= data_manifest_entries.size()) {
+		return nullopt;
+	}
+	auto data_file = data_manifest_entries[file_id];
+	auto manifest_file = GetManifestFileForEntry(data_file, IcebergManifestContentType::DATA);
+	auto path = data_file.entry.data_file.file_path;
+	if (options.allow_moved_paths) {
+		path = IcebergUtils::GetFullPath(GetPath(), path, fs);
+	}
+	return IcebergScanTask {data_file, std::move(manifest_file), std::move(path), {}};
+}
+
+optional<IcebergScanTask> IcebergScanPlanner::GetScanTask(idx_t file_id) const {
+	auto task = GetDataFileTask(file_id);
+	if (task) {
+		task->delete_files = ResolveApplicableDeleteFiles(task->data_file);
+	}
+	return task;
+}
+
+idx_t IcebergScanPlanner::GetTotalFileCount() const {
+	idx_t file_id = 0;
+	while (GetDataFileTask(file_id)) {
+		file_id++;
+	}
+	return file_id;
+}
+
+unique_ptr<NodeStatistics> IcebergScanPlanner::GetCardinality() const {
+	if (GetMetadata().iceberg_version == 1) {
+		return nullptr;
+	}
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	InitializeView(guard);
+	idx_t cardinality = 0;
+	for (idx_t i = 0; i < data_manifests.size(); i++) {
+		auto &manifest = data_manifests[i].entry.file;
+		if (!data_manifest_matches[i]) {
+			continue;
+		}
+		if (!manifest.counts || !manifest.counts->added_rows_count || !manifest.counts->existing_rows_count) {
+			return nullptr;
+		}
+		cardinality += *manifest.counts->added_rows_count + *manifest.counts->existing_rows_count;
+	}
+	for (idx_t i = 0; i < delete_manifests.size(); i++) {
+		auto &manifest = delete_manifests[i].entry.file;
+		if (!delete_manifest_matches[i]) {
+			continue;
+		}
+		if (!manifest.counts || !manifest.counts->added_rows_count) {
+			return nullptr;
+		}
+		cardinality -= *manifest.counts->added_rows_count;
+	}
+	return make_uniq<NodeStatistics>(cardinality, cardinality);
+}
+
+void IcebergScanPlanner::GetStatistics(vector<PartitionStatistics> &result) const {
+	if (GetMetadata().iceberg_version == 1) {
+		return;
+	}
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	InitializeView(guard);
+	for (idx_t i = 0; i < delete_manifests.size(); i++) {
+		if (delete_manifest_matches[i]) {
+			return;
+		}
+	}
+	idx_t count = 0;
+	for (idx_t i = 0; i < data_manifests.size(); i++) {
+		auto &manifest = data_manifests[i].entry.file;
+		if (!data_manifest_matches[i]) {
+			continue;
+		}
+		if (!manifest.counts || !manifest.counts->added_rows_count || !manifest.counts->existing_rows_count) {
+			return;
+		}
+		count += *manifest.counts->existing_rows_count + *manifest.counts->added_rows_count;
+	}
+	PartitionStatistics stats;
+	stats.count = count;
+	stats.count_type = CountType::COUNT_EXACT;
+	result.push_back(stats);
+}
+
+IcebergPartition IcebergScanPlanner::GetPartitionForDataFile(const string &file_path) const {
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	auto entry = shared_state->data_file_partitions.find(file_path);
+	if (entry != shared_state->data_file_partitions.end()) {
+		return entry->second;
+	}
+	throw InvalidConfigurationException("Could not find data file '%s' in manifest entries", file_path);
+}
+
+vector<IcebergDeleteFileReference>
+IcebergScanPlanner::ResolveApplicableDeleteFiles(const BoundIcebergManifestEntry &data_manifest_entry) const {
+	vector<IcebergDeleteFileReference> result;
+	if (!has_matching_delete_manifests.load()) {
+		return result;
+	}
+	vector<idx_t> manifest_indexes;
+	optional_ptr<IcebergScanPlanProvider> provider;
+	{
+		annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+		InitializeView(guard);
+		manifest_indexes =
+		    IcebergDeletePlanner::GetDeleteManifestsForDataFile(GetDeletePlanningContext(), data_manifest_entry);
+		provider = scan_plan_provider.get();
+	}
+	if (manifest_indexes.empty()) {
+		return result;
+	}
+	provider->ReadDeleteManifests(manifest_indexes, table_filters.FilterCount());
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	auto delete_context = GetDeletePlanningContext();
+	auto partition_values = IcebergFilePruner::PartitionValueMap(data_manifest_entry.entry.data_file);
+	for (auto delete_file : provider->GetDeleteFiles(manifest_indexes)) {
+		if (delete_file.manifest_idx >= delete_manifests.size()) {
+			throw InternalException("Delete manifest index %llu is out of bounds for %llu manifests",
+			                        delete_file.manifest_idx, delete_manifests.size());
+		}
+		auto &entries = delete_manifests[delete_file.manifest_idx].entry.GetManifestEntries();
+		if (delete_file.entry_idx >= entries.size()) {
+			throw InternalException("Delete manifest entry index %llu is out of bounds for manifest %llu",
+			                        delete_file.entry_idx, delete_file.manifest_idx);
+		}
+		auto &delete_entry = entries[delete_file.entry_idx];
+		if (IcebergDeletePlanner::DeleteEntryMatchesFilters(delete_context, delete_file.manifest_idx, delete_entry) &&
+		    IcebergDeletePlanner::DeleteEntryAppliesToDataFile(delete_context, delete_file.manifest_idx, delete_entry,
+		                                                       data_manifest_entry, partition_values)) {
+			result.push_back(delete_file);
+		}
+	}
+	return result;
+}
+
+const IcebergManifestListEntry &IcebergScanPlanner::GetDeleteManifest(IcebergDeleteFileReference delete_file) const {
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	if (delete_file.manifest_idx >= delete_manifests.size()) {
+		throw InternalException("Delete manifest index %llu is out of bounds", delete_file.manifest_idx);
+	}
+	auto &manifest = delete_manifests[delete_file.manifest_idx].entry;
+	if (delete_file.entry_idx >= manifest.GetManifestEntries().size()) {
+		throw InternalException("Delete manifest entry index %llu is out of bounds for manifest %llu",
+		                        delete_file.entry_idx, delete_file.manifest_idx);
+	}
+	return manifest;
+}
+
+unique_ptr<IcebergDeletePlanningContext> IcebergScanPlanner::CreateDeletePlanningContext() const {
+	annotated_lock_guard<annotated_mutex> guard(shared_state->lock);
+	return make_uniq<IcebergDeletePlanningContext>(GetDeletePlanningContext());
+}
+
+} // namespace duckdb

--- a/src/planning/scan_plan/iceberg_server_scan_plan_provider.cpp
+++ b/src/planning/scan_plan/iceberg_server_scan_plan_provider.cpp
@@ -3,7 +3,6 @@
 namespace duckdb {
 
 ServerSideScanPlanProvider::ServerSideScanPlanProvider(IcebergServerSideScanPlan plan_p) : plan(std::move(plan_p)) {
-	delete_file_loads.resize(plan.delete_manifests.size());
 }
 
 void ServerSideScanPlanProvider::LoadManifestList() {
@@ -59,24 +58,6 @@ vector<IcebergManifestListEntry> &ServerSideScanPlanProvider::DataManifests() {
 
 vector<IcebergManifestListEntry> &ServerSideScanPlanProvider::DeleteManifests() {
 	return plan.delete_manifests;
-}
-
-shared_ptr<IcebergDeleteFileLoadState> &
-ServerSideScanPlanProvider::GetDeleteFileLoad(IcebergDeleteFileReference delete_file) {
-	if (delete_file.manifest_idx >= plan.delete_manifests.size()) {
-		throw InternalException("Delete manifest index %llu is out of bounds", delete_file.manifest_idx);
-	}
-	auto &manifest_entries = plan.delete_manifests[delete_file.manifest_idx].GetManifestEntries();
-	if (delete_file.entry_idx >= manifest_entries.size()) {
-		throw InternalException("Delete manifest entry index %llu is out of bounds for manifest %llu",
-		                        delete_file.entry_idx, delete_file.manifest_idx);
-	}
-	auto &loads = delete_file_loads[delete_file.manifest_idx];
-	return loads[delete_file.entry_idx];
-}
-
-position_delete_map_t &ServerSideScanPlanProvider::PositionalDeleteData() {
-	return positional_delete_data;
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Shouldn't change any meaningful state/behavior, just separating concerns.